### PR TITLE
Switch to number of rated videos

### DIFF
--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -398,7 +398,7 @@ export default () => {
               comparison-based ratings between pairs of video contents
             </Grid>
             <Grid item xs={4}>
-              <h1 className={classes.statistic}>{getStatistic('videos')}</h1>
+              <h1 className={classes.statistic}>{getStatistic('n_rated_videos')}</h1>
               video contents from YouTube
             </Grid>
           </Grid>


### PR DESCRIPTION
instead of total number of video on the platform which count non rated video (in people rate later list). 
Fix issue #16