### PR TITLE
Remove some verified email banners

### DIFF
--- a/frontend/src/components/ExpertInterface/index.js
+++ b/frontend/src/components/ExpertInterface/index.js
@@ -23,7 +23,6 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Radio from '@material-ui/core/Radio';
 import Checkbox from '@material-ui/core/Checkbox';
 import Rating from '@material-ui/lab/Rating';
-import EmailAddVerifyAlert from '../EmailAddVerifyAlert';
 import SidePanel from './SidePanel';
 import VideoSelector from './VideoSelector';
 import { featureList, featureNames } from '../../constants';
@@ -877,7 +876,6 @@ export default ({ videoIdAOverride = null, videoIdBOverride = null,
       {commentsOpen === 'left' && <SidePanel videoId={videoA} />}
 
       <div className={classes.centered}>
-        <EmailAddVerifyAlert />
 
         <div className={classes.videoContainer}>
           <div id="video-left">

--- a/frontend/src/components/VideoComments/index.js
+++ b/frontend/src/components/VideoComments/index.js
@@ -14,7 +14,6 @@ import { SUBMIT_EDITED_COMMENT, GET_COMMENTS, TournesolAPI } from '../../api';
 import CommentHeader from './CommentHeader';
 import CommentFooter from './CommentFooter';
 import CommentEditor from './CommentEditor';
-import EmailAddVerifyAlert from '../EmailAddVerifyAlert';
 import getUsernames from './getUsernames';
 
 const useStyles = makeStyles((theme) => ({
@@ -221,7 +220,6 @@ export default (props) => {
 
   return (
     <>
-      <EmailAddVerifyAlert />
       <Typography paragraph className={classes.title} color="textSecondary" gutterBottom>
         What do you think about this video? Please respect other users when
         writing comments.


### PR DESCRIPTION
This PR removes the verified email banner, because it is in very non-user friendly places. It now only appears on the home page