### PR TITLE
Always display the tournesol score on VideoCard

### DIFF
--- a/frontend/src/components/VideoCard.js
+++ b/frontend/src/components/VideoCard.js
@@ -338,10 +338,7 @@ const InfoScore = ({ video, myInfo, showMyInfo }) => {
       </span>
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         <span className={classes.score}>
-          Score{' '}
-          {showMyInfo && myInfo !== null
-            ? Math.round(myInfo.score + video.score_search_term)
-            : Math.round(video.score)}
+          Score {video.tournesol_score}
         </span>
         {video.rating_n_ratings !== undefined && (
           <span style={{ color: '#666', fontSize: '90%' }}>


### PR DESCRIPTION
This PR replaces the score displayed on the video cards by the fixed `tournesol_score` entry received from the backend