### PR TITLE
Add github workflow for backend lints and tests

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: flake8 tournesol core --exclude=migrations,tests,dev,__init__.py --max-line-length 99
 
       - name: Run pylint
-        run: pylint --ignore=migrations core tournesol ml
+        run: pylint --ignore=migrations core tournesol
 
       - name: Run pytest
         run: pytest


### PR DESCRIPTION
Adapted from https://github.com/tournesol-app/tournesol-backend/blob/main/.circleci/config.yml

Python version used in tests is now **3.9** instead of **3.7**, to be consistent with the version used by "infra".