### PR TITLE
Use a constant seed to make lang detection deterministic and avoid CI failures

### DIFF
--- a/backend/tournesol/utils/video_language.py
+++ b/backend/tournesol/utils/video_language.py
@@ -1,7 +1,12 @@
 from collections import Counter
-from langdetect import detect, lang_detect_exception
+from langdetect import detect, lang_detect_exception, DetectorFactory
 import re
 from ..models import Video
+
+# Enforce consistent results with a constant seed,
+# as the language detection algorithm is non-deterministic.
+# See https://github.com/Mimino666/langdetect#basic-usage
+DetectorFactory.seed = 0
 
 
 def languages_detection(title, description):


### PR DESCRIPTION
The tests suite could sometimes fail because of the non-deterministic algorithm.

For example: https://github.com/tournesol-app/tournesol/runs/3924799077?check_suite_focus=true