### PR TITLE
infra: Use git repository as source to install mediawiki extensions

### DIFF
--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -154,3 +154,14 @@ all:
       vars:
         ansible_python_interpreter: /usr/bin/python3
         ansible_ssh_pipelining: true
+        mediawiki_extensions:
+          # These commits refer to the branch "REL1_36" on each repository, as observed on 2021-10-19.
+          - name: Math
+            url: https://github.com/wikimedia/mediawiki-extensions-Math/archive/93b1252386dcd8658a285571a76cea0c6852bb0e.zip
+            output_dir: mediawiki-extensions-Math-93b1252386dcd8658a285571a76cea0c6852bb0e
+          - name: PluggableAuth
+            url: https://github.com/wikimedia/mediawiki-extensions-PluggableAuth/archive/087cb4c82e57971c8e65e40ad40e83e971377ee9.zip
+            output_dir: mediawiki-extensions-PluggableAuth-087cb4c82e57971c8e65e40ad40e83e971377ee9
+          - name: OpenIDConnect
+            url: https://github.com/wikimedia/mediawiki-extensions-OpenIDConnect/archive/da7914745ae62816cb7c37578a4aa8a0894b8a87.zip
+            output_dir: mediawiki-extensions-OpenIDConnect-da7914745ae62816cb7c37578a4aa8a0894b8a87

--- a/infra/ansible/roles/mediawiki/tasks/main.yml
+++ b/infra/ansible/roles/mediawiki/tasks/main.yml
@@ -130,16 +130,15 @@
       name: MediaWikiLanguageExtensionBundle-2021.07.tar.bz2
 
 - name: Download Mediawiki extensions
-  get_url:
-    url: "{{item.url}}"
-    dest: "/tmp/{{item.name}}"
-  with_items:
-    - url: https://extdist.wmflabs.org/dist/extensions/Math-REL1_36-cbe6759.tar.gz
-      name: Math-REL1_36-cbe6759.tar.gz
-    - url: https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_36-087cb4c.tar.gz
-      name: PluggableAuth-REL1_36-087cb4c.tar.gz
-    - url: https://extdist.wmflabs.org/dist/extensions/OpenIDConnect-REL1_36-da79147.tar.gz
-      name: OpenIDConnect-REL1_36-da79147.tar.gz
+  unarchive:
+    remote_src: yes
+    src: "{{item.url}}"
+    dest: "/var/lib/mediawiki/extensions"
+  with_items: "{{mediawiki_extensions}}"
+  notify:
+    - Run Composer
+    - Update Mediawiki database
+    - Reload Nginx
 
 - name: Extract Mediawiki language extensions
   unarchive:
@@ -154,18 +153,25 @@
     - Update Mediawiki database
     - Reload Nginx
 
-- name: Extract Mediawiki extensions
-  unarchive:
-    src: "/tmp/{{item.name}}"
-    remote_src: yes
-    dest: "/var/lib/mediawiki/extensions"
-  with_items:
-    - url: https://extdist.wmflabs.org/dist/extensions/Math-REL1_36-cbe6759.tar.gz
-      name: Math-REL1_36-cbe6759.tar.gz
-    - url: https://extdist.wmflabs.org/dist/extensions/PluggableAuth-REL1_36-087cb4c.tar.gz
-      name: PluggableAuth-REL1_36-087cb4c.tar.gz
-    - url: https://extdist.wmflabs.org/dist/extensions/OpenIDConnect-REL1_36-da79147.tar.gz
-      name: OpenIDConnect-REL1_36-da79147.tar.gz
+- name: Check extensions folders
+  stat:
+    path: "/var/lib/mediawiki/extensions/{{item.name}}"
+  register: extensions_state
+  with_items: "{{mediawiki_extensions}}"
+
+- name: Clean up old (not linked) extensions installs
+  file:
+    path: "/var/lib/mediawiki/extensions/{{item.item.name}}"
+    state: absent
+  when: "not item.stat.islnk"
+  with_items: "{{extensions_state.results}}"
+
+- name: Link Mediawiki extensions
+  file:
+    src: "/var/lib/mediawiki/extensions/{{item.output_dir}}"
+    dest: "/var/lib/mediawiki/extensions/{{item.name}}"
+    state: link
+  with_items: "{{mediawiki_extensions}}"
   notify:
     - Run Composer
     - Update Mediawiki database


### PR DESCRIPTION
This is an attempt to work around the issue due to how URLs such as "https://extdist.wmflabs.org/dist/extensions/Math-REL1_36-cbe6759.tar.gz" may expire as soon as a new commit is pushed and a new release is distributed.  

### Advantage
The package is now downloaded "github.com" and relates to a specific commit: it should remain accessible, even if a new version has been pushed.

### Drawback
The update of these extensions is still not automatized. It would be necessary to update the commit hash used in the `url` and `output_dir` in order to install a more recent version.
We may consider use the branch `REL1_36` directly instead of a specific commit, but we would be exposed to unexpected breaking changes at deploy time.

### Implementation details
The structure of the .zip package downloaded from the git repository is slightly different from the .tar.gz distributed on mediawiki.org. The name of the parent directory is based on the repository name and the commit (e.g: `mediawiki-extensions-Math-93b1252386dcd8658a285571a76cea0c6852bb0e`). That's why a symbolic link is used to match the expected structure of the installed extension.