### PR TITLE
Run husky pre-commit hook only when frontend/ has changed

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,4 +1,8 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-cd frontend
-yarn lint
+if git diff --staged --quiet -- frontend/; then
+    echo "Skipping hook: frontend/ is unchanged"
+else
+    cd frontend
+    yarn lint
+fi


### PR DESCRIPTION
Currently `git commit` may fail if `yarn` is not available (e.g because the expected Node environment is not configured).  
It's always possible to use `git commit --no-verify` in this case, but let's not add unnecessary friction for contributions unrelated to the frontend.