### PR TITLE
Define `read_only_fields` on VideoSerializer, to align docs with the rate-later implementation

### DIFF
--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -17,6 +17,9 @@ class VideoSerializer(ModelSerializer):
         fields = [
             "video_id", "name", "description", "publication_date", "views", "uploader", "language"
             ]
+        read_only_fields = [
+            "name", "description", "publication_date", "views", "uploader", "language"
+        ]
 
 
 class VideoReadOnlySerializer(Serializer):

--- a/backend/tournesol/views/video_rate_later.py
+++ b/backend/tournesol/views/video_rate_later.py
@@ -8,7 +8,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework import generics, mixins, status
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
-from drf_spectacular.utils import extend_schema_view, extend_schema
+from drf_spectacular.utils import extend_schema_view, extend_schema, OpenApiResponse
 
 from ..models import Video, VideoRateLater
 from ..serializers import VideoRateLaterSerializer
@@ -31,21 +31,21 @@ class VideoRateLaterList(
         """API call to return list of rate_later videos"""
         return self.list(request, *args, **kwargs)
 
+    @extend_schema(
+        responses={
+            200: VideoRateLaterSerializer,
+            404: OpenApiResponse(
+                description="Not Found: the video doesn't exist in the database."
+            ),
+            409: OpenApiResponse(
+                description="Conflict: the video is already in the rate later list,"
+                            " or there is an other error with the database query."
+            )
+        }
+    )
     def post(self, request, *args, **kwargs):
         """
         Add an existing video to a user's rate later list.
-
-        Status code:
-
-            403 Forbidden
-                the logged user is not the target user
-
-            404 Not Found
-                the video doesn't exist in the database
-
-            409 Conflict
-                 the video is already in the rate later list
-                 or there is an other error with the database request
         """
         try:
             video = get_object_or_404(Video, video_id=request.data["video"]["video_id"])


### PR DESCRIPTION
Closes #215.

When adding a video to a rate-later list, or at video creation, only `video_id` needs to be provided. 
The other fields are fetched from the Youtube API and should never be updated by the client.

To make the docs consistent with the expected behavior, these extra fields are now defined as `read_only_fields`: they are not used in the request body, but are present in the response.

Similar inconsistencies remain between the docs and the actual implementation of the `VideoViewSet` (hence the "FIXME" comments).

