### PR TITLE
style(SideBar): relook the sidebar to match the Figma mock-up

### DIFF
--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -80,6 +80,8 @@ const SideBar = () => {
   const history = useHistory();
   const location = useLocation();
 
+  const isItemSelected = (url: string) => url === location.pathname;
+
   const menuItems = [
     { targetUrl: '/', IconComponent: HomeIcon, displayText: 'Home' },
     //  { targetUrl: "/comparisons", IconComponent: ListIcon, displayText: "My Comparisons"},
@@ -118,29 +120,31 @@ const SideBar = () => {
       }}
     >
       <List onClick={isSmallScreen ? () => dispatch(closeDrawer()) : undefined}>
-        {menuItems.map(({ targetUrl, IconComponent, displayText }) => (
-          <ListItem
-            key={displayText}
-            button
-            selected={targetUrl == location.pathname}
-            onClick={() => history.push(targetUrl)}
-            className={classes.listItem}
-          >
-            <ListItemIcon>
-              <IconComponent
-                className={clsx({
-                  [classes.listItemIcon]: targetUrl !== location.pathname,
-                  [classes.listItemIconSelected]:
-                    targetUrl === location.pathname,
-                })}
+        {menuItems.map(({ targetUrl, IconComponent, displayText }) => {
+          const selected = isItemSelected(targetUrl);
+          return (
+            <ListItem
+              key={displayText}
+              button
+              selected={selected}
+              onClick={() => history.push(targetUrl)}
+              className={classes.listItem}
+            >
+              <ListItemIcon>
+                <IconComponent
+                  className={clsx({
+                    [classes.listItemIcon]: !selected,
+                    [classes.listItemIconSelected]: selected,
+                  })}
+                />
+              </ListItemIcon>
+              <ListItemText
+                primary={displayText}
+                primaryTypographyProps={{ className: classes.listItemText }}
               />
-            </ListItemIcon>
-            <ListItemText
-              primary={displayText}
-              primaryTypographyProps={{ className: classes.listItemText }}
-            />
-          </ListItem>
-        ))}
+            </ListItem>
+          );
+        })}
       </List>
     </Drawer>
   );


### PR DESCRIPTION
The sidebar has now a new style, based on the Figman mock-up.

https://www.figma.com/file/3uI7FiBhXp0hhgdTdHBSkj/Tournesol?node-id=669%3A74

I think I should put those new colors in the theme palette, so that we can re-use them to style other menus.

**menu**
- [x] change the menu background color
- [x] increase the menu width to match the new font

**menu items**
- [x] use the font `Poppins`
- [x] increase the heigh 
- [x] make the icons react to the active / inactive state of the item