### PR TITLE
Reject account creation with existing email address

### DIFF
--- a/backend/core/serializers/user.py
+++ b/backend/core/serializers/user.py
@@ -1,10 +1,25 @@
 from rest_framework.exceptions import ValidationError
+from rest_framework.validators import UniqueValidator
+from rest_framework.serializers import EmailField
 from rest_registration.api.serializers import DefaultRegisterUserSerializer
+
+from core.models.user import User
 
 RESERVED_USERNAMES = ["me"]
 
 
 class RegisterUserSerializer(DefaultRegisterUserSerializer):
+    # Temporary validator, to reject existing email on account creation.
+    # The uniquessness will be enforced in the model, after the database
+    # (and the dev datasets) have been cleaned up, and the migration can
+    # be executed safely.
+    email = EmailField(validators=[
+        UniqueValidator(
+            queryset=User.objects.all(),
+            message="A user with this email address already exists."
+        ),
+    ])
+
     def validate_username(self, value):
         if value in RESERVED_USERNAMES:
             raise ValidationError(f'"{value}" is a reserved username')

--- a/backend/tournesol/tests/test_api_user.py
+++ b/backend/tournesol/tests/test_api_user.py
@@ -54,3 +54,23 @@ class UserRegistrationTest(TestCase):
             "email": "me@example.com",
         }, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cannot_register_with_existing_email(self):
+        client = APIClient()
+        response = client.post("/accounts/register/", data={
+            "username": "test-user",
+            "password": "a_safe_password",
+            "password_confirm": "a_safe_password",
+            "email": "me@example.com",
+        }, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response = client.post("/accounts/register/", data={
+            "username": "test-user2",
+            "password": "a_safe_password",
+            "password_confirm": "a_safe_password",
+            "email": "me@example.com",
+        }, format="json")
+        self.assertContains(response,
+            text="email address already exists",
+            status_code=400
+        )


### PR DESCRIPTION
Related to #232 

This PR is a first step before the uniqueness can be enforced at the database level.