### PR TITLE
refactor(PasswordForm): now uses the new notification functions

### DIFF
--- a/frontend/src/utils/notifications.ts
+++ b/frontend/src/utils/notifications.ts
@@ -1,6 +1,10 @@
 import React from 'react';
 import { ProviderContext, VariantType } from 'notistack';
 
+/**
+ * Display an alert variant, followed by an invitation to reach an
+ * administrator.
+ */
 export const contactAdministrator = (
   display: ProviderContext['enqueueSnackbar'],
   variant: VariantType,
@@ -13,6 +17,15 @@ export const contactAdministrator = (
     variant: 'warning',
   });
   display(message, { variant: variant });
+};
+
+export const showSuccessAlert = (
+  enqueueSnackbar: ProviderContext['enqueueSnackbar'],
+  message: React.ReactNode
+) => {
+  enqueueSnackbar(message, {
+    variant: 'success',
+  });
 };
 
 export const showErrorAlert = (


### PR DESCRIPTION
This uniformization will also help to identify factorizable code between the components `ResetPassword` and `PasswordForm`.

- [x] use notifications.showErrorAlert function to be coherent with the ResetPassword component
- [x] add a new notifications.showSuccessAlert function to avoid repeating `{variant: 'success'}` in each component displaying success messages
- [x] add a help text so that the user can catch non matching passwords on the fly in `PasswordForm`