### PR TITLE
Add visual feedback for actions buttons in rate later list and comparison page

### DIFF
--- a/frontend/src/features/settings/account/PasswordForm.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.tsx
@@ -10,7 +10,7 @@ import {
   contactAdministrator,
   showErrorAlert,
   showSuccessAlert,
-} from '../../../utils/notifications';
+} from 'src/utils/notifications';
 import { AccountsService } from 'src/services/openapi';
 
 const PasswordForm = () => {

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -10,6 +10,8 @@ import { UsersService, Comparison } from 'src/services/openapi';
 import { ensureVideoExistsOrCreate } from 'src/utils/video';
 import ComparisonSliders from 'src/features/comparisons/Comparison';
 import VideoSelector from 'src/features/video_selector/VideoSelector';
+import { showSuccessAlert } from 'src/utils/notifications';
+import { useSnackbar } from 'notistack';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -70,6 +72,7 @@ const ComparisonPage = () => {
   const [initialComparison, setInitialComparison] = useState<Comparison | null>(
     null
   );
+  const { enqueueSnackbar } = useSnackbar();
 
   const searchParams = new URLSearchParams(location.search);
   const videoA: string | null = searchParams.get('videoA');
@@ -114,6 +117,7 @@ const ComparisonPage = () => {
       UsersService.usersMeComparisonsCreate(c);
       setInitialComparison(c);
     }
+    showSuccessAlert(enqueueSnackbar, 'The comparison is correctly submitted.');
   };
 
   return (

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -117,7 +117,10 @@ const ComparisonPage = () => {
       UsersService.usersMeComparisonsCreate(c);
       setInitialComparison(c);
     }
-    showSuccessAlert(enqueueSnackbar, 'The comparison is correctly submitted.');
+    showSuccessAlert(
+      enqueueSnackbar,
+      'The comparison has been succesfully submitted.'
+    );
   };
 
   return (

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -26,28 +26,29 @@ export const CompareNowAction = ({ videoId }: { videoId: string }) => {
 export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
   const video_id = videoId;
   const { enqueueSnackbar } = useSnackbar();
+  const handleCreation = async () => {
+    try {
+      const response = await UsersService.usersMeVideoRateLaterCreate({
+        video: { video_id } as Video,
+      });
+      console.log(response);
+      showSuccessAlert(
+        enqueueSnackbar,
+        'The video has been added to your rate later list.'
+      );
+    } catch (error) {
+      showInfoAlert(
+        enqueueSnackbar,
+        'The video is already in your rate later list.'
+      );
+    }
+  };
   return (
     <Tooltip title="Rate later" placement="left">
       <IconButton
         size="medium"
         color="secondary"
-        onClick={async () => {
-          try {
-            const response = await UsersService.usersMeVideoRateLaterCreate({
-              video: { video_id } as Video,
-            });
-            console.log(response);
-            showSuccessAlert(
-              enqueueSnackbar,
-              'The video has been added to your rate later list.'
-            );
-          } catch (error) {
-            showInfoAlert(
-              enqueueSnackbar,
-              'The video is already in your rate later list.'
-            );
-          }
-        }}
+        onClick={handleCreation}
         style={{ color: '#CDCABC' }}
       >
         <AddIcon />

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -64,6 +64,7 @@ export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
 
 export const RemoveFromRateLater = (asyncCallback?: () => void) => {
   const RemoveFromRateLaterComponnent = ({ videoId }: { videoId: string }) => {
+    const { enqueueSnackbar } = useSnackbar();
     const video_id = videoId;
     return (
       <Tooltip title="Remove" placement="left">
@@ -72,6 +73,10 @@ export const RemoveFromRateLater = (asyncCallback?: () => void) => {
           onClick={async () => {
             await UsersService.usersMeVideoRateLaterDestroy(video_id);
             if (asyncCallback) await asyncCallback();
+            showSuccessAlert(
+              enqueueSnackbar,
+              'The video has been deleted from your rate later list.'
+            );
           }}
           style={{ color: '#CDCABC' }}
         >

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -28,10 +28,9 @@ export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
   const { enqueueSnackbar } = useSnackbar();
   const handleCreation = async () => {
     try {
-      const response = await UsersService.usersMeVideoRateLaterCreate({
+      await UsersService.usersMeVideoRateLaterCreate({
         video: { video_id } as Video,
       });
-      console.log(response);
       showSuccessAlert(
         enqueueSnackbar,
         'The video has been added to your rate later list.'

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -32,22 +32,16 @@ export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
         size="medium"
         color="secondary"
         onClick={async () => {
-          let flag = false;
-          const rateLaterList = await UsersService.usersMeVideoRateLaterList();
-          rateLaterList.results?.forEach((rateLaterVideo) => {
-            if (rateLaterVideo.video.video_id === video_id) {
-              flag = true;
-            }
-          });
-          if (!flag) {
-            await UsersService.usersMeVideoRateLaterCreate({
+          try {
+            const response = await UsersService.usersMeVideoRateLaterCreate({
               video: { video_id } as Video,
             });
+            console.log(response);
             showSuccessAlert(
               enqueueSnackbar,
               'The video has been added to your rate later list.'
             );
-          } else {
+          } catch (error) {
             showInfoAlert(
               enqueueSnackbar,
               'The video is already in your rate later list.'

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -4,6 +4,8 @@ import { IconButton, Tooltip } from '@material-ui/core';
 import CompareIcon from '@material-ui/icons/Compare';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
+import { showSuccessAlert, showInfoAlert } from 'src/utils/notifications';
+import { useSnackbar } from 'notistack';
 
 import { Video, UsersService } from 'src/services/openapi';
 
@@ -23,16 +25,35 @@ export const CompareNowAction = ({ videoId }: { videoId: string }) => {
 
 export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
   const video_id = videoId;
+  const { enqueueSnackbar } = useSnackbar();
   return (
     <Tooltip title="Rate later" placement="left">
       <IconButton
         size="medium"
         color="secondary"
-        onClick={() =>
-          UsersService.usersMeVideoRateLaterCreate({
-            video: { video_id } as Video,
-          })
-        }
+        onClick={async () => {
+          let flag = false;
+          const rateLaterList = await UsersService.usersMeVideoRateLaterList();
+          rateLaterList.results?.forEach((rateLaterVideo) => {
+            if (rateLaterVideo.video.video_id === video_id) {
+              flag = true;
+            }
+          });
+          if (!flag) {
+            await UsersService.usersMeVideoRateLaterCreate({
+              video: { video_id } as Video,
+            });
+            showSuccessAlert(
+              enqueueSnackbar,
+              'The video has been added to your rate later list.'
+            );
+          } else {
+            showInfoAlert(
+              enqueueSnackbar,
+              'The video is already in your rate later list.'
+            );
+          }
+        }}
         style={{ color: '#CDCABC' }}
       >
         <AddIcon />

--- a/frontend/src/utils/notifications.ts
+++ b/frontend/src/utils/notifications.ts
@@ -39,3 +39,12 @@ export const showErrorAlert = (
     variant: 'error',
   });
 };
+
+export const showInfoAlert = (
+  enqueueSnackbar: ProviderContext['enqueueSnackbar'],
+  message: React.ReactNode
+) => {
+  enqueueSnackbar(message, {
+    variant: 'info',
+  });
+};


### PR DESCRIPTION
Closes https://github.com/tournesol-app/tournesol/issues/269
Add multiple responses with pop to inform users that request are handled, and given them feedback on the result of their request.

- Recommendation page : alert print if video added/already exists in rate Later List.
- Rate Later List : pop-up when video deleted from rate later
- Comparison page : pop-up when comparison is submitted