### PR TITLE
Refactor actions and add style to VideoCards

### DIFF
--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -9,11 +9,17 @@ import { mainCriteriaNamesObj } from 'src/utils/constants';
 import type { VideoSerializerWithCriteria } from 'src/services/openapi';
 import { ActionList } from 'src/utils/types';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   main: {
     margin: 4,
     maxWidth: 1000,
-    width: 'calc(100% - 8px)',
+    width: 'calc(100% - 10px)',
+    background: '#FFFFFF',
+    border: '1px solid #DCD8CB',
+    boxShadow:
+      '0px 0px 8px rgba(0, 0, 0, 0.02), 0px 2px 4px rgba(0, 0, 0, 0.05)',
+    borderRadius: '4px',
+    overflow: 'hidden',
   },
   title: {
     fontFamily: 'Poppins',
@@ -84,6 +90,14 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     flexWrap: 'wrap',
     alignContent: 'space-between',
+  },
+  actionsContainer: {
+    display: 'flex',
+    alignItems: 'end',
+    flexDirection: 'column',
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'row',
+    },
   },
 }));
 
@@ -202,7 +216,7 @@ function VideoCard({
           )}
         </Box>
       </Grid>
-      <Grid item xs={12} sm={1}>
+      <Grid item xs={12} sm={1} className={classes.actionsContainer}>
         {actions.map((Action, index) => (
           <Action key={index} videoId={videoId} />
         ))}

--- a/frontend/src/features/videos/VideoList.tsx
+++ b/frontend/src/features/videos/VideoList.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 
-import { Typography, makeStyles, Grid, IconButton } from '@material-ui/core';
-import { Add as AddIcon } from '@material-ui/icons';
+import { Typography, makeStyles, Grid } from '@material-ui/core';
 import type {
   PaginatedVideoSerializerWithCriteriaList,
   VideoSerializerWithCriteria,
-  Video,
 } from 'src/services/openapi';
 import VideoCard from '../videos/VideoCard';
-import { CompareNowAction } from 'src/utils/action';
-import { UsersService } from 'src/services/openapi';
+import { CompareNowAction, AddToRateLaterList } from 'src/utils/action';
 import { useLoginState } from 'src/hooks';
 
 const useStyles = makeStyles(() => ({
@@ -26,26 +23,9 @@ function VideoList({
   const classes = useStyles();
   const { isLoggedIn } = useLoginState();
 
-  const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
-    const video_id = videoId;
-    return (
-      <div>
-        {isLoggedIn && (
-          <IconButton
-            size="medium"
-            color="secondary"
-            onClick={async () => {
-              await UsersService.usersMeVideoRateLaterCreate({
-                video: { video_id } as Video,
-              });
-            }}
-          >
-            <AddIcon />
-          </IconButton>
-        )}
-      </div>
-    );
-  };
+  const actions = isLoggedIn
+    ? [CompareNowAction, AddToRateLaterList]
+    : [CompareNowAction];
 
   return (
     <div>
@@ -53,10 +33,7 @@ function VideoList({
         videos.results.map((video: VideoSerializerWithCriteria) => (
           <Grid container className={classes.card} key={video.video_id}>
             <Grid item xs={12}>
-              <VideoCard
-                video={video}
-                actions={[CompareNowAction, AddToRateLaterList]}
-              />
+              <VideoCard video={video} actions={actions} />
             </Grid>
           </Grid>
         ))

--- a/frontend/src/features/videos/VideoList.tsx
+++ b/frontend/src/features/videos/VideoList.tsx
@@ -23,9 +23,7 @@ function VideoList({
   const classes = useStyles();
   const { isLoggedIn } = useLoginState();
 
-  const actions = isLoggedIn
-    ? [CompareNowAction, AddToRateLaterList]
-    : [CompareNowAction];
+  const actions = isLoggedIn ? [CompareNowAction, AddToRateLaterList] : [];
 
   return (
     <div>

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useCallback } from 'react';
 
-import { Grid, IconButton } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import { Delete as DeleteIcon } from '@material-ui/icons';
 
 import { addToRateLaterList } from 'src/features/rateLater/rateLaterAPI';
 import Pagination from 'src/components/Pagination';
@@ -14,7 +13,7 @@ import {
 } from 'src/services/openapi';
 import { topBarHeight } from 'src/features/frame/components/topbar/TopBar';
 import VideoCard from 'src/features/videos/VideoCard';
-import { CompareNowAction } from 'src/utils/action';
+import { CompareNowAction, RemoveFromRateLater } from 'src/utils/action';
 import { UsersService } from 'src/services/openapi';
 
 const useStyles = makeStyles((theme) => ({
@@ -98,22 +97,6 @@ const RateLaterPage = () => {
     videoListTopRef.current?.scrollIntoView();
   };
 
-  const RemoveVideoFromListAction = ({ videoId }: { videoId: string }) => {
-    const video_id = videoId;
-    return (
-      <IconButton
-        size="medium"
-        color="secondary"
-        onClick={async () => {
-          await UsersService.usersMeVideoRateLaterDestroy(video_id);
-          await loadList();
-        }}
-      >
-        <DeleteIcon />
-      </IconButton>
-    );
-  };
-
   useEffect(() => {
     loadList();
   }, [loadList]);
@@ -181,7 +164,7 @@ const RateLaterPage = () => {
                 <Grid item xs={12}>
                   <VideoCard
                     video={videoWithCriteriaScore}
-                    actions={[CompareNowAction, RemoveVideoFromListAction]}
+                    actions={[CompareNowAction, RemoveFromRateLater(loadList)]}
                   />
                 </Grid>
               </Grid>

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -1,16 +1,63 @@
 import React from 'react';
 
-import { IconButton } from '@material-ui/core';
-import { Compare as CompareIcon } from '@material-ui/icons';
+import { IconButton, Tooltip } from '@material-ui/core';
+import CompareIcon from '@material-ui/icons/Compare';
+import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
+
+import { Video, UsersService } from 'src/services/openapi';
 
 export const CompareNowAction = ({ videoId }: { videoId: string }) => {
   return (
-    <IconButton
-      size="medium"
-      color="secondary"
-      href={`/comparison/?videoA=${videoId}`}
-    >
-      <CompareIcon />
-    </IconButton>
+    <Tooltip title="Compare now" placement="left">
+      <IconButton
+        size="medium"
+        href={`/comparison/?videoA=${videoId}`}
+        style={{ color: '#CDCABC' }}
+      >
+        <CompareIcon />
+      </IconButton>
+    </Tooltip>
   );
+};
+
+export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
+  const video_id = videoId;
+  return (
+    <Tooltip title="Rate later" placement="left">
+      <IconButton
+        size="medium"
+        color="secondary"
+        onClick={() =>
+          UsersService.usersMeVideoRateLaterCreate({
+            video: { video_id } as Video,
+          })
+        }
+        style={{ color: '#CDCABC' }}
+      >
+        <AddIcon />
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export const RemoveFromRateLater = (asyncCallback?: () => void) => {
+  const RemoveFromRateLaterComponnent = ({ videoId }: { videoId: string }) => {
+    const video_id = videoId;
+    return (
+      <Tooltip title="Remove" placement="left">
+        <IconButton
+          size="medium"
+          onClick={async () => {
+            await UsersService.usersMeVideoRateLaterDestroy(video_id);
+            if (asyncCallback) await asyncCallback();
+          }}
+          style={{ color: '#CDCABC' }}
+        >
+          <DeleteIcon />
+        </IconButton>
+      </Tooltip>
+    );
+  };
+  return RemoveFromRateLaterComponnent;
 };


### PR DESCRIPTION
This PR improve the style of the video card:
- Adds border and shadow frmo Figma's mock-up
- Changes color of Video card actions
- Changes layout of actions to be a row on small screens and a column on large screens
- Add tooltip for Video card actions

Additionally I moved the code of the actions we have, previously they were defined inside other components which makes them impossible to re-use.

Before:
![Screenshot 2021-11-06 at 00 31 29](https://user-images.githubusercontent.com/8818081/140589152-af26ef73-539e-4c68-8795-9b56eeee33fe.png)

After:
![Screenshot 2021-11-06 at 00 31 09](https://user-images.githubusercontent.com/8818081/140589157-99aff5ca-3ab8-4b12-aca8-a99cea38d476.png)
