### PR TITLE
Fix display conditions for video score and nb of ratings in VideoCard

### DIFF
--- a/frontend/src/features/videos/VideoCard.spec.tsx
+++ b/frontend/src/features/videos/VideoCard.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Video } from 'src/services/openapi';
+import VideoCard from './VideoCard';
+
+describe('VideoCard content', () => {
+  it('shows video metadata without criterias', () => {
+    const video: Video = {
+      video_id: 'xSqqXN0D4fY',
+      name: 'Video title',
+      description: 'Video description',
+      views: 154988,
+      upload: 'Channel name',
+      rating_n_contributors: 4,
+      rating_n_ratings: 9,
+    };
+    render(<VideoCard video={video} />);
+
+    expect(screen.getByTestId('video-card-info')).toHaveTextContent(
+      'Video title'
+    );
+    expect(screen.getByTestId('video-card-info')).toHaveTextContent(
+      '154988 views'
+    );
+    expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
+      '9 ratings by 4 contributors'
+    );
+    expect(
+      screen.queryByTestId('video-card-overall-score')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows video card with single criteria', () => {
+    const video: Video = {
+      video_id: 'xSqqXN0D4fY',
+      name: 'Video title',
+      description: 'Video description',
+      views: 154988,
+      upload: 'Channel name',
+      rating_n_contributors: 4,
+      rating_n_ratings: 9,
+      criteria_scores: [
+        {
+          criteria: 'largely_recommended',
+          score: 0.4,
+          uncertainty: 0.0,
+          quantile: 1.0,
+        },
+      ],
+    };
+    render(<VideoCard video={video} />);
+
+    expect(screen.getByTestId('video-card-info')).toHaveTextContent(
+      'Video title'
+    );
+    expect(screen.getByTestId('video-card-info')).toHaveTextContent(
+      '154988 views'
+    );
+    expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
+      '9 ratings by 4 contributors'
+    );
+    expect(screen.queryByTestId('video-card-overall-score')).toHaveTextContent(
+      '4'
+    );
+    expect(
+      screen.queryByTestId('video-card-minmax-criterias')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows video card with multiple criteria', () => {
+    const video: Video = {
+      video_id: 'xSqqXN0D4fY',
+      name: 'Video title',
+      description: 'Video description',
+      views: 154988,
+      upload: 'Channel name',
+      rating_n_contributors: 4,
+      rating_n_ratings: 9,
+      criteria_scores: [
+        {
+          criteria: 'engaging',
+          score: 0.9,
+          uncertainty: 0.0,
+          quantile: 1.0,
+        },
+        {
+          criteria: 'pedagogy',
+          score: 0.8,
+          uncertainty: 0.0,
+          quantile: 1.0,
+        },
+      ],
+    };
+    render(<VideoCard video={video} />);
+
+    expect(screen.queryByTestId('video-card-overall-score')).toHaveTextContent(
+      '17'
+    );
+    expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
+      '9 ratings by 4 contributors'
+    );
+    expect(screen.queryByTestId('video-card-minmax-criterias')).toBeVisible();
+  });
+});

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -103,7 +103,7 @@ const useStyles = makeStyles((theme) => ({
 
 function VideoCard({
   video,
-  actions,
+  actions = [],
 }: {
   video: VideoSerializerWithCriteria;
   actions: ActionList;
@@ -147,7 +147,7 @@ function VideoCard({
           height="100%"
         />
       </Grid>
-      <Grid item xs={12} sm={7}>
+      <Grid item xs={12} sm={7} data-testid="video-card-info">
         <div className={classes.top}>
           <Typography className={classes.title} variant="h5">
             {video.name}
@@ -175,7 +175,11 @@ function VideoCard({
           style={{ gap: '12px' }}
         >
           {!!video.criteria_scores && (
-            <Box display="flex" alignItems="center">
+            <Box
+              display="flex"
+              alignItems="center"
+              data-testid="video-card-overall-score"
+            >
               <img
                 className="tournesol"
                 src={'/svg/tournesol.svg'}
@@ -189,9 +193,9 @@ function VideoCard({
           )}
 
           {!!video.rating_n_ratings && video.rating_n_ratings > 0 && (
-            <Box>
+            <Box data-testid="video-card-ratings">
               <span className={classes.ratings}>
-                {video.rating_n_ratings} Ratings by
+                {video.rating_n_ratings} ratings by{' '}
               </span>
               <span className={classes.contributors}>
                 {video.rating_n_contributors} contributors
@@ -200,7 +204,12 @@ function VideoCard({
           )}
 
           {max_criteria !== '' && min_criteria !== max_criteria && (
-            <Box display="flex" alignItems="center" className={classes.rated}>
+            <Box
+              data-testid="video-card-minmax-criterias"
+              display="flex"
+              alignItems="center"
+              className={classes.rated}
+            >
               <span>Rated high:</span>
               <img
                 src={`/svg/${max_criteria}.svg`}

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -174,45 +174,46 @@ function VideoCard({
           alignItems="center"
           style={{ gap: '12px' }}
         >
-          {max_criteria.length > 0 && (
-            <>
-              <Box display="flex" alignItems="center">
-                <img
-                  className="tournesol"
-                  src={'/svg/tournesol.svg'}
-                  alt="logo"
-                  title="Overall score"
-                />
-                <span className={classes.nb_tournesol}>
-                  {total_score.toFixed(0)}
-                </span>
-              </Box>
+          {!!video.criteria_scores && (
+            <Box display="flex" alignItems="center">
+              <img
+                className="tournesol"
+                src={'/svg/tournesol.svg'}
+                alt="logo"
+                title="Overall score"
+              />
+              <span className={classes.nb_tournesol}>
+                {total_score.toFixed(0)}
+              </span>
+            </Box>
+          )}
 
-              {!!video.rating_n_ratings && video.rating_n_ratings > 0 && (
-                <Box>
-                  <span className={classes.ratings}>
-                    {video.rating_n_ratings} Ratings by
-                  </span>
-                  <span className={classes.contributors}>
-                    {video.rating_n_contributors} contributors
-                  </span>
-                </Box>
-              )}
-              <Box display="flex" alignItems="center" className={classes.rated}>
-                <span>Rated high:</span>
-                <img
-                  src={`/svg/${max_criteria}.svg`}
-                  alt={max_criteria}
-                  title={mainCriteriaNamesObj[max_criteria]}
-                />
-                <span>Rated low:</span>
-                <img
-                  src={`/svg/${min_criteria}.svg`}
-                  alt={min_criteria}
-                  title={mainCriteriaNamesObj[min_criteria]}
-                />
-              </Box>
-            </>
+          {!!video.rating_n_ratings && video.rating_n_ratings > 0 && (
+            <Box>
+              <span className={classes.ratings}>
+                {video.rating_n_ratings} Ratings by
+              </span>
+              <span className={classes.contributors}>
+                {video.rating_n_contributors} contributors
+              </span>
+            </Box>
+          )}
+
+          {max_criteria !== '' && min_criteria !== max_criteria && (
+            <Box display="flex" alignItems="center" className={classes.rated}>
+              <span>Rated high:</span>
+              <img
+                src={`/svg/${max_criteria}.svg`}
+                alt={max_criteria}
+                title={mainCriteriaNamesObj[max_criteria]}
+              />
+              <span>Rated low:</span>
+              <img
+                src={`/svg/${min_criteria}.svg`}
+                alt={min_criteria}
+                title={mainCriteriaNamesObj[min_criteria]}
+              />
+            </Box>
           )}
         </Box>
       </Grid>


### PR DESCRIPTION
The number of ratings was hidden when a video was rated on a single criteria "largely_recommended". 
This PR defines specific conditions for each statistics element:

* the "Rated high" and "Rated low" criterias are displayed if these criterias are defined and are different
* the "overall score" is displayed if the criteria scores are available (e.g not on the rate later list where the criteria scores are currently not defined)