### PR TITLE
Video list: avoid serializer initialization overhead with 'many=True'

### DIFF
--- a/backend/tournesol/views/video.py
+++ b/backend/tournesol/views/video.py
@@ -100,7 +100,7 @@ class VideoViewSet(viewsets.ModelViewSet):
 
         count = queryset.count()
         videos = queryset.prefetch_related("criteria_scores")[offset: offset + limit]
-        data_serialised = [VideoSerializerWithCriteria(video).data for video in videos]
+        data_serialised = VideoSerializerWithCriteria(videos, many=True).data
         return Response(OrderedDict([('count', str(count)), ('results', data_serialised)]))
 
     def update(self, request, *args, **kwargs):


### PR DESCRIPTION
I was not completely convinced with the performance gain visible on staging after deploying #284 

There is actually another easy optimization: when serializing multiple objects, `many=True` should be preferred to avoid the overhead of the serializer initialization:
See https://www.django-rest-framework.org/api-guide/serializers/#dealing-with-multiple-objects

On my local environment this brings another 3x speedup.