### PR TITLE
Show indication about email status on account page + Add page about trusted domains

### DIFF
--- a/backend/core/serializers/email_domain.py
+++ b/backend/core/serializers/email_domain.py
@@ -1,0 +1,9 @@
+from rest_framework.serializers import ModelSerializer
+
+from ..models import EmailDomain
+
+
+class EmailDomainSerializer(ModelSerializer):
+    class Meta:
+        model = EmailDomain
+        fields = ("domain", "status")

--- a/backend/core/serializers/user.py
+++ b/backend/core/serializers/user.py
@@ -1,9 +1,10 @@
 from rest_framework.exceptions import ValidationError
 from rest_framework.validators import UniqueValidator
-from rest_framework.serializers import EmailField
+from rest_framework.serializers import EmailField, BooleanField
 from rest_registration.api.serializers import (
     DefaultRegisterUserSerializer,
     DefaultRegisterEmailSerializer,
+    DefaultUserProfileSerializer,
 )
 
 from core.models.user import User
@@ -36,3 +37,13 @@ class RegisterEmailSerializer(DefaultRegisterEmailSerializer):
             message="A user with this email address already exists."
         ),
     ])
+
+
+class UserProfileSerializer(DefaultUserProfileSerializer):
+    is_trusted = BooleanField()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        extra_fields = ('is_trusted',)
+        self.Meta.fields += extra_fields
+        self.Meta.read_only_fields += extra_fields

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -86,6 +86,7 @@ REST_REGISTRATION = {
     'REGISTER_EMAIL_VERIFICATION_ENABLED': True,
     'REGISTER_EMAIL_VERIFICATION_URL': REST_REGISTRATION_MAIN_URL + 'verify-email/',
     'REGISTER_SERIALIZER_CLASS': 'core.serializers.user.RegisterUserSerializer',
+    'PROFILE_SERIALIZER_CLASS': 'core.serializers.user.UserProfileSerializer',
     'VERIFICATION_FROM_EMAIL': 'noreply@tournesol.app',
 }
 

--- a/backend/tournesol/tests/test_api_domains.py
+++ b/backend/tournesol/tests/test_api_domains.py
@@ -1,9 +1,8 @@
 from django.test import TestCase
-from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from core.models import User, EmailDomain
+from core.models import EmailDomain
 
 
 class DomainsApi(TestCase):

--- a/backend/tournesol/tests/test_api_domains.py
+++ b/backend/tournesol/tests/test_api_domains.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.models import User, EmailDomain
+
+
+class DomainsApi(TestCase):
+    def setUp(self):
+        EmailDomain.objects.create(
+            domain="@accepted.test", status=EmailDomain.STATUS_ACCEPTED
+        )
+        EmailDomain.objects.create(
+            domain="@rejected.test", status=EmailDomain.STATUS_REJECTED
+        )
+        EmailDomain.objects.create(
+            domain="@pending.test", status=EmailDomain.STATUS_PENDING
+        )
+
+    def test_accepted_domains_list(self):
+        client = APIClient()
+        response = client.get("/domains/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["results"], [
+            {
+                "domain": "@accepted.test",
+                "status": "ACK"
+            }
+        ])

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -13,6 +13,7 @@ from .views.video import VideoViewSet
 from .views.video_rate_later import VideoRateLaterDetail, VideoRateLaterList
 from .views.user import CurrentUserView
 from .views.ratings import ContributorRatingList, ContributorRatingDetail
+from .views.email_domains import EmailDomainsList
 
 
 router = routers.DefaultRouter()
@@ -74,4 +75,9 @@ urlpatterns = [
         ContributorRatingDetail.as_view(),
         name="ratings_me_detail",
     ),
+    path(
+        "domains/",
+        EmailDomainsList.as_view(),
+        name="email_domains_list"
+    )
 ]

--- a/backend/tournesol/views/email_domains.py
+++ b/backend/tournesol/views/email_domains.py
@@ -1,0 +1,19 @@
+from rest_framework import generics, pagination
+
+from core.models import EmailDomain
+from core.serializers.email_domain import EmailDomainSerializer
+
+
+class EmailDomainPagination(pagination.LimitOffsetPagination):
+    default_limit = 1000
+
+
+class EmailDomainsList(generics.ListAPIView):
+    """
+    List all accepted (=trusted) email domains.
+    """
+
+    queryset = EmailDomain.objects.filter(status=EmailDomain.STATUS_ACCEPTED).order_by("domain")
+    pagination_class = EmailDomainPagination
+    serializer_class = EmailDomainSerializer
+    permission_classes = []

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --testURL=http://localhost:3000",
     "eject": "react-scripts eject",
-    "openapi": "openapi -i scripts/tmp/openapi.yaml -o src/services/openapi",
+    "update-schema": "wget -O scripts/openapi.yaml \"${REACT_APP_API_URL:-http://localhost:8000}/schema/\"",
+    "openapi": "openapi -i scripts/openapi.yaml -o src/services/openapi",
     "lint": "eslint src --ext '.js,.jsx,.ts,.tsx'",
     "lint:fix": "eslint --fix src --ext '.js,.jsx,.ts,.tsx'",
     "prepare": "cd .. && husky install frontend/.husky"

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -45,7 +45,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DefaultUserProfile'
+                $ref: '#/components/schemas/UserProfile'
           description: ''
     post:
       operationId: accounts_profile_create
@@ -56,13 +56,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DefaultUserProfile'
+              $ref: '#/components/schemas/UserProfile'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/DefaultUserProfile'
+              $ref: '#/components/schemas/UserProfile'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/DefaultUserProfile'
+              $ref: '#/components/schemas/UserProfile'
         required: true
       security:
       - oauth2:
@@ -72,7 +72,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DefaultUserProfile'
+                $ref: '#/components/schemas/UserProfile'
           description: ''
     put:
       operationId: accounts_profile_update
@@ -83,13 +83,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DefaultUserProfile'
+              $ref: '#/components/schemas/UserProfile'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/DefaultUserProfile'
+              $ref: '#/components/schemas/UserProfile'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/DefaultUserProfile'
+              $ref: '#/components/schemas/UserProfile'
         required: true
       security:
       - oauth2:
@@ -99,7 +99,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DefaultUserProfile'
+                $ref: '#/components/schemas/UserProfile'
           description: ''
     patch:
       operationId: accounts_profile_partial_update
@@ -110,13 +110,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedDefaultUserProfile'
+              $ref: '#/components/schemas/PatchedUserProfile'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedDefaultUserProfile'
+              $ref: '#/components/schemas/PatchedUserProfile'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedDefaultUserProfile'
+              $ref: '#/components/schemas/PatchedUserProfile'
       security:
       - oauth2:
         - read write groups
@@ -125,7 +125,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DefaultUserProfile'
+                $ref: '#/components/schemas/UserProfile'
           description: ''
   /accounts/register/:
     post:
@@ -166,13 +166,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DefaultRegisterEmail'
+              $ref: '#/components/schemas/RegisterEmail'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/DefaultRegisterEmail'
+              $ref: '#/components/schemas/RegisterEmail'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/DefaultRegisterEmail'
+              $ref: '#/components/schemas/RegisterEmail'
         required: true
       security:
       - oauth2:
@@ -182,7 +182,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DefaultRegisterEmail'
+                $ref: '#/components/schemas/RegisterEmail'
           description: ''
   /accounts/reset-password/:
     post:
@@ -299,6 +299,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VerifyRegistration'
+          description: ''
+  /domains/:
+    get:
+      operationId: domains_list
+      description: List all accepted (=trusted) email domains.
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - domains
+      security:
+      - oauth2:
+        - read write groups
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedEmailDomainList'
           description: ''
   /schema/:
     get:
@@ -792,7 +821,6 @@ paths:
   /video/:
     get:
       operationId: video_list
-      description: ''
       parameters:
       - name: limit
         required: false
@@ -870,7 +898,6 @@ paths:
           description: ''
     put:
       operationId: video_update
-      description: ''
       parameters:
       - in: path
         name: id
@@ -904,7 +931,6 @@ paths:
           description: ''
     patch:
       operationId: video_partial_update
-      description: ''
       parameters:
       - in: path
         name: id
@@ -937,7 +963,6 @@ paths:
           description: ''
     delete:
       operationId: video_destroy
-      description: ''
       parameters:
       - in: path
         name: id
@@ -1070,15 +1095,6 @@ components:
       required:
       - criteria_scores
       - video
-    DefaultRegisterEmail:
-      type: object
-      description: Default serializer used for e-mail registration (e-mail change).
-      properties:
-        email:
-          type: string
-          format: email
-      required:
-      - email
     DefaultSendResetPasswordLink:
       type: object
       description: |-
@@ -1091,151 +1107,6 @@ components:
           type: string
       required:
       - login
-    DefaultUserProfile:
-      type: object
-      description: |-
-        Default serializer used for user profile. It will use these:
-
-        * User fields
-        * :ref:`user-hidden-fields-setting` setting
-        * :ref:`user-public-fields-setting` setting
-        * :ref:`user-editable-fields-setting` setting
-
-        to automagically generate the required serializer fields.
-      properties:
-        id:
-          type: integer
-          readOnly: true
-        username:
-          type: string
-          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
-            only.
-          pattern: ^[\w.@+-]+$
-          maxLength: 150
-        email:
-          type: string
-          format: email
-          readOnly: true
-          title: Email address
-        is_demo:
-          type: boolean
-          description: Is a demo account?
-        first_name:
-          type: string
-          nullable: true
-          description: First name
-          maxLength: 100
-        last_name:
-          type: string
-          nullable: true
-          description: Last name
-          maxLength: 100
-        title:
-          type: string
-          nullable: true
-          description: Your position
-        bio:
-          type: string
-          nullable: true
-          description: Self-description (degree, biography, ...)
-        comment_anonymously:
-          type: boolean
-          description: Comment anonymously by-default
-        show_online_presence:
-          type: boolean
-          description: Show my online presence on Tournesol
-        show_my_profile:
-          type: boolean
-          description: Show my profile on Tournesol
-        birth_year:
-          type: integer
-          maximum: 2100
-          minimum: 1900
-          nullable: true
-          description: Year of birth
-        gender:
-          allOf:
-          - $ref: '#/components/schemas/GenderEnum'
-          description: Your gender
-        nationality:
-          allOf:
-          - $ref: '#/components/schemas/NationalityEnum'
-          description: Your country of nationality
-        residence:
-          allOf:
-          - $ref: '#/components/schemas/ResidenceEnum'
-          description: Your country of residence
-        race:
-          allOf:
-          - $ref: '#/components/schemas/RaceEnum'
-          description: Your ethnicity
-        political_affiliation:
-          allOf:
-          - $ref: '#/components/schemas/PoliticalAffiliationEnum'
-          description: Your political preference
-        religion:
-          allOf:
-          - $ref: '#/components/schemas/ReligionEnum'
-          description: Your religion
-        degree_of_political_engagement:
-          allOf:
-          - $ref: '#/components/schemas/DegreeOfPoliticalEngagementEnum'
-          description: Your degree of political engagement
-        moral_philosophy:
-          allOf:
-          - $ref: '#/components/schemas/MoralPhilosophyEnum'
-          description: Your preferred moral philosophy
-        website:
-          type: string
-          format: uri
-          nullable: true
-          description: Your website URL
-          maxLength: 500
-        linkedin:
-          type: string
-          format: uri
-          nullable: true
-          description: Your LinkedIn URL
-          maxLength: 500
-        youtube:
-          type: string
-          format: uri
-          nullable: true
-          description: Your Youtube channel URL
-          maxLength: 500
-        google_scholar:
-          type: string
-          format: uri
-          nullable: true
-          description: Your Google Scholar URL
-          maxLength: 500
-        orcid:
-          type: string
-          format: uri
-          nullable: true
-          description: Your ORCID URL
-          maxLength: 500
-        researchgate:
-          type: string
-          format: uri
-          nullable: true
-          description: Your Researchgate profile URL
-          maxLength: 500
-        twitter:
-          type: string
-          format: uri
-          nullable: true
-          description: Your Twitter URL
-          maxLength: 500
-        avatar:
-          type: string
-          format: uri
-          nullable: true
-          description: Your profile picture.
-      required:
-      - email
-      - id
-      - username
     DegreeOfPoliticalEngagementEnum:
       enum:
       - Not Specified
@@ -1246,6 +1117,19 @@ components:
       - Activist
       - Professional
       type: string
+    EmailDomain:
+      type: object
+      properties:
+        domain:
+          type: string
+          description: E-mail domain with leading @
+          maxLength: 100
+        status:
+          allOf:
+          - $ref: '#/components/schemas/StatusEnum'
+          description: Status of the domain.
+      required:
+      - domain
     GenderEnum:
       enum:
       - Not Specified
@@ -9678,6 +9562,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ContributorRating'
+    PaginatedEmailDomainList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmailDomain'
     PaginatedVideoRateLaterList:
       type: object
       properties:
@@ -9718,7 +9622,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VideoSerializerWithCriteria'
-    PatchedDefaultUserProfile:
+    PatchedUserProfile:
       type: object
       description: |-
         Default serializer used for user profile. It will use these:
@@ -9859,6 +9763,8 @@ components:
           format: uri
           nullable: true
           description: Your profile picture.
+        is_trusted:
+          type: boolean
     PatchedVideo:
       type: object
       properties:
@@ -9928,6 +9834,15 @@ components:
       - Unknown
       - Other
       type: string
+    RegisterEmail:
+      type: object
+      description: Default serializer used for e-mail registration (e-mail change).
+      properties:
+        email:
+          type: string
+          format: email
+      required:
+      - email
     RegisterUser:
       type: object
       description: |-
@@ -10359,6 +10274,160 @@ components:
       - Zambia
       - Zimbabwe
       type: string
+    StatusEnum:
+      enum:
+      - RJ
+      - ACK
+      - PD
+      type: string
+    UserProfile:
+      type: object
+      description: |-
+        Default serializer used for user profile. It will use these:
+
+        * User fields
+        * :ref:`user-hidden-fields-setting` setting
+        * :ref:`user-public-fields-setting` setting
+        * :ref:`user-editable-fields-setting` setting
+
+        to automagically generate the required serializer fields.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        username:
+          type: string
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+            only.
+          pattern: ^[\w.@+-]+$
+          maxLength: 150
+        email:
+          type: string
+          format: email
+          readOnly: true
+          title: Email address
+        is_demo:
+          type: boolean
+          description: Is a demo account?
+        first_name:
+          type: string
+          nullable: true
+          description: First name
+          maxLength: 100
+        last_name:
+          type: string
+          nullable: true
+          description: Last name
+          maxLength: 100
+        title:
+          type: string
+          nullable: true
+          description: Your position
+        bio:
+          type: string
+          nullable: true
+          description: Self-description (degree, biography, ...)
+        comment_anonymously:
+          type: boolean
+          description: Comment anonymously by-default
+        show_online_presence:
+          type: boolean
+          description: Show my online presence on Tournesol
+        show_my_profile:
+          type: boolean
+          description: Show my profile on Tournesol
+        birth_year:
+          type: integer
+          maximum: 2100
+          minimum: 1900
+          nullable: true
+          description: Year of birth
+        gender:
+          allOf:
+          - $ref: '#/components/schemas/GenderEnum'
+          description: Your gender
+        nationality:
+          allOf:
+          - $ref: '#/components/schemas/NationalityEnum'
+          description: Your country of nationality
+        residence:
+          allOf:
+          - $ref: '#/components/schemas/ResidenceEnum'
+          description: Your country of residence
+        race:
+          allOf:
+          - $ref: '#/components/schemas/RaceEnum'
+          description: Your ethnicity
+        political_affiliation:
+          allOf:
+          - $ref: '#/components/schemas/PoliticalAffiliationEnum'
+          description: Your political preference
+        religion:
+          allOf:
+          - $ref: '#/components/schemas/ReligionEnum'
+          description: Your religion
+        degree_of_political_engagement:
+          allOf:
+          - $ref: '#/components/schemas/DegreeOfPoliticalEngagementEnum'
+          description: Your degree of political engagement
+        moral_philosophy:
+          allOf:
+          - $ref: '#/components/schemas/MoralPhilosophyEnum'
+          description: Your preferred moral philosophy
+        website:
+          type: string
+          format: uri
+          nullable: true
+          description: Your website URL
+          maxLength: 500
+        linkedin:
+          type: string
+          format: uri
+          nullable: true
+          description: Your LinkedIn URL
+          maxLength: 500
+        youtube:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Youtube channel URL
+          maxLength: 500
+        google_scholar:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Google Scholar URL
+          maxLength: 500
+        orcid:
+          type: string
+          format: uri
+          nullable: true
+          description: Your ORCID URL
+          maxLength: 500
+        researchgate:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Researchgate profile URL
+          maxLength: 500
+        twitter:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Twitter URL
+          maxLength: 500
+        avatar:
+          type: string
+          format: uri
+          nullable: true
+          description: Your profile picture.
+        is_trusted:
+          type: boolean
+      required:
+      - email
+      - id
+      - is_trusted
+      - username
     VerifyEmail:
       type: object
       properties:
@@ -10461,9 +10530,9 @@ components:
           type: number
           format: float
           maximum: 1.0
+          minimum: 0.0
           description: Top quantile for all rated videos for aggregated scoresfor
             the given criteria. 0.0=best, 1.0=worst
-          minimum: 0.0
       required:
       - criteria
     VideoRateLater:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import VideoCardPage from './pages/videos/VideoCard';
 import VideoRecommendationPage from './pages/videos/VideoRecommendation';
 import ForgotPassword from './pages/login/ForgotPassword';
 import ResetPassword from './pages/login/ResetPassword';
+import TrustedDomains from './pages/about/TrustedDomains';
 
 import { OpenAPI } from 'src/services/openapi';
 import { LoginState } from './features/login/LoginState.model';
@@ -86,6 +87,9 @@ function App() {
         </Route>
         <Route path="/reset-password">
           <ResetPassword />
+        </Route>
+        <Route path="/about/trusted_domains">
+          <TrustedDomains />
         </Route>
         <Route path="/">
           <HomePage />

--- a/frontend/src/features/settings/account/EmailAddressForm.tsx
+++ b/frontend/src/features/settings/account/EmailAddressForm.tsx
@@ -1,19 +1,68 @@
 import React, { useState, useEffect } from 'react';
 
-import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
-import { CircularProgress, Box, Typography } from '@material-ui/core';
+import {
+  CircularProgress,
+  Box,
+  Typography,
+  Theme,
+  Grid,
+  Button,
+} from '@material-ui/core';
+import { Link as RouterLink } from 'react-router-dom';
 
 import { useSnackbar } from 'notistack';
 
 import { showErrorAlert } from '../../../utils/notifications';
 import { FormTextField } from 'src/components';
 
-import { AccountsService, ApiError } from 'src/services/openapi';
+import { AccountsService, ApiError, UserProfile } from 'src/services/openapi';
+import { Lens as LensIcon, HelpOutline as HelpIcon } from '@material-ui/icons';
+import { useTheme } from '@material-ui/styles';
+
+const TrustStatus = ({ isTrusted }: { isTrusted: boolean }) => {
+  const theme = useTheme<Theme>();
+
+  return (
+    <Box display="flex" flexDirection="row" flexWrap="wrap" alignItems="center">
+      <Typography>
+        <Box display="flex" gridGap="4px" alignItems="center">
+          Email status:
+          <Box
+            display="inline-flex"
+            flexDirection="row"
+            alignItems="center"
+            gridGap="4px"
+            color={
+              isTrusted
+                ? theme.palette.success.main
+                : theme.palette.warning.main
+            }
+            fontWeight="bold"
+          >
+            <LensIcon style={{ fontSize: 16 }} />
+            <Grid item>{isTrusted ? 'Trusted' : 'Non-trusted'}</Grid>
+          </Box>
+        </Box>
+      </Typography>
+
+      <Box display="inline-flex" marginLeft="auto">
+        <Button
+          component={RouterLink}
+          to="/about/trusted_domains"
+          size="small"
+          style={{ fontSize: 13, color: '#777' }}
+          startIcon={<HelpIcon />}
+        >
+          Learn more about trusted domains
+        </Button>
+      </Box>
+    </Box>
+  );
+};
 
 export const EmailAddressForm = () => {
   const { enqueueSnackbar } = useSnackbar();
-  const [currentEmail, setCurrentEmail] = useState<string | null>(null);
+  const [profileData, setProfileData] = useState<UserProfile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSuccess, setIsSuccess] = useState(false);
   const [apiError, setApiError] = useState<ApiError | null>(null);
@@ -41,7 +90,7 @@ export const EmailAddressForm = () => {
     const loadProfile = async () => {
       try {
         const profile = await AccountsService.accountsProfileRetrieve();
-        setCurrentEmail(profile.email);
+        setProfileData(profile);
         setIsLoading(false);
       } catch (err) {
         showErrorAlert(enqueueSnackbar, err?.message || 'Server error');
@@ -67,14 +116,15 @@ export const EmailAddressForm = () => {
         {isLoading && <CircularProgress />}
         {/* "display" is used here to keep the form state during loading. */}
         <div style={{ display: isLoading ? 'none' : undefined }}>
-          {currentEmail && (
+          {profileData && (
             <Box marginBottom={2}>
               <Typography>
                 Your current email address is{' '}
                 <strong>
-                  <code>{currentEmail}</code>
+                  <code>{profileData.email}</code>
                 </strong>
               </Typography>
+              <TrustStatus isTrusted={profileData.is_trusted} />
             </Box>
           )}
           <form onSubmit={handleSubmit}>
@@ -106,5 +156,5 @@ export const EmailAddressForm = () => {
     );
   };
 
-  return <Box minHeight="150px">{getContent()}</Box>;
+  return <Box minHeight="180px">{getContent()}</Box>;
 };

--- a/frontend/src/features/settings/account/EmailAddressForm.tsx
+++ b/frontend/src/features/settings/account/EmailAddressForm.tsx
@@ -21,31 +21,32 @@ import { useTheme } from '@material-ui/styles';
 
 const TrustStatus = ({ isTrusted }: { isTrusted: boolean }) => {
   const theme = useTheme<Theme>();
+  const statusColor = isTrusted
+    ? theme.palette.success.dark
+    : theme.palette.warning.dark;
 
   return (
-    <Box display="flex" flexDirection="row" flexWrap="wrap" alignItems="center">
-      <Typography>
-        <Box display="flex" gridGap="4px" alignItems="center">
-          Email status:
-          <Box
-            display="inline-flex"
-            flexDirection="row"
-            alignItems="center"
-            gridGap="4px"
-            color={
-              isTrusted
-                ? theme.palette.success.dark
-                : theme.palette.warning.dark
-            }
-            fontWeight="bold"
-          >
-            <LensIcon style={{ fontSize: 16 }} />
-            <Grid item>{isTrusted ? 'Trusted' : 'Non-trusted'}</Grid>
-          </Box>
+    <Box
+      display="flex"
+      flexDirection="row"
+      flexWrap="wrap"
+      alignItems="center"
+      justifyContent="space-between"
+    >
+      <Typography
+        component="div"
+        style={{ display: 'flex', alignItems: 'center' }}
+      >
+        Email status:
+        <LensIcon
+          style={{ fontSize: 16, color: statusColor, margin: '0 4px' }}
+        />
+        <Box color={statusColor} fontWeight="bold">
+          {isTrusted ? 'Trusted' : 'Non-trusted'}
         </Box>
       </Typography>
 
-      <Box display="inline-flex" marginLeft="auto">
+      <Box display="inline-flex">
         <Button
           component={RouterLink}
           to="/about/trusted_domains"

--- a/frontend/src/features/settings/account/EmailAddressForm.tsx
+++ b/frontend/src/features/settings/account/EmailAddressForm.tsx
@@ -34,8 +34,8 @@ const TrustStatus = ({ isTrusted }: { isTrusted: boolean }) => {
             gridGap="4px"
             color={
               isTrusted
-                ? theme.palette.success.main
-                : theme.palette.warning.main
+                ? theme.palette.success.dark
+                : theme.palette.warning.dark
             }
             fontWeight="bold"
           >
@@ -117,10 +117,15 @@ export const EmailAddressForm = () => {
         {/* "display" is used here to keep the form state during loading. */}
         <div style={{ display: isLoading ? 'none' : undefined }}>
           {profileData && (
-            <Box marginBottom={2}>
+            <Box
+              marginBottom={2}
+              display="flex"
+              flexDirection="column"
+              gridGap="8px"
+            >
               <Typography>
                 Your current email address is{' '}
-                <strong>
+                <strong style={{ whiteSpace: 'nowrap' }}>
                   <code>{profileData.email}</code>
                 </strong>
               </Typography>

--- a/frontend/src/pages/about/TrustedDomains.tsx
+++ b/frontend/src/pages/about/TrustedDomains.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Typography,
+  Box,
+  Divider,
+  List,
+  ListItem,
+  CircularProgress,
+} from '@material-ui/core';
+
+import { ContentHeader, ContentBox } from 'src/components';
+import { EmailDomain, DomainsService } from 'src/services/openapi';
+
+const DOMAINS_PAGE_SIZE = 1000;
+
+const TrustedDomains = () => {
+  const [domains, setDomains] = useState<EmailDomain[] | null>(null);
+
+  useEffect(() => {
+    const loadDomains = async () => {
+      const result = [];
+      let offset = 0;
+      let response;
+      do {
+        response = await DomainsService.domainsList(DOMAINS_PAGE_SIZE, offset);
+        const responseDomains = response.results || [];
+        offset += responseDomains.length;
+        result.push(...responseDomains);
+      } while (response.next);
+      setDomains(result);
+    };
+    loadDomains();
+  }, []);
+
+  return (
+    <>
+      <ContentHeader title="About trusted email domains" />
+      <ContentBox maxWidth="md">
+        <Box marginBottom={6}>
+          <Typography component="div">
+            <p>
+              In order to protect Tournesol from fake accounts, by default,
+              Tournesol assigns a limited voting right to newly created
+              accounts.
+            </p>
+            <p>
+              You can gain significantly more voting rights by validating{' '}
+              <strong>an email address from a trusted domain</strong>. We are
+              currently working on designing additional means for contributors
+              to gain voting rights.
+            </p>
+            <p>
+              In any case, your contributions are valuable to us, as they will
+              motivate further research in safe and ethical algorithms.
+            </p>
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="h4" color="secondary">
+            Current list of trusted domains
+          </Typography>
+          <Divider />
+          <List>
+            {domains !== null ? (
+              domains.map((domain) => (
+                <ListItem key={domain.domain} dense disableGutters>
+                  {domain.domain}
+                </ListItem>
+              ))
+            ) : (
+              <CircularProgress />
+            )}
+          </List>
+        </Box>
+      </ContentBox>
+    </>
+  );
+};
+
+export default TrustedDomains;

--- a/tests/cypress/integration/tournesol.spec.ts
+++ b/tests/cypress/integration/tournesol.spec.ts
@@ -84,22 +84,3 @@ describe('Password reset flow', () => {
   })
 })
 
-describe('Update email address flow', () => {
-  before(() => {
-    cy.recreateUser("test-email-update", "email1@example.com", "tournesol");
-  })
-
-  it('can update email', () => {
-    cy.visit('/settings/account');
-    cy.focused().type('test-email-update');
-    cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
-    cy.location('pathname').should('equal', '/settings/account');
-    cy.contains('Your current email address is email1@example.com').should('be.visible');
-    cy.get('input[name=email]').type('email2@example.com').type('{enter}');
-    cy.contains('verification email has been sent ').should('be.visible');
-    cy.getEmailLink().then(verifyLink => cy.visit(verifyLink));
-    cy.contains('new email address is now verified').should('be.visible');
-    cy.visit('/settings/account');
-    cy.contains('Your current email address is email2@example.com').should('be.visible');
-  })
-});

--- a/tests/cypress/integration/tournesolAccountPage.spec.ts
+++ b/tests/cypress/integration/tournesolAccountPage.spec.ts
@@ -1,0 +1,39 @@
+describe('Update email address flow', () => {
+  before(() => {
+    cy.recreateUser("test-email-update", "email1@example.com", "tournesol");
+  })
+
+  it('can update email', () => {
+    cy.visit('/settings/account');
+    cy.focused().type('test-email-update');
+    cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+    cy.location('pathname').should('equal', '/settings/account');
+    cy.contains('Your current email address is email1@example.com').should('be.visible');
+    cy.get('input[name=email]').type('email2@example.com').type('{enter}');
+    cy.contains('verification email has been sent ').should('be.visible');
+    cy.getEmailLink().then(verifyLink => cy.visit(verifyLink));
+    cy.contains('new email address is now verified').should('be.visible');
+    cy.visit('/settings/account');
+    cy.contains('Your current email address is email2@example.com').should('be.visible');
+  })
+});
+
+
+describe('Check email status', () => {
+  before(() => {
+    cy.sql("DELETE FROM core_emaildomain where domain='@domain.test'");
+    cy.recreateUser("test-email-status", "test-email-status@domain.test", "tournesol");
+  })
+
+  it('shows email trust status', () => {
+    cy.visit('/settings/account');
+    cy.focused().type('test-email-status');
+    cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+    cy.contains(/Email status:.?Non-trusted/).should('be.visible');
+
+    // Update email domain status
+    cy.sql("UPDATE core_emaildomain SET status='ACK' WHERE domain = '@domain.test';")
+    cy.reload();
+    cy.contains(/Email status:.?Trusted/).should('be.visible');
+  })
+})


### PR DESCRIPTION
Closes #191 

* Indication about the email status on account page: "Trusted" or "Non-trusted":
  A boolean `is_trusted` has been added in the response of `GET /accounts/profile/`

* A page "/about/trusted_domains" explaining the motivation for this mechanism:
  A new route `GET /domains/` has been implemented to fetch the list of accepted email domains

|/settings/account| /about/trusted_domains|
|-|-|
|![Capture d’écran du 2021-11-10 15-05-42](https://user-images.githubusercontent.com/4726554/141128314-88989184-40d8-4e92-a4f5-082a5dc5447d.png)|![image](https://user-images.githubusercontent.com/4726554/141128228-775648d5-ec6a-4c00-97ec-578d1a136e9f.png)|





