### PR TITLE
admin: Define list_display and search_fields in VideoAdmin

### DIFF
--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -3,6 +3,7 @@ Defines Tournesol's backend admin interface
 """
 
 from django.contrib import admin
+from django.utils.html import format_html
 
 from .models import (
     Video,
@@ -16,7 +17,23 @@ from .models import (
 
 @admin.register(Video)
 class VideoAdmin(admin.ModelAdmin):
-    pass
+    list_display = (
+        'video_id',
+        'name',
+        'uploader',
+        'publication_date',
+        'rating_n_ratings',
+        'rating_n_contributors',
+        'language',
+        'link_to_youtube',
+    )
+    search_fields = ('video_id', 'name', 'uploader')
+    list_filter = (
+        ('language', admin.AllValuesFieldListFilter),
+    )
+
+    def link_to_youtube(self, obj):
+        return format_html('<a href="https://youtu.be/{}">Play ▶</a>', obj.video_id)
 
 
 @admin.register(VideoCriteriaScore)


### PR DESCRIPTION
As suggested by @aidanjungo, it should now be easier to look for a specific video, e.g in order to correct its "language".

![image](https://user-images.githubusercontent.com/4726554/141313899-13ce3f75-8405-4bf5-bdc6-686a70a5a16a.png)



