### PR TITLE
Add scripts and documentation to restore Postgres database from a backup

### DIFF
--- a/infra/ansible/restore-backup.yml
+++ b/infra/ansible/restore-backup.yml
@@ -1,0 +1,4 @@
+- hosts: tournesol
+  roles:
+    - restore
+  become: true

--- a/infra/ansible/roles/restore/handlers/main.yml
+++ b/infra/ansible/roles/restore/handlers/main.yml
@@ -1,0 +1,1 @@
+- import_tasks: roles/django/handlers/main.yml

--- a/infra/ansible/roles/restore/tasks/main.yml
+++ b/infra/ansible/roles/restore/tasks/main.yml
@@ -1,31 +1,54 @@
 - name: Restore entire postgres backup
-  shell:
-    cmd: |
-      dropdb -e tournesol --if-exists --force
-      pg_restore -v --exit-on-error --dbname postgres --create \
-        /backups/tournesol/db/{{restore_backup_name}}/tournesol.custom 2>&1
-  become: yes
-  become_user: postgres
   when: restore_backup_name is defined and restore_backup_name != ""
-  register: restore_result
+  block:
+    - name: Stop Gunicorn
+      systemd:
+        name: gunicorn
+        state: stopped
+        daemon_reload: true
 
-- debug:
-    var: restore_result.stdout_lines
+    - name: Restore backup file
+      shell:
+        cmd: |
+          BACKUP_FILE=/backups/tournesol/db/{{restore_backup_name}}/tournesol.custom
+          if ! test -e "$BACKUP_FILE"; then
+            echo "Backup file '$BACKUP_FILE' does not exist"
+            return 1
+          fi
+          dropdb -e tournesol --if-exists --force
+          pg_restore -v --exit-on-error --dbname postgres --create $BACKUP_FILE 2>&1
+      become: yes
+      become_user: postgres
+      register: restore_result
+      notify:
+        - Restart Gunicorn
+        - Migrate Django database
+
+    - debug:
+        var: restore_result.stdout_lines
 
 
 - name: Restore postgres backup without overriding oauth applications
-  shell:
-    cmd: |
-      BACKUP_FILE={{restore_backup_path}}/tournesol.custom
-      psql -d tournesol -c "TRUNCATE oauth2_provider_accesstoken CASCADE"
-      pg_restore -v --single-transaction --clean -d tournesol $BACKUP_FILE \
-        -L <(pg_restore -l $BACKUP_FILE | awk '!/oauth2_provider/ || /FK CONSTRAINT/' ) 2>&1
-  args:
-    executable: /bin/bash
-  become: yes
-  become_user: postgres
-  when: restore_backup_path is defined and restore_backup_path != ""
-  register: restore_result
+  when: external_backup_path is defined and external_backup_path != ""
+  block:
+    - name: Restore backup file
+      shell:
+        cmd: |
+          BACKUP_FILE={{external_backup_path}}/tournesol.custom
+          if ! test -e "$BACKUP_FILE"; then
+            echo "Backup file '$BACKUP_FILE' does not exist"
+            return 1
+          fi
+          psql -d tournesol -c "TRUNCATE oauth2_provider_accesstoken CASCADE"
+          pg_restore -v --single-transaction --clean -d tournesol $BACKUP_FILE \
+            -L <(pg_restore -l $BACKUP_FILE | awk '!/oauth2_provider/ || /FK CONSTRAINT/' ) 2>&1
+      args:
+        executable: /bin/bash
+      become: yes
+      become_user: postgres
+      notify:
+        - Migrate Django database
+      register: restore_result
 
-- debug:
-    var: restore_result.stdout_lines
+    - debug:
+        var: restore_result.stdout_lines

--- a/infra/ansible/roles/restore/tasks/main.yml
+++ b/infra/ansible/roles/restore/tasks/main.yml
@@ -1,0 +1,31 @@
+- name: Restore entire postgres backup
+  shell:
+    cmd: |
+      dropdb -e tournesol --if-exists --force
+      pg_restore -v --exit-on-error --dbname postgres --create \
+        /backups/tournesol/db/{{restore_backup_name}}/tournesol.custom 2>&1
+  become: yes
+  become_user: postgres
+  when: restore_backup_name is defined and restore_backup_name != ""
+  register: restore_result
+
+- debug:
+    var: restore_result.stdout_lines
+
+
+- name: Restore postgres backup without overriding oauth applications
+  shell:
+    cmd: |
+      BACKUP_FILE={{restore_backup_path}}/tournesol.custom
+      psql -d tournesol -c "TRUNCATE oauth2_provider_accesstoken CASCADE"
+      pg_restore -v --single-transaction --clean -d tournesol $BACKUP_FILE \
+        -L <(pg_restore -l $BACKUP_FILE | awk '!/oauth2_provider/ || /FK CONSTRAINT/' ) 2>&1
+  args:
+    executable: /bin/bash
+  become: yes
+  become_user: postgres
+  when: restore_backup_path is defined and restore_backup_path != ""
+  register: restore_result
+
+- debug:
+    var: restore_result.stdout_lines

--- a/infra/ansible/scripts/fetch-and-import-pg-backup.sh
+++ b/infra/ansible/scripts/fetch-and-import-pg-backup.sh
@@ -55,4 +55,4 @@ if ! copy_backup; then
 fi
 
 ansible-playbook -i inventory.yml -l "$ANSIBLE_HOST" restore-backup.yml \
-    -e restore_backup_path=/backups/tournesol/"$FROM_DOMAIN_NAME"/"$BACKUP_NAME"
+    -e external_backup_path=/backups/tournesol/"$FROM_DOMAIN_NAME"/"$BACKUP_NAME"

--- a/infra/ansible/scripts/fetch-and-import-pg-backup.sh
+++ b/infra/ansible/scripts/fetch-and-import-pg-backup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+CURRENT_DIR="$(realpath -e "$(dirname "$0")")"
+cd "$CURRENT_DIR/.."
+
+function usage(){
+    printf "Usage:\n\t%s\n" "${0} --backup-name 2021-11-12-weekly --from staging.tournesol.app --to-ansible-host tournesol-vm"
+}
+
+if test "$#" -lt 6; then
+    usage
+    exit 1
+fi
+
+declare -A ansible_host_to_domain_name=(
+    ["tournesol-vm"]="tournesol-vm"
+    ["tournesol-staging"]="staging.tournesol.app"
+    ["tournesol-prod"]="tournesol.app"
+)
+
+set +u
+while test -n "$1"; do
+    case "$1" in
+      -b|--backup-name)
+          BACKUP_NAME=$2
+          shift 2
+          ;;
+      -f|--from)
+          FROM_DOMAIN_NAME=$2
+          shift 2
+          ;;
+      -t|--to-ansible-host)
+          ANSIBLE_HOST=$2
+          TO_DOMAIN_NAME=${ansible_host_to_domain_name[$ANSIBLE_HOST]}
+          if ! test -n "$TO_DOMAIN_NAME"; then
+            echo "Unknown ansible host '$ANSIBLE_HOST'"
+            exit 1
+          fi
+          shift 2
+          ;;
+    esac
+done
+set -u
+
+function copy_backup() {
+    ssh "$TO_DOMAIN_NAME" -- sudo -u postgres mkdir -m 777 -p /backups/tournesol/"$FROM_DOMAIN_NAME"
+    scp -C -3 -r "$FROM_DOMAIN_NAME":/backups/tournesol/db/"$BACKUP_NAME" "$TO_DOMAIN_NAME":/backups/tournesol/"$FROM_DOMAIN_NAME"/"$BACKUP_NAME" 
+}
+
+if ! copy_backup; then
+  echo "Failed to copy backup from '$FROM_DOMAIN_NAME' to '$TO_DOMAIN_NAME'".
+  exit 1;
+fi
+
+ansible-playbook -i inventory.yml -l "$ANSIBLE_HOST" restore-backup.yml \
+    -e restore_backup_path=/backups/tournesol/"$FROM_DOMAIN_NAME"/"$BACKUP_NAME"

--- a/infra/ansible/scripts/list-backups.sh
+++ b/infra/ansible/scripts/list-backups.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+export VM_ADDR="${1:-"staging.tournesol.app"}"
+export VM_USER="${2:-"$USER"}"
+
+ssh "$VM_USER@$VM_ADDR" -- find /backups/tournesol -type d -mindepth 2 | sed 's|.*/||' | sort -nr

--- a/infra/ansible/scripts/restore-last-prod-backup-on-staging.sh
+++ b/infra/ansible/scripts/restore-last-prod-backup-on-staging.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+CURRENT_DIR="$(realpath -e "$(dirname "$0")")"
+cd "$CURRENT_DIR"
+
+./fetch-and-import-pg-backup.sh --backup-name "$(./list-backups.sh tournesol.app | head -n1)" --from tournesol.app --to-ansible-host tournesol-staging


### PR DESCRIPTION
Closes #201

2 distinct mechanisms are implemented:

1. Restore **an entire backup from the same host:**
To be used after an incident, or in order to restore the database to a previous state (e.g after a temporary experiment on a non-production environment).

2. Fetch and import a backup **from a different host** (e.g for development purposes). 
In this case, some data on the target database is preserved to keep OAuth applications functional.

See [the updated README](https://github.com/tournesol-app/tournesol/blob/restore-pg-backup/infra/README.md#restore-postgres-backup) for more details.