### PR TITLE
chore: upgrade django from 3.2.6 to 3.2.9

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.6
+Django==3.2.9
 django-computed-property==0.3.0
 django-cors-headers==3.7.0
 django-countries==7.2.1


### PR DESCRIPTION
The upgrade fixes few bugs and regressions, mainly related to the admin interface.

See the - small - django release notes here:
- https://docs.djangoproject.com/en/3.2/releases/3.2.7/
- https://docs.djangoproject.com/en/3.2/releases/3.2.8/
- https://docs.djangoproject.com/en/3.2/releases/3.2.9/