### PR TITLE
Browser extension: compatibility with Manifest v2 and Firefox

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,4 +1,4 @@
-# tournesol-chrome-extension
+# Tournesol browser extension
 
 The extension allows to quickly rate a video from youtube on the Tournesol expert rating page.
 

--- a/browser-extension/addRateLaterButton.css
+++ b/browser-extension/addRateLaterButton.css
@@ -12,6 +12,10 @@ button#tournesol-rate-button {
   font-weight: 500;
 }
 
+button#tournesol-rate-button:disabled {
+  opacity: 0.5;
+}
+
 img#tournesol-button-image {
   margin-right: 6px;
   vertical-align: middle;

--- a/browser-extension/addRateLaterButton.js
+++ b/browser-extension/addRateLaterButton.js
@@ -66,15 +66,19 @@ function process() {
     rateLaterButton.append(text_td);
 
     // On click
-    rateLaterButton.onclick = async () => {
+    rateLaterButton.onclick = () => {
       rateLaterButton.disabled = true;
-      let success = await chrome.runtime.sendMessage({
-        message: 'addRateLater',
-        video_id: videoId
-      });
-      if (success) {
-        text_td_text.replaceWith(document.createTextNode('Done!'))
-      }
+      chrome.runtime.sendMessage(
+        {
+          message: 'addRateLater',
+          video_id: videoId
+        },
+        (success) => {
+          if (success) {
+            text_td_text.replaceWith(document.createTextNode('Done!'))
+          }
+        }
+      );
     }
 
     // Insert after like and dislike buttons

--- a/browser-extension/addRateLaterButton.js
+++ b/browser-extension/addRateLaterButton.js
@@ -73,9 +73,12 @@ function process() {
           message: 'addRateLater',
           video_id: videoId
         },
-        (success) => {
-          if (success) {
+        (data) => {
+          if (data.success) {
             text_td_text.replaceWith(document.createTextNode('Done!'))
+          }
+          else {
+            rateLaterButton.disabled = false;
           }
         }
       );

--- a/browser-extension/addRateLaterButton.js
+++ b/browser-extension/addRateLaterButton.js
@@ -53,7 +53,7 @@ function process() {
     img_td.setAttribute('valign', 'middle');
     var image = document.createElement('img');
     image.setAttribute('id', 'tournesol-button-image');
-    image.setAttribute('src', chrome.extension.getURL('rate_now_icon.png'));
+    image.setAttribute('src', chrome.runtime.getURL('rate_now_icon.png'));
     image.setAttribute('width', '20');
     img_td.append(image);
     rateLaterButton.append(img_td);

--- a/browser-extension/addRateLaterButton.js
+++ b/browser-extension/addRateLaterButton.js
@@ -66,13 +66,15 @@ function process() {
     rateLaterButton.append(text_td);
 
     // On click
-    rateLaterButton.onclick = () => {
-      text_td_text.replaceWith(document.createTextNode('Done!'))
-      rateLaterButton.onclick = () => {}
-      chrome.runtime.sendMessage({
+    rateLaterButton.onclick = async () => {
+      rateLaterButton.disabled = true;
+      let success = await chrome.runtime.sendMessage({
         message: 'addRateLater',
         video_id: videoId
       });
+      if (success) {
+        text_td_text.replaceWith(document.createTextNode('Done!'))
+      }
     }
 
     // Insert after like and dislike buttons

--- a/browser-extension/addTournesolRecommendations.js
+++ b/browser-extension/addTournesolRecommendations.js
@@ -152,7 +152,11 @@ const getTournesolComponent = (data) => {
 }
 
 // This part creates video boxes from API's response JSON
-function handleResponse({ data }, sender, sendResponse) {
+function handleResponse({ data: videos }) {
+  if (!videos || videos.length === 0) {
+    return
+  }
+
   // Timer will run until needed elements are generated
   var timer = window.setInterval(function () {
     /*
@@ -173,7 +177,7 @@ function handleResponse({ data }, sender, sendResponse) {
     if (old_container) old_container.remove();
 
     // Generate component to display on Youtube home page
-    tournesol_component = getTournesolComponent(data)
+    tournesol_component = getTournesolComponent(videos)
     
     container.insertBefore(tournesol_component, container.children[1]);
   }, 300);

--- a/browser-extension/addTournesolRecommendations.js
+++ b/browser-extension/addTournesolRecommendations.js
@@ -60,6 +60,7 @@ const getTournesolComponent = (data) => {
       lang_option.append(lang);
       lang_option.onclick = () => {
         localStorage.setItem('tournesol_extension_config_language', lang);
+        window.location.reload();
       };
       return lang_option;
     };

--- a/browser-extension/background.html
+++ b/browser-extension/background.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8"/>
-        <script src="utils.js"></script>
+        <script type="module" src="utils.js"></script>
         <script type="module" src="background.js"></script>
     </head>
     <body>

--- a/browser-extension/background.html
+++ b/browser-extension/background.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <script type="module" src="utils.js"></script>
-        <script type="module" src="background.js"></script>
+        <script type="module" src="background.js" defer></script>
     </head>
     <body>
     </body>

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -34,7 +34,7 @@ function getDateThreeWeeksAgo() {
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.message == "addRateLater") {
-    addRateLater(request.video_id).then(() => sendResponse(true));
+    addRateLater(request.video_id).then(sendResponse);
     return true;
   }
   else if (request.message == "getVideoStatistics") {
@@ -70,7 +70,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // Send message to Tournesol tab on URL change, to sync access token
 // during navigation (after login, logout, etc.)
 chrome.webNavigation.onHistoryStateUpdated.addListener(event => {
-  console.info("EVENT", event);
   chrome.tabs.sendMessage(event.tabId, "historyStateUpdated")
 }, {
   url: [{hostEquals: "tournesol.app"}]

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -66,3 +66,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 });
+
+// Send message to Tournesol tab on URL change, to sync access token
+// during navigation (after login, logout, etc.)
+chrome.webNavigation.onHistoryStateUpdated.addListener(event => {
+  console.info("EVENT", event);
+  chrome.tabs.sendMessage(event.tabId, "historyStateUpdated")
+}, {
+  url: [{hostEquals: "tournesol.app"}]
+});

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -32,9 +32,10 @@ function getDateThreeWeeksAgo() {
   return `${d}-${m}-${y}-${H}-${M}-${S}`;
 }
 
-chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(async (request, sender) => {
   if (request.message == "addRateLater") {
-    addRateLater(request.video_id)
+    await addRateLater(request.video_id);
+    return true;
   }
   else if (request.message == "getVideoStatistics") {
     // getVideoStatistics(request.video_id).then(sendResponse);
@@ -44,21 +45,20 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     const api_url = 'video/';
 
     const request_recommendations = async (options) => {
-      const json = await fetchTournesolApi(`${api_url}${options ? '?' : ''}${options}`, 'GET', null);
-      return json.results;
+      const resp = await fetchTournesolApi(`${api_url}${options ? '?' : ''}${options}`, 'GET');
+      if (resp && resp.ok) {
+        const json = await resp.json();
+        return json.results
+      }
+      return []
     };
 
-    const process = async () => {
-      const threeWeeksAgo = getDateThreeWeeksAgo()
-      const recent = await request_recommendations(`date_gte=${threeWeeksAgo}&language=${request.language}&limit=10`);
-      const old = await request_recommendations(`date_lte=${threeWeeksAgo}&language=${request.language}&limit=50`);
-      const recent_sub = getRandomSubarray(recent, 3);
-      const old_sub = getRandomSubarray(old, 4 - recent_sub.length);
-      const videos = getRandomSubarray([...old_sub, ...recent_sub], 4);
-      sendResponse({ data: videos });
-    };
-
-    process();
-    return true;
+    const threeWeeksAgo = getDateThreeWeeksAgo()
+    const recent = await request_recommendations(`date_gte=${threeWeeksAgo}&language=${request.language}&limit=10`);
+    const old = await request_recommendations(`date_lte=${threeWeeksAgo}&language=${request.language}&limit=50`);
+    const recent_sub = getRandomSubarray(recent, 3);
+    const old_sub = getRandomSubarray(old, 4 - recent_sub.length);
+    const videos = getRandomSubarray([...old_sub, ...recent_sub], 4);
+    return { data: videos };
   }
 });

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -32,9 +32,9 @@ function getDateThreeWeeksAgo() {
   return `${d}-${m}-${y}-${H}-${M}-${S}`;
 }
 
-chrome.runtime.onMessage.addListener(async (request, sender) => {
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.message == "addRateLater") {
-    await addRateLater(request.video_id);
+    addRateLater(request.video_id).then(() => sendResponse(true));
     return true;
   }
   else if (request.message == "getVideoStatistics") {
@@ -53,12 +53,16 @@ chrome.runtime.onMessage.addListener(async (request, sender) => {
       return []
     };
 
-    const threeWeeksAgo = getDateThreeWeeksAgo()
-    const recent = await request_recommendations(`date_gte=${threeWeeksAgo}&language=${request.language}&limit=10`);
-    const old = await request_recommendations(`date_lte=${threeWeeksAgo}&language=${request.language}&limit=50`);
-    const recent_sub = getRandomSubarray(recent, 3);
-    const old_sub = getRandomSubarray(old, 4 - recent_sub.length);
-    const videos = getRandomSubarray([...old_sub, ...recent_sub], 4);
-    return { data: videos };
+    const process = async () => {
+      const threeWeeksAgo = getDateThreeWeeksAgo()
+      const recent = await request_recommendations(`date_gte=${threeWeeksAgo}&language=${request.language}&limit=10`);
+      const old = await request_recommendations(`date_lte=${threeWeeksAgo}&language=${request.language}&limit=50`);
+      const recent_sub = getRandomSubarray(recent, 3);
+      const old_sub = getRandomSubarray(old, 4 - recent_sub.length);
+      const videos = getRandomSubarray([...old_sub, ...recent_sub], 4);
+      return { data: videos };
+    }
+    process().then(sendResponse);
+    return true;
   }
 });

--- a/browser-extension/build.sh
+++ b/browser-extension/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-zip -r -FS tournesol_extension_chrome.zip * -x *.git* *.zip*
+zip -r -FS tournesol_extension.zip * -x *.git* *.zip*

--- a/browser-extension/fetchTournesolToken.js
+++ b/browser-extension/fetchTournesolToken.js
@@ -9,6 +9,6 @@ updateAccessToken();
 
 chrome.runtime.onMessage.addListener(() => {
   // setTimeout seems to be necessary here, as the localStorage
-  // (when the access token is persisted) is written asynchronously.
+  // (where the access token is persisted) is written asynchronously.
   setTimeout(updateAccessToken)
 });

--- a/browser-extension/fetchTournesolToken.js
+++ b/browser-extension/fetchTournesolToken.js
@@ -1,6 +1,14 @@
-const raw_state = JSON.parse(localStorage.getItem('persist:root'))
-const token = JSON.parse(raw_state.token)
-const access_token = token.access_token
-chrome.storage.local.set({access_token: access_token}, () => {
-  console.log("Saved tournesol token in extension")
+function updateAccessToken() {
+  const raw_state = JSON.parse(localStorage.getItem('persist:root')) || {};
+  const token = JSON.parse(raw_state.token) || {};
+  const access_token = token.access_token
+  chrome.storage.local.set({access_token: access_token || null});
+}
+
+updateAccessToken();
+
+chrome.runtime.onMessage.addListener(() => {
+  // setTimeout seems to be necessary here, as the localStorage
+  // (when the access token is persisted) is written asynchronously.
+  setTimeout(updateAccessToken)
 });

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -3,11 +3,6 @@
   "version": "2.0.0",
   "description": "Open Tournesol directly from Youtube",
   "permissions": ["storage", "cookies", "https://tournesol.app/", "https://www.youtube.com/", "contextMenus", "activeTab"],
-  "host_permissions": [
-    "https://api.tournesol.app/",
-    "https://tournesol.app/",
-    "https://www.youtube.com/"
-  ],
   "manifest_version": 2,
   "icons": {
     "64": "favicon64.png",
@@ -17,7 +12,7 @@
     "page": "background.html",
     "persistent": true
   },
-  "action": {
+  "browser_action": {
     "default_icon": {              
       "16": "favicon.png"
     },

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "name": "Tournesol Extension",
   "version": "2.0.0",
   "description": "Open Tournesol directly from Youtube",
-  "permissions": ["storage", "cookies", "https://tournesol.app/", "https://www.youtube.com/", "contextMenus", "activeTab"],
+  "permissions": ["storage", "cookies", "https://tournesol.app/", "https://api.tournesol.app/", "https://www.youtube.com/", "contextMenus", "activeTab"],
   "manifest_version": 2,
   "icons": {
     "64": "favicon64.png",
@@ -34,7 +34,6 @@
     }
   ],
   "web_accessible_resources": [
-	  "rate_now_icon.png",
-	  "utils.mjs"
+	  "rate_now_icon.png"
   ]
 }

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,21 +2,20 @@
   "name": "Tournesol Extension",
   "version": "2.0.0",
   "description": "Open Tournesol directly from Youtube",
-  "permissions": [
-    "storage", "contextMenus", "activeTab", "scripting"
-  ],
+  "permissions": ["storage", "cookies", "https://tournesol.app/", "https://www.youtube.com/", "contextMenus", "activeTab"],
   "host_permissions": [
     "https://api.tournesol.app/",
     "https://tournesol.app/",
     "https://www.youtube.com/"
   ],
-  "manifest_version": 3,
+  "manifest_version": 2,
   "icons": {
     "64": "favicon64.png",
     "512": "favicon512.png"
   },
   "background": {
-    "service_worker": "background.js", "type": "module"
+    "page": "background.html",
+    "persistent": true
   },
   "action": {
     "default_icon": {              
@@ -40,6 +39,7 @@
     }
   ],
   "web_accessible_resources": [
-    { "resources": ["rate_now_icon.png"], "matches": ["https://*.youtube.com/*"] }
+	  "rate_now_icon.png",
+	  "utils.mjs"
   ]
 }

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -2,7 +2,7 @@
   "name": "Tournesol Extension",
   "version": "2.0.0",
   "description": "Open Tournesol directly from Youtube",
-  "permissions": ["storage", "cookies", "https://tournesol.app/", "https://api.tournesol.app/", "https://www.youtube.com/", "contextMenus", "activeTab"],
+  "permissions": ["storage", "cookies", "https://tournesol.app/", "https://api.tournesol.app/", "https://www.youtube.com/", "contextMenus", "activeTab", "webNavigation"],
   "manifest_version": 2,
   "icons": {
     "64": "favicon64.png",

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Open Tournesol directly from Youtube",
   "permissions": ["storage", "cookies", "https://tournesol.app/", "https://api.tournesol.app/", "https://www.youtube.com/", "contextMenus", "activeTab", "webNavigation"],
   "manifest_version": 2,

--- a/browser-extension/menu.html
+++ b/browser-extension/menu.html
@@ -4,15 +4,53 @@
         <meta charset="utf-8"/>
         <style>
             body {
-                background: #fdd835; width: 120px; display: flex; flex-direction: column;
+                background: #ffc800;
+                width: 120px;
+                display: flex;
+                flex-direction: column;
+            }
+            body > img {
+                margin-bottom: 6px;
             }
             button {
-                margin: 2px; background: #336600; color: white; font-size: large; padding: 4px;
+                background-color: #506AD4;
+                color: white;
+                font-size: large;
+                border-width: 0px;
+                border-radius: 4px;
+                margin: 2px;
+                padding: 4px;
+                box-shadow: 2px 2px 3px #506AD488;
+            }
+            button:hover {
+                cursor: pointer;
+                background-color: #6980DF;
+            }
+            button:active {
+                background-color: #3F54AB;
+            }
+            button[data-success]::after {
+                display: block;
+                background-color: #4caf50;
+                font-size: 14px;
+                content: attr(data-success);
+            }
+            button[data-error]::after {
+                display: block;
+                background-color: #f44336;
+                font-size: 14px;
+                content: attr(data-error);
+            }
+            button:disabled {
+                cursor: not-allowed;
+                box-shadow: none;
+                background-color: #6980DF;
             }
         </style>
         <script type="module" src="menu.js"></script>
     </head>
     <body>
+        <img src="https://tournesol.app/svg/Logo.svg"/>
         <button id="rate_now">Rate now</button>
         <button id="rate_later">Rate later</button>
         <button id="details">Analysis</button>

--- a/browser-extension/menu.js
+++ b/browser-extension/menu.js
@@ -17,37 +17,50 @@ function get_current_tab_video_id() {
 }
 
 
-function rate_now() {
+function rate_now(e) {
+  const button = e.target;
   get_current_tab_video_id().then(videoId => {
      chrome.tabs.create({url: `https://tournesol.app/comparison/?videoA=${videoId}`})
   },
     err => {
-      alert('This must be used on the page of a youtube video', 'ok');
+      button.disabled = true
+      button.setAttribute('data-error', 'Go to a Youtube video page.')
     }
   );
 }
 
 
-function rate_later() {
-  get_current_tab_video_id().then(videoId => {
-    const button = document.getElementById('rate_later')
-    button.innerText = 'Done!'
-    button.disabled = true
-    addRateLater(videoId)
+function rate_later(e) {
+  const button = e.target;
+  get_current_tab_video_id().then(async (videoId) => {
+    button.disabled = true;
+    const resp = await addRateLater(videoId);
+    if (resp && resp.ok) {
+      button.setAttribute('data-success', 'Done!');
+    }
+    else if (resp && resp.status === 409) {
+      button.setAttribute('data-success', 'Already added.')
+    }
+    else {
+      button.setAttribute('data-error', 'Failed');
+    }
   },
     err => {
-      alert('This must be used on the page of a youtube video', 'ok');
+      button.disabled = true;
+      button.setAttribute('data-error', 'Go to a Youtube video page.');
     }
   );
 }
 
 
-function details() {
+function details(e) {
+  const button = e.target;
   get_current_tab_video_id().then(videoId => {
      chrome.tabs.create({url: `https://tournesol.app/video/${videoId}`})
   },
     err => {
-      alert('This must be used on the page of a youtube video', 'ok');
+      button.disabled = true;
+      button.setAttribute('data-error', 'Go to a Youtube video page.');
     }
   );
 }

--- a/browser-extension/menu.js
+++ b/browser-extension/menu.js
@@ -24,7 +24,7 @@ function rate_now(e) {
   },
     err => {
       button.disabled = true
-      button.setAttribute('data-error', 'Go to a Youtube video page.')
+      button.setAttribute('data-error', 'Not a Youtube video page.')
     }
   );
 }
@@ -34,20 +34,17 @@ function rate_later(e) {
   const button = e.target;
   get_current_tab_video_id().then(async (videoId) => {
     button.disabled = true;
-    const resp = await addRateLater(videoId);
-    if (resp && resp.ok) {
-      button.setAttribute('data-success', 'Done!');
-    }
-    else if (resp && resp.status === 409) {
-      button.setAttribute('data-success', 'Already added.')
+    const { success, message } = await addRateLater(videoId);
+    if (success) {
+      button.setAttribute('data-success', message);
     }
     else {
-      button.setAttribute('data-error', 'Failed');
+      button.setAttribute('data-error', message);
     }
   },
     err => {
       button.disabled = true;
-      button.setAttribute('data-error', 'Go to a Youtube video page.');
+      button.setAttribute('data-error', 'Not a Youtube video page.');
     }
   );
 }
@@ -60,7 +57,7 @@ function details(e) {
   },
     err => {
       button.disabled = true;
-      button.setAttribute('data-error', 'Go to a Youtube video page.');
+      button.setAttribute('data-error', 'Not a Youtube video page.');
     }
   );
 }

--- a/browser-extension/utils.js
+++ b/browser-extension/utils.js
@@ -1,7 +1,10 @@
-let access_token;
-chrome.storage.local.get(['access_token'], (storage) => {
-  access_token = storage.access_token
-})
+async function getAccessToken() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(['access_token'], items => {
+      resolve(items.access_token)
+    })
+  })
+}
 
 async function getCurrentTab() {
   let queryOptions = { active: true, currentWindow: true };
@@ -27,11 +30,12 @@ export const alertNotLoggedInOrError = () => {
   alertOnCurrentTab('Make sure you are logged in on https://tournesol.app/. If you are logged in and this error persist, please let us know by creating an issue on https://github.com/tournesol-app/tournesol-chrome-extension/')
 }
 
-export const fetchTournesolApi = (url, method, data, callback) => {
+export const fetchTournesolApi = async (url, method, data) => {
   const headers = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
   }
+  const access_token = await getAccessToken();
   if (access_token){
     headers['Authorization']= `Bearer ${access_token}`
   }
@@ -47,7 +51,7 @@ export const fetchTournesolApi = (url, method, data, callback) => {
   return fetch(`https://api.tournesol.app/${url}`, body).then(r => {
     if (r.status == 403 || r.status == 401) alertNotLoggedInOrError()
     return r.json()
-  }).then(callback).catch(console.error)
+  }).catch(console.error)
 }
 
 export const addRateLater = (video_id) => {

--- a/browser-extension/utils.js
+++ b/browser-extension/utils.js
@@ -6,19 +6,9 @@ async function getAccessToken() {
   })
 }
 
-async function getCurrentTab() {
-  let queryOptions = { active: true, currentWindow: true };
-  let [tab] = await chrome.tabs.query(queryOptions);
-  return tab;
-}
-
 export const alertOnCurrentTab = async (msg) => {
-  const tab = await getCurrentTab();
-  function sendAlert(m) { alert(m, 'ok') }
-  chrome.scripting.executeScript({
-    target: {tabId: tab.id},
-    func: sendAlert,
-    args: [msg]
+  browser.tabs.executeScript({
+    code: `alert("${msg}", 'ok')`
   })
 }
 
@@ -49,15 +39,22 @@ export const fetchTournesolApi = async (url, method, data) => {
     body["body"]= JSON.stringify(data)
   }
   return fetch(`https://api.tournesol.app/${url}`, body).then(r => {
-    if (r.status == 403 || r.status == 401) alertNotLoggedInOrError()
-    return r.json()
+    if (r.status === 403 || r.status === 401) {
+      alertNotLoggedInOrError()
+    }
+    return r;
   }).catch(console.error)
 }
 
-export const addRateLater = (video_id) => {
-  fetchTournesolApi('video/', 'POST', {video_id: video_id}, () => {}).then( () => {
-    fetchTournesolApi('users/me/video_rate_later/', 'POST', {video: {video_id: video_id}}, () => {})
-  })
+export const addRateLater = async (video_id) => {
+  return fetchTournesolApi('video/', 'POST', {video_id: video_id})
+    .then(() =>
+      fetchTournesolApi(
+        'users/me/video_rate_later/',
+        'POST',
+        {video: {video_id: video_id}}
+      )
+    )
 };
 
 /*

--- a/browser-extension/utils.js
+++ b/browser-extension/utils.js
@@ -7,7 +7,7 @@ async function getAccessToken() {
 }
 
 export const alertOnCurrentTab = async (msg) => {
-  browser.tabs.executeScript({
+  chrome.tabs.executeScript({
     code: `alert("${msg}", 'ok')`
   })
 }
@@ -17,7 +17,7 @@ export const alertUseOnLinkToYoutube = () => {
 }
 
 export const alertNotLoggedInOrError = () => {
-  alertOnCurrentTab('Make sure you are logged in on https://tournesol.app/. If you are logged in and this error persist, please let us know by creating an issue on https://github.com/tournesol-app/tournesol-chrome-extension/')
+  alertOnCurrentTab('Make sure you are logged in on https://tournesol.app/. If you are logged in and this error persists, please let us know by creating an issue on https://github.com/tournesol-app/tournesol-chrome-extension/')
 }
 
 export const fetchTournesolApi = async (url, method, data) => {
@@ -47,14 +47,30 @@ export const fetchTournesolApi = async (url, method, data) => {
 }
 
 export const addRateLater = async (video_id) => {
-  return fetchTournesolApi('video/', 'POST', {video_id: video_id})
+  const resp = await fetchTournesolApi('video/', 'POST', {video_id: video_id})
     .then(() =>
       fetchTournesolApi(
         'users/me/video_rate_later/',
         'POST',
         {video: {video_id: video_id}}
       )
-    )
+    );
+  if (resp && resp.ok) {
+    return {
+      success: true,
+      message: 'Done!'
+    }
+  }
+  else if (resp && resp.status === 409) {
+    return {
+      success: true,
+      message: 'Already added.'
+    }
+  }
+  return {
+    success: false,
+    message: 'Failed.'
+  }
 };
 
 /*

--- a/browser-extension/utils.js
+++ b/browser-extension/utils.js
@@ -17,7 +17,7 @@ export const alertUseOnLinkToYoutube = () => {
 }
 
 export const alertNotLoggedInOrError = () => {
-  alertOnCurrentTab('Make sure you are logged in on https://tournesol.app/. If you are logged in and this error persists, please let us know by creating an issue on https://github.com/tournesol-app/tournesol-chrome-extension/')
+  alertOnCurrentTab('Make sure you are logged in on https://tournesol.app/. If you are logged in and this error persists, please let us know by creating an issue on https://github.com/tournesol-app/tournesol')
 }
 
 export const fetchTournesolApi = async (url, method, data) => {

--- a/tests/cypress/integration/extension.spec.ts
+++ b/tests/cypress/integration/extension.spec.ts
@@ -1,19 +1,38 @@
-import { skipOn, onlyOn } from '@cypress/skip-test'
+import { onlyOn } from '@cypress/skip-test'
 
 onlyOn('headed', () => {
   describe('Tournesol extension', 
     { browser: ['chromium', 'chrome']}, 
     () => {
-      it('shows Tournesol recommendations on youtube.com', () => {
+      const consent = () => {
+        cy.get('body')
+          .then(($body) => {
+            // Agree to cookies dialog if it's present
+            if ($body.find('#dialog').length) {
+              cy.get('#dialog [role="button"]').last().click();
+            }
+          })
+      }
+
+      beforeEach(() => {
         cy.on('uncaught:exception', (err, runnable) => {
           // returning false here prevents Cypress from
           // failing the test, because of unrelated Youtube errors
           return false
         })
+      })
 
+      it('shows Tournesol recommendations on youtube.com', () => {
         cy.visit('https://www.youtube.com');
+        consent();
         cy.wait(5000);
         cy.contains('Recommended by Tournesol').should('be.visible');
+      })
+
+      it('shows "Rate later" button on video page', () => {
+        cy.visit('https://www.youtube.com/watch?v=6jK9bFWE--g');
+        consent();
+        cy.contains('button', 'Rate later', {matchCase: false}).should('be.visible');
       })
     })
 })


### PR DESCRIPTION
Related to #225 

* Back to Manifest v2, as Firefox does not support v3 yet
  https://blog.mozilla.org/addons/2021/05/27/manifest-v3-update/
  https://bugzilla.mozilla.org/show_bug.cgi?id=1578284

* More robust access token handling:
  * The token is fetched from extension storage on each request to the API
  * The token is updated in the extension storage during navigation on tournesol.app, without explicit reload. 

* Error handling and feedback in UI: buttons are disabled after the first error, error messages are visible on most actions.

* A few cosmetic changes in the popup:
![image](https://user-images.githubusercontent.com/4726554/142391958-df82db4d-9bf1-4239-92b8-1a5259dda89a.png)



