### PR TITLE
dev-env: Implement 'restart' command to rebuild the containers while preserving the data

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+# Building the docker image used by dev-env requires copying
+# the requirements files only. All other files are ignored
+# in the build context, as they will mounted as a volume.
+*
+!*.txt
+!ml/*.txt
+!tests/*.txt

--- a/backend/dev-env/Dockerfile
+++ b/backend/dev-env/Dockerfile
@@ -2,6 +2,6 @@
 FROM python:3.9-slim-bullseye
 ENV PYTHONUNBUFFERED=1
 WORKDIR /backend
-COPY requirements.txt ml_requirements.txt /backend/
+COPY requirements.txt ml/ml_requirements.txt /backend/
 RUN pip install -r ml_requirements.txt
 RUN pip install -r requirements.txt

--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -31,3 +31,10 @@ A superuser will be created automatically with username `user` and the default p
 
 Then, the application is visible on http://localhost:3000.  
 
+#### Rebuild the containers while preserving the database
+
+By default, the database content is initialized from a public dump.
+To restart the containers (e.g to update the backend dependencies) while preserving the data, use:
+```bash
+./run-docker-compose.sh restart
+```

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -22,7 +22,9 @@ services:
       tournesol-dev: {}
 
   api:
-    build: ../backend/dev-env
+    build:
+      context: ../backend
+      dockerfile: dev-env/Dockerfile
     container_name: tournesol-dev-api
     environment:
       - SETTINGS_FILE=/backend/dev-env/settings-tournesol.yaml

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -15,9 +15,8 @@ function compose_up() {
 
 function wait_for_backend() {
   set +e
-  for i in `seq 1 50`; do
-    curl -s localhost:8000
-    if [[ "$?" == "0" ]]; then
+  for _ in $(seq 1 50); do
+    if curl -s localhost:8000 -o /dev/null; then
       echo ""
       return 0
     fi
@@ -28,13 +27,14 @@ function wait_for_backend() {
   exit 1
 }
 
-CURRENT_DIR="$(realpath -e "$(dirname "$0")")"
-cd "$CURRENT_DIR"
-
-DB_DIR="db-data"
+if [[ "${1:-""}" == 'restart' ]]; then
+  echo "Recreating dev containers..."
+  compose_up
+  exit
+fi
 
 if [ -d $DB_DIR ]; then
-  echo "The existing database at `realpath $DB_DIR` will be deleted."
+  echo "The existing database at $(realpath $DB_DIR) will be deleted."
   read -p "Are you sure? (y/n) " -n 1 -r
   echo ""
   if [[ ! $REPLY =~ ^[Yy]$ ]]

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -2,6 +2,17 @@
 
 set -Eeuo pipefail
 
+DB_DIR="db-data"
+
+CURRENT_DIR="$(realpath -e "$(dirname "$0")")"
+cd "$CURRENT_DIR"
+
+function compose_up() {
+  DB_UID=$(id -u) \
+  DB_GID=$(id -g) \
+  docker-compose up --build --force-recreate -d
+}
+
 function wait_for_backend() {
   set +e
   for i in `seq 1 50`; do
@@ -34,14 +45,9 @@ if [ -d $DB_DIR ]; then
 fi
 
 rm -rf $DB_DIR
-
-cp ../backend/requirements.txt ../backend/ml/ml_requirements.txt ../backend/dev-env/
-
 mkdir -p $DB_DIR
 
-DB_UID=$(id -u) \
-DB_GID=$(id -g) \
-docker-compose up --build --force-recreate -d
+compose_up
 
 wait_for_backend
 
@@ -54,7 +60,7 @@ rm "$CURRENT_DIR"/$DB_DIR/dump.sql
 echo 'Creating Superuser:'
 USERNAME="${1:-"user"}"
 PASSWORD="${2:-"tournesol"}"
-EMAIL="${3:-""}"
+EMAIL="${3:-"superuser@example.com"}"
 "$CURRENT_DIR/../backend/dev-env/create-superuser.exp" "$USERNAME" "$PASSWORD" "$EMAIL"
 
 echo 'Creating OAuth Application:'


### PR DESCRIPTION
### Why
There was now easy way to rebuild the container `tournesol-dev-api` without re-initializing the whole dev-env (for example to update the Python dependencies used by the backend).

### Changes 
* It's now possible to run `./run-docker-compose.sh restart` in this case. The database initialization is not executed.
* The Python requirements files are no longer duplicated in backend/ and backend/dev-env/ : the backend/ directory is used as the context to build the docker image
* Apply `shellcheck` corrections (@jstainer-kleis thanks for the tip!)