### PR TITLE
feat: Extensions and Contribute sections on home page

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -31,7 +31,7 @@ const renderComponent = (drawerOpen: boolean) =>
     </Provider>
   );
 
-test('renders Tournesol banner', () => {
-  const { getByText } = renderComponent(true);
-  expect(getByText(/Tournesol/i)).toBeInTheDocument();
+test('Home page renders and contains the word "Tournesol"', () => {
+  const { getAllByText } = renderComponent(true);
+  expect(getAllByText(/Tournesol/i).length).toBeGreaterThan(0);
 });

--- a/frontend/src/features/frame/components/sidebar/Footer.tsx
+++ b/frontend/src/features/frame/components/sidebar/Footer.tsx
@@ -15,7 +15,6 @@ const useStyles = makeStyles(() => ({
   menuLink: {
     margin: 4,
     textDecoration: 'none',
-    fontFamily: 'Poppins',
     fontStyle: 'normal',
     fontWeight: 'bold',
     color: '#A09B87',

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -10,7 +10,6 @@ import {
   Theme,
   Divider,
 } from '@material-ui/core';
-// import ListIcon from '@material-ui/icons/FormatListBulleted';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
@@ -63,6 +62,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.down('sm')]: {
       top: 0,
       height: '100%',
+    },
+    overflowX: 'hidden',
+    '& > *': {
+      // All direct children of the drawer paper should keep a min-width:
+      // their content should not be wrapped during the drawer animation.
+      minWidth: `${sideBarWidth}px`,
     },
   },
   listItem: {
@@ -133,7 +138,10 @@ const SideBar = () => {
         }),
       }}
     >
-      <List onClick={isSmallScreen ? () => dispatch(closeDrawer()) : undefined}>
+      <List
+        disablePadding
+        onClick={isSmallScreen ? () => dispatch(closeDrawer()) : undefined}
+      >
         {menuItems.map(({ targetUrl, IconComponent, displayText }) => {
           if (!IconComponent || !targetUrl)
             return <Divider key={displayText} />;

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -75,7 +75,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: '#806300',
   },
   listItemText: {
-    fontFamily: 'Poppins',
     fontWeight: 'bold',
   },
 }));

--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -16,7 +16,6 @@ const useStyles = makeStyles({
     gap: '8px',
   },
   HeaderButton: {
-    fontFamily: 'Poppins',
     textTransform: 'initial',
     fontWeight: 'bold',
     borderWidth: '2px',

--- a/frontend/src/features/frame/components/topbar/TopBar.tsx
+++ b/frontend/src/features/frame/components/topbar/TopBar.tsx
@@ -80,7 +80,7 @@ const Logo = () => {
       >
         <Menu />
       </IconButton>
-      <Link to="/home">
+      <Link to="/">
         <Hidden xsDown>
           <img src="/svg/Logo.svg" alt="logo" />
         </Hidden>

--- a/frontend/src/pages/home/ContributeSection.tsx
+++ b/frontend/src/pages/home/ContributeSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Link } from 'react-router-dom';
 import { Typography, Button, Box } from '@material-ui/core';
 
 // ContributeSection is a paragraph displayed on the HomePage
@@ -24,10 +25,9 @@ const ContributeSection = () => {
       <Button
         color="primary"
         variant="contained"
-        component="a"
-        href="/comparisons"
+        component={Link}
+        to="/comparison"
       >
-        {' '}
         Compare videos now
       </Button>
     </Box>

--- a/frontend/src/pages/home/ContributeSection.tsx
+++ b/frontend/src/pages/home/ContributeSection.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { Typography, Button, Box } from '@material-ui/core';
+
+// ContributeSection is a paragraph displayed on the HomePage
+// that helps users know how to contribute as users of Tournesol
+const ContributeSection = () => {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      maxWidth="640px"
+      alignItems="flex-start"
+    >
+      <Typography variant="h1">Contribute!</Typography>
+      <Typography paragraph>
+        Tournesol identifies high quality content from comparisons provided by
+        the community. To contribute, you must compare videos that you have
+        watched. First copy paste two links to videos, then tell us which video
+        you think should be largely recommended. If you want to you can also
+        compare the videos in more details based on the multiple comparison
+        criterias.
+      </Typography>
+      <Button
+        color="primary"
+        variant="contained"
+        component="a"
+        href="/comparisons"
+      >
+        {' '}
+        Compare videos now
+      </Button>
+    </Box>
+  );
+};
+
+export default ContributeSection;

--- a/frontend/src/pages/home/ExtensionSection.tsx
+++ b/frontend/src/pages/home/ExtensionSection.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+
+import { Typography, Button, Box } from '@material-ui/core';
+
+const getWebBrowser = () => {
+  if (navigator.userAgent.includes('Chrome/')) return 'chrome';
+  if (navigator.userAgent.includes('Chromium/')) return 'chromium';
+  if (navigator.userAgent.includes('Firefox/')) return 'firefox';
+  return 'other';
+};
+
+// ExtensionSection is a paragraph displayed on the HomePage
+// that automatically detects the user webbrowser to link
+// to one of our extensions (Firefox & Chrome). If another
+// browser is detected, then the user is shown that they
+// can use our extension on Firefox or Chrome.
+const ExtensionSection = () => {
+  const [browser] = useState(getWebBrowser());
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      color="white"
+      maxWidth="640px"
+      alignItems="flex-start"
+    >
+      <Typography variant="h1">Use our extension!</Typography>
+      <Typography paragraph>
+        When using the extension, you will find videos recommended by
+        Tournesol&apos;s community directly on your Youtube home page. You can
+        also add a video in your rate later list or immediatly rate the video
+        with just a few clicks.
+      </Typography>
+      {browser !== 'other' ? (
+        <Button
+          color="primary"
+          variant="contained"
+          component="a"
+          href={
+            browser == 'firefox'
+              ? 'https://addons.mozilla.org/en-US/firefox/addon/tournesol-extension/'
+              : 'https://chrome.google.com/webstore/detail/tournesol-extension/nidimbejmadpggdgooppinedbggeacla'
+          }
+          target="_blank"
+        >
+          Get the extension
+        </Button>
+      ) : (
+        <Typography color="primary" paragraph>
+          The extension is not available on your webbrowser. You may use it on{' '}
+          <b>Firefox</b>, <b>Google Chrome</b> or <b>Chromium</b>.
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default ExtensionSection;

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -1,23 +1,15 @@
 import React from 'react';
 
 import { makeStyles } from '@material-ui/core/styles';
-import { Grid, Typography } from '@material-ui/core';
+import { Grid, Typography, Box } from '@material-ui/core';
+
+import ExtensionSection from './ExtensionSection';
+import ContributeSection from './ContributeSection';
 
 const useStyles = makeStyles((theme) => ({
   root: {
     width: '100%',
-  },
-  rectangle67: {
-    width: '100%',
-    padding: 24,
-    background: '#1282B2',
-  },
-  content: {
-    padding: 24,
-    [theme.breakpoints.down('sm')]: {
-      padding: 8,
-    },
-    marginBottom: 32,
+    paddingBottom: 32,
   },
   wateringSunflower: {
     maxWidth: '100%',
@@ -38,10 +30,10 @@ const useStyles = makeStyles((theme) => ({
     float: 'right',
     marginTop: 24,
     marginBottom: 24,
-    fontFamily: 'Poppins',
     maxWidth: 1000,
   },
   titleContainer: {
+    background: '#1282B2',
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
@@ -51,21 +43,21 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   imageContainer: {
+    background: '#1282B2',
     display: 'flex',
     justifyContent: 'left',
     [theme.breakpoints.down('sm')]: {
       justifyContent: 'center',
     },
+    padding: 16,
   },
-  intro: {
-    maxWidth: 640,
-    fontFamily: 'Poppins',
-    textAlign: 'justify',
-  },
-  introContainer: {
+  container: {
     display: 'flex',
     justifyContent: 'center',
-    marginTop: 32,
+    padding: 32,
+    [theme.breakpoints.down('sm')]: {
+      padding: '32px 8px 32px 8px',
+    },
   },
 }));
 
@@ -74,7 +66,7 @@ const HomePage = () => {
 
   return (
     <div className={classes.root}>
-      <Grid container className={classes.rectangle67}>
+      <Grid container>
         <Grid item xs={12} md={8} className={classes.titleContainer}>
           <Typography variant="h1" className={classes.title}>
             Collaborative Content Recommendations
@@ -83,17 +75,34 @@ const HomePage = () => {
         <Grid item xs={12} md={4} className={classes.imageContainer}>
           <img src="/svg/Watering.svg" className={classes.wateringSunflower} />
         </Grid>
-      </Grid>
-      <Grid container className={classes.content}>
-        <Grid item xs={12} className={classes.introContainer}>
-          <Typography paragraph className={classes.intro}>
-            Tournesol is an <strong>open source</strong> platform which aims to{' '}
-            <strong>collaboratively</strong> identify top videos of public
-            utility by eliciting contributors&apos; judgements on content
-            quality. We hope to contribute to making today&apos;s and
-            tomorrow&apos;s large-scale algorithms{' '}
-            <strong>robustly beneficial</strong> for all of humanity.
-          </Typography>
+        <Grid item xs={12} className={classes.container}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            maxWidth="640px"
+            alignItems="flex-start"
+          >
+            <Typography variant="h1">What is Tournesol?</Typography>
+            <Typography paragraph>
+              Tournesol is an <strong>open source</strong> platform which aims
+              to <strong>collaboratively</strong> identify top videos of public
+              utility by eliciting contributors&apos; judgements on content
+              quality. We hope to contribute to making today&apos;s and
+              tomorrow&apos;s large-scale algorithms{' '}
+              <strong>robustly beneficial</strong> for all of humanity.
+            </Typography>
+          </Box>
+        </Grid>
+        <Grid
+          item
+          xs={12}
+          className={classes.container}
+          style={{ background: '#1282B2' }}
+        >
+          <ExtensionSection />
+        </Grid>
+        <Grid item xs={12} className={classes.container}>
+          <ContributeSection />
         </Grid>
       </Grid>
     </div>

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -29,6 +29,19 @@ export const theme = responsiveFontSizes(
         fontSize: '1.5rem',
         fontWeight: 600,
       },
+      fontFamily: [
+        'Poppins',
+        '-apple-system',
+        'BlinkMacSystemFont',
+        '"Segoe UI"',
+        'Roboto',
+        '"Helvetica Neue"',
+        'Arial',
+        'sans-serif',
+        '"Apple Color Emoji"',
+        '"Segoe UI Emoji"',
+        '"Segoe UI Symbol"',
+      ].join(','),
     },
     overrides: {
       MuiDrawer: {


### PR DESCRIPTION
Changes to the HomePage based on PolyConseil's feedback.

Next steps may be to include the comparison interface and correctly handle signing up the user when a comparison is submitted. Currently clicking "compare videos now" leads to the login/signup page

<img width="762" alt="Screenshot 2021-11-21 at 11 42 04" src="https://user-images.githubusercontent.com/8818081/142758659-329d511c-6f69-41a6-b0ef-1af8923b4862.png">
