### PR TITLE
Extend API to handle `is_public` update in ContributorRating

### DIFF
--- a/backend/ml/management/commands/ml_train.py
+++ b/backend/ml/management/commands/ml_train.py
@@ -107,7 +107,6 @@ def save_data(video_scores, contributor_rating_scores):
             ContributorRating(
                 video_id=video_id,
                 user_id=contributor_id,
-                is_public=False,
             )
             for contributor_id, video_id in ratings_to_create
         ]

--- a/backend/tournesol/migrations/0013_create_all_contributor_ratings.py
+++ b/backend/tournesol/migrations/0013_create_all_contributor_ratings.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+
+
+def forward_func(apps, schema_editor):
+    """
+    Create missing instances of ContributorRating for all existing Comparisons
+    (including non-trusted users, for which no rating has been computed by ML),
+    in order to store the 'is_public' flag related to every pair (user, video).
+    """
+    ContributorRating = apps.get_model("tournesol", "ContributorRating")
+    Comparison = apps.get_model("tournesol", "Comparison")
+    user_video_pairs = set(
+        Comparison.objects.all().values_list("user_id", "video_1_id").distinct()
+    )
+    user_video_pairs.update(
+        Comparison.objects.all().values_list("user_id", "video_2_id").distinct()
+    )
+    ContributorRating.objects.bulk_create(
+        [
+            ContributorRating(user_id=user_id, video_id=video_id)
+            for (user_id, video_id) in user_video_pairs
+        ],
+        batch_size=1000,
+        ignore_conflicts=True,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tournesol", "0012_auto_20211021_0922"),
+    ]
+
+    operations = [
+        migrations.RunPython(code=forward_func, reverse_code=migrations.RunPython.noop)
+    ]

--- a/backend/tournesol/migrations/0014_create_all_contributor_ratings.py
+++ b/backend/tournesol/migrations/0014_create_all_contributor_ratings.py
@@ -27,7 +27,7 @@ def forward_func(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("tournesol", "0012_auto_20211021_0922"),
+        ("tournesol", "0013_add_tag_model"),
     ]
 
     operations = [

--- a/backend/tournesol/models/video.py
+++ b/backend/tournesol/models/video.py
@@ -136,7 +136,7 @@ class Video(models.Model, WithFeatures, WithEmbedding):
         self.rating_n_contributors = Comparison.objects.filter(
             Q(video_1=self) | Q(video_2=self)
         ).distinct("user").count()
-        self.save()
+        self.save(update_fields=['rating_n_ratings', 'rating_n_contributors'])
 
     COMPUTED_PROPERTIES = [
         "n_public_contributors",

--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -265,8 +265,8 @@ class ContributorCriteriaScore(ModelSerializer):
 
 
 class ContributorRatingSerializer(ModelSerializer):
-    video = VideoSerializer()
-    criteria_scores = ContributorCriteriaScore(many=True)
+    video = VideoSerializer(read_only=True)
+    criteria_scores = ContributorCriteriaScore(many=True, read_only=True)
 
     class Meta:
         model = ContributorRating

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -15,11 +15,13 @@ class RatingApi(TestCase):
     _other_user = "random_user"
 
     def setUp(self):
-        user1 = User.objects.create(username=self._user)
-        user2 = User.objects.create(username=self._other_user)
+        self.user1 = User.objects.create(username=self._user)
+        self.user2 = User.objects.create(username=self._other_user)
         video1 = Video.objects.create(video_id='RD4g4XLGFTDG8')
-        ContributorRating.objects.create(video=video1, user=user1)
-        ContributorRating.objects.create(video=video1, user=user2)
+        video2 = Video.objects.create(video_id='RD4g4XLGFTDG9')
+        ContributorRating.objects.create(video=video1, user=self.user1, is_public=False)
+        ContributorRating.objects.create(video=video1, user=self.user2, is_public=False)
+        ContributorRating.objects.create(video=video2, user=self.user2, is_public=True)
 
     def test_anonymous_cant_list(self):
         factory = APIClient()
@@ -31,11 +33,9 @@ class RatingApi(TestCase):
 
     def test_authenticated_can_list(self):
         factory = APIClient()
-        user = User.objects.get(username=self._user)
-        factory.force_authenticate(user=user)
+        factory.force_authenticate(user=self.user1)
         response = factory.get(
             "/users/me/contributor_ratings/",
-            args=[user.username],
             format="json"
         )
         self.assertEqual(response.data["count"], 1)
@@ -43,30 +43,26 @@ class RatingApi(TestCase):
 
     def test_authenticated_cant_create(self):
         factory = APIClient()
-        user = User.objects.get(username=self._user)
-        factory.force_authenticate(user=user)
+        factory.force_authenticate(user=self.user1)
         response = factory.post(
             "/users/me/contributor_ratings/",
             {'video_id': 'NeADlWSDFAQ'},
-            args=[user.username],
             format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_authenticated_fetch_non_existing_video(self):
         factory = APIClient()
-        user = User.objects.get(username=self._user)
-        factory.force_authenticate(user=user)
+        factory.force_authenticate(user=self.user1)
         response = factory.get(
             "/users/me/contributor_ratings/NeADlWSDFAQ/",
-            args=[user.username],
             format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_authenticated_fetch_existing_video(self):
         factory = APIClient()
-        user = User.objects.get(username=self._user)
+        user = self.user1
         factory.force_authenticate(user=user)
         video = Video.objects.create(video_id='6QDWbKnwRcc')
         rating = ContributorRating.objects.create(video=video, user=user)
@@ -79,7 +75,6 @@ class RatingApi(TestCase):
 
         response = factory.get(
             "/users/me/contributor_ratings/6QDWbKnwRcc/",
-            args=[user.username],
             format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -90,3 +85,39 @@ class RatingApi(TestCase):
             "score": 1,
             "uncertainty": 2,
         }])
+
+    def test_ratings_list_with_filter(self):
+        client = APIClient()
+        client.force_authenticate(self.user2)
+
+        response = client.get(
+            "/users/me/contributor_ratings/?is_public=false",
+            format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["video"]["video_id"], "RD4g4XLGFTDG8")
+
+        response = client.get(
+            "/users/me/contributor_ratings/?is_public=true",
+            format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["video"]["video_id"], "RD4g4XLGFTDG9")
+
+    def test_patch_rating_is_public(self):
+        client = APIClient()
+        client.force_authenticate(self.user1)
+        rating = ContributorRating.objects.get(user=self.user1)
+
+        self.assertEqual(rating.is_public, False)
+        response = client.patch(
+            "/users/me/contributor_ratings/RD4g4XLGFTDG8/",
+            data={"is_public": True},
+            format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["is_public"], True, response.json())
+        rating.refresh_from_db()
+        self.assertEqual(rating.is_public, True)

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -4,6 +4,7 @@ API endpoints to interact with the contributor's comparisons
 
 from django.db.models import ObjectDoesNotExist, Q
 from django.http import Http404
+from django.db import transaction
 from drf_spectacular.utils import extend_schema
 
 from rest_framework import generics, mixins, status, exceptions
@@ -89,6 +90,7 @@ class ComparisonListApi(
         """List all comparisons made by the logged user."""
         return self.list(request, *args, **kwargs)
 
+    @transaction.atomic
     def perform_create(self, serializer):
         if self.comparison_already_exists(self.request):
             raise exceptions.ValidationError(

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -6,10 +6,10 @@ from django.db.models import ObjectDoesNotExist, Q
 from django.http import Http404
 from drf_spectacular.utils import extend_schema
 
-from rest_framework import generics, mixins, status
+from rest_framework import generics, mixins, status, exceptions
 from rest_framework.response import Response
 
-from ..models import Comparison, Video
+from ..models import Comparison, ContributorRating
 from ..serializers import ComparisonSerializer, ComparisonUpdateSerializer
 
 
@@ -89,19 +89,22 @@ class ComparisonListApi(
         """List all comparisons made by the logged user."""
         return self.list(request, *args, **kwargs)
 
-    def post(self, request, *args, **kwargs):
-        """Create a new comparison, paired with the logged user."""
-        if self.comparison_already_exists(request):
-            return self.response_400_video_already_exists(request)
+    def perform_create(self, serializer):
+        if self.comparison_already_exists(self.request):
+            raise exceptions.ValidationError(
+                "You've already compared {0} with {1}.".format(
+                    self.request.data['video_a']['video_id'],
+                    self.request.data['video_b']['video_id']
+                )
+            )
+        comparison: Comparison = serializer.save()
+        comparison.video_1.update_n_ratings()
+        comparison.video_2.update_n_ratings()
+        ContributorRating.objects.get_or_create(user=self.request.user, video=comparison.video_1)
+        ContributorRating.objects.get_or_create(user=self.request.user, video=comparison.video_2)
 
-        response = self.create(request, *args, **kwargs)
-        if response.status_code == status.HTTP_201_CREATED:
-            # Update video_a and video_b ratings
-            video_a = Video.objects.get(video_id=request.data['video_a']['video_id'])
-            video_a.update_n_ratings()
-            video_b = Video.objects.get(video_id=request.data['video_b']['video_id'])
-            video_b.update_n_ratings()
-        return response
+    def post(self, request, *args, **kwargs):
+        return self.create(request, *args, **kwargs)
 
 
 class ComparisonListFilteredApi(ComparisonListBaseApi):

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -51,6 +51,6 @@ class ContributorRatingList(generics.ListAPIView):
                 ratings = ratings.filter(is_public=False)
             else:
                 raise exceptions.ValidationError(
-                    "'is_public' query param should be 'true' or 'false'"
+                    "'is_public' query param must be 'true' or 'false'"
                 )
         return ratings

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -9,7 +9,7 @@ from ..models import ContributorRating
 from ..serializers import ContributorRatingSerializer
 
 
-class ContributorRatingDetail(generics.RetrieveAPIView):
+class ContributorRatingDetail(generics.RetrieveUpdateAPIView):
     """
     Retrieve the logged in user's ratings for a specific video
     (computed automatically from the user's comparisons)

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -3,7 +3,9 @@ API endpoint to manipulate contributor ratings
 """
 
 from django.shortcuts import get_object_or_404
-from rest_framework import generics
+from rest_framework import generics, exceptions
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 
 from ..models import ContributorRating
 from ..serializers import ContributorRatingSerializer
@@ -24,6 +26,13 @@ class ContributorRatingDetail(generics.RetrieveUpdateAPIView):
         )
 
 
+@extend_schema_view(
+    get=extend_schema(
+        parameters=[
+            OpenApiParameter("is_public", OpenApiTypes.BOOL, OpenApiParameter.QUERY)
+        ]
+    )
+)
 class ContributorRatingList(generics.ListAPIView):
     """
     Retrieve the logged in user's ratings per video
@@ -33,4 +42,15 @@ class ContributorRatingList(generics.ListAPIView):
     queryset = ContributorRating.objects.none()
 
     def get_queryset(self):
-        return ContributorRating.objects.filter(user=self.request.user)
+        ratings = ContributorRating.objects.filter(user=self.request.user)
+        is_public = self.request.query_params.get('is_public')
+        if is_public:
+            if is_public == "true":
+                ratings = ratings.filter(is_public=True)
+            elif is_public == "false":
+                ratings = ratings.filter(is_public=False)
+            else:
+                raise exceptions.ValidationError(
+                    "'is_public' query param should be 'true' or 'false'"
+                )
+        return ratings


### PR DESCRIPTION
Related to #274 

The boolean `is_public` was already defined in `ContributorRating`. This flag represents whether the contributions of a user related to a specific video should be public (included to the public dataset, associated with the username), or private (only used to compute aggregated scores, without publishing the details about the ratings, comparisons, etc.).

## Changes

* `is_public` can be updated via  `PATCH /users/me/contributor_ratings/<video_id>/`
* `ContributorRating` objects, related to the pair (user, video) will be created when a new comparison is submitted, if the relevant objects don't exist yet. For now, the default value for `is_public` is always "false".
* A custom migration has been implemented to create missing `ContributorRating` objects, related to all `Comparisons` that already exist in the database.
* The list of contributor ratings (`GET /users/me/contributor_ratings/`) can be filtered with `?is_public=true` or `is_public=false`.

## Questions

* Should an additional endpoint be implemented to allow a user to update `is_public` values for all their ratings at once?
* Should we also persist in the database a user preference, whose value would be used as a default value for `is_public` when a new comparison is created?