### PR TITLE
(#194) [front] feat: revoke access token at logout

### DIFF
--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import clsx from 'clsx';
+import { useSnackbar } from 'notistack';
+
 import { makeStyles } from '@material-ui/core/styles';
 import { Button, Grid } from '@material-ui/core';
-import { Link } from 'react-router-dom';
 import { AccountCircle } from '@material-ui/icons';
 
 import { useLoginState } from 'src/hooks';
 import { revokeAccessToken } from '../../../login/loginAPI';
+import { contactAdministratorLowSeverity } from '../../../../utils/notifications';
 
 const useStyles = makeStyles({
   AccountInfo: {
@@ -31,12 +34,19 @@ const useStyles = makeStyles({
 });
 
 const LoggedInActions = () => {
+  const { enqueueSnackbar } = useSnackbar();
+
   const classes = useStyles();
   const { logout, loginState } = useLoginState();
 
   const logoutProcess = async () => {
     if (loginState.access_token) {
-      await revokeAccessToken(loginState.access_token);
+      await revokeAccessToken(loginState.access_token).catch(() => {
+        contactAdministratorLowSeverity(
+          enqueueSnackbar,
+          'A non impacting error occurred during your logout.'
+        );
+      });
     }
     logout();
   };

--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -40,8 +40,8 @@ const LoggedInActions = () => {
   const { logout, loginState } = useLoginState();
 
   const logoutProcess = async () => {
-    if (loginState.access_token) {
-      await revokeAccessToken(loginState.access_token).catch(() => {
+    if (loginState.refresh_token) {
+      await revokeAccessToken(loginState.refresh_token).catch(() => {
         contactAdministratorLowSeverity(
           enqueueSnackbar,
           'A non impacting error occurred during your logout.'

--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { AccountCircle } from '@material-ui/icons';
 
 import { useLoginState } from 'src/hooks';
+import { revokeAccessToken } from '../../../login/loginAPI';
 
 const useStyles = makeStyles({
   AccountInfo: {
@@ -33,11 +34,18 @@ const LoggedInActions = () => {
   const classes = useStyles();
   const { logout, loginState } = useLoginState();
 
+  const logoutProcess = async () => {
+    if (loginState.access_token) {
+      await revokeAccessToken(loginState.access_token);
+    }
+    logout();
+  };
+
   return (
     <>
       <Button
         variant="outlined"
-        onClick={logout}
+        onClick={logoutProcess}
         className={classes.HeaderButton}
       >
         Logout

--- a/frontend/src/features/login/loginAPI.ts
+++ b/frontend/src/features/login/loginAPI.ts
@@ -82,3 +82,20 @@ export const fetchTokenFromRefresh = async (refresh_token: string) => {
   });
   return { data: jresp };
 };
+
+export const revokeAccessToken = async (token: string) => {
+  const params = new URLSearchParams();
+  params.append('token', token);
+  params.append('client_id', client_id);
+  params.append('client_secret', client_secret);
+  const response = await fetch(api_url + '/o/revoke_token/', {
+    method: 'POST',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  return response;
+};

--- a/frontend/src/features/login/loginAPI.ts
+++ b/frontend/src/features/login/loginAPI.ts
@@ -88,6 +88,7 @@ export const revokeAccessToken = async (token: string) => {
   params.append('token', token);
   params.append('client_id', client_id);
   params.append('client_secret', client_secret);
+  params.append('token_type_hint', 'refresh_token');
   const response = await fetch(api_url + '/o/revoke_token/', {
     method: 'POST',
     mode: 'cors',

--- a/frontend/src/utils/notifications.ts
+++ b/frontend/src/utils/notifications.ts
@@ -25,7 +25,7 @@ export const contactAdministrator = (
 /**
  * Display an info alert, followed by an invitation to report an issue.
  *
- * Contrary to `contactAdministrator` this function always use the info alert
+ * Contrary to `contactAdministrator` this function use only the info alert
  * variant to notify the user of the presence of non-impacting error. It should
  * not be used to report blocking errors or errors requiring an action from the
  * user.
@@ -38,7 +38,7 @@ export const contactAdministratorLowSeverity = (
     message = 'Oops, a non impacting error occurred.';
   }
   display('Please, contact an administrator to report the issue.', {
-    variant: 'warning',
+    variant: 'info',
   });
   display(message, { variant: 'info' });
 };

--- a/frontend/src/utils/notifications.ts
+++ b/frontend/src/utils/notifications.ts
@@ -2,8 +2,8 @@ import React from 'react';
 import { ProviderContext, VariantType } from 'notistack';
 
 /**
- * Display an alert variant, followed by an invitation to reach an
- * administrator.
+ * Display an alert variant of any type, followed by an invitation to retry
+ * later, or reach an administrator.
  */
 export const contactAdministrator = (
   display: ProviderContext['enqueueSnackbar'],
@@ -20,6 +20,27 @@ export const contactAdministrator = (
     }
   );
   display(message, { variant: variant });
+};
+
+/**
+ * Display an info alert, followed by an invitation to report an issue.
+ *
+ * Contrary to `contactAdministrator` this function always use the info alert
+ * variant to notify the user of the presence of non-impacting error. It should
+ * not be used to report blocking errors or errors requiring an action from the
+ * user.
+ */
+export const contactAdministratorLowSeverity = (
+  display: ProviderContext['enqueueSnackbar'],
+  message?: string
+) => {
+  if (!message) {
+    message = 'Oops, a non impacting error occurred.';
+  }
+  display('Please, contact an administrator to report the issue.', {
+    variant: 'warning',
+  });
+  display(message, { variant: 'info' });
 };
 
 export const showSuccessAlert = (


### PR DESCRIPTION
Fixes #194 

I added a `logoutProcess` function, in the login / logout component, responsible of calling all logout routines. At the moment there are only two steps: revoking the token, and logout the currently logged user.

Django OAuth Toolkit doc: https://django-oauth-toolkit.readthedocs.io/en/latest/tutorial/tutorial_04.html?highlight=revoke#setup-a-request