### PR TITLE
feat(backend): Implement ContributorRating initialization endpoint

### DIFF
--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -302,6 +302,14 @@ class ContributorRatingCreateSerializer(ContributorRatingSerializer):
             video = Video.objects.get(video_id=video_id)
         except Video.DoesNotExist:
             raise ValidationError(f"Video with video_id '{video_id}' does not exist")
+
+        user = self.context["request"].user
+        if user.contributorvideoratings.filter(video=video).exists():
+            raise ValidationError(
+                "A ContributorRating already exists for this (user, video)",
+                code='unique',
+            )
+
         attrs["video"] = video
-        attrs["user"] = self.context["request"].user
+        attrs["user"] = user
         return attrs

--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -3,19 +3,29 @@ Serializer used by Tournesol's API
 """
 
 from django.db import transaction
-from django.db.models import ObjectDoesNotExist
+from django.db.models import ObjectDoesNotExist, Q
 
 from rest_framework import serializers
+from rest_framework.fields import RegexField, SerializerMethodField
 from rest_framework.serializers import Serializer, ModelSerializer
+from rest_framework.exceptions import ValidationError
+from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.types import OpenApiTypes
 
+from core.utils.constants import YOUTUBE_VIDEO_ID_REGEX
 from .models import (
-    Comparison, ComparisonCriteriaScore, Video, VideoRateLater,
-    VideoCriteriaScore, ContributorRating, ContributorRatingCriteriaScore, Tag
+    Comparison,
+    ComparisonCriteriaScore,
+    Video,
+    VideoRateLater,
+    VideoCriteriaScore,
+    ContributorRating,
+    ContributorRatingCriteriaScore,
+    Tag,
 )
 
 
 class VideoSerializer(ModelSerializer):
-
     class Meta:
         model = Video
         fields = [
@@ -60,9 +70,8 @@ class VideoReadOnlySerializer(Serializer):
 
     ex: adding a new Comparison shouldn't create new Video in the database
     """
-    video_id = serializers.CharField(
-        max_length=20
-    )
+
+    video_id = serializers.CharField(max_length=20)
 
     class Meta:
         fields = ["video_id"]
@@ -74,7 +83,6 @@ class VideoReadOnlySerializer(Serializer):
             raise serializers.ValidationError(
                 "The video with id '{}' does not exist.".format(value)
             )
-
         return value
 
 
@@ -135,6 +143,7 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
 
     Use `ComparisonUpdateSerializer` for the update operation.
     """
+
     video_a = VideoReadOnlySerializer(source="video_1")
     video_b = VideoReadOnlySerializer(source="video_2")
     criteria_scores = ComparisonCriteriaScoreSerializer(many=True)
@@ -142,9 +151,7 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
 
     class Meta:
         model = Comparison
-        fields = [
-            "user", "video_a", "video_b", "criteria_scores", "duration_ms"
-        ]
+        fields = ["user", "video_a", "video_b", "criteria_scores", "duration_ms"]
 
     def to_representation(self, instance):
         """
@@ -174,14 +181,15 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
         default_duration_ms = Comparison._meta.get_field("duration_ms").get_default()
 
         comparison = Comparison.objects.create(
-            video_1=video_1, video_2=video_2, user=validated_data.get("user"),
-            duration_ms=validated_data.get("duration_ms", default_duration_ms)
+            video_1=video_1,
+            video_2=video_2,
+            user=validated_data.get("user"),
+            duration_ms=validated_data.get("duration_ms", default_duration_ms),
         )
 
         for criteria_score in validated_data.pop("criteria_scores"):
             ComparisonCriteriaScore.objects.create(
-                comparison=comparison,
-                **criteria_score
+                comparison=comparison, **criteria_score
             )
 
         return comparison
@@ -196,13 +204,12 @@ class ComparisonUpdateSerializer(ComparisonSerializerMixin, ModelSerializer):
 
     Use `ComparisonSerializer` for all other operations.
     """
+
     criteria_scores = ComparisonCriteriaScoreSerializer(many=True)
 
     class Meta:
         model = Comparison
-        fields = [
-            "criteria_scores", "duration_ms"
-        ]
+        fields = ["criteria_scores", "duration_ms"]
 
     def to_representation(self, instance):
         """
@@ -212,10 +219,7 @@ class ComparisonUpdateSerializer(ComparisonSerializerMixin, ModelSerializer):
         Also add `video_a` and `video_b` fields to make the representation
         consistent across all comparison serializers.
         """
-        ret = super(
-            ComparisonUpdateSerializer,
-            self
-        ).to_representation(instance)
+        ret = super(ComparisonUpdateSerializer, self).to_representation(instance)
 
         video_1_repr = VideoReadOnlySerializer().to_representation(instance.video_1)
         video_2_repr = VideoReadOnlySerializer().to_representation(instance.video_2)
@@ -267,7 +271,37 @@ class ContributorCriteriaScore(ModelSerializer):
 class ContributorRatingSerializer(ModelSerializer):
     video = VideoSerializer(read_only=True)
     criteria_scores = ContributorCriteriaScore(many=True, read_only=True)
+    n_comparisons = SerializerMethodField(
+        help_text="Number of comparisons submitted by the current user about the current video",
+    )
 
     class Meta:
         model = ContributorRating
-        fields = ["video", "is_public", "criteria_scores"]
+        fields = ["video", "is_public", "criteria_scores", "n_comparisons"]
+
+    @extend_schema_field(OpenApiTypes.INT)
+    def get_n_comparisons(self, obj):
+        if hasattr(obj, "n_comparisons"):
+            # Use annotated field if it has been defined by the queryset
+            return obj.n_comparisons
+        return obj.user.comparisons.filter(
+            Q(video_1=obj.video) | Q(video_2=obj.video)
+        ).count()
+
+
+class ContributorRatingCreateSerializer(ContributorRatingSerializer):
+    video_id = RegexField(YOUTUBE_VIDEO_ID_REGEX, write_only=True)
+
+    class Meta:
+        model = ContributorRating
+        fields = ["video_id", "is_public", "video", "criteria_scores", "n_comparisons"]
+
+    def validate(self, attrs):
+        video_id = attrs.pop("video_id")
+        try:
+            video = Video.objects.get(video_id=video_id)
+        except Video.DoesNotExist:
+            raise ValidationError(f"Video with video_id '{video_id}' does not exist")
+        attrs["video"] = video
+        attrs["user"] = self.context["request"].user
+        return attrs

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -70,6 +70,17 @@ class RatingApi(TestCase):
         self.assertEqual(response.data["is_public"], True)
         self.assertEqual(response.data["n_comparisons"], 0)
 
+        # Create the same rating object raises a validation error
+        response = factory.post(
+            "/users/me/contributor_ratings/",
+            {
+                'video_id': 'video-id-03',
+                'is_public': True
+            },
+            format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_authenticated_fetch_non_existing_video(self):
         factory = APIClient()
         factory.force_authenticate(user=self.user1)

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -3,7 +3,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from core.models import User
-from tournesol.models import Video, ContributorRating, ContributorRatingCriteriaScore
+from tournesol.models import Comparison, Video, ContributorRating, ContributorRatingCriteriaScore
 
 
 class RatingApi(TestCase):
@@ -17,8 +17,11 @@ class RatingApi(TestCase):
     def setUp(self):
         self.user1 = User.objects.create(username=self._user)
         self.user2 = User.objects.create(username=self._other_user)
-        video1 = Video.objects.create(video_id='RD4g4XLGFTDG8')
-        video2 = Video.objects.create(video_id='RD4g4XLGFTDG9')
+        video1 = Video.objects.create(video_id='4g4XLGFTDG8')
+        video2 = Video.objects.create(video_id='4g4XLGFTDG9')
+        video3 = Video.objects.create(video_id='video-id-03')
+        Comparison.objects.create(video_1=video1, video_2=video2, user=self.user1)
+        Comparison.objects.create(video_1=video1, video_2=video2, user=self.user2)
         ContributorRating.objects.create(video=video1, user=self.user1, is_public=False)
         ContributorRating.objects.create(video=video1, user=self.user2, is_public=False)
         ContributorRating.objects.create(video=video2, user=self.user2, is_public=True)
@@ -41,7 +44,7 @@ class RatingApi(TestCase):
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_authenticated_cant_create(self):
+    def test_authenticated_cant_create_rating_about_non_existing_video(self):
         factory = APIClient()
         factory.force_authenticate(user=self.user1)
         response = factory.post(
@@ -49,7 +52,23 @@ class RatingApi(TestCase):
             {'video_id': 'NeADlWSDFAQ'},
             format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_authenticated_initialize_rating_as_public(self):
+        factory = APIClient()
+        factory.force_authenticate(user=self.user1)
+        response = factory.post(
+            "/users/me/contributor_ratings/",
+            {
+                'video_id': 'video-id-03',
+                'is_public': True
+            },
+            format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["video"]["video_id"], "video-id-03")
+        self.assertEqual(response.data["is_public"], True)
+        self.assertEqual(response.data["n_comparisons"], 0)
 
     def test_authenticated_fetch_non_existing_video(self):
         factory = APIClient()
@@ -85,6 +104,7 @@ class RatingApi(TestCase):
             "score": 1,
             "uncertainty": 2,
         }])
+        self.assertEqual(response.data["n_comparisons"], 0)
 
     def test_ratings_list_with_filter(self):
         client = APIClient()
@@ -96,7 +116,7 @@ class RatingApi(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
-        self.assertEqual(response.json()["results"][0]["video"]["video_id"], "RD4g4XLGFTDG8")
+        self.assertEqual(response.json()["results"][0]["video"]["video_id"], "4g4XLGFTDG8")
 
         response = client.get(
             "/users/me/contributor_ratings/?is_public=true",
@@ -104,7 +124,7 @@ class RatingApi(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
-        self.assertEqual(response.json()["results"][0]["video"]["video_id"], "RD4g4XLGFTDG9")
+        self.assertEqual(response.json()["results"][0]["video"]["video_id"], "4g4XLGFTDG9")
 
     def test_patch_rating_is_public(self):
         client = APIClient()
@@ -113,7 +133,7 @@ class RatingApi(TestCase):
 
         self.assertEqual(rating.is_public, False)
         response = client.patch(
-            "/users/me/contributor_ratings/RD4g4XLGFTDG8/",
+            "/users/me/contributor_ratings/4g4XLGFTDG8/",
             data={"is_public": True},
             format="json"
         )

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -23,12 +23,21 @@ RatingsWithAnnotations = ContributorRating.objects.annotate(
 )
 
 
+@extend_schema_view(
+    get=extend_schema(
+        description="Retrieve the logged-in user's ratings for a specific video "
+        "(computed automatically from the user's comparisons)"
+    ),
+    put=extend_schema(
+        description="Update public / private status of the logged-in user ratings "
+        "for a specific video."
+    ),
+    patch=extend_schema(
+        description="Update public / private status of the logged-in user ratings "
+        "for a specific video."
+    ),
+)
 class ContributorRatingDetail(generics.RetrieveUpdateAPIView):
-    """
-    Retrieve the logged in user's ratings for a specific video
-    (computed automatically from the user's comparisons)
-    """
-
     serializer_class = ContributorRatingSerializer
 
     def get_object(self):

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -3,12 +3,24 @@ API endpoint to manipulate contributor ratings
 """
 
 from django.shortcuts import get_object_or_404
+from django.db.models import Count, F, Q
 from rest_framework import generics, exceptions
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 
 from ..models import ContributorRating
-from ..serializers import ContributorRatingSerializer
+from ..serializers import ContributorRatingSerializer, ContributorRatingCreateSerializer
+
+
+RatingsWithAnnotations = ContributorRating.objects.annotate(
+    n_comparisons=Count(
+        "user__comparisons",
+        filter=(
+            Q(user__comparisons__video_1=F("video"))
+            | Q(user__comparisons__video_2=F("video"))
+        ),
+    )
+)
 
 
 class ContributorRatingDetail(generics.RetrieveUpdateAPIView):
@@ -16,34 +28,43 @@ class ContributorRatingDetail(generics.RetrieveUpdateAPIView):
     Retrieve the logged in user's ratings for a specific video
     (computed automatically from the user's comparisons)
     """
+
     serializer_class = ContributorRatingSerializer
 
     def get_object(self):
         return get_object_or_404(
-            ContributorRating,
+            RatingsWithAnnotations,
             video__video_id=self.kwargs["video_id"],
-            user=self.request.user
+            user=self.request.user,
         )
 
 
 @extend_schema_view(
     get=extend_schema(
+        description="Retrieve the logged in user's ratings per video "
+        "(computed automatically from the user's comparisons).",
         parameters=[
             OpenApiParameter("is_public", OpenApiTypes.BOOL, OpenApiParameter.QUERY)
-        ]
-    )
+        ],
+    ),
+    post=extend_schema(
+        description="Initialize the rating object for the current user about a "
+        "specific video, with optional visibility settings."
+    ),
 )
-class ContributorRatingList(generics.ListAPIView):
-    """
-    Retrieve the logged in user's ratings per video
-    (computed automatically from the user's comparisons)
-    """
-    serializer_class = ContributorRatingSerializer
+class ContributorRatingList(generics.ListCreateAPIView):
     queryset = ContributorRating.objects.none()
 
+    def get_serializer_class(self):
+        if self.request.method == "POST":
+            return ContributorRatingCreateSerializer
+        return ContributorRatingSerializer
+
     def get_queryset(self):
-        ratings = ContributorRating.objects.filter(user=self.request.user)
-        is_public = self.request.query_params.get('is_public')
+        ratings = RatingsWithAnnotations.filter(
+            user=self.request.user, n_comparisons__gt=0
+        )
+        is_public = self.request.query_params.get("is_public")
         if is_public:
             if is_public == "true":
                 ratings = ratings.filter(is_public=True)


### PR DESCRIPTION
:warning: Depends on #315 

* New endpoint `POST /users/me/contributors_ratings/` to initialize a rating about a specific video, with an optional `is_public` preference.  
This endpoint will typically be called before a user submits their first comparison about a video.

* The `ContributorRating` serializers include a new field `n_comparisons` (= the count of comparisons by the authenticated user about the current video)