### PR TITLE
fix(backend): Fix OpenAPI schema for `VideoViewSet`

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -268,6 +268,7 @@ CRITERIAS = list(CRITERIAS_DICT.keys())
 MAX_FEATURE_WEIGHT = 8
 
 SPECTACULAR_SETTINGS = {
+    'SORT_OPERATION_PARAMETERS': False,
     "SWAGGER_UI_SETTINGS": {
         "deepLinking": True,
         "persistAuthorization": True,

--- a/backend/tournesol/tests/test_api_video.py
+++ b/backend/tournesol/tests/test_api_video.py
@@ -305,7 +305,16 @@ class VideoApi(TestCase):
         response = factory.get("/video/video_id_01/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["video_id"], 'video_id_01')
-    
+
+    def test_get_video_with_score_zero(self):
+        # The default filter used to fetch a list should not be applied to retrieve a single video
+        factory = APIClient()
+        video_null_score = 'vid_score_0'
+        Video.objects.create(video_id=video_null_score)
+        response = factory.get("/video/vid_score_0/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["video_id"], 'vid_score_0')
+
     def test_get_non_existing_video(self):
         factory = APIClient()
         response = factory.get("/video/video_id_00/")


### PR DESCRIPTION
* The parameter `video_id` was not correctly defined as a string for route `GET /video/{video_id}/`.
  The attribute [`lookup_field`](https://www.django-rest-framework.org/api-guide/generic-views/#attributes) is defined in `VideoViewSet` to take advantage of DRF mixins.

* All query parameters to filter videos recommendations are now defined explicitly in the schema.