### PR TITLE
fix(backend): Incorrect video list order when a video matches 'search' query on multiple tags

### DIFF
--- a/backend/tournesol/tests/test_api_video.py
+++ b/backend/tournesol/tests/test_api_video.py
@@ -381,3 +381,18 @@ class VideoApi(TestCase):
         resp = client.get('/video/?date_lte=03-01-21-00-00-00')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data["count"], 3)
+
+    def test_search_in_tags_should_not_affect_order(self):
+        video1 = Video.objects.get(video_id=self._video_id_01)
+        video1.tags.create(name="tag1")
+        video1.tags.create(name="tag2")
+        video1.tags.create(name="tag3")
+        video2 = Video.objects.get(video_id=self._video_id_02)
+        video2.tags.create(name="tag4")
+
+        client = APIClient()
+        resp = client.get('/video/?search=tag')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data["results"]), 2)
+        # Video2 with higher score should remain listed as the top video
+        self.assertEqual(resp.data["results"][0]["video_id"], self._video_id_02)

--- a/backend/tournesol/views/video.py
+++ b/backend/tournesol/views/video.py
@@ -84,6 +84,8 @@ class VideoViewSet(mixins.CreateModelMixin,
 
         search = request.query_params.get('search')
         if search:
+            # Filtering in a nested queryset is necessary here, to be able to annotate
+            # each video without duplicated scores, due to the m2m field 'tags'.
             queryset = queryset.filter(pk__in=Video.objects.filter(
                 Q(name__icontains=search) |
                 Q(description__icontains=search) |

--- a/backend/tournesol/views/video.py
+++ b/backend/tournesol/views/video.py
@@ -84,11 +84,11 @@ class VideoViewSet(mixins.CreateModelMixin,
 
         search = request.query_params.get('search')
         if search:
-            queryset = queryset.filter(
+            queryset = queryset.filter(pk__in=Video.objects.filter(
                 Q(name__icontains=search) |
                 Q(description__icontains=search) |
                 Q(tags__name__icontains=search)
-            )
+            ))
 
         date_lte = request.query_params.get('date_lte') or ""
         if date_lte:


### PR DESCRIPTION
If multiple tags on the same video matches the "search" query, the `criteria_scores` were counted multiple times, leading to a wrong value for `total_score`, and incorrect order in the results.
This is due to how `tags` is defined as a `ManyToManyField`: filtering on tags may cause several instances of the same video to be included in the queryset before the aggregation of scores is computed.

This change makes sure that each `VideoCriteriaScore` is counted only once for each video. 