### PR TITLE
[front] feat: make PasswordForm disabled during HTTP requests

### DIFF
--- a/frontend/src/features/settings/account/PasswordForm.spec.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.spec.tsx
@@ -123,26 +123,33 @@ describe('change password feature', () => {
     const oldPassword = screen.getByTestId('old_password');
     const password = screen.getByTestId('password');
     const passwordConfirm = screen.getByTestId('password_confirm');
+    const submit = screen.getByText(/UPDATE PASSWORD/i);
+
     return {
       oldPassword,
       password,
       passwordConfirm,
+      submit,
       rendered,
     };
   };
 
   it('handles successful password updates', async () => {
-    const { oldPassword, password, passwordConfirm } = setup();
+    const { oldPassword, password, passwordConfirm, submit } = setup();
 
     fireEvent.change(oldPassword, { target: { value: 'success' } });
     fireEvent.change(password, { target: { value: 'new_passwd' } });
     fireEvent.change(passwordConfirm, { target: { value: 'new_passwd' } });
+    expect(submit).toBeEnabled();
+
     await act(async () => {
-      fireEvent.click(screen.getByText(/UPDATE PASSWORD/i));
+      fireEvent.click(submit);
     });
+
     expect(oldPassword).toHaveValue('');
     expect(password).toHaveValue('');
     expect(passwordConfirm).toHaveValue('');
+    expect(submit).toBeEnabled();
     expect(mockEnqueueSnackbar).toBeCalledTimes(1);
     expect(mockEnqueueSnackbar).toBeCalledWith(
       'Password changed successfully',
@@ -153,17 +160,21 @@ describe('change password feature', () => {
   });
 
   it('handles success body responses containing no detail key', async () => {
-    const { oldPassword, password, passwordConfirm } = setup();
+    const { oldPassword, password, passwordConfirm, submit } = setup();
 
     fireEvent.change(oldPassword, { target: { value: 'success_malformed' } });
     fireEvent.change(password, { target: { value: 'new_passwd' } });
     fireEvent.change(passwordConfirm, { target: { value: 'new_passwd' } });
+    expect(submit).toBeEnabled();
+
     await act(async () => {
-      fireEvent.click(screen.getByText(/UPDATE PASSWORD/i));
+      fireEvent.click(submit);
     });
+
     expect(oldPassword).toHaveValue('');
     expect(password).toHaveValue('');
     expect(passwordConfirm).toHaveValue('');
+    expect(submit).toBeEnabled();
     expect(mockEnqueueSnackbar).toBeCalledTimes(1);
     expect(mockEnqueueSnackbar).toBeCalledWith(
       'Password changed successfully',
@@ -174,17 +185,21 @@ describe('change password feature', () => {
   });
 
   it('handles bad requests and displays all error messages', async () => {
-    const { oldPassword, password, passwordConfirm } = setup();
+    const { oldPassword, password, passwordConfirm, submit } = setup();
 
     fireEvent.change(oldPassword, { target: { value: 'errors' } });
     fireEvent.change(password, { target: { value: 'too_short' } });
     fireEvent.change(passwordConfirm, { target: { value: 'too_short' } });
+    expect(submit).toBeEnabled();
+
     await act(async () => {
-      fireEvent.click(screen.getByText(/UPDATE PASSWORD/i));
+      fireEvent.click(submit);
     });
+
     expect(oldPassword).toHaveValue('errors');
     expect(password).toHaveValue('too_short');
     expect(passwordConfirm).toHaveValue('too_short');
+    expect(submit).toBeEnabled();
     expect(mockEnqueueSnackbar).toBeCalledTimes(2);
     expect(mockEnqueueSnackbar).toBeCalledWith('Old password is not correct', {
       variant: 'error',

--- a/frontend/src/features/settings/account/PasswordForm.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.tsx
@@ -19,12 +19,14 @@ const PasswordForm = () => {
   const [oldPassword, setOldPassword] = useState('');
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [disabled, setDisabled] = React.useState(false);
 
   const passwordConfirmMatches =
     password !== '' && password === passwordConfirm;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    setDisabled(true);
 
     const response: void | Record<string, string> =
       await AccountsService.accountsChangePasswordCreate(
@@ -60,6 +62,7 @@ const PasswordForm = () => {
       setPasswordConfirm('');
       (document.activeElement as HTMLElement).blur();
     }
+    setDisabled(false);
   };
 
   return (
@@ -117,7 +120,13 @@ const PasswordForm = () => {
           />
         </Grid>
         <Grid item>
-          <Button type="submit" color="secondary" fullWidth variant="contained">
+          <Button
+            fullWidth
+            type="submit"
+            color="secondary"
+            variant="contained"
+            disabled={disabled}
+          >
             Update password
           </Button>
         </Grid>

--- a/frontend/src/features/settings/account/PasswordForm.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.tsx
@@ -19,7 +19,7 @@ const PasswordForm = () => {
   const [oldPassword, setOldPassword] = useState('');
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
-  const [disabled, setDisabled] = React.useState(false);
+  const [disabled, setDisabled] = useState(false);
 
   const passwordConfirmMatches =
     password !== '' && password === passwordConfirm;


### PR DESCRIPTION
This PR adds a little improvment to `PasswordForm` component UI/UX.

The submit button is now disabled when an HTTP request is processing, as is the submit button of the login form. The tests have been updated accordingly.

Disabling the submit button adds a visual hint indicating that something is going on in the background and informs the user that his/her action has been correctly submitted.

It also prevents users to click several time in a row on the submit button and might prevent unexpected API or UI behaviours.

I also made a similar PR for the `ProfileForm` here: #341 