### PR TITLE
refactor(frontend): Define reusable components for search filters, tweak appearance

### DIFF
--- a/frontend/src/components/filter/ChoicesFilterSection.tsx
+++ b/frontend/src/components/filter/ChoicesFilterSection.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { Typography, FormControlLabel, Checkbox, Box } from '@material-ui/core';
+import { CheckCircle, CheckCircleOutline } from '@material-ui/icons';
+import { FilterSection } from 'src/components/filter/FilterSection';
+
+interface Props {
+  title: string;
+  value: string;
+  choices: Record<string, string>;
+  onChange: (value: string) => void;
+}
+
+const ChoicesFilterSection = ({ title, value, choices, onChange }: Props) => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.checked) {
+      onChange(event.target.name);
+    } else {
+      onChange('');
+    }
+  };
+
+  return (
+    <FilterSection title={title}>
+      <Box display="flex" flexDirection="column">
+        {Object.entries(choices).map(([choiceValue, choiceLabel]) => {
+          const checked = value === choiceValue;
+          return (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  icon={<CheckCircleOutline />}
+                  checkedIcon={<CheckCircle />}
+                  checked={checked}
+                  onChange={handleChange}
+                  name={choiceValue}
+                  size="small"
+                />
+              }
+              label={
+                <Typography
+                  variant="body2"
+                  color={checked ? 'secondary' : 'textPrimary'}
+                >
+                  {choiceLabel}
+                </Typography>
+              }
+              key={choiceValue}
+            />
+          );
+        })}
+      </Box>
+    </FilterSection>
+  );
+};
+
+export default ChoicesFilterSection;

--- a/frontend/src/components/filter/ChoicesFilterSection.tsx
+++ b/frontend/src/components/filter/ChoicesFilterSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Typography, FormControlLabel, Checkbox, Box } from '@material-ui/core';
 import { CheckCircle, CheckCircleOutline } from '@material-ui/icons';
-import { FilterSection } from 'src/components/filter/FilterSection';
+import { FilterSection } from 'src/components';
 
 interface Props {
   title: string;

--- a/frontend/src/components/filter/FilterSection.tsx
+++ b/frontend/src/components/filter/FilterSection.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+
+interface Props {
+  title: string;
+  children: React.ReactNode;
+}
+
+export const FilterSection = ({ title, children }: Props) => {
+  return (
+    <>
+      <Typography
+        variant="h6"
+        style={{ borderBottom: '1px solid #E7E5DB', marginBottom: '0.3em' }}
+      >
+        {title}
+      </Typography>
+      {children}
+    </>
+  );
+};

--- a/frontend/src/components/filter/FilterSection.tsx
+++ b/frontend/src/components/filter/FilterSection.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
 import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+
+const useStyles = makeStyles({
+  filterTitle: {
+    borderBottom: '1px solid #E7E5DB',
+    marginBottom: '0.3em',
+  },
+});
 
 interface Props {
   title: string;
@@ -7,12 +15,10 @@ interface Props {
 }
 
 const FilterSection = ({ title, children }: Props) => {
+  const classes = useStyles();
   return (
     <>
-      <Typography
-        variant="h6"
-        style={{ borderBottom: '1px solid #E7E5DB', marginBottom: '0.3em' }}
-      >
+      <Typography variant="h6" className={classes.filterTitle}>
         {title}
       </Typography>
       {children}

--- a/frontend/src/components/filter/FilterSection.tsx
+++ b/frontend/src/components/filter/FilterSection.tsx
@@ -6,7 +6,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-export const FilterSection = ({ title, children }: Props) => {
+const FilterSection = ({ title, children }: Props) => {
   return (
     <>
       <Typography
@@ -19,3 +19,5 @@ export const FilterSection = ({ title, children }: Props) => {
     </>
   );
 };
+
+export default FilterSection;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -3,3 +3,5 @@ export { default as ContentHeader } from './ContentHeader';
 export { default as ContentBox } from './ContentBox';
 export { default as Lines } from './Lines';
 export { default as FormTextField } from './FormTextField';
+export { default as FilterSection } from './filter/FilterSection';
+export { default as ChoicesFilterSection } from './filter/ChoicesFilterSection';

--- a/frontend/src/features/recommendation/CriteriaFilter.tsx
+++ b/frontend/src/features/recommendation/CriteriaFilter.tsx
@@ -73,6 +73,21 @@ const CustomSlider = withStyles({
   },
 })(Slider);
 
+interface Props {
+  children: React.ReactElement;
+  open: boolean;
+  value: number;
+}
+
+function ValueLabelComponent(props: Props) {
+  const { children, open, value } = props;
+  return (
+    <Tooltip open={open} enterTouchDelay={0} placement="top" title={value}>
+      {children}
+    </Tooltip>
+  );
+}
+
 function CriteriaFilter({
   setFilter,
 }: {
@@ -95,21 +110,6 @@ function CriteriaFilter({
     } else {
       return 'Crucial';
     }
-  }
-
-  interface Props {
-    children: React.ReactElement;
-    open: boolean;
-    value: number;
-  }
-
-  function ValueLabelComponent(props: Props) {
-    const { children, open, value } = props;
-    return (
-      <Tooltip open={open} enterTouchDelay={0} placement="top" title={value}>
-        {children}
-      </Tooltip>
-    );
   }
 
   return (

--- a/frontend/src/features/recommendation/CriteriaFilter.tsx
+++ b/frontend/src/features/recommendation/CriteriaFilter.tsx
@@ -10,17 +10,19 @@ import {
   Tooltip,
 } from '@material-ui/core';
 import { mainCriteriaNames } from 'src/utils/constants';
+import { FilterSection } from 'src/components/filter/FilterSection';
 
 const useStyles = makeStyles(() => ({
   featuresContainer: {
     display: 'flex',
     flexDirection: 'column',
-    alignItems: 'center',
+    alignItems: 'left',
+    margin: '2px 0px',
   },
   sliderContainer: {
     display: 'flex',
     flexDirection: 'row',
-    width: 'calc(100% - 64px)',
+    width: '100%',
     alignItems: 'center',
     margin: '-2px',
   },
@@ -28,28 +30,34 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 4,
   },
   criteria_img: {
-    marginRight: 4,
+    marginRight: 6,
+  },
+  criteriaName: {
+    flex: 1,
+    fontSize: '0.85rem',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
   valueText: {
-    margin: 4,
+    maxWidth: 'calc(100% - 8px)',
+    margin: 2,
+    fontSize: '0.7rem',
+    fontWeight: 600,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
 }));
 
 const CustomSlider = withStyles({
   root: {
     color: '#1282B2',
-    height: 2,
-    padding: '15px 0',
   },
   active: {},
-  track: {
-    height: 2,
-  },
   rail: {
-    height: 2,
     opacity: 0.5,
     backgroundColor: '#bfbfbf',
   },
@@ -105,11 +113,8 @@ function CriteriaFilter({
   }
 
   return (
-    <Grid item xs={12} sm={12} md={6}>
-      <Typography variant="h5" component="h2">
-        Criteria
-      </Typography>
-      <Grid container>
+    <FilterSection title="Criteria">
+      <Grid container spacing={1}>
         {mainCriteriaNames.map(([criteria, criteria_name]) => (
           <Grid item xs={12} sm={6} key={criteria}>
             <div
@@ -121,16 +126,17 @@ function CriteriaFilter({
                   item
                   xs={12}
                   direction="row"
-                  justifyContent="center"
+                  justifyContent="flex-start"
                   alignItems="center"
                   container
                 >
                   <img
                     className={classes.criteria_img}
                     src={`/svg/${criteria}.svg`}
+                    width="16px"
                   />
-                  <Typography>
-                    <span>{criteria_name}</span>
+                  <Typography className={classes.criteriaName}>
+                    <span title={criteria_name}>{criteria_name}</span>
                   </Typography>
                 </Grid>
               </div>
@@ -143,9 +149,9 @@ function CriteriaFilter({
                   alignItems="flex-start"
                   container
                 >
-                  <span className={classes.valueText}>
+                  <Typography className={classes.valueText}>
                     {valuetoText(parseInt(searchParams.get(criteria) || '50'))}
-                  </span>
+                  </Typography>
                 </Grid>
                 <Grid
                   item
@@ -175,7 +181,7 @@ function CriteriaFilter({
           </Grid>
         ))}
       </Grid>
-    </Grid>
+    </FilterSection>
   );
 }
 

--- a/frontend/src/features/recommendation/CriteriaFilter.tsx
+++ b/frontend/src/features/recommendation/CriteriaFilter.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
 } from '@material-ui/core';
 import { mainCriteriaNames } from 'src/utils/constants';
-import { FilterSection } from 'src/components/filter/FilterSection';
+import { FilterSection } from 'src/components';
 
 const useStyles = makeStyles(() => ({
   featuresContainer: {

--- a/frontend/src/features/recommendation/CriteriaFilter.tsx
+++ b/frontend/src/features/recommendation/CriteriaFilter.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { useLocation } from 'react-router-dom';
 import {
   Grid,
@@ -9,6 +8,7 @@ import {
   Slider,
   Tooltip,
 } from '@material-ui/core';
+
 import { mainCriteriaNames } from 'src/utils/constants';
 import { FilterSection } from 'src/components';
 

--- a/frontend/src/features/recommendation/DateFilter.tsx
+++ b/frontend/src/features/recommendation/DateFilter.tsx
@@ -1,46 +1,25 @@
 import React from 'react';
+import ChoicesFilterSection from 'src/components/filter/ChoicesFilterSection';
 
-import { useLocation } from 'react-router-dom';
-import { Box, FormControlLabel, Checkbox, Typography } from '@material-ui/core';
-import { CheckCircle, CheckCircleOutline } from '@material-ui/icons';
-import { FilterSection } from 'src/components/filter/FilterSection';
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
 
-function DateFilter({
-  setFilter,
-}: {
-  setFilter: (k: string, v: string) => void;
-}) {
-  const Location = useLocation();
-  const searchParams = new URLSearchParams(Location.search);
+const dateChoices = {
+  Today: 'Today',
+  Week: 'This week',
+  Month: 'This month',
+  Year: 'This year',
+};
 
-  const dateChoices = ['Today', 'Week', 'Month', 'Year'];
-  const date = searchParams.get('date') || 'Any';
-
-  const handleDateChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setFilter('date', event.target.name);
-  };
-
+function DateFilter(props: Props) {
   return (
-    <FilterSection title="Upload date">
-      <Box display="flex" flexDirection="column">
-        {dateChoices.map((label) => (
-          <FormControlLabel
-            control={
-              <Checkbox
-                icon={<CheckCircleOutline />}
-                checkedIcon={<CheckCircle />}
-                checked={date == label}
-                onChange={handleDateChange}
-                name={label}
-                size="small"
-              />
-            }
-            label={<Typography variant="body2">{label}</Typography>}
-            key={label}
-          />
-        ))}
-      </Box>
-    </FilterSection>
+    <ChoicesFilterSection
+      title="Upload date"
+      choices={dateChoices}
+      {...props}
+    />
   );
 }
 

--- a/frontend/src/features/recommendation/DateFilter.tsx
+++ b/frontend/src/features/recommendation/DateFilter.tsx
@@ -1,29 +1,15 @@
 import React from 'react';
 
 import { useLocation } from 'react-router-dom';
-import {
-  Grid,
-  Typography,
-  FormControlLabel,
-  Checkbox,
-  makeStyles,
-} from '@material-ui/core';
+import { Box, FormControlLabel, Checkbox, Typography } from '@material-ui/core';
 import { CheckCircle, CheckCircleOutline } from '@material-ui/icons';
-
-const useStyles = makeStyles(() => ({
-  main: {
-    display: 'flex',
-    flexDirection: 'column',
-    paddingLeft: 4,
-  },
-}));
+import { FilterSection } from 'src/components/filter/FilterSection';
 
 function DateFilter({
   setFilter,
 }: {
   setFilter: (k: string, v: string) => void;
 }) {
-  const classes = useStyles();
   const Location = useLocation();
   const searchParams = new URLSearchParams(Location.search);
 
@@ -35,11 +21,8 @@ function DateFilter({
   };
 
   return (
-    <Grid item xs={12} sm={6} md={3}>
-      <div className={classes.main}>
-        <Typography variant="h5" component="h2">
-          Date Uploaded
-        </Typography>
+    <FilterSection title="Upload date">
+      <Box display="flex" flexDirection="column">
         {dateChoices.map((label) => (
           <FormControlLabel
             control={
@@ -49,14 +32,15 @@ function DateFilter({
                 checked={date == label}
                 onChange={handleDateChange}
                 name={label}
+                size="small"
               />
             }
-            label={label}
+            label={<Typography variant="body2">{label}</Typography>}
             key={label}
           />
         ))}
-      </div>
-    </Grid>
+      </Box>
+    </FilterSection>
   );
 }
 

--- a/frontend/src/features/recommendation/DateFilter.tsx
+++ b/frontend/src/features/recommendation/DateFilter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ChoicesFilterSection from 'src/components/filter/ChoicesFilterSection';
+import { ChoicesFilterSection } from 'src/components';
 
 interface Props {
   value: string;

--- a/frontend/src/features/recommendation/LanguageFilter.tsx
+++ b/frontend/src/features/recommendation/LanguageFilter.tsx
@@ -1,52 +1,24 @@
 import React from 'react';
+import ChoicesFilterSection from 'src/components/filter/ChoicesFilterSection';
 
-import { useLocation } from 'react-router-dom';
-import { Typography, FormControlLabel, Checkbox, Box } from '@material-ui/core';
-import { CheckCircle, CheckCircleOutline } from '@material-ui/icons';
-import { FilterSection } from 'src/components/filter/FilterSection';
+const languageChoices = {
+  en: 'English',
+  fr: 'French',
+  de: 'German',
+};
 
-function LanguageFilter({
-  setFilter,
-}: {
-  setFilter: (k: string, v: string) => void;
-}) {
-  const Location = useLocation();
-  const searchParams = new URLSearchParams(Location.search);
-  const language = searchParams.get('language') || '';
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
 
-  const languageChoices = {
-    en: 'English',
-    fr: 'French',
-    de: 'German',
-  };
-
-  const handleLanguageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setFilter('language', event.target.name);
-  };
-
+function LanguageFilter(props: Props) {
   return (
-    <FilterSection title="Language">
-      <Box display="flex" flexDirection="column">
-        {Object.entries(languageChoices).map(
-          ([language_key, language_value]) => (
-            <FormControlLabel
-              control={
-                <Checkbox
-                  icon={<CheckCircleOutline />}
-                  checkedIcon={<CheckCircle />}
-                  checked={language == language_key}
-                  onChange={handleLanguageChange}
-                  name={language_key}
-                  size="small"
-                />
-              }
-              label={<Typography variant="body2">{language_value}</Typography>}
-              key={language_key}
-            />
-          )
-        )}
-      </Box>
-    </FilterSection>
+    <ChoicesFilterSection
+      title="Language"
+      choices={languageChoices}
+      {...props}
+    ></ChoicesFilterSection>
   );
 }
 

--- a/frontend/src/features/recommendation/LanguageFilter.tsx
+++ b/frontend/src/features/recommendation/LanguageFilter.tsx
@@ -1,29 +1,15 @@
 import React from 'react';
 
 import { useLocation } from 'react-router-dom';
-import {
-  Grid,
-  Typography,
-  FormControlLabel,
-  Checkbox,
-  makeStyles,
-} from '@material-ui/core';
+import { Typography, FormControlLabel, Checkbox, Box } from '@material-ui/core';
 import { CheckCircle, CheckCircleOutline } from '@material-ui/icons';
-
-const useStyles = makeStyles(() => ({
-  main: {
-    display: 'flex',
-    flexDirection: 'column',
-    paddingLeft: 4,
-  },
-}));
+import { FilterSection } from 'src/components/filter/FilterSection';
 
 function LanguageFilter({
   setFilter,
 }: {
   setFilter: (k: string, v: string) => void;
 }) {
-  const classes = useStyles();
   const Location = useLocation();
   const searchParams = new URLSearchParams(Location.search);
   const language = searchParams.get('language') || '';
@@ -39,11 +25,8 @@ function LanguageFilter({
   };
 
   return (
-    <Grid item xs={12} sm={6} md={3}>
-      <div className={classes.main}>
-        <Typography variant="h5" component="h2">
-          Language
-        </Typography>
+    <FilterSection title="Language">
+      <Box display="flex" flexDirection="column">
         {Object.entries(languageChoices).map(
           ([language_key, language_value]) => (
             <FormControlLabel
@@ -54,15 +37,16 @@ function LanguageFilter({
                   checked={language == language_key}
                   onChange={handleLanguageChange}
                   name={language_key}
+                  size="small"
                 />
               }
-              label={language_value}
+              label={<Typography variant="body2">{language_value}</Typography>}
               key={language_key}
             />
           )
         )}
-      </div>
-    </Grid>
+      </Box>
+    </FilterSection>
   );
 }
 

--- a/frontend/src/features/recommendation/LanguageFilter.tsx
+++ b/frontend/src/features/recommendation/LanguageFilter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ChoicesFilterSection from 'src/components/filter/ChoicesFilterSection';
+import { ChoicesFilterSection } from 'src/components';
 
 const languageChoices = {
   en: 'English',

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -1,26 +1,16 @@
 import React, { useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 
-import { makeStyles, Collapse, Button, Grid } from '@material-ui/core';
+import { Collapse, Button, Grid, Box, Theme } from '@material-ui/core';
+import { useTheme } from '@material-ui/styles';
+
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import LanguageFilter from './LanguageFilter';
 import DateFilter from './DateFilter';
 import CriteriaFilter from './CriteriaFilter';
 
-const useStyles = makeStyles(() => ({
-  filter: {
-    color: '#506AD4',
-    margin: '8px',
-  },
-  collapse: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    alignContent: 'space-between',
-  },
-}));
-
 function SearchFilter() {
-  const classes = useStyles();
+  const theme: Theme = useTheme();
   const [expanded, setExpanded] = useState(false);
   const Location = useLocation();
   const history = useHistory();
@@ -45,31 +35,36 @@ function SearchFilter() {
   }
 
   return (
-    <div className="filters">
+    <Box color="text.secondary">
       <Button
-        color="secondary"
         size="large"
-        className={classes.filter}
         startIcon={!expanded ? <ExpandMore /> : <ExpandLess />}
         aria-expanded={expanded}
         aria-label="show more"
         onClick={handleExpandClick}
+        style={{
+          padding: '8px 0',
+          color: expanded
+            ? theme.palette.secondary.main
+            : theme.palette.text.hint,
+        }}
       >
         Filters
       </Button>
-      <Collapse
-        className={classes.collapse}
-        in={expanded}
-        timeout="auto"
-        unmountOnExit
-      >
-        <Grid container>
-          <CriteriaFilter setFilter={setFilter} />
-          <DateFilter setFilter={setFilter} />
-          <LanguageFilter setFilter={setFilter} />
+      <Collapse in={expanded} timeout="auto" unmountOnExit>
+        <Grid container spacing={4} style={{ marginBottom: '8px' }}>
+          <Grid item xs={12} sm={12} md={6}>
+            <CriteriaFilter setFilter={setFilter} />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <DateFilter setFilter={setFilter} />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <LanguageFilter setFilter={setFilter} />
+          </Grid>
         </Grid>
       </Collapse>
-    </div>
+    </Box>
   );
 }
 

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -21,17 +21,16 @@ function SearchFilter() {
   };
 
   function setFilter(key: string, value: string) {
-    if (searchParams.get(key) === value) {
-      searchParams.delete(key);
+    if (value) {
+      searchParams.set(key, value);
     } else {
       searchParams.delete(key);
-      searchParams.append(key, value);
     }
     // Reset pagination if filters change
-    if (key != 'offset') {
+    if (key !== 'offset') {
       searchParams.delete('offset');
     }
-    history.push('/recommendations/?' + searchParams.toString());
+    history.push({ search: searchParams.toString() });
   }
 
   return (
@@ -46,21 +45,27 @@ function SearchFilter() {
           padding: '8px 0',
           color: expanded
             ? theme.palette.secondary.main
-            : theme.palette.text.hint,
+            : theme.palette.action.active,
         }}
       >
         Filters
       </Button>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
         <Grid container spacing={4} style={{ marginBottom: '8px' }}>
+          <Grid item xs={12} sm={6} md={3}>
+            <DateFilter
+              value={searchParams.get('date') ?? ''}
+              onChange={(value) => setFilter('date', value)}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <LanguageFilter
+              value={searchParams.get('language') ?? ''}
+              onChange={(value) => setFilter('language', value)}
+            />
+          </Grid>
           <Grid item xs={12} sm={12} md={6}>
             <CriteriaFilter setFilter={setFilter} />
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <DateFilter setFilter={setFilter} />
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <LanguageFilter setFilter={setFilter} />
           </Grid>
         </Grid>
       </Collapse>

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -1,16 +1,32 @@
 import React, { useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
+import clsx from 'clsx';
 
 import { Collapse, Button, Grid, Box, Theme } from '@material-ui/core';
-import { useTheme } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import LanguageFilter from './LanguageFilter';
 import DateFilter from './DateFilter';
 import CriteriaFilter from './CriteriaFilter';
 
+const useStyles = makeStyles((theme: Theme) => ({
+  filtersButton: {
+    padding: '8px 0',
+  },
+  filtersButtonDefault: {
+    color: theme.palette.action.active,
+  },
+  filtersButtonExpanded: {
+    color: theme.palette.secondary.main,
+  },
+  filtersContainer: {
+    marginBottom: '8px',
+  },
+}));
+
 function SearchFilter() {
-  const theme: Theme = useTheme();
+  const classes = useStyles();
   const [expanded, setExpanded] = useState(false);
   const Location = useLocation();
   const history = useHistory();
@@ -41,17 +57,15 @@ function SearchFilter() {
         aria-expanded={expanded}
         aria-label="show more"
         onClick={handleExpandClick}
-        style={{
-          padding: '8px 0',
-          color: expanded
-            ? theme.palette.secondary.main
-            : theme.palette.action.active,
-        }}
+        className={clsx(classes.filtersButton, {
+          [classes.filtersButtonDefault]: !expanded,
+          [classes.filtersButtonExpanded]: expanded,
+        })}
       >
         Filters
       </Button>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
-        <Grid container spacing={4} style={{ marginBottom: '8px' }}>
+        <Grid container spacing={4} className={classes.filtersContainer}>
           <Grid item xs={6} md={3} lg={2}>
             <DateFilter
               value={searchParams.get('date') ?? ''}

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -52,13 +52,13 @@ function SearchFilter() {
       </Button>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
         <Grid container spacing={4} style={{ marginBottom: '8px' }}>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid item xs={6} md={3} lg={2}>
             <DateFilter
               value={searchParams.get('date') ?? ''}
               onChange={(value) => setFilter('date', value)}
             />
           </Grid>
-          <Grid item xs={12} sm={6} md={3}>
+          <Grid item xs={6} md={3} lg={2}>
             <LanguageFilter
               value={searchParams.get('language') ?? ''}
               onChange={(value) => setFilter('language', value)}

--- a/frontend/src/pages/videos/VideoRecommendation.tsx
+++ b/frontend/src/pages/videos/VideoRecommendation.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 
-import { CircularProgress } from '@material-ui/core';
+import { CircularProgress, Box } from '@material-ui/core';
 
 import type { PaginatedVideoSerializerWithCriteriaList } from 'src/services/openapi';
 import Pagination from 'src/components/Pagination';
@@ -44,7 +44,9 @@ function VideoRecommendationPage() {
 
   return (
     <ContentBox noMinPadding>
-      <SearchFilter />
+      <Box px={{ xs: 2, sm: 0 }}>
+        <SearchFilter />
+      </Box>
       {isLoading ? (
         <CircularProgress />
       ) : (

--- a/frontend/src/pages/videos/VideoRecommendation.tsx
+++ b/frontend/src/pages/videos/VideoRecommendation.tsx
@@ -39,11 +39,10 @@ function VideoRecommendationPage() {
         setIsLoading(false);
       }
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.search]);
 
   return (
-    <ContentBox noMinPadding>
+    <ContentBox noMinPadding maxWidth="xl">
       <Box px={{ xs: 2, sm: 0 }}>
         <SearchFilter />
       </Box>


### PR DESCRIPTION
### Description

This is a prerequisite to implement the new page "My rated videos", that will also include similar filters (on public/private ratings, etc.)

2 new components: 
* **`FilterSection`**: a generic filter section with an underlined title
* **`ChoicesFilterSection`**: a filter column, with multiple checkboxes defined by a list of `choices`.   
Used by `LanguageFilter` and `DateFilter`.

### Screenshots

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/4726554/144819193-83da4a88-fd88-4263-ad82-2fa6533c84d4.png)|![image](https://user-images.githubusercontent.com/4726554/144819305-cfae78b0-8c4c-4bb3-a65a-e30b13f070d9.png)
|![image](https://user-images.githubusercontent.com/4726554/144819685-2b107c67-730c-4667-9438-dd68c20a2414.png)|![image](https://user-images.githubusercontent.com/4726554/144819766-dac02bda-e11d-4075-b5c4-235325f898cd.png)


