### PR TITLE
frontend: Use absolute URL in meta tags, with explicit 'PUBLIC_URL' on build

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -14,6 +14,7 @@
     <meta property="og:title" content="Tournesol">
     <meta property="og:image" content="%PUBLIC_URL%/tournesol_screenshot_og.png">
     <meta property="og:url" content="%PUBLIC_URL%">
+    <meta property="twitter:card" content="summary_large_image">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -13,6 +13,7 @@
     <meta property="og:site_name" content="Tournesol">
     <meta property="og:title" content="Tournesol">
     <meta property="og:image" content="%PUBLIC_URL%/tournesol_screenshot_og.png">
+    <meta property="og:url" content="%PUBLIC_URL%">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/infra/ansible/roles/frontend/templates/.env.j2
+++ b/infra/ansible/roles/frontend/templates/.env.j2
@@ -1,3 +1,4 @@
+PUBLIC_URL={{frontend_scheme}}://{{domain_name}}
 REACT_APP_API_URL={{api_scheme}}://{{api_domain_name}}
 REACT_APP_OAUTH_CLIENT_ID={{frontend_oauth_client_id}}
 REACT_APP_OAUTH_CLIENT_SECRET={{frontend_oauth_client_secret}}


### PR DESCRIPTION
Following #350, as some platforms such as Twitter does not support relative URLs in meta tags.