### PR TITLE
feat(backend): Implement route to update is_public status for all ContributorRating

### DIFF
--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.db.models import ObjectDoesNotExist, Q
 
 from rest_framework import serializers
-from rest_framework.fields import RegexField, SerializerMethodField
+from rest_framework.fields import RegexField, SerializerMethodField, BooleanField
 from rest_framework.serializers import Serializer, ModelSerializer
 from rest_framework.exceptions import ValidationError
 from drf_spectacular.utils import extend_schema_field
@@ -312,3 +312,7 @@ class ContributorRatingCreateSerializer(ContributorRatingSerializer):
         attrs["video"] = video
         attrs["user"] = user
         return attrs
+
+
+class ContributorRatingUpdateAllSerializer(Serializer):
+    is_public = BooleanField()

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -152,3 +152,15 @@ class RatingApi(TestCase):
         self.assertEqual(response.json()["is_public"], True, response.json())
         rating.refresh_from_db()
         self.assertEqual(rating.is_public, True)
+
+    def test_patch_all_ratings(self):
+        client = APIClient()
+        client.force_authenticate(self.user2)
+        self.assertEqual(self.user2.contributorvideoratings.count(), 2)
+        self.assertEqual(self.user2.contributorvideoratings.filter(is_public=False).count(), 1)
+        response = client.patch(
+            "/users/me/contributor_ratings/_all/",
+            data={"is_public": False}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.user2.contributorvideoratings.filter(is_public=False).count(), 2)

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -12,7 +12,11 @@ from .views.exports import ExportComparisonsView, ExportAllView
 from .views.video import VideoViewSet
 from .views.video_rate_later import VideoRateLaterDetail, VideoRateLaterList
 from .views.user import CurrentUserView
-from .views.ratings import ContributorRatingList, ContributorRatingDetail
+from .views.ratings import (
+    ContributorRatingList,
+    ContributorRatingDetail,
+    ContributorRatingUpdateAll,
+)
 from .views.email_domains import EmailDomainsList
 
 
@@ -69,6 +73,11 @@ urlpatterns = [
         "users/me/contributor_ratings/",
         ContributorRatingList.as_view(),
         name="ratings_me_list",
+    ),
+    path(
+        "users/me/contributor_ratings/_all/",
+        ContributorRatingUpdateAll.as_view(),
+        name="ratings_me_list_update_is_public",
     ),
     path(
         "users/me/contributor_ratings/<str:video_id>/",


### PR DESCRIPTION
Related to #274 

The new route `PATCH /users/me/contributor_ratings/_all/`  will be used on the page "My rated videos" to allow marking of all existing user contributions as "public" or "private".