### PR TITLE
frontend: Update OpenAPI schema, generate API client with named arguments

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "test": "react-scripts test --testURL=http://localhost:3000",
     "eject": "react-scripts eject",
     "update-schema": "wget -O scripts/openapi.yaml \"${REACT_APP_API_URL:-http://localhost:8000}/schema/\"",
-    "openapi": "openapi -i scripts/openapi.yaml -o src/services/openapi",
+    "openapi": "openapi --useOptions -i scripts/openapi.yaml -o src/services/openapi",
     "lint": "eslint src --ext '.js,.jsx,.ts,.tsx'",
     "lint:fix": "eslint --fix src --ext '.js,.jsx,.ts,.tsx'",
     "prepare": "cd .. && husky install frontend/.husky"

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -636,6 +636,11 @@ paths:
       operationId: users_me_comparisons_list_filtered
       description: List all comparisons made by the logged user.
       parameters:
+      - in: path
+        name: video_id
+        schema:
+          type: string
+        required: true
       - name: limit
         required: false
         in: query
@@ -648,11 +653,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - in: path
-        name: video_id
-        schema:
-          type: string
-        required: true
       tags:
       - users
       security:
@@ -671,10 +671,6 @@ paths:
       description: Retrieve the logged in user's ratings per video (computed automatically
         from the user's comparisons).
       parameters:
-      - in: query
-        name: is_public
-        schema:
-          type: boolean
       - name: limit
         required: false
         in: query
@@ -687,6 +683,10 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: is_public
+        schema:
+          type: boolean
       tags:
       - users
       security:
@@ -953,7 +953,8 @@ paths:
   /video/:
     get:
       operationId: video_list
-      description: ''
+      description: Retrieve a list of recommended videos, sorted by decreasing total
+        score.
       parameters:
       - name: limit
         required: false
@@ -967,6 +968,78 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: search
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
+      - in: query
+        name: date_lte
+        schema:
+          type: string
+          format: date-time
+        description: "Return videos published **before** this date.  \nAccepted formats:\
+          \ ISO 8601 datetime (e.g `2021-12-01T12:45:00`) or legacy: `dd-mm-yy-hh-mm-ss`."
+      - in: query
+        name: date_gte
+        schema:
+          type: string
+          format: date-time
+        description: "Return videos published **after** this date.  \nAccepted formats:\
+          \ ISO 8601 datetime (e.g `2021-12-01T12:45:00`) or legacy: `dd-mm-yy-hh-mm-ss`."
+      - in: query
+        name: largely_recommended
+        schema:
+          type: integer
+        description: Weight for criteria 'largely_recommended', between 0 and 100
+      - in: query
+        name: reliability
+        schema:
+          type: integer
+        description: Weight for criteria 'reliability', between 0 and 100
+      - in: query
+        name: importance
+        schema:
+          type: integer
+        description: Weight for criteria 'importance', between 0 and 100
+      - in: query
+        name: engaging
+        schema:
+          type: integer
+        description: Weight for criteria 'engaging', between 0 and 100
+      - in: query
+        name: pedagogy
+        schema:
+          type: integer
+        description: Weight for criteria 'pedagogy', between 0 and 100
+      - in: query
+        name: layman_friendly
+        schema:
+          type: integer
+        description: Weight for criteria 'layman_friendly', between 0 and 100
+      - in: query
+        name: diversity_inclusion
+        schema:
+          type: integer
+        description: Weight for criteria 'diversity_inclusion', between 0 and 100
+      - in: query
+        name: backfire_risk
+        schema:
+          type: integer
+        description: Weight for criteria 'backfire_risk', between 0 and 100
+      - in: query
+        name: better_habits
+        schema:
+          type: integer
+        description: Weight for criteria 'better_habits', between 0 and 100
+      - in: query
+        name: entertaining_relaxing
+        schema:
+          type: integer
+        description: Weight for criteria 'entertaining_relaxing', between 0 and 100
       tags:
       - video
       security:
@@ -981,7 +1054,7 @@ paths:
           description: ''
     post:
       operationId: video_create
-      description: Add a video to the db if it does not already exist
+      description: Add a video to the db if it does not already exist.
       tags:
       - video
       requestBody:
@@ -1006,16 +1079,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/Video'
           description: ''
-  /video/{id}/:
+  /video/{video_id}/:
     get:
       operationId: video_retrieve
-      description: Get video details and criteria that are related to it
+      description: Retrieve details about a single video.
       parameters:
       - in: path
-        name: id
+        name: video_id
         schema:
-          type: integer
-        description: A unique integer value identifying this video.
+          type: string
+          description: Video ID from YouTube URL, matches ^[A-Za-z0-9-_]{11}$
         required: true
       tags:
       - video
@@ -10567,8 +10640,13 @@ components:
           type: integer
           readOnly: true
           description: Total number of certified contributors who rated the video
+        duration:
+          type: integer
+          nullable: true
+          readOnly: true
       required:
       - description
+      - duration
       - language
       - name
       - publication_date
@@ -10596,9 +10674,9 @@ components:
           type: number
           format: float
           maximum: 1.0
+          minimum: 0.0
           description: Top quantile for all rated videos for aggregated scoresfor
             the given criteria. 0.0=best, 1.0=worst
-          minimum: 0.0
       required:
       - criteria
     VideoRateLater:
@@ -10656,10 +10734,6 @@ components:
           nullable: true
           description: Name of the channel (uploader)
           maxLength: 1000
-        criteria_scores:
-          type: array
-          items:
-            $ref: '#/components/schemas/VideoCriteriaScore'
         language:
           nullable: true
           description: Language of the video
@@ -10678,8 +10752,17 @@ components:
           maximum: 2147483647
           minimum: -2147483648
           description: Total number of certified contributors who rated the video
+        duration:
+          type: integer
+          nullable: true
+          readOnly: true
+        criteria_scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/VideoCriteriaScore'
       required:
       - criteria_scores
+      - duration
       - video_id
   securitySchemes:
     oauth2:

--- a/frontend/src/features/rateLater/rateLaterAPI.ts
+++ b/frontend/src/features/rateLater/rateLaterAPI.ts
@@ -9,6 +9,8 @@ export const addToRateLaterList = async ({
 }) => {
   await ensureVideoExistsOrCreate(video_id);
   return UsersService.usersMeVideoRateLaterCreate({
-    video: { video_id } as Video,
+    requestBody: {
+      video: { video_id } as Video,
+    },
   });
 };

--- a/frontend/src/features/recommendation/RecommendationApi.tsx
+++ b/frontend/src/features/recommendation/RecommendationApi.tsx
@@ -1,4 +1,8 @@
 import { VideoService } from 'src/services/openapi';
+import { allCriteriaNamesObj } from 'src/utils/constants';
+import { snakeToCamel } from 'src/utils/string';
+
+const CRITERIA_KEYS = Object.keys(allCriteriaNamesObj);
 
 export const getRecommendedVideos = async (searchString: string) => {
   const dayInMillisecondes = 1000 * 60 * 60 * 24;
@@ -53,16 +57,9 @@ export const getRecommendedVideos = async (searchString: string) => {
       search: params.get('search') ?? undefined,
       language: params.get('language') ?? undefined,
       dateGte: params.get('date_gte') ?? undefined,
-      largelyRecommended: getNumberValue('largely_recommended'),
-      reliability: getNumberValue('reliability'),
-      importance: getNumberValue('importance'),
-      engaging: getNumberValue('engaging'),
-      pedagogy: getNumberValue('pedagogy'),
-      laymanFriendly: getNumberValue('layman_friendly'),
-      diversityInclusion: getNumberValue('diversity_inclusion'),
-      backfireRisk: getNumberValue('backfire_risk'),
-      betterHabits: getNumberValue('better_habits'),
-      entertainingRelaxing: getNumberValue('entertaining_relaxing'),
+      ...Object.fromEntries(
+        CRITERIA_KEYS.map((c) => [snakeToCamel(c), getNumberValue(c)])
+      ),
     });
   } catch (err) {
     console.error(err);

--- a/frontend/src/features/settings/account/EmailAddressForm.tsx
+++ b/frontend/src/features/settings/account/EmailAddressForm.tsx
@@ -74,7 +74,9 @@ const EmailAddressForm = () => {
 
     try {
       await AccountsService.accountsRegisterEmailCreate({
-        email: new FormData(event.currentTarget).get('email') as string,
+        requestBody: {
+          email: new FormData(event.currentTarget).get('email') as string,
+        },
       });
       setIsSuccess(true);
     } catch (err) {

--- a/frontend/src/features/settings/account/PasswordForm.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.tsx
@@ -31,9 +31,11 @@ const PasswordForm = () => {
     const response: void | Record<string, string> =
       await AccountsService.accountsChangePasswordCreate(
         {
-          old_password: oldPassword,
-          password,
-          password_confirm: passwordConfirm,
+          requestBody: {
+            old_password: oldPassword,
+            password,
+            password_confirm: passwordConfirm,
+          },
         }
         // handle errors and unknown errors
       ).catch((reason: { body: { [k: string]: string[] } }) => {

--- a/frontend/src/features/settings/profile/ProfileForm.tsx
+++ b/frontend/src/features/settings/profile/ProfileForm.tsx
@@ -46,9 +46,11 @@ const ProfileForm = () => {
     setDisabled(true);
 
     const response = await AccountsService.accountsProfilePartialUpdate({
-      username,
-      // handle errors and unknown errors
+      requestBody: {
+        username,
+      },
     }).catch((reason: { body: { [k: string]: string[] } }) => {
+      // handle errors and unknown errors
       if (reason && 'body' in reason) {
         const newErrorMessages = Object.values(reason['body']).flat();
         newErrorMessages.map((msg) => showErrorAlert(enqueueSnackbar, msg));

--- a/frontend/src/features/video_selector/VideoSelector.tsx
+++ b/frontend/src/features/video_selector/VideoSelector.tsx
@@ -61,7 +61,7 @@ const VideoSelector = ({
     setLoading(true);
     try {
       const contributorRating =
-        await UsersService.usersMeContributorRatingsRetrieve(videoId);
+        await UsersService.usersMeContributorRatingsRetrieve({ videoId });
       onChange({
         videoId,
         rating: contributorRating,
@@ -72,9 +72,11 @@ const VideoSelector = ({
           await ensureVideoExistsOrCreate(videoId);
           const contributorRating =
             await UsersService.usersMeContributorRatingsCreate({
-              video_id: videoId,
-              is_public: true,
-            } as ContributorRatingCreate);
+              requestBody: {
+                video_id: videoId,
+                is_public: true,
+              } as ContributorRatingCreate,
+            });
           onChange({
             videoId,
             rating: contributorRating,

--- a/frontend/src/features/videos/PublicStatusAction.tsx
+++ b/frontend/src/features/videos/PublicStatusAction.tsx
@@ -4,8 +4,11 @@ import { Tooltip, Typography, Box, Switch } from '@material-ui/core';
 import { UsersService, ContributorRating } from 'src/services/openapi';
 
 const setPublicStatus = async (videoId: string, isPublic: boolean) => {
-  return await UsersService.usersMeContributorRatingsPartialUpdate(videoId, {
-    is_public: isPublic,
+  return await UsersService.usersMeContributorRatingsPartialUpdate({
+    videoId,
+    requestBody: {
+      is_public: isPublic,
+    },
   });
 };
 

--- a/frontend/src/pages/about/TrustedDomains.tsx
+++ b/frontend/src/pages/about/TrustedDomains.tsx
@@ -22,7 +22,10 @@ const TrustedDomains = () => {
       let offset = 0;
       let response;
       do {
-        response = await DomainsService.domainsList(DOMAINS_PAGE_SIZE, offset);
+        response = await DomainsService.domainsList({
+          limit: DOMAINS_PAGE_SIZE,
+          offset,
+        });
         const responseDomains = response.results || [];
         offset += responseDomains.length;
         result.push(...responseDomains);

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -98,7 +98,10 @@ const ComparisonPage = () => {
       setSelectorB({ videoId: videoB, rating: null });
     }
     if (videoA && videoB)
-      UsersService.usersMeComparisonsRetrieve(videoA, videoB)
+      UsersService.usersMeComparisonsRetrieve({
+        videoIdA: videoA,
+        videoIdB: videoB,
+      })
         .then((comparison) => {
           setInitialComparison(comparison);
           setIsLoading(false);
@@ -115,13 +118,13 @@ const ComparisonPage = () => {
   const onSubmitComparison = async (c: Comparison) => {
     if (initialComparison) {
       const { video_a, video_b, criteria_scores, duration_ms } = c;
-      await UsersService.usersMeComparisonsUpdate(
-        video_a.video_id,
-        video_b.video_id,
-        { criteria_scores, duration_ms }
-      );
+      await UsersService.usersMeComparisonsUpdate({
+        videoIdA: video_a.video_id,
+        videoIdB: video_b.video_id,
+        requestBody: { criteria_scores, duration_ms },
+      });
     } else {
-      await UsersService.usersMeComparisonsCreate(c);
+      await UsersService.usersMeComparisonsCreate({ requestBody: c });
       setInitialComparison(c);
       // Refresh ratings statistics after the comparisons have been submitted
       setSubmitted(true);

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -23,7 +23,7 @@ function ComparisonsPage() {
   }
 
   useEffect(() => {
-    UsersService.usersMeComparisonsList(limit, offset).then((data) => {
+    UsersService.usersMeComparisonsList({ limit, offset }).then((data) => {
       setComparisons(data.results);
       setCount(data.count || 0);
     });

--- a/frontend/src/pages/login/ForgotPassword.tsx
+++ b/frontend/src/pages/login/ForgotPassword.tsx
@@ -35,9 +35,9 @@ const ForgotPassword = () => {
     const formData = new FormData(event.currentTarget);
     const formObject: unknown = Object.fromEntries(formData);
     try {
-      await AccountsService.accountsSendResetPasswordLinkCreate(
-        formObject as DefaultSendResetPasswordLink
-      );
+      await AccountsService.accountsSendResetPasswordLinkCreate({
+        requestBody: formObject as DefaultSendResetPasswordLink,
+      });
       setSuccess(true);
     } catch (err) {
       setApiError(err as ApiError);

--- a/frontend/src/pages/login/ResetPassword.tsx
+++ b/frontend/src/pages/login/ResetPassword.tsx
@@ -32,7 +32,9 @@ function ResetPassword() {
     };
 
     try {
-      await AccountsService.accountsResetPasswordCreate(resetPasswordData);
+      await AccountsService.accountsResetPasswordCreate({
+        requestBody: resetPasswordData,
+      });
       logout();
       enqueueSnackbar(
         'Your password has been modified successfully. You can now log in to Tournesol.',

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -71,10 +71,10 @@ const RateLaterPage = () => {
     setIsLoading(true);
     let rateLaterResponse;
     try {
-      rateLaterResponse = await UsersService.usersMeVideoRateLaterList(
+      rateLaterResponse = await UsersService.usersMeVideoRateLaterList({
         limit,
-        offset
-      );
+        offset,
+      });
     } catch (err) {
       console.error('Fetch rater list failed.', err);
       setIsLoading(false);

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -32,9 +32,9 @@ const Signup = () => {
     const formData = new FormData(event.currentTarget);
     const formObject: unknown = Object.fromEntries(formData);
     try {
-      const createdUser = await AccountsService.accountsRegisterCreate(
-        formObject as RegisterUser
-      );
+      const createdUser = await AccountsService.accountsRegisterCreate({
+        requestBody: formObject as RegisterUser,
+      });
       setSuccessEmailAddress(createdUser.email || '');
     } catch (err) {
       setApiError(err as ApiError);

--- a/frontend/src/pages/signup/Verify.tsx
+++ b/frontend/src/pages/signup/Verify.tsx
@@ -15,9 +15,9 @@ const executeVerifyUser = async (searchParams: Record<string, string>) => {
     timestamp: Number(timestamp),
     signature,
   };
-  return await AccountsService.accountsVerifyRegistrationCreate(
-    verificationData
-  );
+  return await AccountsService.accountsVerifyRegistrationCreate({
+    requestBody: verificationData,
+  });
 };
 
 const executeVerifyEmail = async (searchParams: Record<string, string>) => {
@@ -28,7 +28,9 @@ const executeVerifyEmail = async (searchParams: Record<string, string>) => {
     signature,
     email,
   };
-  return await AccountsService.accountsVerifyEmailCreate(verificationData);
+  return await AccountsService.accountsVerifyEmailCreate({
+    requestBody: verificationData,
+  });
 };
 
 const VerifySignature = ({ verify }: { verify: 'user' | 'email' }) => {

--- a/frontend/src/pages/videos/VideoRecommendation.tsx
+++ b/frontend/src/pages/videos/VideoRecommendation.tsx
@@ -31,14 +31,12 @@ function VideoRecommendationPage() {
   }
 
   useEffect(() => {
-    setIsLoading(true);
-    getRecommendedVideos(
-      location.search,
-      (videos: PaginatedVideoSerializerWithCriteriaList) => {
-        setVideos(videos);
-        setIsLoading(false);
-      }
-    );
+    const fetchVideos = async () => {
+      setIsLoading(true);
+      setVideos(await getRecommendedVideos(location.search));
+      setIsLoading(false);
+    };
+    fetchVideos();
   }, [location.search]);
 
   return (

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -29,7 +29,9 @@ export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
   const handleCreation = async () => {
     try {
       await UsersService.usersMeVideoRateLaterCreate({
-        video: { video_id } as Video,
+        requestBody: {
+          video: { video_id } as Video,
+        },
       });
       showSuccessAlert(
         enqueueSnackbar,
@@ -59,13 +61,12 @@ export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
 export const RemoveFromRateLater = (asyncCallback?: () => void) => {
   const RemoveFromRateLaterComponnent = ({ videoId }: { videoId: string }) => {
     const { enqueueSnackbar } = useSnackbar();
-    const video_id = videoId;
     return (
       <Tooltip title="Remove" placement="left">
         <IconButton
           size="medium"
           onClick={async () => {
-            await UsersService.usersMeVideoRateLaterDestroy(video_id);
+            await UsersService.usersMeVideoRateLaterDestroy({ videoId });
             if (asyncCallback) await asyncCallback();
             showSuccessAlert(
               enqueueSnackbar,

--- a/frontend/src/utils/string.spec.ts
+++ b/frontend/src/utils/string.spec.ts
@@ -1,0 +1,17 @@
+import { snakeToCamel } from './string';
+
+describe('snake_case to camelCase conversion', () => {
+  const testCases = [
+    ['abc', 'abc'],
+    ['long_key', 'longKey'],
+    ['_abc', '_abc'],
+    ['_long_key', '_longKey'],
+    ['largely_recommended', 'largelyRecommended'],
+  ];
+
+  testCases.forEach(([input, expected]) =>
+    it(input, () => {
+      expect(snakeToCamel(input)).toEqual(expected);
+    })
+  );
+});

--- a/frontend/src/utils/string.ts
+++ b/frontend/src/utils/string.ts
@@ -1,0 +1,8 @@
+export const snakeToCamel = (str: string) => {
+  // Convert `str` from snake_case to camelCase
+  return str.replace(
+    /(.)([-_][a-z])/g,
+    (_, g1: string, g2: string) =>
+      `${g1}${g2.toUpperCase().replace('-', '').replace('_', '')}`
+  );
+};

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -21,7 +21,7 @@ export async function ensureVideoExistsOrCreate(video_id: string) {
   // It's currently impractical to check if the API error
   // is blocking or not.
   try {
-    await VideoService.videoCreate({ video_id } as Video);
+    await VideoService.videoCreate({ requestBody: { video_id } as Video });
   } catch (err) {
     if (
       err.status === 400 &&
@@ -70,7 +70,9 @@ export async function getVideoFromRateLaterListForComparison(
   otherVideo: string | null,
   currentVideo: string | null
 ): Promise<string | null> {
-  const rateLaterResult = await UsersService.usersMeVideoRateLaterList(99, 0);
+  const rateLaterResult = await UsersService.usersMeVideoRateLaterList({
+    limit: 99,
+  });
   const rateLaterList =
     rateLaterResult?.results?.map((v) => v.video.video_id) || [];
   const rateLaterVideoId = await retryRandomPick(
@@ -87,11 +89,11 @@ export async function getVideoFromPreviousComparisons(
   currentVideo: string | null
 ): Promise<string | null> {
   const comparisonCount: number =
-    (await UsersService.usersMeComparisonsList(0, 0))?.count || 0;
-  const comparisonVideoResult = await UsersService.usersMeComparisonsList(
-    99,
-    Math.floor(Math.random() * comparisonCount)
-  );
+    (await UsersService.usersMeComparisonsList({ limit: 0 }))?.count || 0;
+  const comparisonVideoResult = await UsersService.usersMeComparisonsList({
+    limit: 99,
+    offset: Math.floor(Math.random() * comparisonCount),
+  });
   const cl = comparisonVideoResult?.results || [];
   const comparisonVideoList = [
     ...cl.map((v) => v.video_a.video_id),
@@ -131,7 +133,7 @@ export async function getVideoForComparison(
     );
     if (videoFromComparisons) return videoFromComparisons;
   }
-  const videoResult = await VideoService.videoList(100, 0);
+  const videoResult = await VideoService.videoList({ limit: 100 });
   const videoList = (videoResult?.results || []).map((v) => v.video_id);
   const videoId = await retryRandomPick(5, otherVideo, currentVideo, videoList);
   if (videoId) return videoId;

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -72,6 +72,7 @@ export async function getVideoFromRateLaterListForComparison(
 ): Promise<string | null> {
   const rateLaterResult = await UsersService.usersMeVideoRateLaterList({
     limit: 99,
+    offset: 0,
   });
   const rateLaterList =
     rateLaterResult?.results?.map((v) => v.video.video_id) || [];
@@ -89,7 +90,8 @@ export async function getVideoFromPreviousComparisons(
   currentVideo: string | null
 ): Promise<string | null> {
   const comparisonCount: number =
-    (await UsersService.usersMeComparisonsList({ limit: 0 }))?.count || 0;
+    (await UsersService.usersMeComparisonsList({ limit: 0, offset: 0 }))
+      ?.count || 0;
   const comparisonVideoResult = await UsersService.usersMeComparisonsList({
     limit: 99,
     offset: Math.floor(Math.random() * comparisonCount),
@@ -133,7 +135,7 @@ export async function getVideoForComparison(
     );
     if (videoFromComparisons) return videoFromComparisons;
   }
-  const videoResult = await VideoService.videoList({ limit: 100 });
+  const videoResult = await VideoService.videoList({ limit: 100, offset: 0 });
   const videoList = (videoResult?.results || []).map((v) => v.video_id);
   const videoId = await retryRandomPick(5, otherVideo, currentVideo, videoList);
   if (videoId) return videoId;


### PR DESCRIPTION
Now that the `/video/` endpoints are correctly described in the schema (#332), the corresponding routes can be called using the generated client. However, `openapi-typescript-codegen` uses unnamed arguments by default. It would make the usage of this endpoint (currently with 16 optional query parameters) very impractical.

That's why this PR sets [`--useOptions`](https://github.com/ferdikoomen/openapi-typescript-codegen#argument-style-vs-object-style---useoptions) in the "openapi" command line, to use options objects as arguments: parameters must be named explicitly, and no specific order is required. Moreover, the body is passed as `requestBody`. As a result, this PR includes many adjustments in how the generated client is used. But the behavior should be unchanged.