### PR TITLE
e2e: Fix flaky test case with higher timeout for cypress commands in extension.spec.ts

### DIFF
--- a/tests/cypress/integration/extension.spec.ts
+++ b/tests/cypress/integration/extension.spec.ts
@@ -2,7 +2,10 @@ import { onlyOn } from '@cypress/skip-test'
 
 onlyOn('headed', () => {
   describe('Tournesol extension', 
-    { browser: ['chromium', 'chrome']}, 
+    {
+      browser: ['chromium', 'chrome'],
+      defaultCommandTimeout: 8000,
+    },
     () => {
       const consent = () => {
         cy.get('body')
@@ -25,7 +28,6 @@ onlyOn('headed', () => {
       it('shows Tournesol recommendations on youtube.com', () => {
         cy.visit('https://www.youtube.com');
         consent();
-        cy.wait(5000);
         cy.contains('Recommended by Tournesol').should('be.visible');
       })
 


### PR DESCRIPTION
The default timeout is 4000ms. It seems to be too low to load a video page completely on CI machines.  
And using a larger timeout is preferable to calling `cy.wait()` explicitly as it was done in one of the test case.