### PR TITLE
fix(infra): Configure certbot service to authenticate via nginx

### DIFF
--- a/infra/ansible/roles/nginx/tasks/main.yml
+++ b/infra/ansible/roles/nginx/tasks/main.yml
@@ -81,4 +81,12 @@
   notify:
     - Reload Nginx
 
+- name: Override certbot service to authenticate via nginx
+  template:
+    src: certbot.service
+    dest: /lib/systemd/system/certbot.service
+  notify:
+    # Make sure that systemd reloads any changes
+    - Reload Nginx
+
 - meta: flush_handlers

--- a/infra/ansible/roles/nginx/templates/certbot.service
+++ b/infra/ansible/roles/nginx/templates/certbot.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Certbot
+Documentation=file:///usr/share/doc/python-certbot-doc/html/index.html
+Documentation=https://certbot.eff.org/docs
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/certbot --nginx -q renew
+PrivateTmp=true


### PR DESCRIPTION
During the provisioning, TLS certificates are generated with `certbot certonly --standalone` and this "standalone" setting is persisted in the letsencrypt configuration.  

On renewal, the certbot.service should use existing "nginx" instance as the authenticator, instead of using a standalone server (which would fail as the port is not available). Hence this configuration that forces `certbot.service` to use the `--nginx` option. 