### PR TITLE
fix(frontend): Update CSP to allow inline script used by development environment

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -8,4 +8,4 @@ REACT_APP_OAUTH_CLIENT_SECRET=iB9j9hM5ekFpKlZQ6uNGloFJIWLVnq8LoG7SNdCtHY5oM7w9KY
 REACT_APP_CSP_CONNECT_SRC=https://noembed.com
 REACT_APP_CSP_FRAME_SRC=https://www.youtube.com
 REACT_APP_CSP_IMAGE_SRC="https://i.ytimg.com https://www.paypal.com https://www.paypalobjects.com"
-REACT_APP_CSP_SCRIPT_SRC="https://www.youtube.com/iframe_api https://www.youtube.com/s/player/"
+REACT_APP_CSP_SCRIPT_SRC="'unsafe-inline' https://www.youtube.com/iframe_api https://www.youtube.com/s/player/"

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -8,4 +8,5 @@ REACT_APP_OAUTH_CLIENT_SECRET=iB9j9hM5ekFpKlZQ6uNGloFJIWLVnq8LoG7SNdCtHY5oM7w9KY
 REACT_APP_CSP_CONNECT_SRC=https://noembed.com
 REACT_APP_CSP_FRAME_SRC=https://www.youtube.com
 REACT_APP_CSP_IMAGE_SRC="https://i.ytimg.com https://www.paypal.com https://www.paypalobjects.com"
+# 'unsafe-inline' is added here for development purposes only (used by hot reloading)
 REACT_APP_CSP_SCRIPT_SRC="'unsafe-inline' https://www.youtube.com/iframe_api https://www.youtube.com/s/player/"


### PR DESCRIPTION
The development server uses inline script to implement hot reloading and handle compilation errors.

Currently, automatic reloading is failing with an error and the application is frozen:

>Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self' https://www.youtube.com/iframe_api https://www.youtube.com/s/player/".
...

It seems it's related with how `react-error-overlay`  injects an iframe to display potential errors:  
https://github.com/facebook/create-react-app/blob/9673858a3715287c40aef9e800c431c7d45c05a2/packages/react-error-overlay/src/index.js#L139-L154