### PR TITLE
View count display

### DIFF
--- a/backend/scripts/dataset-import/.gitignore
+++ b/backend/scripts/dataset-import/.gitignore
@@ -1,3 +1,4 @@
 /metadata
 /public-dataset
 /dump.sql
+/venv-import-dataset

--- a/frontend/src/features/videos/VideoCard.spec.tsx
+++ b/frontend/src/features/videos/VideoCard.spec.tsx
@@ -20,9 +20,8 @@ describe('VideoCard content', () => {
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
       'Video title'
     );
-    // handle all the possible number notations of 154988 with a regex
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
-      /(1.?54.?988|١٥٤٬٩٨٨|۱۵۴٬۹۸۸) views/
+      '154,988 views'
     );
     expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
       '9 comparisons by 4 contributors'
@@ -55,9 +54,8 @@ describe('VideoCard content', () => {
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
       'Video title'
     );
-    // handle all the possible number notations of 154988 with a regex
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
-      /(1.?54.?988|١٥٤٬٩٨٨|۱۵۴٬۹۸۸) views/
+      '154,988 views'
     );
     expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
       '9 comparisons by 4 contributors'

--- a/frontend/src/features/videos/VideoCard.spec.tsx
+++ b/frontend/src/features/videos/VideoCard.spec.tsx
@@ -20,8 +20,9 @@ describe('VideoCard content', () => {
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
       'Video title'
     );
+    // handle all the possible number notations of 154988 with a regex
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
-      '154,988 views'
+      /(1.?54.?988|١٥٤٬٩٨٨|۱۵۴٬۹۸۸) views/
     );
     expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
       '9 comparisons by 4 contributors'
@@ -54,8 +55,9 @@ describe('VideoCard content', () => {
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
       'Video title'
     );
+    // handle all the possible number notations of 154988 with a regex
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
-      '154,988 views'
+      /(1.?54.?988|١٥٤٬٩٨٨|۱۵۴٬۹۸۸) views/
     );
     expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
       '9 comparisons by 4 contributors'

--- a/frontend/src/features/videos/VideoCard.spec.tsx
+++ b/frontend/src/features/videos/VideoCard.spec.tsx
@@ -21,7 +21,7 @@ describe('VideoCard content', () => {
       'Video title'
     );
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
-      '154988 views'
+      '154,988 views'
     );
     expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
       '9 comparisons by 4 contributors'
@@ -55,7 +55,7 @@ describe('VideoCard content', () => {
       'Video title'
     );
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
-      '154988 views'
+      '154,988 views'
     );
     expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
       '9 comparisons by 4 contributors'

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -210,7 +210,7 @@ function VideoCard({
         <div className={classes.youtube_complements}>
           {video.views && (
             <span className={classes.youtube_complements_p}>
-              {video.views.toLocaleString()} views
+              {video.views.toLocaleString('en-US')} views
             </span>
           )}
           {video.publication_date && (

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -210,7 +210,7 @@ function VideoCard({
         <div className={classes.youtube_complements}>
           {video.views && (
             <span className={classes.youtube_complements_p}>
-              {video.views} views
+              {video.views.toLocaleString()} views
             </span>
           )}
           {video.publication_date && (


### PR DESCRIPTION
I would prefer to implement solution 4 since dots are not conspicuous and need a bit of focus to be seen.
![Capture d’écran de 2021-12-12 20-04-47](https://user-images.githubusercontent.com/47578089/146262149-ce90eac0-341a-476a-a5bc-8441346006ea.png)
But then as we said if I don't know the browser's default localization, I can't tell in what format it will be rendered and what I should expect.
I found a regex that does the job for all the languages : /(1.?54.?988|١٥٤٬٩٨٨|۱۵۴٬۹۸۸) views/
It is complicated and uses non-ascii caracters, so /1.?54.?988 views/  is also pretty good except it doesn't work for arabic.

Closes #288 