### PR TITLE
[front] fix: warning about missing ref in ReactPlayer

### DIFF
--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -126,19 +126,25 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const PlayerWrapper = ({
-  duration,
-  children,
-}: {
-  duration?: string;
-  children: React.ReactNode;
-}) => {
+const PlayerWrapper = React.forwardRef(function PlayerWrapper(
+  {
+    duration,
+    children,
+  }: {
+    duration?: string;
+    children: React.ReactNode;
+  },
+  ref
+) {
   const [isDurationVisible, setIsDurationVisible] = useState(true);
   return (
     <Box
       position="relative"
       height="100%"
       onClick={() => setIsDurationVisible(false)}
+      // Use spread operator to work around missing typing for 'ref' in MUI `Box`
+      // See https://github.com/mui-org/material-ui/issues/17010
+      {...{ ref }}
     >
       {isDurationVisible && duration && (
         <Box
@@ -158,7 +164,7 @@ const PlayerWrapper = ({
       {children}
     </Box>
   );
-};
+});
 
 function VideoCard({
   video,


### PR DESCRIPTION
After a wrapper has been introduced in #321, a warning in React dev tools passed unnoticed.

> Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?  
Check the render method of `ReactPlayer`.
...

Using [`React.forwardRef()`](https://reactjs.org/docs/react-api.html#reactforwardref), the wrapper ref can be forwarded to the inner `Box`.
