### PR TITLE
[backend] fix: ignore nan when saving criteria scores after ml_train

### DIFF
--- a/backend/ml/management/commands/ml_train.py
+++ b/backend/ml/management/commands/ml_train.py
@@ -1,4 +1,5 @@
 import logging
+import numpy as np
 
 from tournesol.models import (
     ComparisonCriteriaScore,
@@ -88,6 +89,7 @@ def save_data(video_scores, contributor_rating_scores):
                 uncertainty=uncertainty,
             )
             for video_id, criteria, score, uncertainty in video_scores
+            if not np.isnan(score)
         ]
     )
 
@@ -124,6 +126,7 @@ def save_data(video_scores, contributor_rating_scores):
                 uncertainty=uncertainty,
             )
             for contributor_id, video_id, criteria, score, uncertainty in contributor_rating_scores
+            if not np.isnan(score)
         ]
     )
 


### PR DESCRIPTION
Storing `nan` values in the database causes serialization errors in the API when `criteria_scores` are included in the response.  
We could also handle this case in the serializers, but it seems preferable to me to avoid including invalid scores in the database during the ml_train job.

The root cause is unclear. The issue has been observed on staging, after a user submitted comparisons where every criteria score has value `-10`. Are the computed local scores undefined when the criteria scores are constant?