### PR TITLE
Languages filter frontend

### DIFF
--- a/frontend/src/components/ChoicesFilterSection.tsx
+++ b/frontend/src/components/ChoicesFilterSection.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 
-import { Typography, FormControlLabel, Checkbox, Box } from '@material-ui/core';
-import { CheckCircle, CheckCircleOutline } from '@material-ui/icons';
 import { TitledSection } from 'src/components';
+import { Typography, FormControlLabel, Checkbox, Box } from '@material-ui/core';
+import {
+  CheckCircle,
+  CheckCircleOutline,
+  CheckBox,
+  CheckBoxOutlineBlank,
+} from '@material-ui/icons';
 
 interface Props {
   title: string;
   value: string;
   choices: Record<string, string>;
-  exclusiveChoice: boolean;
+  multipleChoice: boolean;
   onChange: (value: string) => void;
 }
 
@@ -16,18 +21,11 @@ const ChoicesFilterSection = ({
   title,
   value,
   choices,
-  exclusiveChoice,
+  multipleChoice,
   onChange,
 }: Props) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (exclusiveChoice) {
-      // Only one value allowed
-      if (event.target.checked) {
-        onChange(event.target.name);
-      } else {
-        onChange('');
-      }
-    } else {
+    if (multipleChoice) {
       // Multiple values allowed
       let all_values = value ? value.split(',') : [];
 
@@ -39,23 +37,36 @@ const ChoicesFilterSection = ({
         all_values = all_values.filter((item) => item !== event.target.name);
       }
       onChange(all_values.join(','));
+    } else {
+      // Only one value allowed
+      if (event.target.checked) {
+        onChange(event.target.name);
+      } else {
+        onChange('');
+      }
     }
   };
+
+  const valuesList = multipleChoice ? value.split(',') : [value];
 
   return (
     <TitledSection title={title}>
       <Box display="flex" flexDirection="column">
         {Object.entries(choices).map(([choiceValue, choiceLabel]) => {
-          const checked = exclusiveChoice
-            ? value === choiceValue
-            : value != '' && value.split(',').includes(choiceValue);
+          const checked = valuesList.includes(choiceValue);
 
           return (
             <FormControlLabel
               control={
                 <Checkbox
-                  icon={<CheckCircleOutline />}
-                  checkedIcon={<CheckCircle />}
+                  icon={
+                    multipleChoice ? (
+                      <CheckBoxOutlineBlank />
+                    ) : (
+                      <CheckCircleOutline />
+                    )
+                  }
+                  checkedIcon={multipleChoice ? <CheckBox /> : <CheckCircle />}
                   checked={checked}
                   onChange={handleChange}
                   name={choiceValue}

--- a/frontend/src/components/ChoicesFilterSection.tsx
+++ b/frontend/src/components/ChoicesFilterSection.tsx
@@ -8,15 +8,37 @@ interface Props {
   title: string;
   value: string;
   choices: Record<string, string>;
+  exclusiveChoice: boolean;
   onChange: (value: string) => void;
 }
 
-const ChoicesFilterSection = ({ title, value, choices, onChange }: Props) => {
+const ChoicesFilterSection = ({
+  title,
+  value,
+  choices,
+  exclusiveChoice,
+  onChange,
+}: Props) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.checked) {
-      onChange(event.target.name);
+    if (exclusiveChoice) {
+      // Only one value allowed
+      if (event.target.checked) {
+        onChange(event.target.name);
+      } else {
+        onChange('');
+      }
     } else {
-      onChange('');
+      // Multiple values allowed
+      let all_values = value ? value.split(',') : [];
+
+      if (event.target.checked) {
+        // Add the checked value
+        all_values.push(event.target.name);
+      } else {
+        // Remove the unchecked value
+        all_values = all_values.filter((item) => item !== event.target.name);
+      }
+      onChange(all_values.join(','));
     }
   };
 
@@ -24,7 +46,10 @@ const ChoicesFilterSection = ({ title, value, choices, onChange }: Props) => {
     <TitledSection title={title}>
       <Box display="flex" flexDirection="column">
         {Object.entries(choices).map(([choiceValue, choiceLabel]) => {
-          const checked = value === choiceValue;
+          const checked = exclusiveChoice
+            ? value === choiceValue
+            : value != '' && value.split(',').includes(choiceValue);
+
           return (
             <FormControlLabel
               control={
@@ -35,6 +60,7 @@ const ChoicesFilterSection = ({ title, value, choices, onChange }: Props) => {
                   onChange={handleChange}
                   name={choiceValue}
                   size="small"
+                  data-testid={title + ': ' + choiceLabel}
                 />
               }
               label={

--- a/frontend/src/components/ChoicesFilterSection.tsx
+++ b/frontend/src/components/ChoicesFilterSection.tsx
@@ -21,7 +21,7 @@ const ChoicesFilterSection = ({
   title,
   value,
   choices,
-  multipleChoice,
+  multipleChoice = false,
   onChange,
 }: Props) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/features/ratings/IsPublicFilter.tsx
+++ b/frontend/src/features/ratings/IsPublicFilter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ChoicesFilterSection } from 'src/components';
 
-const isPublicChoices = {
+export const isPublicChoices = {
   true: 'Public',
   false: 'Private',
 };
@@ -15,6 +15,7 @@ function IsPublicFilter(props: FilterProps) {
   return (
     <ChoicesFilterSection
       title="Filter by visibility"
+      exclusiveChoice={true}
       choices={isPublicChoices}
       {...props}
     ></ChoicesFilterSection>

--- a/frontend/src/features/ratings/IsPublicFilter.tsx
+++ b/frontend/src/features/ratings/IsPublicFilter.tsx
@@ -15,7 +15,7 @@ function IsPublicFilter(props: FilterProps) {
   return (
     <ChoicesFilterSection
       title="Filter by visibility"
-      exclusiveChoice={true}
+      multipleChoice={false}
       choices={isPublicChoices}
       {...props}
     ></ChoicesFilterSection>

--- a/frontend/src/features/recommendation/DateFilter.tsx
+++ b/frontend/src/features/recommendation/DateFilter.tsx
@@ -6,7 +6,7 @@ interface Props {
   onChange: (value: string) => void;
 }
 
-const dateChoices = {
+export const dateChoices = {
   Today: 'Today',
   Week: 'This week',
   Month: 'This month',

--- a/frontend/src/features/recommendation/DateFilter.tsx
+++ b/frontend/src/features/recommendation/DateFilter.tsx
@@ -17,6 +17,7 @@ function DateFilter(props: Props) {
   return (
     <ChoicesFilterSection
       title="Upload date"
+      exclusiveChoice={true}
       choices={dateChoices}
       {...props}
     />

--- a/frontend/src/features/recommendation/DateFilter.tsx
+++ b/frontend/src/features/recommendation/DateFilter.tsx
@@ -17,7 +17,7 @@ function DateFilter(props: Props) {
   return (
     <ChoicesFilterSection
       title="Upload date"
-      exclusiveChoice={true}
+      multipleChoice={false}
       choices={dateChoices}
       {...props}
     />

--- a/frontend/src/features/recommendation/LanguageFilter.tsx
+++ b/frontend/src/features/recommendation/LanguageFilter.tsx
@@ -16,7 +16,7 @@ function LanguageFilter(props: Props) {
   return (
     <ChoicesFilterSection
       title="Language"
-      exclusiveChoice={false}
+      multipleChoice={true}
       choices={languageChoices}
       {...props}
     ></ChoicesFilterSection>

--- a/frontend/src/features/recommendation/LanguageFilter.tsx
+++ b/frontend/src/features/recommendation/LanguageFilter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ChoicesFilterSection } from 'src/components';
 
-const languageChoices = {
+export const languageChoices = {
   en: 'English',
   fr: 'French',
   de: 'German',

--- a/frontend/src/features/recommendation/LanguageFilter.tsx
+++ b/frontend/src/features/recommendation/LanguageFilter.tsx
@@ -16,6 +16,7 @@ function LanguageFilter(props: Props) {
   return (
     <ChoicesFilterSection
       title="Language"
+      exclusiveChoice={false}
       choices={languageChoices}
       {...props}
     ></ChoicesFilterSection>

--- a/frontend/src/features/recommendation/SearchFilter.spec.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.spec.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { ThemeProvider } from '@material-ui/core/styles';
+import { theme } from 'src/theme';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+import SearchFilter from './SearchFilter';
+import { dateChoices } from './DateFilter';
+import { languageChoices } from './LanguageFilter';
+import { mainCriteriaNames } from 'src/utils/constants';
+
+describe('Filters feature', () => {
+  let pushSpy = null;
+  beforeEach(() => {
+    // Used to spy on URL parameters updates
+    const history = createMemoryHistory();
+    pushSpy = jest.spyOn(history, 'push');
+
+    // Some context is needed by the component SearchFilter
+    render(
+      <Router history={history}>
+        <ThemeProvider theme={theme}>
+          <SearchFilter />
+        </ThemeProvider>
+      </Router>
+    );
+  });
+
+  function clickOnShowMore(wasClosed = true) {
+    const checkboxDisplayFilters = screen.queryByLabelText('show more');
+    expect(checkboxDisplayFilters).not.toBeNull();
+
+    // aria-expanded should be set to false if the filters menu was closed, and true otherwise
+    expect(checkboxDisplayFilters.getAttribute('aria-expanded')).toBe(
+      (!wasClosed).toString()
+    );
+
+    fireEvent.click(checkboxDisplayFilters);
+
+    // Now it should have changed
+    expect(checkboxDisplayFilters.getAttribute('aria-expanded')).toBe(
+      wasClosed.toString()
+    );
+  }
+
+  function verifyFiltersPresence() {
+    // Check date filters presence
+    for (const [, label] of Object.entries(dateChoices)) {
+      expect(screen.queryAllByTestId('Upload date: ' + label)).toHaveLength(1);
+    }
+
+    // Check language filters presence
+    for (const [, label] of Object.entries(languageChoices)) {
+      expect(screen.queryAllByTestId('Language: ' + label)).toHaveLength(1);
+    }
+
+    // Check criteria filters presence
+    for (const [, label] of mainCriteriaNames) {
+      expect(screen.queryAllByTitle(label)).toHaveLength(1);
+    }
+  }
+
+  // Click on a date filter checkbox and verify the resulting URL parameters
+  function clickOnDateCheckbox({ checkbox, expectInUrl }) {
+    const dateCheckbox = screen.queryByTestId(
+      'Upload date: ' + dateChoices[checkbox]
+    );
+    expect(dateCheckbox).not.toBeNull();
+
+    fireEvent.click(dateCheckbox);
+
+    // Check that it updated the URL with the new date type filter
+    // Use encodeURI to escape comas (in URL, "," => "%2C")
+    expect(pushSpy).toHaveBeenLastCalledWith({
+      search: expectInUrl ? 'date=' + encodeURIComponent(expectInUrl) : '',
+    });
+  }
+
+  // Click on a language checkbox and verify the resulting URL parameters
+  function clickOnLanguageCheckbox({ checkbox, expectInUrl }) {
+    const languageCheckbox = screen.queryByTestId(
+      'Language: ' + languageChoices[checkbox]
+    );
+    expect(languageCheckbox).not.toBeNull();
+
+    fireEvent.click(languageCheckbox);
+
+    // Check that it updated the URL with the new language filter
+    // Use encodeURI to escape comas (in URL, "," => "%2C")
+    expect(pushSpy).toHaveBeenLastCalledWith({
+      search: expectInUrl ? 'language=' + encodeURIComponent(expectInUrl) : '',
+    });
+  }
+
+  it('Can open and close the filters menu', () => {
+    // Click to open the filters menu. The checks are made inside clickOnShowMore.
+    clickOnShowMore();
+
+    // Click again to close back the filters menu
+    clickOnShowMore(false);
+  });
+
+  it('Check that all the filter checkboxes and sliders are present', () => {
+    // Click to open the filters menu
+    clickOnShowMore();
+
+    // Check the presence of all the filters checkboxes
+    verifyFiltersPresence();
+  });
+
+  it('Can only check one date filter at once', () => {
+    clickOnShowMore();
+
+    // click on the checkbox "This week", and check that the URL now contains "date=Week"
+    clickOnDateCheckbox({ checkbox: 'Week', expectInUrl: 'Week' });
+
+    // Now set it to "This Month".
+    // Verify that the previous option "This week" is automatically unchecked (date="Month").
+    clickOnDateCheckbox({ checkbox: 'Month', expectInUrl: 'Month' });
+
+    // Same with "Today" and "This year"
+    clickOnDateCheckbox({ checkbox: 'Today', expectInUrl: 'Today' });
+    clickOnDateCheckbox({ checkbox: 'Year', expectInUrl: 'Year' });
+
+    // Uncheck the last option, and verify that there is no date filter in the URL
+    clickOnDateCheckbox({ checkbox: 'Year', expectInUrl: '' });
+  });
+
+  it('Can check multiple language filters at once', () => {
+    clickOnShowMore();
+
+    // click on the checkbox English ("en"), and check that the URL contains "language=en"
+    clickOnLanguageCheckbox({ checkbox: 'en', expectInUrl: 'en' });
+
+    // click on the checkbox French ("fr"), and check that the URL contains "language=en,fr"
+    clickOnLanguageCheckbox({ checkbox: 'fr', expectInUrl: 'en,fr' });
+
+    // click on the checkbox German ("de"), and check that the URL contains "language=de,en,fr"
+    clickOnLanguageCheckbox({ checkbox: 'de', expectInUrl: 'en,fr,de' });
+
+    // Now remove click again on the checkboxes and verify that it was removed from the URL
+    clickOnLanguageCheckbox({ checkbox: 'fr', expectInUrl: 'en,de' });
+    clickOnLanguageCheckbox({ checkbox: 'en', expectInUrl: 'de' });
+    clickOnLanguageCheckbox({ checkbox: 'de', expectInUrl: '' });
+  });
+});


### PR DESCRIPTION
part 2/3 of issue #349 (backend, **frontend**, extension)

If you lack time, don't hesitate to assign it to another reviewer.

### Modifications
- added an option in the component ChoicesFilterSection to enable checkboxes that can have multiple options checked at once
- added tests that cover the language filters and date filters rendering

I could also make a test for the criteria filters. But I don't know if it is really useful. It may just be inconvenient if someone ever wants to modify it. And currently the default URL parameters can be unexpectedly displayed in the URL (remark 1 below).

### (unrelated) minor remarks : 
1 - the criteria parameters like "reliability=50" are not removed from the URL, even when they are set at their default value (50).
2 - weird but probably normal : Could not verify the attribute "checked" of the checkboxes, as it doesn't appear in the DOM. I think it is updated in the React component, but never updated in the DOM (in HTML, it is just a default value).
3 - 1 warning in VideoCard.spec.tsx ([warning.txt](https://github.com/tournesol-app/tournesol/files/7776428/warning.txt)). Probably nothing important, but a bit unsettling.