### PR TITLE
ci: investigate the error Unable to find LTS release 'fermium'

### DIFF
--- a/docs/architecture-decision-log/README.md
+++ b/docs/architecture-decision-log/README.md
@@ -14,7 +14,7 @@ Learn more about A.D.R. in [this other documentation][github-adr].
 
 Table of Content
 
-* [What's new](#whats-new)
+* [What's new?](#whats-new)
 * [Keywords](#keywords)
 * [Usage](#summary)
   * [Rules](#rules)


### PR DESCRIPTION
There was an error in the `Frontend lint and tests` job, at the step `Run actions/setup-node@v2`

```
Attempt to resolve LTS alias from manifest...
Error: Unable to find LTS release 'fermium' for Node version 'lts/fermium'.
```

(see [the complete log](https://github.com/tournesol-app/tournesol/runs/4640925953?check_suite_focus=true))

but the error seems to be occasional and not recurring.

Another error has occured during my investigation, this time during the step `Set up job`

```
Download action repository 'actions/setup-node@v2' (SHA:04c56d2f954f1e4c69436aa54cfef261a018f458)
Warning: Failed to download action 'https://api.github.com/repos/actions/setup-node/tarball/04c56d2f954f1e4c69436aa54cfef261a018f458'. Error: The operation was canceled.
Warning: Back off 16.888 seconds before retry.
Warning: Failed to download action 'https://api.github.com/repos/actions/setup-node/tarball/04c56d2f954f1e4c69436aa54cfef261a018f458'. Error: The operation was canceled.
Warning: Back off 22.873 seconds before retry.
Error: The operation was canceled.
```

(see [the complete log](https://github.com/tournesol-app/tournesol/runs/4642930235?check_suite_focus=true))

but simply after having pushed a new branch without any modification, the error disappeared =|

(see [the success](https://github.com/tournesol-app/tournesol/runs/4643103298?check_suite_focus=true))