### PR TITLE
[review branch] to merge into `cache_public_dataset`

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,14 +13,13 @@ Django app for tournesol app.
 - Create a python env and install the requirements
   `pip install -r requirements.txt`
 
-- Install migrations on database
-  `python manage.py migrate`
+- Install migrations on database `python manage.py migrate`
 
-- Create superuser
-  `python manage.py createsuperuser`
+- Create the database cache `python manage.py createcachetable`
 
-- Run the server
-  `python manage.py runserver`
+- Create superuser `python manage.py createsuperuser`
+
+- Run the server `python manage.py runserver`
 
 ## Dependencies
 

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: 
         - bash
         - -c
-        - "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+        - "python manage.py migrate && python manage.py createcachetable && python manage.py runserver 0.0.0.0:8000"
     volumes:
       - ../backend:/backend
     ports:

--- a/infra/ansible/roles/django/handlers/main.yml
+++ b/infra/ansible/roles/django/handlers/main.yml
@@ -17,6 +17,13 @@
   become: true
   become_user: gunicorn
 
+- name: Create database cache
+  shell:
+    cmd: "source /srv/tournesol-backend/venv/bin/activate && SETTINGS_FILE=/etc/tournesol/settings.yaml python /srv/tournesol-backend/manage.py createcachetable"
+    executable: /usr/bin/bash
+  become: true
+  become_user: gunicorn
+
 - name: Notify backend upgrade
   shell:
     cmd: "wget -qO /dev/null --post-data='{\"content\": \"**{{domain_name}}** - new back end deployed: {{git_reference}}\"}' --header='Content-Type:application/json' '{{discord_alerting_webhook}}?wait=true'"

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -85,6 +85,7 @@
   become_user: gunicorn
   notify:
     - Migrate Django database
+    - Create database cache
     - Collect Django static assets
     - Restart Gunicorn
     - Notify backend upgrade

--- a/infra/ansible/roles/restore/tasks/main.yml
+++ b/infra/ansible/roles/restore/tasks/main.yml
@@ -23,6 +23,7 @@
       notify:
         - Restart Gunicorn
         - Migrate Django database
+        - Create database cache
 
     - debug:
         var: restore_result.stdout_lines
@@ -48,6 +49,7 @@
       become_user: postgres
       notify:
         - Migrate Django database
+        - Create database cache
       register: restore_result
 
     - debug:


### PR DESCRIPTION
**important** this PR targets the feature branch `cache_public_dataset`, and must not be merged into `main`

- related to pull request #392 
- related to issue #383

---

As suggested by @amatissart , the Django command `createcachetable` was missing in our deployment routines. It is now automatically run by the development environment each time the API container is started. It is also run for each deployment made by Ansible.