### PR TITLE
[front] Change displayed text in comparisons

### DIFF
--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -6,6 +6,7 @@ interface PaginationProps {
   offset: number;
   count: number;
   onOffsetChange: (n: number) => void;
+  itemType?: string;
 }
 
 const useStyles = makeStyles({
@@ -26,6 +27,7 @@ const Pagination = ({
   limit,
   onOffsetChange,
   count,
+  itemType = 'videos',
 }: PaginationProps) => {
   const classes = useStyles();
 
@@ -43,7 +45,7 @@ const Pagination = ({
         Previous {limit}
       </Button>
       <span className={classes.paginationStatusText}>
-        Showing videos {offset + 1} to {Math.min(count, offset + limit)}
+        Showing {itemType} {offset + 1} to {Math.min(count, offset + limit)}
         {count && ` of ${count}`}
       </span>
       <Button

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -46,6 +46,7 @@ function ComparisonsPage() {
         count={count}
         onOffsetChange={handleOffsetChange}
         limit={limit}
+        itemType="comparisons"
       />
       <ComparisonList comparisons={comparisons} />
     </div>


### PR DESCRIPTION
Changed the top line from "videos" to "comparisons" in the comparison tab.