### PR TITLE
[front] refactor: simplify API responses handling in several forms

### DIFF
--- a/frontend/src/features/login/Login.spec.tsx
+++ b/frontend/src/features/login/Login.spec.tsx
@@ -12,6 +12,7 @@ import { Provider } from 'react-redux';
 import thunk, { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from '@reduxjs/toolkit';
 import fetchMock from 'fetch-mock-jest';
+import { SnackbarProvider } from 'notistack';
 import Login from './Login';
 import { LoginState } from './LoginState.model';
 import {
@@ -120,11 +121,13 @@ describe('login feature', () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={['/login']}>
-          <Switch>
-            <Route path="/login">
-              <Login />
-            </Route>
-          </Switch>
+          <SnackbarProvider maxSnack={6} autoHideDuration={6000}>
+            <Switch>
+              <Route path="/login">
+                <Login />
+              </Route>
+            </Switch>
+          </SnackbarProvider>
         </MemoryRouter>
       </Provider>
     );

--- a/frontend/src/features/login/Login.tsx
+++ b/frontend/src/features/login/Login.tsx
@@ -1,22 +1,27 @@
 import React, { useEffect, useState } from 'react';
 
 import { Link as RouterLink } from 'react-router-dom';
-import { TextField, Grid, Button, Link, Box } from '@mui/material';
-import { useAppSelector, useAppDispatch } from '../../app/hooks';
-import { getTokenAsync, selectLogin } from './loginSlice';
-import { LoginState } from './LoginState.model';
-import { hasValidToken } from './loginUtils';
 import { useLocation, Redirect } from 'react-router-dom';
+import { TextField, Grid, Button, Link, Box } from '@mui/material';
+import { useSnackbar } from 'notistack';
+
+import { useAppSelector, useAppDispatch } from 'src/app/hooks';
+import { ContentHeader, ContentBox } from 'src/components';
+
+import { getTokenAsync, selectLogin } from './loginSlice';
+import { hasValidToken } from './loginUtils';
+import { LoginState } from './LoginState.model';
 import RedirectState from './RedirectState';
-import { Alert, ContentHeader, ContentBox } from 'src/components';
+import { showErrorAlert } from '../../utils/notifications';
 
 const Login = () => {
+  const { enqueueSnackbar } = useSnackbar();
+
   const login: LoginState = useAppSelector(selectLogin);
   const dispatch = useAppDispatch();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [validToken, setValidToken] = useState(hasValidToken(login));
-  const [loginError, setLoginError] = useState<Error | null>(null);
   const location = useLocation();
   const { from: fromUrl } = (location?.state ?? {}) as RedirectState;
 
@@ -34,13 +39,12 @@ const Login = () => {
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    setLoginError(null);
     const result: unknown = await dispatch(
       getTokenAsync({ username: username, password: password })
     );
     const resultWithError = result as { error: Error | undefined };
     if (resultWithError.error) {
-      setLoginError(resultWithError.error);
+      showErrorAlert(enqueueSnackbar, resultWithError.error.message);
     }
   };
 
@@ -96,7 +100,6 @@ const Login = () => {
               </Button>
             </Grid>
           </Grid>
-          {loginError && <Alert>❌ {loginError.message}</Alert>}
         </form>
         <Box my={2}>
           <Link

--- a/frontend/src/features/rateLater/RateLaterAddForm.tsx
+++ b/frontend/src/features/rateLater/RateLaterAddForm.tsx
@@ -1,31 +1,24 @@
 import React, { useState } from 'react';
 import { Grid, TextField, Button } from '@mui/material';
-import Alert from 'src/components/Alert';
-import { ApiError } from 'src/services/openapi/core/ApiError';
 import { extractVideoId } from 'src/utils/video';
 
 interface FormProps {
-  addVideo: (id: string) => void;
+  addVideo: (id: string) => Promise<boolean>;
 }
 
 const RateLaterAddForm = ({ addVideo }: FormProps) => {
-  const [apiError, setApiError] = useState<ApiError | null>(null);
-  const [hasSucceeded, setHasSucceeded] = useState(false);
   const [formVideo, setFormVideo] = useState('');
 
+  /**
+   * The potential API errors raised by the function `addVideo` are not caught
+   * here, and are considered already handled by the function itself.
+   */
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    setApiError(null);
-    setHasSucceeded(false);
-    try {
-      await addVideo(extractVideoId(formVideo) || '');
-      await setFormVideo('');
-    } catch (err) {
-      console.error('Add to rate later list failed.', `${err}\n`, err.body);
-      setApiError(err);
-      return;
+    const success = await addVideo(extractVideoId(formVideo) || '');
+    if (success) {
+      setFormVideo('');
     }
-    setHasSucceeded(true);
   };
 
   return (
@@ -60,14 +53,6 @@ const RateLaterAddForm = ({ addVideo }: FormProps) => {
           </Button>
         </Grid>
       </Grid>
-
-      {hasSucceeded && <Alert>✅ Video added to your Rate Later list!</Alert>}
-      {apiError && apiError?.status === 409 && (
-        <Alert>⚠️ The video is already in your Rate Later list.</Alert>
-      )}
-      {apiError && apiError?.status !== 409 && (
-        <Alert>❌ An error has occured. {apiError.statusText}</Alert>
-      )}
     </form>
   );
 };

--- a/frontend/src/features/settings/account/PasswordForm.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.tsx
@@ -6,12 +6,9 @@ import TextField from '@mui/material/TextField';
 
 import { useSnackbar } from 'notistack';
 
-import {
-  contactAdministrator,
-  showErrorAlert,
-  showSuccessAlert,
-} from 'src/utils/notifications';
-import { AccountsService } from 'src/services/openapi';
+import { AccountsService, ApiError } from 'src/services/openapi';
+import { showSuccessAlert } from 'src/utils/notifications';
+import { displayErrors } from 'src/utils/api/response';
 
 const PasswordForm = () => {
   const { enqueueSnackbar } = useSnackbar();
@@ -29,26 +26,18 @@ const PasswordForm = () => {
     setDisabled(true);
 
     const response: void | Record<string, string> =
-      await AccountsService.accountsChangePasswordCreate(
-        {
-          requestBody: {
-            old_password: oldPassword,
-            password,
-            password_confirm: passwordConfirm,
-          },
-        }
-        // handle errors and unknown errors
-      ).catch((reason: { body: { [k: string]: string[] } }) => {
-        if (reason && 'body' in reason) {
-          const newErrorMessages = Object.values(reason['body']).flat();
-          newErrorMessages.map((msg) => showErrorAlert(enqueueSnackbar, msg));
-        } else {
-          contactAdministrator(
-            enqueueSnackbar,
-            'error',
-            'Sorry, an error has occurred, cannot update password.'
-          );
-        }
+      await AccountsService.accountsChangePasswordCreate({
+        requestBody: {
+          old_password: oldPassword,
+          password,
+          password_confirm: passwordConfirm,
+        },
+      }).catch((reason: ApiError) => {
+        displayErrors(
+          enqueueSnackbar,
+          reason,
+          'Sorry, an error has occurred, cannot update password.'
+        );
       });
 
     // handle success and malformed success

--- a/frontend/src/features/settings/profile/ProfileForm.tsx
+++ b/frontend/src/features/settings/profile/ProfileForm.tsx
@@ -6,13 +6,13 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 
-import { useLoginState } from '../../../hooks';
+import { useLoginState } from 'src/hooks';
+import { displayErrors } from 'src/utils/api/response';
 import {
   contactAdministrator,
-  showErrorAlert,
   showSuccessAlert,
-} from '../../../utils/notifications';
-import { AccountsService } from '../../../services/openapi';
+} from 'src/utils/notifications';
+import { AccountsService, ApiError } from 'src/services/openapi';
 
 const ProfileForm = () => {
   const { updateUsername } = useLoginState();
@@ -49,18 +49,12 @@ const ProfileForm = () => {
       requestBody: {
         username,
       },
-    }).catch((reason: { body: { [k: string]: string[] } }) => {
-      // handle errors and unknown errors
-      if (reason && 'body' in reason) {
-        const newErrorMessages = Object.values(reason['body']).flat();
-        newErrorMessages.map((msg) => showErrorAlert(enqueueSnackbar, msg));
-      } else {
-        contactAdministrator(
-          enqueueSnackbar,
-          'error',
-          'Sorry, an error has occurred, cannot update the profile.'
-        );
-      }
+    }).catch((reason: ApiError) => {
+      displayErrors(
+        enqueueSnackbar,
+        reason,
+        'Sorry, an error has occurred, cannot update the profile.'
+      );
     });
 
     // handle success and malformed success

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -85,7 +85,7 @@ const RateLaterPage = () => {
             {
               status: 409,
               variant: 'warning',
-              msg: 'This video is already in your rate later list',
+              msg: 'This video is already in your rate later list.',
             },
           ]
         );

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -6,11 +6,14 @@ import Typography from '@mui/material/Typography';
 
 import { addToRateLaterList } from 'src/features/rateLater/rateLaterAPI';
 import RateLaterAddForm from 'src/features/rateLater/RateLaterAddForm';
-import { VideoRateLater } from 'src/services/openapi';
+import { ApiError, VideoRateLater } from 'src/services/openapi';
 import { CompareNowAction, RemoveFromRateLater } from 'src/utils/action';
 import { UsersService } from 'src/services/openapi';
 import { ContentBox, LoaderWrapper, Pagination } from 'src/components';
 import VideoList from 'src/features/videos/VideoList';
+import { showSuccessAlert } from '../../utils/notifications';
+import { useSnackbar } from 'notistack';
+import { displayErrors } from '../../utils/api/response';
 
 const useStyles = makeStyles({
   rateLaterIntro: {
@@ -37,6 +40,8 @@ const useStyles = makeStyles({
 });
 
 const RateLaterPage = () => {
+  const { enqueueSnackbar } = useSnackbar();
+
   const classes = useStyles();
   const [isLoading, setIsLoading] = React.useState(true);
   const [offset, setOffset] = React.useState(0);
@@ -69,9 +74,29 @@ const RateLaterPage = () => {
     setIsLoading(false);
   }, [offset, setVideoCount, setRateLaterList]);
 
-  const addToRateLater = async (video_id: string) => {
-    await addToRateLaterList({ video_id });
-    await loadList();
+  const addToRateLater = async (video_id: string): Promise<boolean> => {
+    const response = await addToRateLaterList({ video_id }).catch(
+      (reason: ApiError) => {
+        displayErrors(
+          enqueueSnackbar,
+          reason,
+          'Sorry, an error has occurred, cannot add the video to your rate later list.',
+          [
+            {
+              status: 409,
+              variant: 'warning',
+              msg: 'This video is already in your rate later list',
+            },
+          ]
+        );
+      }
+    );
+    if (response) {
+      showSuccessAlert(enqueueSnackbar, 'Video added to your rate later list.');
+      await loadList();
+      return true;
+    }
+    return false;
   };
 
   const onOffsetChange = (newOffset: number) => {

--- a/frontend/src/utils/api/response.ts
+++ b/frontend/src/utils/api/response.ts
@@ -1,0 +1,75 @@
+import { ProviderContext, VariantType } from 'notistack';
+import { ApiError } from 'src/services/openapi';
+import {
+  contactAdministrator,
+  showErrorAlert,
+  showInfoAlert,
+} from 'src/utils/notifications';
+
+/**
+ * Display all errors contained in an `ApiError` object.
+ *
+ * This function provides a generic way to display all error messages returned
+ * by an API call. It can be used in every form to harmonize the messages
+ * processing.
+ *
+ * Ex
+ *      const response = await addNewVideo({ video_id }).catch(
+ *        (reason: ApiError) => {
+ *          displayErrors(enqueueSnackbar, reason);
+ *        }
+ *      );
+ *
+ * The optional `overrideStatuses` parameter allows the developers to display
+ * in the UI custom messages for a specific set of HTTP response status code.
+ * They will override those contained in the response.
+ *
+ * Ex
+ *      const response = await addNewVideo({ video_id }).catch(
+ *        (reason: ApiError) => {
+ *          displayErrors(
+ *            enqueueSnackbar,
+ *            reason,
+ *            'Sorry, an error has occurred. The video cannot be added.',
+ *            [{ status: 409, variant: 'error', msg: 'Video already added.' }]
+ *          );
+ *        }
+ *      );
+ *
+ * Unknown `Error` or malformed `ApiError` are displayed as an invitation to
+ * try again later or contact an administrator.
+ */
+export const displayErrors = (
+  display: ProviderContext['enqueueSnackbar'],
+  reason: ApiError | Error,
+  message?: string,
+  overrideStatuses?: Array<{
+    status: number;
+    msg: string;
+    variant: VariantType;
+  }>
+) => {
+  if (reason && 'body' in reason) {
+    // override message from the API
+    if (overrideStatuses) {
+      const status = overrideStatuses.filter(
+        (elem) => elem.status === reason.status
+      );
+      if (status) {
+        display(status[0].msg, { variant: status[0].variant });
+        return;
+      }
+    }
+
+    // HTTP 429 Too Many Requests are considered information
+    if (reason.status === 429) {
+      showInfoAlert(display, reason.body['detail']);
+    } else {
+      const newErrorMessages = Object.values(reason['body']).flat();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      newErrorMessages.map((msg) => showErrorAlert(display, msg));
+    }
+  } else {
+    contactAdministrator(display, 'error', message);
+  }
+};

--- a/frontend/src/utils/api/response.ts
+++ b/frontend/src/utils/api/response.ts
@@ -52,11 +52,11 @@ export const displayErrors = (
   if (reason && 'body' in reason) {
     // override message from the API
     if (overrideStatuses) {
-      const status = overrideStatuses.filter(
+      const status = overrideStatuses.find(
         (elem) => elem.status === reason.status
       );
       if (status) {
-        display(status[0].msg, { variant: status[0].variant });
+        display(status.msg, { variant: status.variant });
         return;
       }
     }

--- a/frontend/src/utils/api/response.ts
+++ b/frontend/src/utils/api/response.ts
@@ -65,10 +65,12 @@ export const displayErrors = (
     if (reason.status === 429) {
       showInfoAlert(display, reason.body['detail']);
     } else {
-      const newErrorMessages = Object.values(reason['body']).flat();
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      newErrorMessages.map((msg) => showErrorAlert(display, msg));
+      const body = reason.body;
+      const newErrorMessages =
+        typeof body === 'string'
+          ? [body]
+          : Object.values(reason['body']).flat();
+      newErrorMessages.map((msg) => showErrorAlert(display, msg as string));
     }
   } else {
     contactAdministrator(display, 'error', message);

--- a/frontend/src/utils/api/response.ts
+++ b/frontend/src/utils/api/response.ts
@@ -66,7 +66,8 @@ export const displayErrors = (
       showInfoAlert(display, reason.body['detail']);
     } else {
       const newErrorMessages = Object.values(reason['body']).flat();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       newErrorMessages.map((msg) => showErrorAlert(display, msg));
     }
   } else {


### PR DESCRIPTION
**related to:** #211 

**will fix the tech' debt:** #287 

**to merge before pull request:** #405 

---

In the front end not all forms handle the errors returned by the API in the same way, and it forces me to copy several times the same lines to handle properly the HTTP 429 Too Many Requests status in the PR #405.

This merge request should help by reducing the quantity of duplicated code, and will make the development of the previously mentioned PR a lot easier.

Fortunately we already have a rather generic piece of code able to treat the majority of forms as equal, so I decided to factorize it in a `src/utils/api/responses.ts` function.

This function:
- is documented
- uses `notistack`
- automatically handles `HTTP 429` with a nice " retry after X seconds "
- automatically handles all other HTTP status code
- displays a generic message when the API fails to deliver a standard ApiError object
- its behaviour can be easily overriden

For the moment, only `PasswordForm`, `RateLater` and `ProfileForm` have been updated to use this new function instead of using a custom code.

I also refactored `Login` to use `notistack` instead of `Alert` to keep it harmonized with the rest of the application. The only remaining component using `Alert` is now `Signup`.

Here is an example, in the PasswordForm component:

**before**

```typescript
      .catch((reason: { body: { [k: string]: string[] } }) => {
        if (reason && 'body' in reason) {
          const newErrorMessages = Object.values(reason['body']).flat();
          newErrorMessages.map((msg) => showErrorAlert(enqueueSnackbar, msg));
        } else {
          contactAdministrator(
            enqueueSnackbar,
            'error',
            'Sorry, an error has occurred, cannot update password.'
          );
        }
```

**after**

```typescript
      .catch((reason: ApiError) => {
        displayErrors(
          enqueueSnackbar,
          reason,
          'Sorry, an error has occurred, cannot update password.'
        );
      }
```

