### PR TITLE
browser menu relooking

### DIFF
--- a/browser-extension/menu.html
+++ b/browser-extension/menu.html
@@ -13,12 +13,12 @@
                 margin-bottom: 6px;
             }
             button {
+                border-width: 2px;
                 background-color: #506AD4;
                 color: white;
                 font-size: large;
-                border-width: 0px;
-                border-radius: 4px;
-                margin: 2px;
+                border-radius: 15px;
+                margin: 4px 0px 4px 0px;
                 padding: 4px;
                 box-shadow: 2px 2px 3px #506AD488;
             }


### PR DESCRIPTION
I tried some CSS on the extension menu, and I think it actually looks better with. Here is how it looks in chrome :

![Capture d’écran de 2022-01-06 14-34-43](https://user-images.githubusercontent.com/47578089/148390970-dfd5a9d6-946d-41a0-b9fd-d2466006091b.png)

and in firefox:
![Capture d’écran de 2022-01-06 14-43-27](https://user-images.githubusercontent.com/47578089/148392139-32d0a04b-373f-4b10-a949-b78265bc2c4e.png)

