### PR TITLE
[back] feat: enable localized error messages in API

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -107,6 +107,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/backend/tournesol/tests/test_api_i18n.py
+++ b/backend/tournesol/tests/test_api_i18n.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+
+class ApiI18n(TestCase):
+    def test_default_language_english(self):
+        client = APIClient()
+        response = client.post(
+            "/accounts/register/",
+            data={
+                "email": "test",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        response_data = response.json()
+        self.assertEqual(response_data["password"], ["This field is required."])
+        self.assertEqual(response_data["email"], ["Enter a valid email address."])
+
+    def test_set_language_in_headers(self):
+        client = APIClient(HTTP_ACCEPT_LANGUAGE="fr")
+        response = client.post(
+            "/accounts/register/",
+            data={
+                "email": "test",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        response_data = response.json()
+        self.assertEqual(response_data["password"], ["Ce champ est obligatoire."])
+        self.assertEqual(
+            response_data["email"], ["Saisissez une adresse e-mail valide."]
+        )

--- a/backend/tournesol/utils/cache.py
+++ b/backend/tournesol/utils/cache.py
@@ -1,6 +1,6 @@
 from django.conf import settings
-from django.views.decorators.cache import cache_page
 from django.utils import translation
+from django.views.decorators.cache import cache_page
 
 
 def cache_page_no_i18n(timeout: float):

--- a/backend/tournesol/utils/cache.py
+++ b/backend/tournesol/utils/cache.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.views.decorators.cache import cache_page
+from django.utils import translation
+
+
+def cache_page_no_i18n(timeout: float):
+    """
+    This decorator activates the default language before calling `cache_page`.
+
+    By default, `cache_page` includes the request language code in its cache key.
+    Some API responses (e.g public export files) don't depend on the language
+    and can be cached under a single key using this decorator.
+    """
+
+    def decorator(view):
+        cached_view = cache_page(timeout=timeout)(view)
+
+        def wrapper(request, *args, **kwargs):
+            translation.activate(settings.LANGUAGE_CODE)
+            request.LANGUAGE_CODE = translation.get_language()
+            return cached_view(request, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -4,13 +4,13 @@ from io import StringIO
 
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from drf_spectacular.utils import extend_schema, OpenApiTypes
 
 from tournesol.serializers import ComparisonSerializer
 from tournesol.models import Comparison, ContributorRating
+from tournesol.utils.cache import cache_page_no_i18n
 
 
 def write_comparisons_file(request, write_target):
@@ -86,7 +86,7 @@ class ExportComparisonsView(APIView):
 class ExportPublicComparisonsView(APIView):
     permission_classes = [AllowAny]
 
-    @method_decorator(cache_page(60*10))  # 10 minutes cache
+    @method_decorator(cache_page_no_i18n(60*10))  # 10 minutes cache
     @extend_schema(
         description="Download public data in .csv file",
         responses={200: OpenApiTypes.BINARY}


### PR DESCRIPTION
Related to #329 

Basically, this PR adds the `LocaleMiddleware` provided by Django, used for language detection:
https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#how-django-discovers-language-preference

As DRF provides translated error messages for its validation errors, they will be present in API responses and displayed by frontend consistently with the current language, based on the standard `Accept-Language` that has been configured in #385.

A small side-effect of this change is about caching. `cache_page` uses the current language in its cache key. So a custom decorator `cache_page_no_i18n` has been implemented to force the default locale on API views where caching a distinct response per language would be wasteful.