### PR TITLE
[front] feat: add tooltips in sidebar & add title to each pages

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -198,7 +198,7 @@
   },
   "clickToDownload": "Click to Download",
   "myComparisonsPage": {
-    "contentHeader": "My comparisons"
+    "title": "My comparisons"
   },
   "home": {
     "contributeTitle": "Contribute!",
@@ -225,7 +225,7 @@
     "resetPasswordButton": "Reset password"
   },
   "myRateLaterListPage": {
-    "contentHeader": "My rate-later list"
+    "title": "My rate-later list"
   },
   "signup": {
     "successMessage": "Success!<1></1>A verification link has been sent to <3>{{email}}</3> .",
@@ -243,10 +243,10 @@
     "verificationFailed": "Verification failed"
   },
   "myRatedVideosPage": {
-    "contentHeader": "My rated videos"
+    "title": "My rated videos"
   },
   "recommendationsPage": {
-    "contentHeader": "Recommendations"
+    "title": "Recommendations"
   },
   "noVideoCorrespondsToSearchCriterias": "No video corresponds to your search criterias.",
   "actions": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -197,8 +197,8 @@
     "trustedDomainsCurrentList": "Current list of trusted domains"
   },
   "clickToDownload": "Click to Download",
-  "recommendations": {
-    "title": "Recommendations"
+  "myComparisonsPage": {
+    "title": "My comparisons"
   },
   "home": {
     "contributeTitle": "Contribute!",
@@ -239,8 +239,11 @@
     "yourNewEmailAddressIsNowVerified": "Your new email address is now verified.",
     "verificationFailed": "Verification failed"
   },
+  "myRatedVideosPage": {
+    "title": "My rated videos"
+  },
   "recommendationsPage": {
-    "title": "recommendations"
+    "title": "Recommendations"
   },
   "noVideoCorrespondsToSearchCriterias": "No video corresponds to your search criterias.",
   "actions": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -197,6 +197,9 @@
     "trustedDomainsCurrentList": "Current list of trusted domains"
   },
   "clickToDownload": "Click to Download",
+  "recommendations": {
+    "title": "Recommendations"
+  },
   "home": {
     "contributeTitle": "Contribute!",
     "contributeDetail": "Tournesol identifies high quality content from comparisons provided by the community. To contribute, you must compare videos that you have watched. First copy paste two links to videos, then tell us which video you think should be largely recommended. If you want to you can also compare the videos in more details based on the multiple comparison criterias.",
@@ -235,6 +238,9 @@
     "yourAccountIsNowVerified": "Your account is now verified.",
     "yourNewEmailAddressIsNowVerified": "Your new email address is now verified.",
     "verificationFailed": "Verification failed"
+  },
+  "recommendationsPage": {
+    "title": "recommendations"
   },
   "noVideoCorrespondsToSearchCriterias": "No video corresponds to your search criterias.",
   "actions": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -197,11 +197,8 @@
     "trustedDomainsCurrentList": "Current list of trusted domains"
   },
   "clickToDownload": "Click to Download",
-  "contentHeader": {
-    "myComparisons": "My comparisons",
-    "myRateLaterList": "My rate-later list",
-    "myRatedVideos": "My rated videos",
-    "recommendations": "Recommendations"
+  "myComparisonsPage": {
+    "contentHeader": "My comparisons"
   },
   "home": {
     "contributeTitle": "Contribute!",
@@ -227,6 +224,9 @@
     "passwordsDoNotMatch": "Passwords do not match",
     "resetPasswordButton": "Reset password"
   },
+  "myRateLaterListPage": {
+    "contentHeader": "My rate-later list"
+  },
   "signup": {
     "successMessage": "Success!<1></1>A verification link has been sent to <3>{{email}}</3> .",
     "title": "Account creation",
@@ -241,6 +241,12 @@
     "yourAccountIsNowVerified": "Your account is now verified.",
     "yourNewEmailAddressIsNowVerified": "Your new email address is now verified.",
     "verificationFailed": "Verification failed"
+  },
+  "myRatedVideosPage": {
+    "contentHeader": "My rated videos"
+  },
+  "recommendationsPage": {
+    "contentHeader": "Recommendations"
   },
   "noVideoCorrespondsToSearchCriterias": "No video corresponds to your search criterias.",
   "actions": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -197,8 +197,11 @@
     "trustedDomainsCurrentList": "Current list of trusted domains"
   },
   "clickToDownload": "Click to Download",
-  "myComparisonsPage": {
-    "title": "My comparisons"
+  "contentHeader": {
+    "myComparisons": "My comparisons",
+    "myRateLaterList": "My rate-later list",
+    "myRatedVideos": "My rated videos",
+    "recommendations": "Recommendations"
   },
   "home": {
     "contributeTitle": "Contribute!",
@@ -238,12 +241,6 @@
     "yourAccountIsNowVerified": "Your account is now verified.",
     "yourNewEmailAddressIsNowVerified": "Your new email address is now verified.",
     "verificationFailed": "Verification failed"
-  },
-  "myRatedVideosPage": {
-    "title": "My rated videos"
-  },
-  "recommendationsPage": {
-    "title": "Recommendations"
   },
   "noVideoCorrespondsToSearchCriterias": "No video corresponds to your search criterias.",
   "actions": {

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -9,7 +9,7 @@ import {
   Drawer,
   List,
   Theme,
-  Divider,
+  Divider, Tooltip,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
@@ -177,14 +177,20 @@ const SideBar = () => {
                 },
               }}
             >
-              <ListItemIcon>
-                <IconComponent
-                  className={clsx({
-                    [classes.listItemIcon]: !selected,
-                    [classes.listItemIconSelected]: selected,
-                  })}
-                />
-              </ListItemIcon>
+              <Tooltip
+                title={drawerOpen === true ? '' : displayText}
+                placement="right"
+                arrow
+              >
+                <ListItemIcon>
+                  <IconComponent
+                    className={clsx({
+                      [classes.listItemIcon]: !selected,
+                      [classes.listItemIconSelected]: selected,
+                    })}
+                  />
+                </ListItemIcon>
+              </Tooltip>
               <ListItemText
                 primary={displayText}
                 primaryTypographyProps={{ className: classes.listItemText }}

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -9,7 +9,8 @@ import {
   Drawer,
   List,
   Theme,
-  Divider, Tooltip,
+  Divider,
+  Tooltip,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -34,7 +34,7 @@ function ComparisonsPage() {
 
   return (
     <>
-      <ContentHeader title={t('myComparisonsPage.contentHeader')} />
+      <ContentHeader title={t('myComparisonsPage.title')} />
       <div
         style={{
           display: 'flex',

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -34,7 +34,7 @@ function ComparisonsPage() {
 
   return (
     <>
-      <ContentHeader title={t('contentHeader.myComparisons')} />
+      <ContentHeader title={t('myComparisonsPage.contentHeader')} />
       <div
         style={{
           display: 'flex',

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-import ContentHeader from 'src/components/ContentHeader';
-import Pagination from 'src/components/Pagination';
+import { ContentHeader, Pagination } from 'src/components';
 import ComparisonList from 'src/features/comparisons/ComparisonList';
 import type { Comparison } from 'src/services/openapi';
 import { UsersService } from 'src/services/openapi';

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import ContentHeader from 'src/components/ContentHeader';
+import Pagination from 'src/components/Pagination';
+import ComparisonList from 'src/features/comparisons/ComparisonList';
 import type { Comparison } from 'src/services/openapi';
 import { UsersService } from 'src/services/openapi';
-import ComparisonList from 'src/features/comparisons/ComparisonList';
-import Pagination from 'src/components/Pagination';
 
 function ComparisonsPage() {
   const { t } = useTranslation();
@@ -33,25 +34,28 @@ function ComparisonsPage() {
   }, [offset]);
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        flexDirection: 'column',
-        paddingBottom: 16,
-        paddingTop: 16,
-        gap: 16,
-      }}
-    >
-      <Pagination
-        offset={offset}
-        count={count}
-        onOffsetChange={handleOffsetChange}
-        limit={limit}
-        itemType={t('pagination.comparisons')}
-      />
-      <ComparisonList comparisons={comparisons} />
-    </div>
+    <>
+      <ContentHeader title={t('myComparisonsPage.title')} />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          flexDirection: 'column',
+          paddingBottom: 16,
+          paddingTop: 16,
+          gap: 16,
+        }}
+      >
+        <Pagination
+          offset={offset}
+          count={count}
+          onOffsetChange={handleOffsetChange}
+          limit={limit}
+          itemType={t('pagination.comparisons')}
+        />
+        <ComparisonList comparisons={comparisons} />
+      </div>
+    </>
   );
 }
 

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -34,7 +34,7 @@ function ComparisonsPage() {
 
   return (
     <>
-      <ContentHeader title={t('myComparisonsPage.title')} />
+      <ContentHeader title={t('contentHeader.myComparisons')} />
       <div
         style={{
           display: 'flex',

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -9,7 +9,7 @@ import RateLaterAddForm from 'src/features/rateLater/RateLaterAddForm';
 import { ApiError, VideoRateLater } from 'src/services/openapi';
 import { CompareNowAction, RemoveFromRateLater } from 'src/utils/action';
 import { UsersService } from 'src/services/openapi';
-import { ContentBox, LoaderWrapper, Pagination } from 'src/components';
+import { ContentBox, ContentHeader, LoaderWrapper, Pagination } from 'src/components';
 import VideoList from 'src/features/videos/VideoList';
 import { useNotifications } from 'src/hooks';
 
@@ -105,69 +105,72 @@ const RateLaterPage = () => {
   const videos = rateLaterList.map((r) => r.video);
 
   return (
-    <ContentBox noMinPadding maxWidth="md">
-      <Card className={classes.rateLaterIntro} elevation={4}>
-        <CardContent>
-          <Typography variant="h6">
-            {t('ratelater.addVideosToRateLaterList')}
-          </Typography>
-          <Trans t={t} i18nKey="ratelater.rateLaterFormIntroduction">
-            Copy-paste the id or the URL of a favorite video of yours.
-            <br />
-            You can search them in your{' '}
-            <a href="https://www.youtube.com/feed/history">
-              YouTube history page
-            </a>
-            , or your{' '}
-            <a href="https://www.youtube.com/playlist?list=LL">
-              liked video playlist
-            </a>
-            .<br />
-            Our{' '}
-            <a href="https://chrome.google.com/webstore/detail/tournesol-extension/nidimbejmadpggdgooppinedbggeacla?hl=en">
-              browser extension
-            </a>{' '}
-            can also help you import videos effortlessly.
-            <br />
-            You will then be able to rate the videos you imported.
-          </Trans>
-        </CardContent>
-        <CardActions>
-          <RateLaterAddForm addVideo={addToRateLater} />
-        </CardActions>
-      </Card>
-
-      <div className={classes.rateLaterContent} ref={videoListTopRef}>
-        {videoCount !== null && (
-          <Typography variant="subtitle1">
-            <Trans t={t} i18nKey="ratelater.listHasNbVideos" count={videoCount}>
-              Your rate-later list now has <strong>{{ videoCount }}</strong>{' '}
-              video(s).
+    <>
+      <ContentHeader title={t('contentHeader.myRateLaterList')} />
+      <ContentBox noMinPadding maxWidth="md">
+        <Card className={classes.rateLaterIntro} elevation={4}>
+          <CardContent>
+            <Typography variant="h6">
+              {t('ratelater.addVideosToRateLaterList')}
+            </Typography>
+            <Trans t={t} i18nKey="ratelater.rateLaterFormIntroduction">
+              Copy-paste the id or the URL of a favorite video of yours.
+              <br />
+              You can search them in your{' '}
+              <a href="https://www.youtube.com/feed/history">
+                YouTube history page
+              </a>
+              , or your{' '}
+              <a href="https://www.youtube.com/playlist?list=LL">
+                liked video playlist
+              </a>
+              .<br />
+              Our{' '}
+              <a href="https://chrome.google.com/webstore/detail/tournesol-extension/nidimbejmadpggdgooppinedbggeacla?hl=en">
+                browser extension
+              </a>{' '}
+              can also help you import videos effortlessly.
+              <br />
+              You will then be able to rate the videos you imported.
             </Trans>
-          </Typography>
-        )}
+          </CardContent>
+          <CardActions>
+            <RateLaterAddForm addVideo={addToRateLater} />
+          </CardActions>
+        </Card>
 
-        {!!videoCount && (
-          <div className={classes.stickyPagination}>
-            <Pagination
-              offset={offset}
-              count={videoCount}
-              onOffsetChange={onOffsetChange}
-              limit={limit}
-            />
-          </div>
-        )}
+        <div className={classes.rateLaterContent} ref={videoListTopRef}>
+          {videoCount !== null && (
+            <Typography variant="subtitle1">
+              <Trans t={t} i18nKey="ratelater.listHasNbVideos" count={videoCount}>
+                Your rate-later list now has <strong>{{ videoCount }}</strong>{' '}
+                video(s).
+              </Trans>
+            </Typography>
+          )}
 
-        <Box width="100%" textAlign="center">
-          <LoaderWrapper isLoading={isLoading}>
-            <VideoList
-              videos={videos}
-              actions={[CompareNowAction, RemoveFromRateLater(loadList)]}
-            />
-          </LoaderWrapper>
-        </Box>
-      </div>
-    </ContentBox>
+          {!!videoCount && (
+            <div className={classes.stickyPagination}>
+              <Pagination
+                offset={offset}
+                count={videoCount}
+                onOffsetChange={onOffsetChange}
+                limit={limit}
+              />
+            </div>
+          )}
+
+          <Box width="100%" textAlign="center">
+            <LoaderWrapper isLoading={isLoading}>
+              <VideoList
+                videos={videos}
+                actions={[CompareNowAction, RemoveFromRateLater(loadList)]}
+              />
+            </LoaderWrapper>
+          </Box>
+        </div>
+      </ContentBox>
+    </>
   );
 };
 

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -111,7 +111,7 @@ const RateLaterPage = () => {
 
   return (
     <>
-      <ContentHeader title={t('myRateLaterListPage.contentHeader')} />
+      <ContentHeader title={t('myRateLaterListPage.title')} />
       <ContentBox noMinPadding maxWidth="md">
         <Card className={classes.rateLaterIntro} elevation={4}>
           <CardContent>

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -111,7 +111,7 @@ const RateLaterPage = () => {
 
   return (
     <>
-      <ContentHeader title={t('contentHeader.myRateLaterList')} />
+      <ContentHeader title={t('myRateLaterListPage.contentHeader')} />
       <ContentBox noMinPadding maxWidth="md">
         <Card className={classes.rateLaterIntro} elevation={4}>
           <CardContent>

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -9,7 +9,12 @@ import RateLaterAddForm from 'src/features/rateLater/RateLaterAddForm';
 import { ApiError, VideoRateLater } from 'src/services/openapi';
 import { CompareNowAction, RemoveFromRateLater } from 'src/utils/action';
 import { UsersService } from 'src/services/openapi';
-import { ContentBox, ContentHeader, LoaderWrapper, Pagination } from 'src/components';
+import {
+  ContentBox,
+  ContentHeader,
+  LoaderWrapper,
+  Pagination,
+} from 'src/components';
 import VideoList from 'src/features/videos/VideoList';
 import { useNotifications } from 'src/hooks';
 
@@ -142,7 +147,11 @@ const RateLaterPage = () => {
         <div className={classes.rateLaterContent} ref={videoListTopRef}>
           {videoCount !== null && (
             <Typography variant="subtitle1">
-              <Trans t={t} i18nKey="ratelater.listHasNbVideos" count={videoCount}>
+              <Trans
+                t={t}
+                i18nKey="ratelater.listHasNbVideos"
+                count={videoCount}
+              >
                 Your rate-later list now has <strong>{{ videoCount }}</strong>{' '}
                 video(s).
               </Trans>

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -10,7 +10,7 @@ import type {
 import Pagination from 'src/components/Pagination';
 import VideoList from 'src/features/videos/VideoList';
 import { UsersService } from 'src/services/openapi';
-import { ContentBox, LoaderWrapper } from 'src/components';
+import { ContentBox, ContentHeader, LoaderWrapper } from 'src/components';
 import {
   PublicStatusAction,
   RatingsContext,
@@ -50,6 +50,7 @@ const VideoRatingsPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const location = useLocation();
   const history = useHistory();
+  const { t } = useTranslation();
   const searchParams = new URLSearchParams(location.search);
   const limit = 20;
   const offset = Number(searchParams.get('offset') || 0);
@@ -118,6 +119,7 @@ const VideoRatingsPage = () => {
         onChange: onRatingChange,
       }}
     >
+      <ContentHeader title={t('myRatedVideosPage.title')} />
       <ContentBox noMinPadding maxWidth="md">
         <Box px={{ xs: 2, sm: 0 }}>
           <RatingsFilter />

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -119,7 +119,7 @@ const VideoRatingsPage = () => {
         onChange: onRatingChange,
       }}
     >
-      <ContentHeader title={t('contentHeader.myRatedVideos')} />
+      <ContentHeader title={t('myRatedVideosPage.contentHeader')} />
       <ContentBox noMinPadding maxWidth="md">
         <Box px={{ xs: 2, sm: 0 }}>
           <RatingsFilter />

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -119,7 +119,7 @@ const VideoRatingsPage = () => {
         onChange: onRatingChange,
       }}
     >
-      <ContentHeader title={t('myRatedVideosPage.contentHeader')} />
+      <ContentHeader title={t('myRatedVideosPage.title')} />
       <ContentBox noMinPadding maxWidth="md">
         <Box px={{ xs: 2, sm: 0 }}>
           <RatingsFilter />

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -119,7 +119,7 @@ const VideoRatingsPage = () => {
         onChange: onRatingChange,
       }}
     >
-      <ContentHeader title={t('myRatedVideosPage.title')} />
+      <ContentHeader title={t('contentHeader.myRatedVideos')} />
       <ContentBox noMinPadding maxWidth="md">
         <Box px={{ xs: 2, sm: 0 }}>
           <RatingsFilter />

--- a/frontend/src/pages/videos/VideoRecommendation.tsx
+++ b/frontend/src/pages/videos/VideoRecommendation.tsx
@@ -44,7 +44,7 @@ function VideoRecommendationPage() {
 
   return (
     <>
-      <ContentHeader title={t('contentHeader.recommendations')} />
+      <ContentHeader title={t('recommendationsPage.contentHeader')} />
       <ContentBox noMinPadding maxWidth="lg">
         <Box px={{ xs: 2, sm: 0 }}>
           <SearchFilter />

--- a/frontend/src/pages/videos/VideoRecommendation.tsx
+++ b/frontend/src/pages/videos/VideoRecommendation.tsx
@@ -44,7 +44,7 @@ function VideoRecommendationPage() {
 
   return (
     <>
-      <ContentHeader title={t('recommendationsPage.title')} />
+      <ContentHeader title={t('contentHeader.recommendations')} />
       <ContentBox noMinPadding maxWidth="lg">
         <Box px={{ xs: 2, sm: 0 }}>
           <SearchFilter />

--- a/frontend/src/pages/videos/VideoRecommendation.tsx
+++ b/frontend/src/pages/videos/VideoRecommendation.tsx
@@ -8,7 +8,7 @@ import Pagination from 'src/components/Pagination';
 import VideoList from 'src/features/videos/VideoList';
 import SearchFilter from 'src/features/recommendation/SearchFilter';
 import { getRecommendedVideos } from 'src/features/recommendation/RecommendationApi';
-import { ContentBox } from 'src/components';
+import { ContentBox, ContentHeader } from 'src/components';
 import LoaderWrapper from 'src/components/LoaderWrapper';
 import { scrollToTop } from 'src/utils/ui';
 
@@ -43,27 +43,30 @@ function VideoRecommendationPage() {
   }, [location.search]);
 
   return (
-    <ContentBox noMinPadding maxWidth="lg">
-      <Box px={{ xs: 2, sm: 0 }}>
-        <SearchFilter />
-      </Box>
-      <LoaderWrapper isLoading={isLoading}>
-        <VideoList
-          videos={videos.results || []}
-          emptyMessage={
-            isLoading ? '' : t('noVideoCorrespondsToSearchCriterias')
-          }
-        />
-      </LoaderWrapper>
-      {!isLoading && videoCount > 0 && (
-        <Pagination
-          offset={offset}
-          count={videoCount}
-          onOffsetChange={handleOffsetChange}
-          limit={limit}
-        />
-      )}
-    </ContentBox>
+    <>
+      <ContentHeader title={t('recommendationsPage.title')} />
+      <ContentBox noMinPadding maxWidth="lg">
+        <Box px={{ xs: 2, sm: 0 }}>
+          <SearchFilter />
+        </Box>
+        <LoaderWrapper isLoading={isLoading}>
+          <VideoList
+            videos={videos.results || []}
+            emptyMessage={
+              isLoading ? '' : t('noVideoCorrespondsToSearchCriterias')
+            }
+          />
+        </LoaderWrapper>
+        {!isLoading && videoCount > 0 && (
+          <Pagination
+            offset={offset}
+            count={videoCount}
+            onOffsetChange={handleOffsetChange}
+            limit={limit}
+          />
+        )}
+      </ContentBox>
+    </>
   );
 }
 

--- a/frontend/src/pages/videos/VideoRecommendation.tsx
+++ b/frontend/src/pages/videos/VideoRecommendation.tsx
@@ -44,7 +44,7 @@ function VideoRecommendationPage() {
 
   return (
     <>
-      <ContentHeader title={t('recommendationsPage.contentHeader')} />
+      <ContentHeader title={t('recommendationsPage.title')} />
       <ContentBox noMinPadding maxWidth="lg">
         <Box px={{ xs: 2, sm: 0 }}>
           <SearchFilter />


### PR DESCRIPTION
**closes** #395 

---

As requested in the issue, the tooltips will be displayed only when the sidebar is not expanded.

I also added translation keys `xxx.contentHeader` that contains all page titles. I was about to use keys like `myComparisonsPage.title` but I realized they could be confounded with the actual page title display in the browser tab. What do you think @amatissart ?

I can refactor the existing keys to match this pattern if needed (`signup.title` will become `signupPage.contentHeader`). Maybe `signupPage.mainTitle` is more user-friendly for the translators.

**edit:** I finally decided to keep `key.title` as it's simple and coherent with the rest. We can use `key.tabTitle` for browser tabs.

**example of a displayed tooltip**

![screencapture-localhost-3000-recommendations-2022-01-11-12_40_04](https://user-images.githubusercontent.com/39056254/148954013-b121edc5-b8ff-4c95-8917-fdb022f4725d.png)

**the new titles**

![screencapture-localhost-3000-recommendations-2022-01-11-14_40_23](https://user-images.githubusercontent.com/39056254/148954025-dccbacee-d00a-4c6f-b156-84bb1f4d5b1d.png)

![screencapture-localhost-3000-rate-later-2022-01-11-14_40_35](https://user-images.githubusercontent.com/39056254/148954047-753e8495-9aae-4929-a27e-a419a5a7b56d.png)



