### PR TITLE
[backend] feat: Translate registration emails

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,4 +1,5 @@
 **__pycache__/
+*.mo
 .DS_Store
 global_scores.json 
 local_scores.json 

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,6 +15,14 @@ This method requires more efforts to set up the environment, as it implies
 knowing how to: create a Python virtual environment; install and configure
 a Django application; and how to install and configure a PostgreSQL server.
 
+#### Required packages
+
+- `python` >= 3.9
+- `postgresql-13-server`
+- `gettext` >= 0.21
+
+#### Procedure
+
 - Create a postgres database.
 
 - Create a config file in /etc/django/settings-tournesol.yaml. You can find an example in documentation folder.

--- a/backend/core/locale/fr/LC_MESSAGES/django.po
+++ b/backend/core/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,73 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-01-17 11:26+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: core/models/user.py:27
+msgid "email address"
+msgstr "adresse e-mail"
+
+#: core/templates/accounts/register/body.txt:2
+msgid "Please verify your Tournesol account by clicking on this link:"
+msgstr ""
+"Veuillez confirmer la création de votre compte Tournesol en cliquant sur ce "
+"lien:"
+
+#: core/templates/accounts/register/subject.txt:2
+msgid "Please verify your Tournesol account"
+msgstr "Activation de votre compte Tournesol"
+
+#: core/templates/accounts/register_email/body.txt:3
+msgid ""
+"You or someone else requested change to this e-mail for which there is an "
+"existing account.\n"
+"You need to either remove this account assigned to this e-mail or change the "
+"e-mail of it.\n"
+"\n"
+"If this wasn't you, please just ignore this email.\n"
+msgstr ""
+"Vous ou quelqu'un d'autre a demandé à utiliser cette adresse e-mail alors "
+"qu'un compte associé à cette adresse existe déjà.\n"
+"Vous pouvez soit supprimer ce compte, ou modifier l'adresse qui lui est "
+"associé.\n"
+"\n"
+"Si cette demande ne provient pas de vous, vous pouvez ignorer ce message.\n"
+
+#: core/templates/accounts/register_email/body.txt:9
+#, python-format
+msgid "You can verify the email %(email)s by clicking on this link:"
+msgstr ""
+"Veuillez confirmer l'adresse e-mail %(email)s en cliquant sur ce lien:"
+
+#: core/templates/accounts/register_email/subject.txt:3
+msgid "Your e-mail is already in use on Tournesol"
+msgstr "Votre adresse e-mail est déjà utilisée sur Tournesol"
+
+#: core/templates/accounts/register_email/subject.txt:5
+msgid "Please verify new e-mail on Tournesol"
+msgstr "Veuillez confirmer votre nouvelle adresse e-mail sur Tournesol"
+
+#: core/templates/accounts/reset_password/body.txt:2
+msgid "You can reset your password on Tournesol by clicking on this link:"
+msgstr ""
+"Vous pouvez réinitialiser votre mot de passe sur Tournesol en cliquant sur "
+"ce lien:"
+
+#: core/templates/accounts/reset_password/subject.txt:2
+msgid "Tournesol Password Reset"
+msgstr "Réinitialisation de votre mot de passe sur Tournesol"

--- a/backend/core/templates/accounts/register/body.txt
+++ b/backend/core/templates/accounts/register/body.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% translate "Please verify your Tournesol account by clicking on this link:" %}
+
+{{ verification_url | safe }}

--- a/backend/core/templates/accounts/register/subject.txt
+++ b/backend/core/templates/accounts/register/subject.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% translate "Please verify your Tournesol account" %} 🌻

--- a/backend/core/templates/accounts/register_email/body.txt
+++ b/backend/core/templates/accounts/register_email/body.txt
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% if email_already_used %}
+{% blocktranslate %}You or someone else requested change to this e-mail for which there is an existing account.
+You need to either remove this account assigned to this e-mail or change the e-mail of it.
+
+If this wasn't you, please just ignore this email.
+{% endblocktranslate %}
+{% else %}
+{% blocktranslate %}You can verify the email {{ email }} by clicking on this link:{% endblocktranslate %}
+
+{{ verification_url | safe }}
+{% endif %}

--- a/backend/core/templates/accounts/register_email/subject.txt
+++ b/backend/core/templates/accounts/register_email/subject.txt
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% if email_already_used %}
+{% translate "Your e-mail is already in use on Tournesol" %}
+{% else %}
+{% translate "Please verify new e-mail on Tournesol" %}
+{% endif %}

--- a/backend/core/templates/accounts/reset_password/body.txt
+++ b/backend/core/templates/accounts/reset_password/body.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% translate "You can reset your password on Tournesol by clicking on this link:" %}
+
+{{ verification_url | safe }}

--- a/backend/core/templates/accounts/reset_password/subject.txt
+++ b/backend/core/templates/accounts/reset_password/subject.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% translate "Tournesol Password Reset" %}

--- a/backend/dev-env/Dockerfile
+++ b/backend/dev-env/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.9-slim-bullseye
 ENV PYTHONUNBUFFERED=1
 WORKDIR /backend
 
+RUN apt-get update && apt-get install -y gettext && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt ml/ml_requirements.txt /backend/
 COPY tests/requirements.txt /backend/requirements.dev.txt
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,7 @@ django-filter==2.4.0
 django-language-field==0.0.3
 django-oauth-toolkit==1.5.0
 django-prometheus==2.1.0
-django-rest-registration==0.6.4
+django-rest-registration==0.7.0
 djangorestframework==3.12.4
 drf-spectacular==0.21.0
 fuzzysearch==0.7.3

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -88,6 +88,18 @@ REST_REGISTRATION = {
     'REGISTER_SERIALIZER_CLASS': 'core.serializers.user.RegisterUserSerializer',
     'PROFILE_SERIALIZER_CLASS': 'core.serializers.user.UserProfileSerializer',
     'VERIFICATION_FROM_EMAIL': 'noreply@tournesol.app',
+    'REGISTER_VERIFICATION_EMAIL_TEMPLATES': {
+        'body': 'accounts/register/body.txt',
+        'subject': 'accounts/register/subject.txt'
+    },
+    'REGISTER_EMAIL_VERIFICATION_EMAIL_TEMPLATES': {
+        'body': 'accounts/register_email/body.txt',
+        'subject': 'accounts/register_email/subject.txt'
+    },
+    'RESET_PASSWORD_VERIFICATION_EMAIL_TEMPLATES': {
+        'body': 'accounts/reset_password/body.txt',
+        'subject': 'accounts/reset_password/subject.txt'
+    }
 }
 
 EMAIL_BACKEND = server_settings.get('EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend')
@@ -121,7 +133,9 @@ ROOT_URLCONF = "settings.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [BASE_DIR / "templates"],
+        "DIRS": [
+            BASE_DIR / "core" / "templates",
+        ],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -132,6 +146,10 @@ TEMPLATES = [
             ],
         },
     },
+]
+
+LOCALE_PATHS = [
+    BASE_DIR / "core" / "locale",
 ]
 
 WSGI_APPLICATION = "settings.wsgi.application"

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -28,10 +28,13 @@ services:
     container_name: tournesol-dev-api
     environment:
       - SETTINGS_FILE=/backend/dev-env/settings-tournesol.yaml
-    command: 
-        - bash
-        - -c
-        - "python manage.py migrate && python manage.py createcachetable && python manage.py runserver 0.0.0.0:8000"
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        python manage.py migrate
+        python manage.py createcachetable
+        django-admin compilemessages
+        python manage.py runserver 0.0.0.0:8000
     volumes:
       - ../backend:/backend
     ports:

--- a/infra/ansible/roles/django/handlers/main.yml
+++ b/infra/ansible/roles/django/handlers/main.yml
@@ -17,6 +17,14 @@
   become: true
   become_user: gunicorn
 
+- name: Compile Django messages
+  shell:
+    chdir: /srv/tournesol-backend
+    cmd: "source /srv/tournesol-backend/venv/bin/activate && django-admin compilemessages"
+    executable: /usr/bin/bash
+  become: true
+  become_user: gunicorn
+
 - name: Create database cache
   shell:
     cmd: "source /srv/tournesol-backend/venv/bin/activate && SETTINGS_FILE=/etc/tournesol/settings.yaml python /srv/tournesol-backend/manage.py createcachetable"

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -3,6 +3,7 @@
     name:
       - python3.9
       - virtualenv
+      - gettext  # Required by django to compile messages
     install_recommends: no
     update_cache: yes
 
@@ -85,6 +86,7 @@
   become_user: gunicorn
   notify:
     - Migrate Django database
+    - Compile Django messages
     - Create database cache
     - Collect Django static assets
     - Restart Gunicorn


### PR DESCRIPTION
Create templates for emails related to account registration, email update and password resets.  
The templates are derived from [rest_registration](https://github.com/apragacz/django-rest-registration/tree/0.7.0/rest_registration/templates/rest_registration), and translated in french only.

As they are the first translation and templates files introduced in our own Django app, I had to update the settings to configure the paths to these folders. And ensure that messages are compiled before deployment and during dev-env setup.