### PR TITLE
[front] fix: Language names could be missing due to limited support of `Intl.DisplayNames`

### DIFF
--- a/frontend/i18next-parser.config.js
+++ b/frontend/i18next-parser.config.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 const SUPPORTED_LANGUAGES = require('./package').config.supported_languages;
 
 module.exports = {
@@ -24,7 +26,7 @@ module.exports = {
   // Key separator used in your translation keys
   // If you want to use plain english keys, separators such as `.` and `:` will conflict. You might want to set `keySeparator: false` and `namespaceSeparator: false`. That way, `t('Status: Loading...')` will not think that there are a namespace and three separator dots for instance.
 
-  locales: SUPPORTED_LANGUAGES,
+  locales: SUPPORTED_LANGUAGES.map((l) => l.code),
   // An array of the locales in your applications
 
   namespaceSeparator: ':',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -82,8 +82,8 @@
   },
   "config": {
     "supported_languages": [
-      "en",
-      "fr"
+      {"code": "en", "name": "English"},
+      {"code": "fr", "name": "Français"}
     ]
   }
 }

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -5,14 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from 'src/i18n';
 import MenuButton from './MenuButton';
 
-const getLanguageName = (code: string) => {
-  if (!Intl.DisplayNames) {
-    return code;
-  }
-  return new Intl.DisplayNames(code, {
-    type: 'language',
-  }).of(code);
-};
+const codeToLanguage = Object.fromEntries(
+  SUPPORTED_LANGUAGES.map((l) => [l.code, l])
+);
 
 const LanguageSelector = () => {
   const { i18n } = useTranslation();
@@ -23,9 +18,9 @@ const LanguageSelector = () => {
       <MenuButton
         startIcon={<Language />}
         sx={{ width: '100%', px: 3 }}
-        menuContent={SUPPORTED_LANGUAGES.map((lang) => (
+        menuContent={SUPPORTED_LANGUAGES.map(({ code, name }) => (
           <MenuItem
-            key={lang}
+            key={code}
             sx={{
               minWidth: '200px',
               '&.Mui-selected': {
@@ -35,13 +30,13 @@ const LanguageSelector = () => {
                 bgcolor: 'action.selected',
               },
             }}
-            onClick={() => i18n.changeLanguage(lang)}
-            selected={lang == currentLanguage}
+            onClick={() => i18n.changeLanguage(code)}
+            selected={code === currentLanguage}
           >
             <Box component="span" sx={{ textTransform: 'capitalize' }}>
-              {getLanguageName(lang)}
+              {name}
             </Box>
-            &nbsp;({lang})
+            &nbsp;({code})
           </MenuItem>
         ))}
         menuProps={{
@@ -61,7 +56,7 @@ const LanguageSelector = () => {
           fontWeight="bold"
           sx={{ textTransform: 'capitalize' }}
         >
-          {getLanguageName(currentLanguage)}
+          {codeToLanguage[currentLanguage]?.name ?? currentLanguage}
         </Box>
       </MenuButton>
     </Box>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -20,7 +20,7 @@ i18n
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
     fallbackLng: 'en',
-    supportedLngs: SUPPORTED_LANGUAGES,
+    supportedLngs: SUPPORTED_LANGUAGES.map((l) => l.code),
     debug: false,
     returnEmptyString: false,
     interpolation: {


### PR DESCRIPTION
Especially on Chrome Android, it seems that language names are not provided, although `Intl.DisplayNames` API is available.

This PR defines the language name associated with each code in the `supported_languages` list.