### PR TITLE
[back] ci: add `isort` as a check

### DIFF
--- a/backend/.isort.cfg
+++ b/backend/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+skip = migrations
+profile = black
+line_length = 99
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -84,7 +84,9 @@ All of them should be automatically triggered by the continuous integration
 system using single script `scripts/ci/lint.sh`.
 
 You are encouraged to run this script locally before creating a new commit.
-Note that the script must be run from the root of the back end folder. 
+Note that the script must be run from the root of the back end folder.
+
+### Run the checks
 
 ```shell
 # with a manually installed back end
@@ -106,6 +108,18 @@ docker exec tournesol-dev-api scripts/ci/lint.sh core/apps.py core/models/
 
 An output finishing by `+ exit 0` means all checks have been successful,
 `+ exit 1` means at least one check has failed.
+
+### Automatically fix some errors
+
+Some tools, like `isort` are able to automatically fixes the target files.
+
+```shell
+# with a manually installed back end
+./scripts/ci/lint-fix.sh
+
+# with an automatically installed back end with Docker
+docker exec tournesol-dev-api scripts/ci/lint-fix.sh
+```
 
 ## F.A.Q.
 

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -3,17 +3,19 @@ Defines Admin interface for Tournesol's core app
 """
 
 from typing import List, Tuple
+
 from django.contrib import admin
 from django.contrib.admin.utils import flatten_fieldsets
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.db.models.query import QuerySet
+
 from .models import (
-    User,
-    UserPreference,
     Degree,
+    EmailDomain,
     Expertise,
     ExpertiseKeyword,
-    EmailDomain,
+    User,
+    UserPreference,
     VerifiableEmail,
 )
 

--- a/backend/core/models/user.py
+++ b/backend/core/models/user.py
@@ -3,20 +3,21 @@ Defines Tournesol's User model and user preferences
 """
 
 import logging
-from django.db import models
-from django.db.models import Q, CheckConstraint, F, Func, Value
-from django.db.models.expressions import OuterRef, Exists
-from django.db.models.functions import Lower
+
 from django.contrib.auth.models import AbstractUser
 from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+from django.db.models import CheckConstraint, F, Func, Q, Value
+from django.db.models.expressions import Exists, OuterRef
+from django.db.models.functions import Lower
 from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
 from django_countries import countries
 
-from settings.settings import MAX_VALUE, CRITERIAS, CRITERIAS_DICT
+from settings.settings import CRITERIAS, CRITERIAS_DICT, MAX_VALUE
 
 from ..utils.constants import featureIsEnabledByDeFault
-from ..utils.models import enum_list, WithDynamicFields, WithFeatures
+from ..utils.models import WithDynamicFields, WithFeatures, enum_list
 from ..utils.validators import validate_avatar
 
 logger = logging.getLogger(__name__)

--- a/backend/core/serializers/user.py
+++ b/backend/core/serializers/user.py
@@ -1,9 +1,9 @@
 from rest_framework.exceptions import ValidationError
+from rest_framework.serializers import BooleanField, EmailField
 from rest_framework.validators import UniqueValidator
-from rest_framework.serializers import EmailField, BooleanField
 from rest_registration.api.serializers import (
-    DefaultRegisterUserSerializer,
     DefaultRegisterEmailSerializer,
+    DefaultRegisterUserSerializer,
     DefaultUserProfileSerializer,
 )
 

--- a/backend/core/tests/test_trusted_users.py
+++ b/backend/core/tests/test_trusted_users.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from core.models import User, EmailDomain
+from core.models import EmailDomain, User
 
 
 class TestTrustedUsers(TestCase):

--- a/backend/core/utils/models.py
+++ b/backend/core/utils/models.py
@@ -3,14 +3,13 @@ Utils methods for Tournesol's core app
 """
 
 import base64
+import logging
 import pickle
 from functools import reduce
-import logging
 
-from django.db.models import JSONField
-
-from computed_property.fields import ComputedField
 import numpy as np
+from computed_property.fields import ComputedField
+from django.db.models import JSONField
 
 from settings.settings import CRITERIAS
 

--- a/backend/ml/core.py
+++ b/backend/ml/core.py
@@ -1,13 +1,18 @@
-import os
 import logging
+import os
 from time import time
+
 import gin
 
-from ml.licchavi import Licchavi
 from ml.handle_data import (
-    select_criteria, shape_data, distribute_data,
-    distribute_data_from_save, format_out_loc, format_out_glob)
-
+    distribute_data,
+    distribute_data_from_save,
+    format_out_glob,
+    format_out_loc,
+    select_criteria,
+    shape_data,
+)
+from ml.licchavi import Licchavi
 
 TOURNESOL_DEV = bool(int(os.environ.get("TOURNESOL_DEV", 0)))  # dev mode
 FOLDER_PATH = "ml/checkpoints/"

--- a/backend/ml/data_utility.py
+++ b/backend/ml/data_utility.py
@@ -1,9 +1,10 @@
-import torch
-import numpy as np
 import json
-import pickle
 import os
+import pickle
 import shutil
+
+import numpy as np
+import torch
 
 """
 Utility functions used in "handle_data.py"

--- a/backend/ml/dev/experiments.py
+++ b/backend/ml/dev/experiments.py
@@ -1,6 +1,6 @@
-from .licchavi_dev import LicchaviDev
-from .visualisation import seedall, disp_one_by_line, output_infos
 from .fake_data import generate_data
+from .licchavi_dev import LicchaviDev
+from .visualisation import disp_one_by_line, output_infos, seedall
 
 """
 Not used in production, for testing only

--- a/backend/ml/dev/fake_data.py
+++ b/backend/ml/dev/fake_data.py
@@ -1,8 +1,9 @@
-import random
-import numpy as np
-from math import exp, sinh
-import scipy.stats as st
 import logging
+import random
+from math import exp, sinh
+
+import numpy as np
+import scipy.stats as st
 
 
 # ----------- fake data generation ---------------

--- a/backend/ml/dev/licchavi_dev.py
+++ b/backend/ml/dev/licchavi_dev.py
@@ -1,8 +1,8 @@
 import logging
+
 import torch
 
 from ml.licchavi import Licchavi
-
 
 """ LicchaviDev(Licchavi) class used for experiments only
 

--- a/backend/ml/dev/ml_benchmark.py
+++ b/backend/ml/dev/ml_benchmark.py
@@ -1,9 +1,11 @@
 import timeit
+
 import torch
 
-from ml.losses import _bbt_loss, _approx_bbt_loss, get_fit_loss, get_s_loss
-from .fake_data import generate_data
+from ml.losses import _approx_bbt_loss, _bbt_loss, get_fit_loss, get_s_loss
+
 from ..core import ml_run
+from .fake_data import generate_data
 
 """
 Module used for testing performances (speed)

--- a/backend/ml/dev/visualisation.py
+++ b/backend/ml/dev/visualisation.py
@@ -1,10 +1,11 @@
-import numpy as np
-import torch
 import random
 
+import numpy as np
+import torch
+
 from ml.data_utility import replace_dir
-from .plots import (plot_metrics, plot_density, plot_s_predict_gt,
-                    plot_loc_uncerts)
+
+from .plots import plot_density, plot_loc_uncerts, plot_metrics, plot_s_predict_gt
 
 """
 Visualisation methods, mainly for testing and debugging

--- a/backend/ml/handle_data.py
+++ b/backend/ml/handle_data.py
@@ -1,17 +1,19 @@
-from ml.losses import round_loss
-import numpy as np
-import torch
 import logging
 
+import numpy as np
+import torch
+
+from ml.losses import round_loss
+
 from .data_utility import (
-    get_batch_r,
-    rescale_rating,
-    sort_by_first,
-    reverse_idxs,
-    get_mask,
-    get_all_vids,
     expand_dic,
+    get_all_vids,
+    get_batch_r,
+    get_mask,
     one_hot_vids,
+    rescale_rating,
+    reverse_idxs,
+    sort_by_first,
 )
 
 """

--- a/backend/ml/licchavi.py
+++ b/backend/ml/licchavi.py
@@ -1,22 +1,23 @@
-import torch
-from copy import deepcopy
-from time import time
 import logging
+from copy import deepcopy
 from logging import info as loginf
-import gin
+from time import time
 
-from .losses import model_norm, round_loss, predict, loss_fit_s_gen, loss_gen_reg
+import gin
+import torch
+
+from .data_utility import expand_tens, one_hot_vids
+from .dev.visualisation import disp_one_by_line
+from .losses import loss_fit_s_gen, loss_gen_reg, model_norm, predict, round_loss
 from .metrics import (
-    extract_grad,
-    get_uncertainty_loc,
-    get_uncertainty_glob,
     check_equilibrium_glob,
     check_equilibrium_loc,
+    extract_grad,
+    get_uncertainty_glob,
+    get_uncertainty_loc,
     scalar_product,
 )
-from .data_utility import expand_tens, one_hot_vids
 from .nodes import Node
-from .dev.visualisation import disp_one_by_line
 
 """
 Machine Learning algorithm, used in "core.py"

--- a/backend/ml/management/commands/ml_train.py
+++ b/backend/ml/management/commands/ml_train.py
@@ -1,16 +1,16 @@
 import logging
 
+from django.core.management.base import BaseCommand
+
+from ml.core import TOURNESOL_DEV, ml_run
+from settings.settings import CRITERIAS
 from tournesol.models import (
     ComparisonCriteriaScore,
     ContributorRating,
     ContributorRatingCriteriaScore,
-    VideoCriteriaScore,
     User,
+    VideoCriteriaScore,
 )
-from django.core.management.base import BaseCommand
-
-from settings.settings import CRITERIAS
-from ml.core import ml_run, TOURNESOL_DEV
 
 """
 Machine Learning main python file

--- a/backend/ml/management/commands/ml_train_dev.py
+++ b/backend/ml/management/commands/ml_train_dev.py
@@ -3,9 +3,9 @@ import logging
 from django.core.management.base import BaseCommand
 
 from ml.core import TOURNESOL_DEV
-from .ml_train import fetch_data
 from ml.dev.experiments import run_experiment
 
+from .ml_train import fetch_data
 
 """
 Machine Learning command file for developpement

--- a/backend/ml/metrics.py
+++ b/backend/ml/metrics.py
@@ -1,10 +1,11 @@
-from torch.autograd.functional import hessian
-import torch
-from copy import deepcopy
 import logging
+from copy import deepcopy
 from statistics import median
 
-from .losses import round_loss, loss_fit_s_gen, loss_gen_reg, models_dist
+import torch
+from torch.autograd.functional import hessian
+
+from .losses import loss_fit_s_gen, loss_gen_reg, models_dist, round_loss
 
 """
 Metrics used for training monitoring in "licchavi.py"

--- a/backend/ml/tests/ml_tests.py
+++ b/backend/ml/tests/ml_tests.py
@@ -1,30 +1,29 @@
 import numpy as np
 import torch
 
+from ml.core import _set_licchavi, _train_predict, ml_run
 from ml.data_utility import (
-    rescale_rating,
-    get_all_vids,
-    get_mask,
-    reverse_idxs,
-    sort_by_first,
     expand_dic,
     expand_tens,
+    get_all_vids,
+    get_mask,
+    rescale_rating,
+    reverse_idxs,
+    sort_by_first,
 )
-from ml.handle_data import select_criteria, shape_data, distribute_data
-from ml.losses import _bbt_loss, _approx_bbt_loss, get_s_loss, models_dist, model_norm
+from ml.dev.fake_data import generate_data
+from ml.handle_data import distribute_data, select_criteria, shape_data
+from ml.licchavi import Licchavi, get_model, get_s
+from ml.losses import _approx_bbt_loss, _bbt_loss, get_s_loss, model_norm, models_dist
 from ml.metrics import (
-    extract_grad,
-    scalar_product,
     _random_signs,
-    get_uncertainty_glob,
     check_equilibrium_glob,
     check_equilibrium_loc,
+    extract_grad,
+    get_uncertainty_glob,
     get_uncertainty_loc,
+    scalar_product,
 )
-from ml.licchavi import Licchavi, get_model, get_s
-from ml.dev.fake_data import generate_data
-from ml.core import _set_licchavi, _train_predict, ml_run
-
 
 """
 Test module for ml

--- a/backend/scripts/ci/lint-fix.sh
+++ b/backend/scripts/ci/lint-fix.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Python Code Quality Fixes
+
+isort --settings-path .isort.cfg ${@:-core ml settings tournesol}

--- a/backend/scripts/ci/lint.sh
+++ b/backend/scripts/ci/lint.sh
@@ -6,10 +6,13 @@ set -uxo pipefail
 # return 0 if all checks return 0
 # 1 instead
 
-pylint --rcfile=.pylintrc ${@:-core tournesol}
+isort --settings-path .isort.cfg --check-only ${@:-core ml settings tournesol}
 chk1=$?
 
 flake8 --config=.flake8 ${@:-}
 chk2=$?
 
-! (( chk1 || chk2 ))
+pylint --rcfile=.pylintrc ${@:-core tournesol}
+chk3=$?
+
+! (( chk1 || chk2 || chk3 ))

--- a/backend/settings/asgi.py
+++ b/backend/settings/asgi.py
@@ -8,8 +8,8 @@ https://docs.djangoproject.com/en/3.2/howto/deployment/asgi/
 """
 
 import os
-import yaml
 
+import yaml
 from django.core.asgi import get_asgi_application
 
 # Get the local settings of the server

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -10,10 +10,10 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 import os
-import yaml
-
 from collections import OrderedDict
 from pathlib import Path
+
+import yaml
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/backend/settings/urls.py
+++ b/backend/settings/urls.py
@@ -15,10 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.http import HttpResponseForbidden
-from django.urls import path, include
-from drf_spectacular.views import SpectacularSwaggerView, SpectacularAPIView
-
+from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_registration.api.urls import urlpatterns as original_registration_urlpatterns
+
 exclude_patterns = ["login", "logout"]
 filtered_registration_urls = [pattern for pattern in original_registration_urlpatterns if pattern.name not in exclude_patterns]
 

--- a/backend/settings/wsgi.py
+++ b/backend/settings/wsgi.py
@@ -8,8 +8,8 @@ https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/
 """
 
 import os
-import yaml
 
+import yaml
 from django.core.wsgi import get_wsgi_application
 
 server_settings = {}

--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -5,12 +5,12 @@ Defines Tournesol's backend admin interface
 from django.contrib import admin
 
 from .models import (
-    Video,
-    VideoCriteriaScore,
-    ContributorRating,
-    ContributorRatingCriteriaScore,
     Comparison,
     ComparisonCriteriaScore,
+    ContributorRating,
+    ContributorRatingCriteriaScore,
+    Video,
+    VideoCriteriaScore,
 )
 
 

--- a/backend/tournesol/models/__init__.py
+++ b/backend/tournesol/models/__init__.py
@@ -2,6 +2,6 @@
 Models for Tournesol app
 """
 
-from .video import *
-from .ratings import *
 from .comparisons import *
+from .ratings import *
+from .video import *

--- a/backend/tournesol/models/comparisons.py
+++ b/backend/tournesol/models/comparisons.py
@@ -2,27 +2,17 @@
 Models for Tournesol's main functions related to contributor's comparisons
 """
 
-import uuid
 import logging
-import numpy as np
-
-from django.db import models
-from django.db.models import (
-    ObjectDoesNotExist,
-    Q,
-    F,
-    Count,
-)
-from django.core.validators import MaxValueValidator, MinValueValidator
+import uuid
 
 import computed_property
+import numpy as np
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+from django.db.models import Count, F, ObjectDoesNotExist, Q
 
 from core.models import User
-from core.utils.models import (
-    WithFeatures,
-    WithDynamicFields,
-    enum_list,
-)
+from core.utils.models import WithDynamicFields, WithFeatures, enum_list
 from settings.settings import CRITERIAS, CRITERIAS_DICT, MAX_VALUE
 
 

--- a/backend/tournesol/models/video.py
+++ b/backend/tournesol/models/video.py
@@ -3,28 +3,21 @@ Models for Tournesol's main functions related to videos
 """
 
 import logging
-import numpy as np
 from datetime import timedelta
 
+import numpy as np
 from django.conf import settings
-from django.core.validators import RegexValidator
+from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.db import models
 from django.db.models import Q
-from django.core.validators import MaxValueValidator, MinValueValidator
-from django.utils.html import format_html
 from django.utils import timezone
-
+from django.utils.html import format_html
 from languages.languages import LANGUAGES
 from tqdm.auto import tqdm
 
 from core.models import User
-from core.utils.models import (
-    WithFeatures,
-    WithEmbedding,
-    query_or,
-    query_and,
-)
 from core.utils.constants import YOUTUBE_VIDEO_ID_REGEX
+from core.utils.models import WithEmbedding, WithFeatures, query_and, query_or
 from tournesol.models.comparisons import Comparison
 from tournesol.models.tags import Tag
 from tournesol.utils import VideoSearchEngine
@@ -258,7 +251,7 @@ class Video(models.Model, WithFeatures, WithEmbedding):
         are older than `VIDEO_METADATA_EXPIRE_SECONDS`.
         The request can be forced with `force=True`.
         """
-        from tournesol.utils.api_youtube import get_video_metadata, VideoNotFound
+        from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata
 
         if (
             not force

--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -3,26 +3,27 @@ Serializer used by Tournesol's API
 """
 
 from typing import Optional
+
 from django.db import transaction
 from django.db.models import ObjectDoesNotExist, Q
-
-from rest_framework import serializers
-from rest_framework.fields import RegexField, SerializerMethodField, BooleanField
-from rest_framework.serializers import Serializer, ModelSerializer
-from rest_framework.exceptions import ValidationError
-from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+from rest_framework.fields import BooleanField, RegexField, SerializerMethodField
+from rest_framework.serializers import ModelSerializer, Serializer
 
 from core.utils.constants import YOUTUBE_VIDEO_ID_REGEX
+
 from .models import (
     Comparison,
     ComparisonCriteriaScore,
-    Video,
-    VideoRateLater,
-    VideoCriteriaScore,
     ContributorRating,
     ContributorRatingCriteriaScore,
     Tag,
+    Video,
+    VideoCriteriaScore,
+    VideoRateLater,
 )
 
 

--- a/backend/tournesol/tests/factories/comparison.py
+++ b/backend/tournesol/tests/factories/comparison.py
@@ -1,9 +1,9 @@
 import factory
 import factory.fuzzy
 
+from core.tests.factories.user import UserFactory
 from tournesol.models import comparisons as comparison_models
 from tournesol.tests.factories.video import VideoFactory
-from core.tests.factories.user import UserFactory
 
 
 class ComparisonFactory(factory.django.DjangoModelFactory):

--- a/backend/tournesol/tests/factories/ratings.py
+++ b/backend/tournesol/tests/factories/ratings.py
@@ -1,9 +1,9 @@
 import factory
 import factory.fuzzy
 
+from core.tests.factories.user import UserFactory
 from tournesol.models import ratings as ratings_models
 from tournesol.tests.factories.video import VideoFactory
-from core.tests.factories.user import UserFactory
 
 
 class ContributorRatingFactory(factory.django.DjangoModelFactory):

--- a/backend/tournesol/tests/factories/video.py
+++ b/backend/tournesol/tests/factories/video.py
@@ -4,8 +4,8 @@ import string
 
 import factory
 
-from tournesol.models import video as video_models
 from core.tests.factories.user import UserFactory
+from tournesol.models import video as video_models
 
 
 def generate_youtube_id():

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -1,20 +1,20 @@
-from copy import deepcopy
 import datetime
+from copy import deepcopy
 from unittest.mock import patch
 
 from django.db.models import ObjectDoesNotExist, Q
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
-
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from core.models import User
 from core.tests.factories.user import UserFactory
-from tournesol.tests.factories.video import VideoFactory
 from tournesol.tests.factories.comparison import ComparisonFactory
-from ..models import Video, Comparison
+from tournesol.tests.factories.video import VideoFactory
+
+from ..models import Comparison, Video
 
 
 class ComparisonApiTestCase(TestCase):

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -2,11 +2,14 @@ from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from tournesol.models import ContributorRating
-from tournesol.tests.factories.video import VideoFactory
-from tournesol.tests.factories.comparison import ComparisonFactory
 from core.tests.factories.user import UserFactory
-from tournesol.tests.factories.ratings import ContributorRatingFactory, ContributorRatingCriteriaScoreFactory
+from tournesol.models import ContributorRating
+from tournesol.tests.factories.comparison import ComparisonFactory
+from tournesol.tests.factories.ratings import (
+    ContributorRatingCriteriaScoreFactory,
+    ContributorRatingFactory,
+)
+from tournesol.tests.factories.video import VideoFactory
 
 
 class RatingApi(TestCase):

--- a/backend/tournesol/tests/test_api_user.py
+++ b/backend/tournesol/tests/test_api_user.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from core.models import User, EmailDomain
+from core.models import EmailDomain, User
 from core.tests.factories.user import UserFactory
 
 

--- a/backend/tournesol/tests/test_api_video.py
+++ b/backend/tournesol/tests/test_api_video.py
@@ -8,8 +8,9 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from core.models import User
+from tournesol.tests.factories.video import VideoCriteriaScoreFactory, VideoFactory
 from tournesol.utils.video_language import compute_video_language
-from tournesol.tests.factories.video import VideoFactory, VideoCriteriaScoreFactory
+
 from ..models import Tag, Video
 
 

--- a/backend/tournesol/tests/test_api_video_rate_later.py
+++ b/backend/tournesol/tests/test_api_video_rate_later.py
@@ -4,9 +4,9 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from core.models import User
+from core.tests.factories.user import UserFactory
 from tournesol.models import Video, VideoRateLater
 from tournesol.tests.factories.video import VideoFactory, VideoRateLaterFactory
-from core.tests.factories.user import UserFactory
 
 
 class VideoRateLaterApi(TestCase):

--- a/backend/tournesol/tests/test_exports.py
+++ b/backend/tournesol/tests/test_exports.py
@@ -1,16 +1,16 @@
 import csv
 import io
 
-from django.test import TestCase
 from django.core.cache import cache
+from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from core.models import User
-from tournesol.models import ComparisonCriteriaScore, ContributorRating
-from tournesol.tests.factories.video import VideoFactory
-from tournesol.tests.factories.comparison import ComparisonFactory, ComparisonCriteriaScoreFactory
 from core.tests.factories.user import UserFactory
+from tournesol.models import ComparisonCriteriaScore, ContributorRating
+from tournesol.tests.factories.comparison import ComparisonCriteriaScoreFactory, ComparisonFactory
+from tournesol.tests.factories.video import VideoFactory
 
 
 class ExportTest(TestCase):

--- a/backend/tournesol/tests/test_throttling.py
+++ b/backend/tournesol/tests/test_throttling.py
@@ -2,11 +2,11 @@ from unittest.mock import patch
 
 from django.core.cache import cache
 from django.test import TestCase
-
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from core.tests.factories.user import UserFactory
+
 
 class ThrottlingTestCase(TestCase):
     """

--- a/backend/tournesol/throttling.py
+++ b/backend/tournesol/throttling.py
@@ -1,8 +1,4 @@
-from rest_framework.throttling import (
-    AnonRateThrottle,
-    ScopedRateThrottle,
-    UserRateThrottle,
-)
+from rest_framework.throttling import AnonRateThrottle, ScopedRateThrottle, UserRateThrottle
 
 
 class BurstAnonRateThrottle(AnonRateThrottle):

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -8,17 +8,16 @@ from django.urls import include, path
 from rest_framework import routers
 
 from .views import ComparisonDetailApi, ComparisonListApi, ComparisonListFilteredApi
-from .views.exports import ExportComparisonsView, ExportAllView, ExportPublicComparisonsView
-from .views.video import VideoViewSet
-from .views.video_rate_later import VideoRateLaterDetail, VideoRateLaterList
-from .views.user import CurrentUserView
+from .views.email_domains import EmailDomainsList
+from .views.exports import ExportAllView, ExportComparisonsView, ExportPublicComparisonsView
 from .views.ratings import (
-    ContributorRatingList,
     ContributorRatingDetail,
+    ContributorRatingList,
     ContributorRatingUpdateAll,
 )
-from .views.email_domains import EmailDomainsList
-
+from .views.user import CurrentUserView
+from .views.video import VideoViewSet
+from .views.video_rate_later import VideoRateLaterDetail, VideoRateLaterList
 
 router = routers.DefaultRouter()
 router.register(r'video', VideoViewSet)

--- a/backend/tournesol/utils/api_youtube.py
+++ b/backend/tournesol/utils/api_youtube.py
@@ -1,8 +1,9 @@
 import logging
+
+import googleapiclient.discovery
 from django.conf import settings
 from django.utils import timezone
 from django.utils.dateparse import parse_duration
-import googleapiclient.discovery
 
 from tournesol.utils.video_language import compute_video_language
 

--- a/backend/tournesol/utils/video_language.py
+++ b/backend/tournesol/utils/video_language.py
@@ -1,6 +1,8 @@
-from collections import Counter
-from langdetect import detect, lang_detect_exception, DetectorFactory
 import re
+from collections import Counter
+
+from langdetect import DetectorFactory, detect, lang_detect_exception
+
 from ..models import Video
 
 # Enforce consistent results with a constant seed,

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -2,12 +2,11 @@
 API endpoints to interact with the contributor's comparisons
 """
 
+from django.db import transaction
 from django.db.models import ObjectDoesNotExist, Q
 from django.http import Http404
-from django.db import transaction
 from drf_spectacular.utils import extend_schema
-
-from rest_framework import generics, mixins, status, exceptions
+from rest_framework import exceptions, generics, mixins, status
 from rest_framework.response import Response
 
 from ..models import Comparison, ContributorRating

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -4,12 +4,12 @@ from io import StringIO
 
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
+from drf_spectacular.utils import OpenApiTypes, extend_schema
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.views import APIView
-from rest_framework.permissions import IsAuthenticated, AllowAny
-from drf_spectacular.utils import extend_schema, OpenApiTypes
 
-from tournesol.serializers import ComparisonSerializer
 from tournesol.models import Comparison, ContributorRating
+from tournesol.serializers import ComparisonSerializer
 from tournesol.utils.cache import cache_page_no_i18n
 
 

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -2,17 +2,17 @@
 API endpoint to manipulate contributor ratings
 """
 
+from django.db.models import Func, OuterRef, Q, Subquery
 from django.shortcuts import get_object_or_404
-from django.db.models import Q, Subquery, Func, OuterRef
-from rest_framework import generics, exceptions
-from rest_framework.response import Response
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from rest_framework import exceptions, generics
+from rest_framework.response import Response
 
-from ..models import ContributorRating, Comparison
+from ..models import Comparison, ContributorRating
 from ..serializers import (
-    ContributorRatingSerializer,
     ContributorRatingCreateSerializer,
+    ContributorRatingSerializer,
     ContributorRatingUpdateAllSerializer,
 )
 

--- a/backend/tournesol/views/user.py
+++ b/backend/tournesol/views/user.py
@@ -1,12 +1,11 @@
 import logging
 
 from django.contrib.auth import logout
-from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework import status
-from drf_spectacular.utils import extend_schema
-
+from rest_framework.views import APIView
 
 logger = logging.getLogger(__name__)
 

--- a/backend/tournesol/views/video.py
+++ b/backend/tournesol/views/video.py
@@ -3,28 +3,28 @@ API endpoint to manipulate videos
 """
 import re
 
-from django.utils import timezone, dateparse
-from django.db.models import Q, Case, When, Sum, F
 from django.conf import settings
-
+from django.db.models import Case, F, Q, Sum, When
+from django.utils import dateparse, timezone
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.viewsets import GenericViewSet
-from rest_framework.exceptions import ValidationError, NotFound
-from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
-from drf_spectacular.types import OpenApiTypes
 
-from ..serializers import VideoSerializerWithCriteria, VideoSerializer
-from ..models import Video
 from tournesol.throttling import (
     BurstAnonRateThrottle,
     BurstUserRateThrottle,
     PostScopeRateThrottle,
     SustainedAnonRateThrottle,
-    SustainedUserRateThrottle
+    SustainedUserRateThrottle,
 )
-from tournesol.utils.api_youtube import get_video_metadata, VideoNotFound
+from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata
+
+from ..models import Video
+from ..serializers import VideoSerializer, VideoSerializerWithCriteria
 
 
 @extend_schema_view(

--- a/backend/tournesol/views/video_rate_later.py
+++ b/backend/tournesol/views/video_rate_later.py
@@ -4,11 +4,10 @@ API endpoint to manipulate contributor's rate later list
 
 from django.db import IntegrityError
 from django.shortcuts import get_object_or_404
-
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import generics, mixins, status
-from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
-from drf_spectacular.utils import extend_schema_view, extend_schema, OpenApiResponse
+from rest_framework.response import Response
 
 from ..models import Video, VideoRateLater
 from ..serializers import VideoRateLaterSerializer


### PR DESCRIPTION
follows the work of the pull request #438 

---

### changed

To improve the back end linters collection, the `./scripts/ci/lint.sh` now also run the `isort --check-only` command. This change affects both the GitHub CI and the local script.

### added

A new script, `./scripts/ci/lint-fix.sh` will help the developpers to automatically fix some errors. Currently, only `isort` is able to fix the target files, hence the " some ". If we decide to use `black`, we will be able to add it to this script.

### future

The scripts`./scripts/ci/lint.sh` and `./scripts/ci/lint-fix.sh` can be integrated as tasks or sub-commands with Python project management tools like `pipenv` or `PDM`.