### PR TITLE
[infra] Enable gzip compression in Nginx and precompress static files

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,11 +28,12 @@
     "redux": "^4.1.2",
     "redux-persist": "^6.0.0",
     "typescript": "~4.5.4",
-    "web-vitals": "^2.1.0"
+    "web-vitals": "^2.1.0",
+    "precompress": "7.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && precompress -i json,js,css,xml,svg,html,ttf build",
     "test": "react-scripts test --testURL=http://localhost:3000",
     "eject": "react-scripts eject",
     "update-schema": "wget -O scripts/openapi.yaml \"${REACT_APP_API_URL:-http://localhost:8000}/schema/\"",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build && precompress -i json,js,css,xml,svg,html,ttf build",
+    "build": "react-scripts build && precompress -t gz -i json,js,css,xml,svg,html,ttf build",
     "test": "react-scripts test --testURL=http://localhost:3000",
     "eject": "react-scripts eject",
     "update-schema": "wget -O scripts/openapi.yaml \"${REACT_APP_API_URL:-http://localhost:8000}/schema/\"",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8143,6 +8143,11 @@ postcss@^8.1.6, postcss@^8.2.15, postcss@^8.3.5, postcss@^8.4.4:
     picocolors "^1.0.0"
     source-map-js "^1.0.1"
 
+precompress@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/precompress/-/precompress-7.0.1.tgz#8b04e16faf9f08707ef66671569e4889a8eab44f"
+  integrity sha512-JQikeszeU8PLwF/fC1Buo8XDq2wewu8Vxt3kGiPNTzrB8ZtvnOaeizPsMhZwH+TShXvfms4b7fnLo9VURwv3aw==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"

--- a/infra/ansible/roles/nginx/tasks/main.yml
+++ b/infra/ansible/roles/nginx/tasks/main.yml
@@ -54,25 +54,11 @@
     install_recommends: no
     update_cache: yes
 
-- name: Restrict TLS ssl_protocols
-  lineinfile:
-    path: /etc/nginx/nginx.conf
-    regexp: '^\s*ssl_protocols'
-    line: "\t\tssl_protocols TLSv1.2;"
-  notify:
-    - Reload Nginx
-
-- name: Add TLS parameters
-  blockinfile:
-    path: /etc/nginx/nginx.conf
-    insertafter: '^\s*ssl_prefer_server_ciphers'
-    block: |
-      ssl_ecdh_curve secp384r1;
-      ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
-      ssl_session_cache shared:SSL:10m;
-      ssl_session_tickets off;
-  notify:
-    - Reload Nginx
+- name: Set Nginx configuration
+  template:
+    src: nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
+  notify: Reload Nginx
 
 - name: Disable Nginx default site
   file:

--- a/infra/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/infra/ansible/roles/nginx/templates/nginx.conf.j2
@@ -68,6 +68,9 @@ http {
         gzip_vary on; # Distinguish compressed and uncompressed cache
         gunzip on;    # Uncompress for clients that don't support compression
 
+        # Static pre-compressed files for better performances
+        gzip_static on;
+
         ##
         # Virtual Host Configs
         ##

--- a/infra/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/infra/ansible/roles/nginx/templates/nginx.conf.j2
@@ -1,0 +1,77 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+        worker_connections 768;
+        # multi_accept on;
+}
+
+http {
+
+        ##
+        # Basic Settings
+        ##
+
+        sendfile on;
+        tcp_nopush on;
+        types_hash_max_size 2048;
+        # server_tokens off;
+
+        # server_names_hash_bucket_size 64;
+        # server_name_in_redirect off;
+
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+
+        ##
+        # SSL Settings
+        ##
+
+        ssl_protocols TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        ssl_ecdh_curve secp384r1;
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_tickets off;
+
+        ##
+        # Logging Settings
+        ##
+
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+
+        ##
+        # Gzip Settings
+        ##
+
+        gzip on;
+        gzip_comp_level 2;   # Possible values from 1 to 9 (with 9 = most compressed but slowest compression)
+        gzip_min_length 256; # Compress the files larger than 256 bytes or that don't have the flag content-length.
+        # Compress some responses to proxy (https://docs.nginx.com/nginx/admin-guide/web-server/compression/)
+        gzip_proxied no-cache no-store private expired auth;
+        # Compressed types
+        gzip_types
+            text/plain
+            text/css
+            text/js
+            text/xml
+            text/javascript
+            application/javascript
+            application/json
+            application/xml
+            application/rss+xml
+            image/svg+xml
+            image/x-icon;
+        gzip_vary on; # Distinguish compressed and uncompressed cache
+        gunzip on;    # Uncompress for clients that don't support compression
+
+        ##
+        # Virtual Host Configs
+        ##
+
+        include /etc/nginx/conf.d/*.conf;
+        include /etc/nginx/sites-enabled/*;
+}


### PR DESCRIPTION
original config file :
[nginx.txt](https://github.com/tournesol-app/tournesol/files/7884622/nginx.txt)

 new config file :
[new_nginx.txt](https://github.com/tournesol-app/tournesol/files/7884624/new_nginx.txt)

I discussed with JST of the BREACH vulnerability. We think it is not a problem in Tournesol.

A further improvement could be to use the compression algorithm Brotli for better performances. Brotli (compared to gzip) is slower for compression, slightly slower for decompression but gives a better compression ratio, for example :
main.45fd59e7.js => 939173 bytes (uncompressed)
main.45fd59e7.js.gz => 289515 bytes (gzip)
main.45fd59e7.js.br => 212442 bytes (brotli)
precompress by default also produces brotli files. But the difficulty is that to use brotli we need to install the nginx module ngx_http_brotli_static_module. Not sure this is possible when installing nginx with apt.
If you think adding Brotli is worth, I will see with JST how this could be done.