### PR TITLE
[front] feat: Add explicit messages about the username being public

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -216,7 +216,7 @@
     "whoTournesolSharesUsersNContributorsDataWith": "Who Tournesol shares users' and contributors' data with?",
     "whoTournesolSharesUsersNContributorsDataWithParagraph": "Tournesol highly values the protection of users' and contributors' data. In particular, Tournesol knows that some of the contributors' judgments may conflict with the agendas of some political leaders or of their employer. We want contributors to express judgments without the fear of any consequence for their personal life. This is why Tournesol has the option of providing judgments privately or anonymously. Privately provided raw judgments will not be shared with any third party.",
     "publicData": "Public data",
-    "whereGoPublicData": "Contributors are encouraged, when possible, to compare videos publicly. This will allow us to collect a public database, which, hopefully, will stimulate research on more beneficial recommendation algorithms. Private ratings, i.e. ratings for which at least one video is rated privately by the contributor, will never be made public, nor shared with third parties.",
+    "whereGoPublicData": "Contributors are encouraged, when possible, to compare videos publicly. This will allow us to collect a public database, which, hopefully, will stimulate research on more beneficial recommendation algorithms. This database consists of detailed public contributions, associated with the usernames of the contributors who submitted them. Private ratings, i.e. ratings for which at least one video is rated privately by the contributor, will never be made public, nor shared with third parties.",
     "aggregateData": "Aggregate data",
     "whereGoAggregateData": "Our algorithms combine contributors’ public and private data to provide aggregate statistics, which are made public. This is typically the case of the Tournesol scores given to different videos. Tournesol also plans to release statistics about subsets of contributors, e.g. to determine how pedagogical a physics video is according to biologists. In any such case, we apply the principles of differential privacy, by adding randomness to the actual aggregation, in order to increase the privacy of your data.",
     "researchPurposes": "Research purposes",
@@ -261,7 +261,7 @@
     "successMessage": "Success!<1></1>A verification link has been sent to <3>{{email}}</3> .",
     "title": "Account creation",
     "accountCreationFailed": "Account creation failed.",
-    "iAgreeWithThePrivacyPolicy": "I have read and agree with the <2>privacy policy</2>"
+    "iAgreeWithThePrivacyPolicy": "I have read and agree with the <2>privacy policy</2>."
   },
   "emailAddress": "Email address",
   "confirmYourPassword": "Confirm your password",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -125,7 +125,7 @@
     "errorOccurredWhenRetrievingProfile": "Désolé, une erreur est survenue, impossible de récupérer votre profil.",
     "errorOccurredWhenUpdatingProfile": "Désolé, une erreur est survenue, impossible de mettre à jour votre mot de passe.",
     "profileChangedSuccessfully": "Profil bien mis à jour.",
-    "captionUsernameWillAppearInPublicDatabase": "Votre identifiant apparaîtra dans les données publiques de Tournesol, si vous choisissez de rendre publique au moins l'une de vos données. Vous pouvez le changer à n'importe quel moment.",
+    "captionUsernameWillAppearInPublicDatabase": "Votre nom d'utilisateur apparaîtra dans les données publiques de Tournesol, si vous choisissez de rendre publique au moins l'une de vos données. Vous pouvez le changer à n'importe quel moment.",
     "updateProfile": "Mettre à jour le profil",
     "account": "Compte",
     "title": "Paramètres",
@@ -220,7 +220,7 @@
     "whoTournesolSharesUsersNContributorsDataWith": "Avec qui Tournesol partage-t-il les données des utilisateurs et des contributeurs ?",
     "whoTournesolSharesUsersNContributorsDataWithParagraph": "Tournesol accorde beaucoup d'importance à la protection des données de ses utilisateurs et contributeurs. En particulier, Tournesol sait que les jugements des contributeurs peuvent entrer en conflit avec les opinions de leaders politiques et d'employeurs. Nous souhaitons que des contributeurs puissent exprimer leurs jugements sans craindre de conséquences sur leur vie personnelle. C'est pourquoi Tournesol offre la possibilité de soumettre des jugements de manière privée ou anonyme. Ces jugements privés ne sont partagés avec aucune tierce partie.",
     "publicData": "Données publiques",
-    "whereGoPublicData": "Les contributeurs sont encouragés, si possible, à comparer des vidéos publiquement. Cela nous permettra de constituer une base de données publique, qui, nous l'espérons, stimulera la recherche menée sur des algorithmes de recommandations plus bénéfiques. Les jugements privés, c'est-à-dire les comparaisons pour lesquelles au moins l'une des vidéos est évaluée en privé par le contributeur, ne sont jamais rendues publiques, et ne sont partagées avec aucune tierce partie.",
+    "whereGoPublicData": "Les contributeurs sont encouragés, si possible, à comparer des vidéos publiquement. Cela nous permettra de constituer une base de données publique, qui, nous l'espérons, stimulera la recherche menée sur des algorithmes de recommandations plus bénéfiques. Cette base de données comprend le detail des contributions publiques, associées aux noms d'utilisateur des contributeurs qui les ont transmises. Les jugements privés, c'est-à-dire les comparaisons pour lesquelles au moins l'une des vidéos est évaluée en privé par le contributeur, ne sont jamais rendues publiques, et ne sont partagées avec aucune tierce partie.",
     "aggregateData": "Données aggrégées",
     "whereGoAggregateData": "Nos algorithmes combinent les contributions publiques et privées pour produire des statistiques agrégées, qui sont rendues publiques. Cela est notamment le cas des scores Tournesol associés aux différentes vidéos. Tournesol prévoit également de mettre à disposition des statistiques sur des sous-ensembles de contributeurs, pour par exemple déterminer dans quelle mesure une vidéo traitant de physique est considérée comme pédagogique pour les biologistes. Dans ce cas de figure, nous appliquons les principes de confidentialité différentielle, en ajoutant un degré d'aléa au résultat agrégé, de façon à renforcer le caractère privé de ces données.",
     "researchPurposes": "Objectifs de recherche",
@@ -265,7 +265,7 @@
     "successMessage": "Bravo !<1></1>Un lien de vérification vient d'être envoyé à <3>{{email}}</3> .",
     "title": "Inscription",
     "accountCreationFailed": "Création du compte échouée.",
-    "iAgreeWithThePrivacyPolicy": "J'ai lu et j'accepte la <2>politique de confidentialité</2>"
+    "iAgreeWithThePrivacyPolicy": "J'ai lu et j'accepte la <2>politique de confidentialité</2>."
   },
   "emailAddress": "Adresse e-mail",
   "confirmYourPassword": "Confirmez votre mot de passe",

--- a/frontend/src/components/FormTextField.tsx
+++ b/frontend/src/components/FormTextField.tsx
@@ -9,6 +9,7 @@ interface Props {
   onChange?: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
+  helperText?: React.ReactNode;
   [propName: string]: unknown;
 }
 
@@ -17,6 +18,7 @@ const FormTextField = ({
   label,
   formError,
   onChange,
+  helperText,
   ...rest
 }: Props) => {
   const errorMessages = formError?.[name];
@@ -36,7 +38,7 @@ const FormTextField = ({
       size="small"
       variant="outlined"
       error={showError}
-      helperText={showError && <Lines messages={errorMessages} />}
+      helperText={showError ? <Lines messages={errorMessages} /> : helperText}
       onChange={(e) => {
         setShowError(false);
         if (onChange) {

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -85,6 +85,9 @@ const Signup = () => {
                   name="username"
                   label={t('username')}
                   formError={formError}
+                  helperText={t(
+                    'settings.captionUsernameWillAppearInPublicDatabase'
+                  )}
                 />
               </Grid>
               <Grid item xs={12}>
@@ -103,8 +106,9 @@ const Signup = () => {
                   formError={formError}
                 />
               </Grid>
-              <Grid item xs={12}>
+              <Grid item xs={12} display="flex" alignItems="center">
                 <Checkbox
+                  color="secondary"
                   checked={acceptPolicy}
                   onClick={() => setAcceptPolicy(!acceptPolicy)}
                 />


### PR DESCRIPTION
On the signup page, and in the privacy policy.

Closes #444 

![image](https://user-images.githubusercontent.com/4726554/150124632-8b11f9db-be1e-4d04-8eab-085d12afb726.png)
