### PR TITLE
[front] fix: Remove hard-coded wiki hostname on About page

### DIFF
--- a/frontend/src/features/comparisons/CriteriaSlider.tsx
+++ b/frontend/src/features/comparisons/CriteriaSlider.tsx
@@ -7,7 +7,7 @@ import Slider from '@mui/material/Slider';
 import Grid from '@mui/material/Grid';
 import Checkbox from '@mui/material/Checkbox';
 
-import { handleWikiUrl } from 'src/utils/url';
+import { getWikiBaseUrl } from 'src/utils/url';
 import { optionalCriterias } from 'src/utils/constants';
 
 const useStyles = makeStyles(() => ({
@@ -75,9 +75,7 @@ const CriteriaSlider = ({
           )}
           <Typography>
             <a
-              href={`${handleWikiUrl(
-                window.location.host
-              )}/wiki/Quality_criteria`}
+              href={`${getWikiBaseUrl()}/wiki/Quality_criteria`}
               id={`id_explanation_${criteria}`}
               target="_blank"
               rel="noreferrer"

--- a/frontend/src/features/frame/components/sidebar/Footer.tsx
+++ b/frontend/src/features/frame/components/sidebar/Footer.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import makeStyles from '@mui/styles/makeStyles';
 import { Box, Divider, Theme } from '@mui/material';
 
-import { handleWikiUrl } from 'src/utils/url';
+import { getWikiBaseUrl } from 'src/utils/url';
 import { LanguageSelector } from 'src/components';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -39,7 +39,7 @@ const Footer = () => {
       <div className={classes.linksContainer}>
         <a
           className={classes.menuLink}
-          href={handleWikiUrl(window.location.host)}
+          href={getWikiBaseUrl()}
           target="_blank"
           rel="noreferrer"
         >

--- a/frontend/src/pages/about/About.tsx
+++ b/frontend/src/pages/about/About.tsx
@@ -4,6 +4,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { Grid, Typography, Box, Card, Link } from '@mui/material';
 
 import { ContentHeader } from 'src/components';
+import { getWikiBaseUrl } from 'src/utils/url';
 import PublicDownloadSection from './PublicDownloadSection';
 
 const useStyles = makeStyles(() => ({
@@ -117,7 +118,7 @@ const AboutPage = () => {
                 </a>
                 , our{' '}
                 <a
-                  href="https://wiki.staging.tournesol.app/wiki/Main_Page"
+                  href={getWikiBaseUrl()}
                   target="_blank"
                   rel="noreferrer"
                   style={{ color: 'white' }}

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -1,6 +1,6 @@
-export const handleWikiUrl = (host: string) => {
-  if (host == 'localhost:3000') {
+export const getWikiBaseUrl = () => {
+  if (location.hostname === 'localhost') {
     return 'https://wiki.staging.tournesol.app';
   }
-  return `https://wiki.${host}`;
+  return `https://wiki.${location.host}`;
 };


### PR DESCRIPTION
"wiki.staging.tournesol.app" was used on all environments :fearful: 

Issue observed during Tournesol video tutorial.