### PR TITLE
[front] feat: Implement embedded mode and error messages about storage access from iframe

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -41,6 +41,16 @@
     "myRateLaterList": "My rate later list",
     "about": "About"
   },
+  "frame": {
+    "onChromeOrDerivatives": "On Chrome, Chromium, or derivatives",
+    "addWebsiteToChromeExceptions": "On the settings page related to Cookies and other site data (<1>{{page}}</1>), add <4>{{host}}</4> to the list of <7>\"Sites that can always use cookies\"</7>.",
+    "findMoreDetailsOnPage": "Find more details on <2>this page</2>.",
+    "onFirefox": "On Firefox",
+    "addWebsiteToFirefoxExceptions": "On the settings page about Browser Privacy (<1>{{page}}</1>), in the section about <3>Cookies and site data</3>, click on <6>Manage Exceptions</6>.<8></8>Then, add <10>{{host}}</10> to the list of websites that are always allowed to use cookies and site data.",
+    "tournesolInFrameIsCurrentlyBlocked": "Tournesol integration is blocked on this website",
+    "thirdPartyStorageIsBlockedAddException": "It seems that using third-party storage is blocked on your browser. In order to access all features provided by the Tournesol web extension, including the integration with YouTube, you can simply add an exception about the website <1>{{host}}</1> in your browser settings, by following the instructions below.",
+    "storageErrorReloadPageAfterApplyingChanges": "After applying these changes, please reload this page."
+  },
   "logoutNonImpactingError": "A non impacting error occurred during your logout.",
   "logoutButton": "Logout",
   "loginButton": "Log in",
@@ -187,8 +197,8 @@
     "donateHowTo": "How to make a donation?",
     "donateWithUtipTitle": "With uTip",
     "donateWithUtipDescription": "uTip is an online crowdfunding platform. Visit our <2>uTip page</2> to make a one-time or recurring donation.",
-    "donateByDirectTransferCHF": "By direct transfer in Swiss Francs (CHF)",
     "donateByDirectTransferEUR": "By direct transfer in Euros (EUR)",
+    "donateByDirectTransferCHF": "By direct transfer in Swiss Francs (CHF)",
     "donateByPaypal": "By PayPal",
     "publicDatabase": "Public Database",
     "publicDatabaseDetailAndLicense": "Contributors on Tournesol can decide to make their data public. We hope this important data will prove useful for researchers on ethics of algorithms and large scale recommender systems. Our public database can be downloaded by clicking the button below and is published under <2>Open Data Commons Attribution License (ODC-By)</2>.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -41,6 +41,16 @@
     "myRateLaterList": "À comparer plus tard",
     "about": "À propos"
   },
+  "frame": {
+    "onChromeOrDerivatives": "Sur Chrome, Chromium, ou dérivés",
+    "addWebsiteToChromeExceptions": "Sur la page de paramètres concernant les Cookies et autres données des sites (<1>{{page}}</1>), ajoutez <4>{{host}}</4> à la liste des <7>\"Sites autorisés à utiliser des cookies\"</7>.",
+    "findMoreDetailsOnPage": "Plus de détails sur <2>cette page</2>.",
+    "onFirefox": "Sur Firefox",
+    "addWebsiteToFirefoxExceptions": "Sur la page de paramètres Vie Privée et sécurité (<1>{{page}}</1>), dans la section concernant les <3>Cookies et données de sites</3>, cliquez sur <6>Gérer les exceptions</6>.<8></8>Ajoutez alors <10>{{host}}</10> à la liste des sites web qui sont toujours autorisés à utiliser des cookies ou des données de site.",
+    "tournesolInFrameIsCurrentlyBlocked": "L'intégration de Tournesol est bloquée sur ce site",
+    "thirdPartyStorageIsBlockedAddException": "Il semble que l'utilisation d'un stockage intersite est bloquée sur votre navigateur. Afin d'accéder à l'ensemble des fonctionnalités de l'extension Tournesol, y compris l'intégration avec YouTube, vous pouvez simplement ajouter une exception concernant le site <1>{{host}}</1> dans les paramètres de votre navigateur en suivant les instructions ci-dessous.",
+    "storageErrorReloadPageAfterApplyingChanges": "Après avoir appliqué ces changements, veuillez rafraîchir cette page."
+  },
   "logoutNonImpactingError": "Une petite erreur est survenue pendant la déconnexion.",
   "logoutButton": "Se déconnecter",
   "loginButton": "Se connecter",
@@ -191,8 +201,8 @@
     "donateHowTo": "Comment faire un don ?",
     "donateWithUtipTitle": "Avec uTip",
     "donateWithUtipDescription": "uTip est une plateforme de financement participatif. Visitez notre <2>page uTip</2> pour faire un don unique ou recurrent.",
-    "donateByDirectTransferCHF": "Par virement direct en Franc Suisses (CHF)",
     "donateByDirectTransferEUR": "Par virement direct en Euros (EUR)",
+    "donateByDirectTransferCHF": "Par virement direct en Franc Suisses (CHF)",
     "donateByPaypal": "Par PayPal",
     "publicDatabase": "Base de données publique",
     "publicDatabaseDetailAndLicense": "Les contributeurs de Tournesol peuvent décider de rendre leurs données publiques. Nous espérons que ces données importantes se révéleront utiles pour les chercheurs et chercheuses travaillant sur l'éthique des algorithmes, et les systèmes de recommandation à grande échelle. Notre base de données publique, disponible sous licence <2>Open Data Commons Attribution License (ODC-By)</2>, peut être téléchargée en cliquant sur le bouton ci-dessous.",

--- a/frontend/src/features/frame/components/StorageError.tsx
+++ b/frontend/src/features/frame/components/StorageError.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { useTranslation, Trans } from 'react-i18next';
+import { Box, Typography, Link } from '@mui/material';
+import { getWebBrowser } from 'src/utils/extension';
+
+const ChromeInstructions = () => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Typography variant="h6" gutterBottom>
+        {t('frame.onChromeOrDerivatives')}
+      </Typography>
+      <Typography gutterBottom>
+        <Trans t={t} i18nKey="frame.addWebsiteToChromeExceptions">
+          On the settings page related to Cookies and other site data (
+          <code>{{ page: 'chrome://settings/cookies' }}</code>), add{' '}
+          <strong>{{ host: location.host }}</strong> to the list of{' '}
+          <strong>&quot;Sites that can always use cookies&quot;</strong>.
+        </Trans>
+      </Typography>
+      <Typography>
+        <Trans t={t} i18nKey="frame.findMoreDetailsOnPage">
+          Find more details on{' '}
+          <Link
+            color="secondary"
+            target="_blank"
+            href="https://support.google.com/chrome/answer/95647"
+            rel="noreferrer"
+          >
+            this page
+          </Link>
+          .
+        </Trans>
+      </Typography>
+    </>
+  );
+};
+
+const FirefoxInstructions = () => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Typography variant="h6" gutterBottom>
+        {t('frame.onFirefox')}
+      </Typography>
+      <Typography gutterBottom>
+        <Trans t={t} i18nKey="frame.addWebsiteToFirefoxExceptions">
+          On the settings page about Browser Privacy (
+          <code>{{ page: 'about:preferences#privacy' }}</code>), in the section
+          about <strong>{'Cookies and site data'}</strong>, click on{' '}
+          <strong>{'Manage Exceptions'}</strong>.<br />
+          Then, add <strong>{{ host: location.host }}</strong> to the list of
+          websites that are always allowed to use cookies and site data.
+        </Trans>
+      </Typography>
+    </>
+  );
+};
+
+const StorageError = () => {
+  const { t } = useTranslation();
+  const browser = getWebBrowser();
+
+  return (
+    <Box maxWidth="sm" my={3} mx="auto">
+      <img src="/svg/LogoSmall.svg" alt="logo" />
+      <Typography variant="h4" gutterBottom>
+        {t('frame.tournesolInFrameIsCurrentlyBlocked')}
+      </Typography>
+      <Typography my={2}>
+        <Trans t={t} i18nKey="frame.thirdPartyStorageIsBlockedAddException">
+          It seems that using third-party storage is blocked on your browser. In
+          order to access all features provided by the Tournesol web extension,
+          including the integration with YouTube, you can simply add an
+          exception about the website <strong>{{ host: location.host }}</strong>{' '}
+          in your browser settings, by following the instructions below.
+        </Trans>
+      </Typography>
+      <Box my={2}>
+        {browser === 'firefox' ? (
+          <FirefoxInstructions />
+        ) : (
+          <ChromeInstructions />
+        )}
+      </Box>
+      <Typography my={2}>
+        {t('frame.storageErrorReloadPageAfterApplyingChanges')}
+      </Typography>
+    </Box>
+  );
+};
+
+export default StorageError;

--- a/frontend/src/utils/extension.ts
+++ b/frontend/src/utils/extension.ts
@@ -1,4 +1,4 @@
-const getWebBrowser = () => {
+export const getWebBrowser = () => {
   if (navigator.userAgent.includes('Chrome/')) return 'chrome';
   if (navigator.userAgent.includes('Chromium/')) return 'chromium';
   if (navigator.userAgent.includes('Firefox/')) return 'firefox';


### PR DESCRIPTION
Related to #492, to help with the integration of Tournesol pages in iframes. 

#### 1. All frontend URLs accepts a parameter `?embed=1`
  
When this parameter is present during the app initialization, the `<TopBar>` and `<SideBar>` will not be rendered, allowing any page to be integrated in a minimalist way.

E.g the login page:

![image](https://user-images.githubusercontent.com/4726554/150519585-e4bc1b34-43e4-408e-b742-1548928e2f7a.png)

#### 2. Handle problems related to `localStorage` access from iframes

The implementation suggested in #492 should work on most systems, without any change related to privacy or security settings on the server and on the clients. 

However some users may have configured their browser with stricter rules (e.g "Strict Mode" on Firefox, or "Block third-party cookies" on Chrome), where third-party storage (i.e tournesol.app local storage, containing user configuration and credentials) cannot be accessed or persisted from the context of an iframe embedded in another website.  
More details in the commented code.

This PR implements a method to detect this situation, and show instructions about how to add an exception specifically for Tournesol purposes.

|On Firefox|On Chrome|
|-|-|
|![image](https://user-images.githubusercontent.com/4726554/150521835-38d4cc30-6ee6-4c68-9e5b-8cbc64a3e7d8.png)|![image](https://user-images.githubusercontent.com/4726554/150521926-552f4c49-6a92-4805-b6d8-23ecd01c080c.png)|



 