### PR TITLE
[front] fix: Login form could be stuck in loading state

### DIFF
--- a/frontend/src/features/login/Login.tsx
+++ b/frontend/src/features/login/Login.tsx
@@ -17,6 +17,7 @@ const Login = () => {
   const { showErrorAlert } = useNotifications();
   const login: LoginState = useAppSelector(selectLogin);
   const dispatch = useAppDispatch();
+  const [formIsDirty, setFormIsDirty] = useState(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [validToken, setValidToken] = useState(hasValidToken(login));
@@ -36,6 +37,7 @@ const Login = () => {
   }, [login, validToken]);
 
   const handleSubmit = async (event: React.FormEvent) => {
+    setFormIsDirty(true);
     event.preventDefault();
     const result: unknown = await dispatch(
       getTokenAsync({ username: username, password: password })
@@ -92,7 +94,7 @@ const Login = () => {
                 color="secondary"
                 fullWidth
                 variant="contained"
-                disabled={login.status == 'loading'}
+                disabled={formIsDirty && login.status === 'loading'}
               >
                 {t('login.logInAction')}
               </Button>

--- a/frontend/src/features/login/Login.tsx
+++ b/frontend/src/features/login/Login.tsx
@@ -17,7 +17,7 @@ const Login = () => {
   const { showErrorAlert } = useNotifications();
   const login: LoginState = useAppSelector(selectLogin);
   const dispatch = useAppDispatch();
-  const [formIsDirty, setFormIsDirty] = useState(false);
+  const [formHasBeenSubmitted, setFormHasBeenSubmitted] = useState(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [validToken, setValidToken] = useState(hasValidToken(login));
@@ -37,7 +37,7 @@ const Login = () => {
   }, [login, validToken]);
 
   const handleSubmit = async (event: React.FormEvent) => {
-    setFormIsDirty(true);
+    setFormHasBeenSubmitted(true);
     event.preventDefault();
     const result: unknown = await dispatch(
       getTokenAsync({ username: username, password: password })
@@ -94,7 +94,7 @@ const Login = () => {
                 color="secondary"
                 fullWidth
                 variant="contained"
-                disabled={formIsDirty && login.status === 'loading'}
+                disabled={formHasBeenSubmitted && login.status === 'loading'}
               >
                 {t('login.logInAction')}
               </Button>


### PR DESCRIPTION
After a login request has been interrupted (e.g the tab has been closed), the token status can be persisted with the value "loading". 

In this situation, the login form should not be disabled, if no request has been submitted on the current page yet.