### PR TITLE
[extension] feat: also display login iframe from browser action

### DIFF
--- a/browser-extension/addModal.js
+++ b/browser-extension/addModal.js
@@ -27,6 +27,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (modal) {
       modal.style.display = 'none';
     }
+    return;
+  }
+
+  if (request.message === "displayModal") {
+    const modal = document.getElementById(EXT_MODAL_ID);
+    modal.style.display = EXT_MODAL_VISIBLE_STATE;
+    if (modal) {
+      sendResponse({success: true});
+    } else {
+      sendResponse({success: false, message: "modal not found in DOM"});
+    }
   }
 });
 

--- a/browser-extension/addModal.js
+++ b/browser-extension/addModal.js
@@ -22,12 +22,9 @@ if (document.body) {
 }
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.message === "hideExtensionModal") {
-    const modal = document.getElementById(EXT_MODAL_ID);
-
-    if (modal) {
-      modal.style.display = 'none';
-    }
+  if (request.message === "hideModal") {
+    const hidden = hideModal();
+    sendResponse({success: hidden});
     return;
   }
 
@@ -87,7 +84,7 @@ function initTournesolModal() {
     document.onclick = function(event) {
       const expectedModal = document.getElementById(EXT_MODAL_ID);
       if (event.target === expectedModal) {
-        expectedModal.style.display = 'none';
+        expectedModal.style.display = EXT_MODAL_INVISIBLE_STATE;
       }
     }
 
@@ -97,8 +94,8 @@ function initTournesolModal() {
       const currentDisplay = expectedModal.style.display;
 
       if ((event.key === 'Escape' || event.code === 'Escape')
-          && currentDisplay !== 'none') {
-        expectedModal.style.display = 'none';
+          && currentDisplay !== EXT_MODAL_INVISIBLE_STATE) {
+        expectedModal.style.display = EXT_MODAL_INVISIBLE_STATE;
       }
     }
   }
@@ -131,5 +128,15 @@ function displayModal() {
   // without discarding a local outdated token, will erroneously display
   // the Tournesol home page, instead of the login form.
   iframe.src = iframe.src;
+  return true;
+}
+
+function hideModal() {
+  const modal = document.getElementById(EXT_MODAL_ID);
+  if (!modal) {
+    return false;
+  }
+
+  modal.style.display = EXT_MODAL_INVISIBLE_STATE;
   return true;
 }

--- a/browser-extension/addModal.js
+++ b/browser-extension/addModal.js
@@ -113,13 +113,13 @@ function displayModal() {
     return false;
   }
 
-  const displayModal = function displayModal() {
+  const display = function display() {
     modal.style.display = EXT_MODAL_VISIBLE_STATE;
     iframe.removeEventListener('load', displayModal);
   }
 
   // prevent visual blink while refreshing the iframe
-  iframe.addEventListener('load', displayModal);
+  iframe.addEventListener('load', display);
 
   // This manual iframe refresh allows to trigger an access token
   // refresh (see the content scripts configuration in manifest.json).

--- a/browser-extension/addRateLaterButton.js
+++ b/browser-extension/addRateLaterButton.js
@@ -99,24 +99,7 @@ function addRateLaterButton() {
         );
 
       }).catch((reason) => {
-        const iframe = document.getElementById(IFRAME_TOURNESOL_LOGIN_ID);
-
-        const displayModal = function displayModal() {
-          const modal = document.getElementById(EXT_MODAL_ID);
-          modal.style.display = EXT_MODAL_VISIBLE_STATE;
-          iframe.removeEventListener('load', displayModal);
-        }
-
-        // prevent visual blink while refreshing the iframe
-        iframe.addEventListener('load', displayModal);
-
-        // This manual iframe refresh allows to trigger an access token
-        // refresh (see the content scripts configuration in manifest.json).
-        // This operation is mandatory here as it allows to dismiss any
-        // outdated token in the chrome.storage.local. Using the iframe
-        // without discarding a local outdated token, will erroneously display
-        // the Tournesol home page, instead of the login form.
-        iframe.src = iframe.src;
+        chrome.runtime.sendMessage({message: "displayModal"});
       });
     }
 

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -86,12 +86,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   // the access token has been refreshed.
   if (request.message === "accessTokenRefreshed") {
     chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-      chrome.tabs.sendMessage(tabs[0].id, {message: "hideExtensionModal"});
+      chrome.tabs.sendMessage(tabs[0].id, {message: "hideModal"});
     });
 
     return true;
   }
 
+  // Forward the need to the proper content script.
   if (request.message === "displayModal") {
     chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {message: "displayModal"}, function (response) {

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -92,6 +92,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 
+  if (request.message === "displayModal") {
+    chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+      chrome.tabs.sendMessage(tabs[0].id, {message: "displayModal"}, function (response) {
+        sendResponse(response);
+      });
+    });
+    return true;
+  }
+
   if (request.message == "addRateLater") {
     addRateLater(request.video_id).then(sendResponse);
     return true;

--- a/browser-extension/browserAction/menu.js
+++ b/browser-extension/browserAction/menu.js
@@ -39,7 +39,16 @@ function rate_later(e) {
       button.setAttribute('data-success', message);
     }
     else {
-      button.setAttribute('data-error', message);
+
+      // ask the content script to display the modal containing the login iframe
+      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {message: "displayModal"}, function(response) {
+          if (!response.success) {
+            button.setAttribute('data-error', 'Failed');
+          }
+        });
+      });
+
     }
   },
     err => {

--- a/browser-extension/browserAction/menu.js
+++ b/browser-extension/browserAction/menu.js
@@ -35,16 +35,16 @@ function rate_later(e) {
   get_current_tab_video_id().then(async (videoId) => {
     button.disabled = true;
     const { success, message } = await addRateLater(videoId);
+
     if (success) {
       button.setAttribute('data-success', message);
-    }
-    else {
+    } else {
 
       // ask the content script to display the modal containing the login iframe
       chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
         chrome.tabs.sendMessage(tabs[0].id, {message: "displayModal"}, function(response) {
           if (!response.success) {
-            button.setAttribute('data-error', 'Failed');
+            button.setAttribute('data-error', 'Failed.');
           }
         });
       });

--- a/browser-extension/config/const.js
+++ b/browser-extension/config/const.js
@@ -11,6 +11,8 @@
 const EXT_MODAL_ID = 'x-tournesol-modal';
 // the value of the CSS property display used to make the modal visible
 const EXT_MODAL_VISIBLE_STATE = 'flex';
+// the value of the CSS property display used to make the modal invisible
+const EXT_MODAL_INVISIBLE_STATE = 'none';
 // CSS selector identifying the element in the YT page the Tournesol modal
 // will wait for before being added to the DOM
 const EXT_MODAL_WAIT_FOR = 'div#info.ytd-watch-flexy';


### PR DESCRIPTION
**related to** #426 

**complete the work of** #492 

---

The extension is now able to display the Tournesol login form from the browser action popup.

### additional changes

Make the `addModal.js` content script the only script responsible of displaying and hiding the modal.

Make it more explicit that the login `iframe` is by default integrated in the modal ( if we decide in the future to make the modal able to display anything ).

Make some message listeners able to return a response, instead of just silently succeed or fail.