### PR TITLE
[extension] feat: also display login iframe from context menu

### DIFF
--- a/browser-extension/addModal.js
+++ b/browser-extension/addModal.js
@@ -2,13 +2,13 @@
  * Create and add a hidden modal in the DOM, by default including a Tournesol
  * login iframe.
  *
- * This content script is meant to be run on each YouTube video page.
+ * This content script is meant to be run on each YouTube page.
  *
  * @require config/const.js
  */
 
 /**
- * Youtube doesnt completely load a video page, so content script doesn't
+ * Youtube doesnt completely load a page, so content script doesn't
  * launch correctly without these events.
  *
  * This part is called on connection for the first time on youtube.com/*
@@ -40,11 +40,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 
 function initTournesolModal() {
-  const videoId = new URL(location.href).searchParams.get('v');
-
-  // Only enable this script on youtube.com/watch?v=* pages
-  if (!location.pathname.startsWith('/watch') || !videoId) return;
-
   // Timers will run until needed elements are generated
   const iframeTimer = window.setInterval(createTournesolModal, 300);
 
@@ -52,10 +47,10 @@ function initTournesolModal() {
    * Create the extension modal, including a default iframe to the Tournesol
    * application.
    *
-   * Adding an hidden iframe in each YouTube video page allows to silently
-   * trigger a token refresh in the background. This makes the already logged
-   * users able to use the extension features seamlessly, without requiring to
-   * visit the Tournesol application site to trigger a token refresh.
+   * Adding an hidden iframe in each YouTube page allows to silently trigger
+   * a token refresh in the background. This makes the already logged users
+   * able to use the extension features seamlessly, without requiring to visit
+   * the Tournesol application site to trigger a token refresh.
    */
   function createTournesolModal() {
     // don't do anything if the required parent is not available
@@ -100,7 +95,6 @@ function initTournesolModal() {
     }
   }
 };
-
 
 /**
  * Single entry point to display the extension modal.

--- a/browser-extension/addModal.js
+++ b/browser-extension/addModal.js
@@ -53,9 +53,6 @@ function initTournesolModal() {
    * the Tournesol application site to trigger a token refresh.
    */
   function createTournesolModal() {
-    // don't do anything if the required parent is not available
-    if (!document.querySelector(EXT_MODAL_WAIT_FOR)) return;
-
     // don't do anything if the modal is already in the DOM
     if (document.getElementById(EXT_MODAL_ID)) {
       window.clearInterval(iframeTimer);

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -1,5 +1,6 @@
 import {
   addRateLater,
+  alertOnCurrentTab,
   alertUseOnLinkToYoutube,
   fetchTournesolApi,
   getAccessToken,
@@ -14,23 +15,41 @@ const oversamplingRatioForOldVideos = 50;
 const recentVideoProportion = 0.75;
 const recentVideoProportionForAdditionalVideos = 0.5;
 
-
-chrome.contextMenus.removeAll(function (e, tab) {
-  chrome.contextMenus.create({
-    id: 'tournesol_add_rate_later',
-    title: 'Rate later on Tournesol',
-    contexts: ['link'],
+/**
+ * Build the extension context menu.
+ *
+ * TODO: could be moved in its own `contextMenus` folder, imported and
+ *       executed here. Investigate if it's possible.
+ */
+const createContextMenu = function createContextMenu() {
+  chrome.contextMenus.removeAll(function() {
+    chrome.contextMenus.create({
+      id: 'tournesol_add_rate_later',
+      title: 'Rate later on Tournesol',
+      contexts: ['link'],
+    });
   });
-});
 
-chrome.contextMenus.onClicked.addListener(function (e, tab) {
-  var videoId = new URL(e.linkUrl).searchParams.get('v');
-  if (!videoId) {
-    alertUseOnLinkToYoutube()
-  } else {
-    addRateLater(videoId)
-  }
-});
+  chrome.contextMenus.onClicked.addListener(function (e, tab) {
+    var videoId = new URL(e.linkUrl).searchParams.get('v');
+    if (!videoId) {
+      alertUseOnLinkToYoutube()
+    } else {
+      addRateLater(videoId).then((response) => {
+        if (!response.success) {
+          chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            chrome.tabs.sendMessage(tabs[0].id, {message: "displayModal"}, function (response) {
+              if (!response.success) {
+                alertOnCurrentTab('Sorry, an error occured while opening the Tournesol login form.');
+              }
+            });
+          });
+        }
+      });
+    }
+  });
+}
+createContextMenu();
 
 /**
  * Remove the X-FRAME-OPTIONS and FRAME-OPTIONS headers included in the

--- a/browser-extension/config/const.js
+++ b/browser-extension/config/const.js
@@ -15,7 +15,7 @@ const EXT_MODAL_VISIBLE_STATE = 'flex';
 const EXT_MODAL_INVISIBLE_STATE = 'none';
 // CSS selector identifying the element in the YT page the Tournesol modal
 // will wait for before being added to the DOM
-const EXT_MODAL_WAIT_FOR = 'div#info.ytd-watch-flexy';
+const EXT_MODAL_WAIT_FOR = 'div#content.ytd-app';
 
 // unique HTML id of the Tournesol login iframe
 const IFRAME_TOURNESOL_LOGIN_ID = 'x-tournesol-iframe-login';

--- a/browser-extension/config/const.js
+++ b/browser-extension/config/const.js
@@ -13,9 +13,6 @@ const EXT_MODAL_ID = 'x-tournesol-modal';
 const EXT_MODAL_VISIBLE_STATE = 'flex';
 // the value of the CSS property display used to make the modal invisible
 const EXT_MODAL_INVISIBLE_STATE = 'none';
-// CSS selector identifying the element in the YT page the Tournesol modal
-// will wait for before being added to the DOM
-const EXT_MODAL_WAIT_FOR = 'div#content.ytd-app';
 
 // unique HTML id of the Tournesol login iframe
 const IFRAME_TOURNESOL_LOGIN_ID = 'x-tournesol-iframe-login';

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
**related to** #426 

**complete the work of** #508 

---

This pull request makes the login `iframe` appear when the users use the context action `Rate later on Tournesol` on a YouTube video.

It also make the automatic access token refresh process available on all YouTube pages. 

After the merge, and if I'm not forgetting anything, all rate later actions of the extension will trigger the login `iframe`.

The following steps are:
- enhanced the UX by adding a close button on top of the `iframe`
- https://github.com/tournesol-app/tournesol/issues/510
- add tests!