### PR TITLE
[back] feat: create video automatically in API views that require an existing video

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -310,6 +310,9 @@ CRITERIAS = list(CRITERIAS_DICT.keys())
 MAX_FEATURE_WEIGHT = 8
 
 SPECTACULAR_SETTINGS = {
+    # Split data components into 2 distinct schemas for request and response.
+    # It helps with the support of "read_only" fields by code generators.
+    'COMPONENT_SPLIT_REQUEST': True,
     'SORT_OPERATION_PARAMETERS': False,
     "SWAGGER_UI_SETTINGS": {
         "deepLinking": True,

--- a/backend/tournesol/errors.py
+++ b/backend/tournesol/errors.py
@@ -1,0 +1,6 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class ConflictError(APIException):
+    status_code = status.HTTP_409_CONFLICT

--- a/backend/tournesol/models/video.py
+++ b/backend/tournesol/models/video.py
@@ -291,6 +291,21 @@ class Video(models.Model, WithFeatures, WithEmbedding):
             setattr(self, f, metadata[f])
         self.save(update_fields=fields)
 
+    @classmethod
+    def create_from_video_id(cls, video_id):
+        from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata
+        try:
+            extra_data = get_video_metadata(video_id)
+        except VideoNotFound:
+            raise
+        tags = extra_data.pop('tags', [])
+        video = cls.objects.create(video_id=video_id, **extra_data)
+        for tag_name in tags:
+            #  The return object is a tuple having first an instance of Tag, and secondly a bool
+            tag, _ = Tag.objects.get_or_create(name=tag_name)
+            video.tags.add(tag)
+        return video
+
 
 class VideoCriteriaScore(models.Model):
     """Scores per criteria for Videos"""

--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -4,23 +4,24 @@ Serializer used by Tournesol's API
 
 from typing import Optional
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import ObjectDoesNotExist, Q
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.fields import BooleanField, RegexField, SerializerMethodField
 from rest_framework.serializers import ModelSerializer, Serializer
 
 from core.utils.constants import YOUTUBE_VIDEO_ID_REGEX
+from tournesol.errors import ConflictError
+from tournesol.utils.api_youtube import VideoNotFound
 
 from .models import (
     Comparison,
     ComparisonCriteriaScore,
     ContributorRating,
     ContributorRatingCriteriaScore,
-    Tag,
     Video,
     VideoCriteriaScore,
     VideoRateLater,
@@ -56,14 +57,11 @@ class VideoSerializer(ModelSerializer):
             "duration",
         ]
 
-    def save(self, **kwargs):
-        tags = kwargs.pop('tags', [])
-        video = super().save(**kwargs)
-        for tag_name in tags:
-            #  The return object is a tuple having first an instance of Tag, and secondly a bool
-            tag = Tag.objects.get_or_create(name=tag_name)
-            video.tags.add(tag[0].id)
-        return video
+    def create(self, validated_data):
+        try:
+            return Video.create_from_video_id(validated_data["video_id"])
+        except VideoNotFound:
+            raise NotFound("The video has not been found. `video_id` may be incorrect.")
 
     # Convert duration to seconds to facilitate use of Humanize package
     def get_duration(self, obj) -> Optional[int]:
@@ -72,29 +70,26 @@ class VideoSerializer(ModelSerializer):
         return None
 
 
-class VideoReadOnlySerializer(Serializer):
+class RelatedVideoSerializer(VideoSerializer):
     """
-    A video serializer without all the Video model auto-validations.
+    A video serializer that will create the Video object on validation
+    if it does not exist in the database yet.
 
     Used by ModelSerializer(s) having one or more nested relations with Video,
-    and having the constraint of not creating new videos in database when
-    creating new objects.
-
-    ex: adding a new Comparison shouldn't create new Video in the database
+    and having the constraint to ensure that video instances exist before
+    they can be saved properly.
     """
 
-    video_id = serializers.CharField(max_length=20)
-
-    class Meta:
-        fields = ["video_id"]
+    video_id = RegexField(YOUTUBE_VIDEO_ID_REGEX)
 
     def validate_video_id(self, value):
         try:
             Video.objects.get(video_id=value)
         except ObjectDoesNotExist:
-            raise serializers.ValidationError(
-                "The video with id '{}' does not exist.".format(value)
-            )
+            try:
+                Video.create_from_video_id(value)
+            except VideoNotFound:
+                raise ValidationError("The video has not been found. `video_id` may be incorrect.")
         return value
 
 
@@ -119,11 +114,20 @@ class VideoSerializerWithCriteria(VideoSerializer):
 
 
 class VideoRateLaterSerializer(ModelSerializer):
-    video = VideoSerializer()
+    video = RelatedVideoSerializer()
+    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
     class Meta:
         model = VideoRateLater
-        fields = ["video"]
+        fields = ["user", "video"]
+
+    def create(self, validated_data):
+        video_id = validated_data.pop("video")["video_id"]
+        video = Video.objects.get(video_id=video_id)
+        try:
+            return super().create({"video": video, **validated_data})
+        except IntegrityError:
+            raise ConflictError
 
 
 class ComparisonCriteriaScoreSerializer(ModelSerializer):
@@ -151,8 +155,8 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
     Use `ComparisonUpdateSerializer` for the update operation.
     """
 
-    video_a = VideoReadOnlySerializer(source="video_1")
-    video_b = VideoReadOnlySerializer(source="video_2")
+    video_a = RelatedVideoSerializer(source="video_1")
+    video_b = RelatedVideoSerializer(source="video_2")
     criteria_scores = ComparisonCriteriaScoreSerializer(many=True)
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
@@ -177,24 +181,21 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
 
     @transaction.atomic
     def create(self, validated_data):
-        video_id_1 = validated_data.get("video_1").get("video_id")
-        video_id_2 = validated_data.get("video_2").get("video_id")
-        # the validation performed by the VideoReadOnlySerializer guarantees
-        # that the video submitted exist in the database
+        video_id_1 = validated_data.pop("video_1").get("video_id")
+        video_id_2 = validated_data.pop("video_2").get("video_id")
+        # the validation performed by the RelatedVideoSerializer guarantees
+        # that the videos submitted exist in the database
         video_1 = Video.objects.get(video_id=video_id_1)
         video_2 = Video.objects.get(video_id=video_id_2)
-
-        # get default values directly from the model
-        default_duration_ms = Comparison._meta.get_field("duration_ms").get_default()
+        criteria_scores = validated_data.pop("criteria_scores")
 
         comparison = Comparison.objects.create(
             video_1=video_1,
             video_2=video_2,
-            user=validated_data.get("user"),
-            duration_ms=validated_data.get("duration_ms", default_duration_ms),
+            **validated_data,
         )
 
-        for criteria_score in validated_data.pop("criteria_scores"):
+        for criteria_score in criteria_scores:
             ComparisonCriteriaScore.objects.create(
                 comparison=comparison, **criteria_score
             )
@@ -213,10 +214,12 @@ class ComparisonUpdateSerializer(ComparisonSerializerMixin, ModelSerializer):
     """
 
     criteria_scores = ComparisonCriteriaScoreSerializer(many=True)
+    video_a = VideoSerializer(source="video_1", read_only=True)
+    video_b = VideoSerializer(source="video_2", read_only=True)
 
     class Meta:
         model = Comparison
-        fields = ["criteria_scores", "duration_ms"]
+        fields = ["criteria_scores", "duration_ms", "video_a", "video_b"]
 
     def to_representation(self, instance):
         """
@@ -227,10 +230,6 @@ class ComparisonUpdateSerializer(ComparisonSerializerMixin, ModelSerializer):
         consistent across all comparison serializers.
         """
         ret = super(ComparisonUpdateSerializer, self).to_representation(instance)
-
-        video_1_repr = VideoReadOnlySerializer().to_representation(instance.video_1)
-        video_2_repr = VideoReadOnlySerializer().to_representation(instance.video_2)
-        ret["video_a"], ret["video_b"] = video_1_repr, video_2_repr
 
         if self.context.get("reverse", False):
             ret["video_a"], ret["video_b"] = ret["video_b"], ret["video_a"]
@@ -305,18 +304,15 @@ class ContributorRatingCreateSerializer(ContributorRatingSerializer):
 
     def validate(self, attrs):
         video_id = attrs.pop("video_id")
-        try:
-            video = Video.objects.get(video_id=video_id)
-        except Video.DoesNotExist:
-            raise ValidationError(f"Video with video_id '{video_id}' does not exist")
-
+        video_serializer = RelatedVideoSerializer(data={"video_id": video_id})
+        video_serializer.is_valid(raise_exception=True)
+        video = Video.objects.get(video_id=video_id)
         user = self.context["request"].user
         if user.contributorvideoratings.filter(video=video).exists():
             raise ValidationError(
                 "A ContributorRating already exists for this (user, video)",
                 code='unique',
             )
-
         attrs["video"] = video
         attrs["user"] = user
         return attrs

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -157,6 +157,8 @@ class ComparisonApiTestCase(TestCase):
         response = client.post(
             reverse("tournesol:comparisons_me_list"), data, format="json",
         )
+        # check the authorization
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
 
         comparison = Comparison.objects.select_related("user", "video_1", "video_2").get(
             user=user,
@@ -164,9 +166,6 @@ class ComparisonApiTestCase(TestCase):
             video_2__video_id=data["video_b"]["video_id"],
         )
         comparisons_nbr = Comparison.objects.filter(user=user).count()
-
-        # check the authorization
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # check the database integrity
         self.assertEqual(comparisons_nbr,

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -53,12 +53,22 @@ class RatingApi(TestCase):
         self.assertEqual(rating["is_public"], False)
         self.assertEqual(rating["n_comparisons"], 1)
 
-    def test_authenticated_cant_create_rating_about_non_existing_video(self):
+    def test_authenticated_can_create_rating_about_non_existing_video(self):
         factory = APIClient()
         factory.force_authenticate(user=self.user1)
         response = factory.post(
             "/users/me/contributor_ratings/",
             {'video_id': 'NeADlWSDFAQ'},
+            format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_authenticated_cant_create_rating_about_invalid_id(self):
+        factory = APIClient()
+        factory.force_authenticate(user=self.user1)
+        response = factory.post(
+            "/users/me/contributor_ratings/",
+            {'video_id': 'invalid'},
             format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -74,7 +84,7 @@ class RatingApi(TestCase):
             },
             format="json"
         )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
         self.assertEqual(response.data["video"]["video_id"], self.video3.video_id)
         self.assertEqual(response.data["is_public"], True)
         self.assertEqual(response.data["n_comparisons"], 0)

--- a/backend/tournesol/tests/test_api_video_rate_later.py
+++ b/backend/tournesol/tests/test_api_video_rate_later.py
@@ -127,7 +127,25 @@ class VideoRateLaterApi(TestCase):
             data,
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+
+    def test_authenticated_can_create_with_new_video_id(self):
+        """
+        An authenticated user can add in its own rate later list a video
+        that does not exist yet in the database.
+        """
+        client = APIClient()
+
+        user = User.objects.get(username=self._user)
+        data = {"video": {"video_id": "newvideo001"}}
+
+        client.force_authenticate(user=user)
+        response = client.post(
+            "/users/me/video_rate_later/",
+            data,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_authenticated_cant_create_twice(self):
         """

--- a/backend/tournesol/views/video.py
+++ b/backend/tournesol/views/video.py
@@ -9,7 +9,7 @@ from django.utils import dateparse, timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.viewsets import GenericViewSet
@@ -21,7 +21,6 @@ from tournesol.throttling import (
     SustainedAnonRateThrottle,
     SustainedUserRateThrottle,
 )
-from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata
 
 from ..models import Video
 from ..serializers import VideoSerializer, VideoSerializerWithCriteria
@@ -168,11 +167,3 @@ class VideoViewSet(mixins.CreateModelMixin,
         if self.action in ("retrieve", "list"):
             return VideoSerializerWithCriteria
         return VideoSerializer
-
-    def perform_create(self, serializer):
-        video_id = serializer.validated_data["video_id"]
-        try:
-            extra_data = get_video_metadata(video_id)
-        except VideoNotFound:
-            raise NotFound("The video has not been found. `video_id` may be incorrect.")
-        serializer.save(**extra_data)

--- a/backend/tournesol/views/video_rate_later.py
+++ b/backend/tournesol/views/video_rate_later.py
@@ -2,20 +2,25 @@
 API endpoint to manipulate contributor's rate later list
 """
 
-from django.db import IntegrityError
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
-from rest_framework import generics, mixins, status
+from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 
-from ..models import Video, VideoRateLater
+from ..models import VideoRateLater
 from ..serializers import VideoRateLaterSerializer
 
 
-class VideoRateLaterList(
-    mixins.ListModelMixin, generics.GenericAPIView
-):
+@extend_schema_view(
+    post=extend_schema(responses={
+        200: VideoRateLaterSerializer,
+        409: OpenApiResponse(
+            description="Conflict: the video is already in the rate later list,"
+                        " or there is an other error with the database query."
+        )
+    })
+)
+class VideoRateLaterList(generics.ListCreateAPIView):
     """
     List all videos of a user's rate later list, or add a video to the list.
     """
@@ -26,45 +31,6 @@ class VideoRateLaterList(
 
     def get_queryset(self):
         return VideoRateLater.objects.filter(user=self.request.user)
-
-    def get(self, request, *args, **kwargs):
-        """API call to return list of rate_later videos"""
-        return self.list(request, *args, **kwargs)
-
-    @extend_schema(
-        responses={
-            200: VideoRateLaterSerializer,
-            404: OpenApiResponse(
-                description="Not Found: the video doesn't exist in the database."
-            ),
-            409: OpenApiResponse(
-                description="Conflict: the video is already in the rate later list,"
-                            " or there is an other error with the database query."
-            )
-        }
-    )
-    def post(self, request, *args, **kwargs):
-        """
-        Add an existing video to a user's rate later list.
-        """
-        try:
-            video = get_object_or_404(Video, video_id=request.data["video"]["video_id"])
-        except KeyError:
-            return Response(
-                {
-                    "detail": "Required field video.video_id not found.",
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        video_rate_later = VideoRateLater(user=request.user, video=video)
-
-        try:
-            video_rate_later.save()
-        except IntegrityError:
-            return Response({"detail": "409 Conflict"}, status=status.HTTP_409_CONFLICT)
-
-        return Response(VideoRateLaterSerializer(video_rate_later).data)
 
 
 @extend_schema_view(

--- a/browser-extension/utils.js
+++ b/browser-extension/utils.js
@@ -57,14 +57,6 @@ export const fetchTournesolApi = async (url, method, data) => {
 }
 
 export const addRateLater = async (video_id) => {
-  const addVideoResponse = await fetchTournesolApi('video/', 'POST', {video_id: video_id});
-  if(!addVideoResponse || addVideoResponse.status === 401){
-    return {
-      success: false,
-      message: 'Failed.'
-    }
-  }
-
   const ratingStatusReponse = 
     await fetchTournesolApi('users/me/video_rate_later/', 'POST', {video: {video_id: video_id}});
   if (ratingStatusReponse && ratingStatusReponse.ok) {

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -13,13 +13,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ChangePassword'
+              $ref: '#/components/schemas/ChangePasswordRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ChangePassword'
+              $ref: '#/components/schemas/ChangePasswordRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ChangePassword'
+              $ref: '#/components/schemas/ChangePasswordRequest'
         required: true
       security:
       - oauth2:
@@ -56,13 +56,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserProfile'
+              $ref: '#/components/schemas/UserProfileRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/UserProfile'
+              $ref: '#/components/schemas/UserProfileRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/UserProfile'
+              $ref: '#/components/schemas/UserProfileRequest'
         required: true
       security:
       - oauth2:
@@ -83,13 +83,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserProfile'
+              $ref: '#/components/schemas/UserProfileRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/UserProfile'
+              $ref: '#/components/schemas/UserProfileRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/UserProfile'
+              $ref: '#/components/schemas/UserProfileRequest'
         required: true
       security:
       - oauth2:
@@ -110,13 +110,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedUserProfile'
+              $ref: '#/components/schemas/PatchedUserProfileRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedUserProfile'
+              $ref: '#/components/schemas/PatchedUserProfileRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedUserProfile'
+              $ref: '#/components/schemas/PatchedUserProfileRequest'
       security:
       - oauth2:
         - read write groups
@@ -137,13 +137,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RegisterUser'
+              $ref: '#/components/schemas/RegisterUserRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/RegisterUser'
+              $ref: '#/components/schemas/RegisterUserRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/RegisterUser'
+              $ref: '#/components/schemas/RegisterUserRequest'
         required: true
       security:
       - oauth2:
@@ -166,13 +166,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RegisterEmail'
+              $ref: '#/components/schemas/RegisterEmailRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/RegisterEmail'
+              $ref: '#/components/schemas/RegisterEmailRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/RegisterEmail'
+              $ref: '#/components/schemas/RegisterEmailRequest'
         required: true
       security:
       - oauth2:
@@ -194,13 +194,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ResetPassword'
+              $ref: '#/components/schemas/ResetPasswordRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ResetPassword'
+              $ref: '#/components/schemas/ResetPasswordRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ResetPassword'
+              $ref: '#/components/schemas/ResetPasswordRequest'
         required: true
       security:
       - oauth2:
@@ -223,13 +223,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DefaultSendResetPasswordLink'
+              $ref: '#/components/schemas/DefaultSendResetPasswordLinkRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/DefaultSendResetPasswordLink'
+              $ref: '#/components/schemas/DefaultSendResetPasswordLinkRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/DefaultSendResetPasswordLink'
+              $ref: '#/components/schemas/DefaultSendResetPasswordLinkRequest'
         required: true
       security:
       - oauth2:
@@ -252,13 +252,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VerifyEmail'
+              $ref: '#/components/schemas/VerifyEmailRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/VerifyEmail'
+              $ref: '#/components/schemas/VerifyEmailRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/VerifyEmail'
+              $ref: '#/components/schemas/VerifyEmailRequest'
         required: true
       security:
       - oauth2:
@@ -281,13 +281,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VerifyRegistration'
+              $ref: '#/components/schemas/VerifyRegistrationRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/VerifyRegistration'
+              $ref: '#/components/schemas/VerifyRegistrationRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/VerifyRegistration'
+              $ref: '#/components/schemas/VerifyRegistrationRequest'
         required: true
       security:
       - oauth2:
@@ -544,13 +544,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Comparison'
+              $ref: '#/components/schemas/ComparisonRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/Comparison'
+              $ref: '#/components/schemas/ComparisonRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/Comparison'
+              $ref: '#/components/schemas/ComparisonRequest'
         required: true
       security:
       - oauth2:
@@ -609,13 +609,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ComparisonUpdate'
+              $ref: '#/components/schemas/ComparisonUpdateRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ComparisonUpdate'
+              $ref: '#/components/schemas/ComparisonUpdateRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ComparisonUpdate'
+              $ref: '#/components/schemas/ComparisonUpdateRequest'
         required: true
       security:
       - oauth2:
@@ -727,13 +727,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContributorRatingCreate'
+              $ref: '#/components/schemas/ContributorRatingCreateRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ContributorRatingCreate'
+              $ref: '#/components/schemas/ContributorRatingCreateRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ContributorRatingCreate'
+              $ref: '#/components/schemas/ContributorRatingCreateRequest'
         required: true
       security:
       - oauth2:
@@ -784,13 +784,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ContributorRating'
+              $ref: '#/components/schemas/ContributorRatingRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ContributorRating'
+              $ref: '#/components/schemas/ContributorRatingRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ContributorRating'
+              $ref: '#/components/schemas/ContributorRatingRequest'
       security:
       - oauth2:
         - read write groups
@@ -817,13 +817,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedContributorRating'
+              $ref: '#/components/schemas/PatchedContributorRatingRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedContributorRating'
+              $ref: '#/components/schemas/PatchedContributorRatingRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedContributorRating'
+              $ref: '#/components/schemas/PatchedContributorRatingRequest'
       security:
       - oauth2:
         - read write groups
@@ -844,13 +844,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedContributorRatingUpdateAll'
+              $ref: '#/components/schemas/PatchedContributorRatingUpdateAllRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedContributorRatingUpdateAll'
+              $ref: '#/components/schemas/PatchedContributorRatingUpdateAllRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedContributorRatingUpdateAll'
+              $ref: '#/components/schemas/PatchedContributorRatingUpdateAllRequest'
       security:
       - oauth2:
         - read write groups
@@ -898,7 +898,8 @@ paths:
   /users/me/video_rate_later/:
     get:
       operationId: users_me_video_rate_later_list
-      description: API call to return list of rate_later videos
+      description: List all videos of a user's rate later list, or add a video to
+        the list.
       parameters:
       - name: limit
         required: false
@@ -926,20 +927,21 @@ paths:
           description: ''
     post:
       operationId: users_me_video_rate_later_create
-      description: Add an existing video to a user's rate later list.
+      description: List all videos of a user's rate later list, or add a video to
+        the list.
       tags:
       - users
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/VideoRateLater'
+              $ref: '#/components/schemas/VideoRateLaterRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/VideoRateLater'
+              $ref: '#/components/schemas/VideoRateLaterRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/VideoRateLater'
+              $ref: '#/components/schemas/VideoRateLaterRequest'
         required: true
       security:
       - oauth2:
@@ -951,8 +953,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/VideoRateLater'
           description: ''
-        '404':
-          description: 'Not Found: the video doesn''t exist in the database.'
         '409':
           description: 'Conflict: the video is already in the rate later list, or
             there is an other error with the database query.'
@@ -1113,13 +1113,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Video'
+              $ref: '#/components/schemas/VideoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/Video'
+              $ref: '#/components/schemas/VideoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/Video'
+              $ref: '#/components/schemas/VideoRequest'
         required: true
       security:
       - oauth2:
@@ -1167,9 +1167,22 @@ components:
           type: string
         password:
           type: string
+      required:
+      - old_password
+      - password
+    ChangePasswordRequest:
+      type: object
+      properties:
+        old_password:
+          type: string
+          minLength: 1
+        password:
+          type: string
+          minLength: 1
         password_confirm:
           type: string
           writeOnly: true
+          minLength: 1
       required:
       - old_password
       - password
@@ -1185,9 +1198,9 @@ components:
         Use `ComparisonUpdateSerializer` for the update operation.
       properties:
         video_a:
-          $ref: '#/components/schemas/VideoReadOnly'
+          $ref: '#/components/schemas/RelatedVideo'
         video_b:
-          $ref: '#/components/schemas/VideoReadOnly'
+          $ref: '#/components/schemas/RelatedVideo'
         criteria_scores:
           type: array
           items:
@@ -1221,6 +1234,54 @@ components:
       required:
       - criteria
       - score
+    ComparisonCriteriaScoreRequest:
+      type: object
+      properties:
+        criteria:
+          type: string
+          minLength: 1
+          description: Name of the criteria
+          maxLength: 32
+        score:
+          type: number
+          format: float
+          maximum: 10.0
+          minimum: -10.0
+          description: Score for the given comparison
+        weight:
+          type: number
+          format: float
+          description: Weight of the comparison
+      required:
+      - criteria
+      - score
+    ComparisonRequest:
+      type: object
+      description: |-
+        A comparison serializer used for the operations create, retrieve and list.
+
+        Given the context determined by the view, it will represent the comparison
+        in the reverse order.
+
+        Use `ComparisonUpdateSerializer` for the update operation.
+      properties:
+        video_a:
+          $ref: '#/components/schemas/RelatedVideoRequest'
+        video_b:
+          $ref: '#/components/schemas/RelatedVideoRequest'
+        criteria_scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComparisonCriteriaScoreRequest'
+        duration_ms:
+          type: number
+          format: float
+          nullable: true
+          description: Time it took to rate the videos (in milliseconds)
+      required:
+      - criteria_scores
+      - video_a
+      - video_b
     ComparisonUpdate:
       type: object
       description: |-
@@ -1240,6 +1301,37 @@ components:
           format: float
           nullable: true
           description: Time it took to rate the videos (in milliseconds)
+        video_a:
+          allOf:
+          - $ref: '#/components/schemas/Video'
+          readOnly: true
+        video_b:
+          allOf:
+          - $ref: '#/components/schemas/Video'
+          readOnly: true
+      required:
+      - criteria_scores
+      - video_a
+      - video_b
+    ComparisonUpdateRequest:
+      type: object
+      description: |-
+        A comparison serializer used only for updates.
+
+        Given the context determined by the view, it will represent or save the
+        comparison in the reverse order.
+
+        Use `ComparisonSerializer` for all other operations.
+      properties:
+        criteria_scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComparisonCriteriaScoreRequest'
+        duration_ms:
+          type: number
+          format: float
+          nullable: true
+          description: Time it took to rate the videos (in milliseconds)
       required:
       - criteria_scores
     ContributorCriteriaScore:
@@ -1247,6 +1339,24 @@ components:
       properties:
         criteria:
           type: string
+          description: Name of the criteria
+          maxLength: 32
+        score:
+          type: number
+          format: float
+          description: Score for the given criteria
+        uncertainty:
+          type: number
+          format: float
+          description: Uncertainty about the video's score for the given criteria
+      required:
+      - criteria
+    ContributorCriteriaScoreRequest:
+      type: object
+      properties:
+        criteria:
+          type: string
+          minLength: 1
           description: Name of the criteria
           maxLength: 32
         score:
@@ -1286,10 +1396,6 @@ components:
     ContributorRatingCreate:
       type: object
       properties:
-        video_id:
-          type: string
-          writeOnly: true
-          pattern: ^[A-Za-z0-9-_]{11}$
         is_public:
           type: boolean
           description: Should the rating be public?
@@ -1311,7 +1417,25 @@ components:
       - criteria_scores
       - n_comparisons
       - video
+    ContributorRatingCreateRequest:
+      type: object
+      properties:
+        video_id:
+          type: string
+          writeOnly: true
+          minLength: 1
+          pattern: ^[A-Za-z0-9-_]{11}$
+        is_public:
+          type: boolean
+          description: Should the rating be public?
+      required:
       - video_id
+    ContributorRatingRequest:
+      type: object
+      properties:
+        is_public:
+          type: boolean
+          description: Should the rating be public?
     ContributorRatingUpdateAll:
       type: object
       properties:
@@ -1329,6 +1453,19 @@ components:
       properties:
         login:
           type: string
+      required:
+      - login
+    DefaultSendResetPasswordLinkRequest:
+      type: object
+      description: |-
+        Default serializer used for sending reset password link.
+
+        It will use :ref:`send-reset-password-link-serializer-use-email-setting`
+        setting.
+      properties:
+        login:
+          type: string
+          minLength: 1
       required:
       - login
     DegreeOfPoliticalEngagementEnum:
@@ -9846,32 +9983,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VideoSerializerWithCriteria'
-    PatchedContributorRating:
+    PatchedContributorRatingRequest:
       type: object
       properties:
-        video:
-          allOf:
-          - $ref: '#/components/schemas/Video'
-          readOnly: true
         is_public:
           type: boolean
           description: Should the rating be public?
-        criteria_scores:
-          type: array
-          items:
-            $ref: '#/components/schemas/ContributorCriteriaScore'
-          readOnly: true
-        n_comparisons:
-          type: integer
-          readOnly: true
-          description: Number of comparisons submitted by the current user about the
-            current video
-    PatchedContributorRatingUpdateAll:
+    PatchedContributorRatingUpdateAllRequest:
       type: object
       properties:
         is_public:
           type: boolean
-    PatchedUserProfile:
+    PatchedUserProfileRequest:
       type: object
       description: |-
         Default serializer used for user profile. It will use these:
@@ -9883,20 +10006,13 @@ components:
 
         to automagically generate the required serializer fields.
       properties:
-        id:
-          type: integer
-          readOnly: true
         username:
           type: string
+          minLength: 1
           description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
           pattern: ^[\w.@+-]+$
           maxLength: 150
-        email:
-          type: string
-          format: email
-          readOnly: true
-          title: Email address
         is_demo:
           type: boolean
           description: Is a demo account?
@@ -10009,7 +10125,7 @@ components:
           maxLength: 500
         avatar:
           type: string
-          format: uri
+          format: binary
           nullable: true
           description: Your profile picture.
         is_trusted:
@@ -10047,6 +10163,16 @@ components:
         email:
           type: string
           format: email
+      required:
+      - email
+    RegisterEmailRequest:
+      type: object
+      description: Default serializer used for e-mail registration (e-mail change).
+      properties:
+        email:
+          type: string
+          format: email
+          minLength: 1
       required:
       - email
     RegisterUser:
@@ -10192,15 +10318,242 @@ components:
           format: uri
           nullable: true
           description: Your profile picture.
-        password_confirm:
-          type: string
-          writeOnly: true
       required:
       - email
       - id
       - password
+      - username
+    RegisterUserRequest:
+      type: object
+      description: |-
+        Default serializer used for user registration. It will use these:
+
+        * User fields
+        * :ref:`user-hidden-fields-setting` setting
+        * :ref:`user-public-fields-setting` setting
+
+        to automagically generate the required serializer fields.
+      properties:
+        password:
+          type: string
+          minLength: 1
+          maxLength: 128
+        username:
+          type: string
+          minLength: 1
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+            only.
+          pattern: ^[\w.@+-]+$
+          maxLength: 150
+        email:
+          type: string
+          format: email
+          minLength: 1
+          title: Email address
+          maxLength: 254
+        is_demo:
+          type: boolean
+          description: Is a demo account?
+        first_name:
+          type: string
+          nullable: true
+          description: First name
+          maxLength: 100
+        last_name:
+          type: string
+          nullable: true
+          description: Last name
+          maxLength: 100
+        title:
+          type: string
+          nullable: true
+          description: Your position
+        bio:
+          type: string
+          nullable: true
+          description: Self-description (degree, biography, ...)
+        comment_anonymously:
+          type: boolean
+          description: Comment anonymously by-default
+        show_online_presence:
+          type: boolean
+          description: Show my online presence on Tournesol
+        show_my_profile:
+          type: boolean
+          description: Show my profile on Tournesol
+        birth_year:
+          type: integer
+          maximum: 2100
+          minimum: 1900
+          nullable: true
+          description: Year of birth
+        gender:
+          allOf:
+          - $ref: '#/components/schemas/GenderEnum'
+          description: Your gender
+        nationality:
+          allOf:
+          - $ref: '#/components/schemas/NationalityEnum'
+          description: Your country of nationality
+        residence:
+          allOf:
+          - $ref: '#/components/schemas/ResidenceEnum'
+          description: Your country of residence
+        race:
+          allOf:
+          - $ref: '#/components/schemas/RaceEnum'
+          description: Your ethnicity
+        political_affiliation:
+          allOf:
+          - $ref: '#/components/schemas/PoliticalAffiliationEnum'
+          description: Your political preference
+        religion:
+          allOf:
+          - $ref: '#/components/schemas/ReligionEnum'
+          description: Your religion
+        degree_of_political_engagement:
+          allOf:
+          - $ref: '#/components/schemas/DegreeOfPoliticalEngagementEnum'
+          description: Your degree of political engagement
+        moral_philosophy:
+          allOf:
+          - $ref: '#/components/schemas/MoralPhilosophyEnum'
+          description: Your preferred moral philosophy
+        website:
+          type: string
+          format: uri
+          nullable: true
+          description: Your website URL
+          maxLength: 500
+        linkedin:
+          type: string
+          format: uri
+          nullable: true
+          description: Your LinkedIn URL
+          maxLength: 500
+        youtube:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Youtube channel URL
+          maxLength: 500
+        google_scholar:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Google Scholar URL
+          maxLength: 500
+        orcid:
+          type: string
+          format: uri
+          nullable: true
+          description: Your ORCID URL
+          maxLength: 500
+        researchgate:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Researchgate profile URL
+          maxLength: 500
+        twitter:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Twitter URL
+          maxLength: 500
+        avatar:
+          type: string
+          format: binary
+          nullable: true
+          description: Your profile picture.
+        password_confirm:
+          type: string
+          writeOnly: true
+          minLength: 1
+      required:
+      - email
+      - password
       - password_confirm
       - username
+    RelatedVideo:
+      type: object
+      description: |-
+        A video serializer that will create the Video object on validation
+        if it does not exist in the database yet.
+
+        Used by ModelSerializer(s) having one or more nested relations with Video,
+        and having the constraint to ensure that video instances exist before
+        they can be saved properly.
+      properties:
+        video_id:
+          type: string
+          pattern: ^[A-Za-z0-9-_]{11}$
+        name:
+          type: string
+          readOnly: true
+          description: Video Title
+        description:
+          type: string
+          readOnly: true
+          description: Video Description from the web page
+        publication_date:
+          type: string
+          format: date
+          readOnly: true
+          description: Video publication date
+        views:
+          type: integer
+          readOnly: true
+          description: Number of views
+        uploader:
+          type: string
+          readOnly: true
+          description: Name of the channel (uploader)
+        language:
+          allOf:
+          - $ref: '#/components/schemas/LanguageEnum'
+          readOnly: true
+          description: Language of the video
+        rating_n_ratings:
+          type: integer
+          readOnly: true
+          description: Total number of pairwise comparisons for this videofrom certified
+            contributors
+        rating_n_contributors:
+          type: integer
+          readOnly: true
+          description: Total number of certified contributors who rated the video
+        duration:
+          type: integer
+          nullable: true
+          readOnly: true
+      required:
+      - description
+      - duration
+      - language
+      - name
+      - publication_date
+      - rating_n_contributors
+      - rating_n_ratings
+      - uploader
+      - video_id
+      - views
+    RelatedVideoRequest:
+      type: object
+      description: |-
+        A video serializer that will create the Video object on validation
+        if it does not exist in the database yet.
+
+        Used by ModelSerializer(s) having one or more nested relations with Video,
+        and having the constraint to ensure that video instances exist before
+        they can be saved properly.
+      properties:
+        video_id:
+          type: string
+          minLength: 1
+          pattern: ^[A-Za-z0-9-_]{11}$
+      required:
+      - video_id
     ReligionEnum:
       enum:
       - Not Specified
@@ -10224,6 +10577,25 @@ components:
           type: string
         password:
           type: string
+      required:
+      - password
+      - signature
+      - timestamp
+      - user_id
+    ResetPasswordRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          minLength: 1
+        timestamp:
+          type: integer
+        signature:
+          type: string
+          minLength: 1
+        password:
+          type: string
+          minLength: 1
       required:
       - password
       - signature
@@ -10636,6 +11008,145 @@ components:
       - id
       - is_trusted
       - username
+    UserProfileRequest:
+      type: object
+      description: |-
+        Default serializer used for user profile. It will use these:
+
+        * User fields
+        * :ref:`user-hidden-fields-setting` setting
+        * :ref:`user-public-fields-setting` setting
+        * :ref:`user-editable-fields-setting` setting
+
+        to automagically generate the required serializer fields.
+      properties:
+        username:
+          type: string
+          minLength: 1
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+            only.
+          pattern: ^[\w.@+-]+$
+          maxLength: 150
+        is_demo:
+          type: boolean
+          description: Is a demo account?
+        first_name:
+          type: string
+          nullable: true
+          description: First name
+          maxLength: 100
+        last_name:
+          type: string
+          nullable: true
+          description: Last name
+          maxLength: 100
+        title:
+          type: string
+          nullable: true
+          description: Your position
+        bio:
+          type: string
+          nullable: true
+          description: Self-description (degree, biography, ...)
+        comment_anonymously:
+          type: boolean
+          description: Comment anonymously by-default
+        show_online_presence:
+          type: boolean
+          description: Show my online presence on Tournesol
+        show_my_profile:
+          type: boolean
+          description: Show my profile on Tournesol
+        birth_year:
+          type: integer
+          maximum: 2100
+          minimum: 1900
+          nullable: true
+          description: Year of birth
+        gender:
+          allOf:
+          - $ref: '#/components/schemas/GenderEnum'
+          description: Your gender
+        nationality:
+          allOf:
+          - $ref: '#/components/schemas/NationalityEnum'
+          description: Your country of nationality
+        residence:
+          allOf:
+          - $ref: '#/components/schemas/ResidenceEnum'
+          description: Your country of residence
+        race:
+          allOf:
+          - $ref: '#/components/schemas/RaceEnum'
+          description: Your ethnicity
+        political_affiliation:
+          allOf:
+          - $ref: '#/components/schemas/PoliticalAffiliationEnum'
+          description: Your political preference
+        religion:
+          allOf:
+          - $ref: '#/components/schemas/ReligionEnum'
+          description: Your religion
+        degree_of_political_engagement:
+          allOf:
+          - $ref: '#/components/schemas/DegreeOfPoliticalEngagementEnum'
+          description: Your degree of political engagement
+        moral_philosophy:
+          allOf:
+          - $ref: '#/components/schemas/MoralPhilosophyEnum'
+          description: Your preferred moral philosophy
+        website:
+          type: string
+          format: uri
+          nullable: true
+          description: Your website URL
+          maxLength: 500
+        linkedin:
+          type: string
+          format: uri
+          nullable: true
+          description: Your LinkedIn URL
+          maxLength: 500
+        youtube:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Youtube channel URL
+          maxLength: 500
+        google_scholar:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Google Scholar URL
+          maxLength: 500
+        orcid:
+          type: string
+          format: uri
+          nullable: true
+          description: Your ORCID URL
+          maxLength: 500
+        researchgate:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Researchgate profile URL
+          maxLength: 500
+        twitter:
+          type: string
+          format: uri
+          nullable: true
+          description: Your Twitter URL
+          maxLength: 500
+        avatar:
+          type: string
+          format: binary
+          nullable: true
+          description: Your profile picture.
+        is_trusted:
+          type: boolean
+      required:
+      - is_trusted
+      - username
     VerifyEmail:
       type: object
       properties:
@@ -10653,6 +11164,26 @@ components:
       - signature
       - timestamp
       - user_id
+    VerifyEmailRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          format: email
+          minLength: 1
+        timestamp:
+          type: integer
+        signature:
+          type: string
+          minLength: 1
+      required:
+      - email
+      - signature
+      - timestamp
+      - user_id
     VerifyRegistration:
       type: object
       properties:
@@ -10662,6 +11193,21 @@ components:
           type: integer
         signature:
           type: string
+      required:
+      - signature
+      - timestamp
+      - user_id
+    VerifyRegistrationRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          minLength: 1
+        timestamp:
+          type: integer
+        signature:
+          type: string
+          minLength: 1
       required:
       - signature
       - timestamp
@@ -10752,22 +11298,24 @@ components:
       type: object
       properties:
         video:
-          $ref: '#/components/schemas/Video'
+          $ref: '#/components/schemas/RelatedVideo'
       required:
       - video
-    VideoReadOnly:
+    VideoRateLaterRequest:
       type: object
-      description: |-
-        A video serializer without all the Video model auto-validations.
-
-        Used by ModelSerializer(s) having one or more nested relations with Video,
-        and having the constraint of not creating new videos in database when
-        creating new objects.
-
-        ex: adding a new Comparison shouldn't create new Video in the database
+      properties:
+        video:
+          $ref: '#/components/schemas/RelatedVideoRequest'
+      required:
+      - video
+    VideoRequest:
+      type: object
       properties:
         video_id:
           type: string
+          minLength: 1
+          description: Video ID from YouTube URL, matches ^[A-Za-z0-9-_]{11}$
+          pattern: ^[A-Za-z0-9-_]{11}$
           maxLength: 20
       required:
       - video_id

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -6,7 +6,10 @@ import ExpandLess from '@mui/icons-material/ExpandLess';
 import { Info as InfoIcon } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 
-import type { Comparison, ComparisonCriteriaScore } from 'src/services/openapi';
+import type {
+  ComparisonRequest,
+  ComparisonCriteriaScore,
+} from 'src/services/openapi';
 import {
   allCriterias,
   optionalCriterias,
@@ -41,15 +44,15 @@ const ComparisonComponent = ({
   videoB,
   isComparisonPublic,
 }: {
-  submit: (c: Comparison) => Promise<void>;
-  initialComparison: Comparison | null;
+  submit: (c: ComparisonRequest) => Promise<void>;
+  initialComparison: ComparisonRequest | null;
   videoA: string;
   videoB: string;
   isComparisonPublic?: boolean;
 }) => {
   const { t } = useTranslation();
   const classes = useStyles();
-  const castToComparison = (c: Comparison | null): Comparison => {
+  const castToComparison = (c: ComparisonRequest | null): ComparisonRequest => {
     return c
       ? c
       : {
@@ -60,7 +63,7 @@ const ComparisonComponent = ({
             .map((criteria) => ({ criteria, score: 0 })),
         };
   };
-  const [comparison, setComparison] = useState<Comparison>(
+  const [comparison, setComparison] = useState<ComparisonRequest>(
     castToComparison(initialComparison)
   );
   const [submitted, setSubmitted] = useState(false);

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -5,7 +5,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { Compare as CompareIcon } from '@mui/icons-material';
 
 import type { Comparison } from 'src/services/openapi';
-import { VideoCardFromId } from '../videos/VideoCard';
+import VideoCard from '../videos/VideoCard';
 
 const useStyles = makeStyles((theme: Theme) => ({
   content: {
@@ -36,7 +36,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
   const { video_a, video_b } = comparison;
   return (
     <Box className={classes.comparisonContainer}>
-      <VideoCardFromId compact videoId={video_a.video_id} />
+      <VideoCard compact video={video_a} />
       <Box className={classes.centering} style={{ position: 'relative' }}>
         <div
           style={{
@@ -57,7 +57,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
           </Fab>
         </Tooltip>
       </Box>
-      <VideoCardFromId compact videoId={video_b.video_id} />
+      <VideoCard compact video={video_b} />
     </Box>
   );
 };

--- a/frontend/src/features/rateLater/rateLaterAPI.ts
+++ b/frontend/src/features/rateLater/rateLaterAPI.ts
@@ -1,4 +1,3 @@
-import { ensureVideoExistsOrCreate } from 'src/utils/video';
 import { UsersService } from 'src/services/openapi';
 import { Video } from 'src/services/openapi';
 
@@ -7,7 +6,6 @@ export const addToRateLaterList = async ({
 }: {
   video_id: string;
 }) => {
-  await ensureVideoExistsOrCreate(video_id);
   return UsersService.usersMeVideoRateLaterCreate({
     requestBody: {
       video: { video_id } as Video,

--- a/frontend/src/features/video_selector/VideoSelector.tsx
+++ b/frontend/src/features/video_selector/VideoSelector.tsx
@@ -16,11 +16,7 @@ import {
   getVideoForComparison,
   isVideoIdValid,
 } from 'src/utils/video';
-import {
-  UsersService,
-  ContributorRating,
-  ContributorRatingCreate,
-} from 'src/services/openapi';
+import { UsersService, ContributorRating } from 'src/services/openapi';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -80,7 +76,7 @@ const VideoSelector = ({
               requestBody: {
                 video_id: videoId,
                 is_public: true,
-              } as ContributorRatingCreate,
+              },
             });
           onChange({
             videoId,

--- a/frontend/src/features/video_selector/VideoSelector.tsx
+++ b/frontend/src/features/video_selector/VideoSelector.tsx
@@ -10,11 +10,8 @@ import Tooltip from '@mui/material/Tooltip';
 import { UserRatingPublicToggle } from 'src/features/videos/PublicStatusAction';
 import VideoCard, { EmptyVideoCard } from 'src/features/videos/VideoCard';
 
-import { useNotifications } from 'src/hooks';
-
 import { ActionList } from 'src/utils/types';
 import {
-  ensureVideoExistsOrCreate,
   extractVideoId,
   getVideoForComparison,
   isVideoIdValid,
@@ -23,7 +20,6 @@ import {
   UsersService,
   ContributorRating,
   ContributorRatingCreate,
-  ApiError,
 } from 'src/services/openapi';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -62,7 +58,6 @@ const VideoSelector = ({
   submitted = false,
 }: Props) => {
   const { t } = useTranslation();
-  const { displayErrorsFrom } = useNotifications();
 
   const { videoId, rating } = value;
   const classes = useStyles();
@@ -79,12 +74,6 @@ const VideoSelector = ({
       });
     } catch (err) {
       if (err?.status === 404) {
-        await ensureVideoExistsOrCreate(videoId).catch((reason: ApiError) => {
-          displayErrorsFrom(reason);
-          setLoading(false);
-          return;
-        });
-
         try {
           const contributorRating =
             await UsersService.usersMeContributorRatingsCreate({
@@ -105,7 +94,7 @@ const VideoSelector = ({
       }
     }
     setLoading(false);
-  }, [videoId, onChange, displayErrorsFrom]);
+  }, [videoId, onChange]);
 
   useEffect(() => {
     if (isVideoIdValid(videoId) && rating == null) {

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -12,7 +12,7 @@ import {
   Theme,
 } from '@mui/material';
 
-import { UsersService, Comparison } from 'src/services/openapi';
+import { UsersService, ComparisonRequest } from 'src/services/openapi';
 import ComparisonSliders from 'src/features/comparisons/Comparison';
 import VideoSelector, {
   VideoSelectorValue,
@@ -49,9 +49,8 @@ const ComparisonPage = () => {
   const history = useHistory();
   const location = useLocation();
   const [isLoading, setIsLoading] = useState(true);
-  const [initialComparison, setInitialComparison] = useState<Comparison | null>(
-    null
-  );
+  const [initialComparison, setInitialComparison] =
+    useState<ComparisonRequest | null>(null);
   const { showSuccessAlert } = useNotifications();
   const searchParams = new URLSearchParams(location.search);
   const videoA: string = searchParams.get('videoA') || '';
@@ -116,7 +115,7 @@ const ComparisonPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [videoA, videoB]);
 
-  const onSubmitComparison = async (c: Comparison) => {
+  const onSubmitComparison = async (c: ComparisonRequest) => {
     if (initialComparison) {
       const { video_a, video_b, criteria_scores, duration_ms } = c;
       await UsersService.usersMeComparisonsUpdate({

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -8,7 +8,11 @@ import {
   Lines,
   FormTextField,
 } from 'src/components';
-import { AccountsService, RegisterUser, ApiError } from 'src/services/openapi';
+import {
+  AccountsService,
+  ApiError,
+  RegisterUserRequest,
+} from 'src/services/openapi';
 import { Link } from 'react-router-dom';
 
 const SignupSuccess = ({ email }: { email: string }) => {
@@ -40,7 +44,7 @@ const Signup = () => {
     const formObject: unknown = Object.fromEntries(formData);
     try {
       const createdUser = await AccountsService.accountsRegisterCreate({
-        requestBody: formObject as RegisterUser,
+        requestBody: formObject as RegisterUserRequest,
       });
       setSuccessEmailAddress(createdUser.email || '');
     } catch (err) {

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -1,4 +1,4 @@
-import { VideoService, UsersService, Video } from 'src/services/openapi';
+import { VideoService, UsersService } from 'src/services/openapi';
 
 export function extractVideoId(idOrUrl: string) {
   const matchUrl = idOrUrl.match(
@@ -13,29 +13,6 @@ export function extractVideoId(idOrUrl: string) {
 
 export function isVideoIdValid(videoId: string) {
   return !!videoId.match(/^[A-Za-z0-9-_]{11}$/);
-}
-
-export async function ensureVideoExistsOrCreate(video_id: string) {
-  // FIXME: should the video be created automatically?
-  // And if so, shouldn't the backend be responsible for it?
-  // It's currently impractical to check if the API error
-  // is blocking or not.
-  // To address in https://github.com/tournesol-app/tournesol/issues/202
-  try {
-    await VideoService.videoCreate({ requestBody: { video_id } as Video });
-  } catch (err) {
-    if (
-      err.status === 400 &&
-      (err.body?.video_id?.[0]?.includes('already exists') ||
-        err.body?.video_id?.[0]?.includes('existe déjà'))
-    ) {
-      console.debug(
-        'Video already exists in the database: API error can be ignored'
-      );
-    } else {
-      throw err;
-    }
-  }
 }
 
 function pick(arr: string[]): string | null {


### PR DESCRIPTION
Closes #202 and Fixes #436

* Video creation is handled by `RelatedVideoSerializer` (replacing `VideoReadOnlySerializer`)
* `RelatedVideoSerializer` and `VideoSerializer` uses the same `Video.create_from_video_id()` method to create the video (and fetch metadata) if necessary.
* Custom implementations for video_rate_later and comparisons views can be simplified to take advantage of the serializers
  * Bonus: the `GET /users/me/comparisons` response now includes the videos metadata  
  (fix #436)
* Frontend and Browser extension are updated to avoid unnecessary API calls to check that a video exists.