### PR TITLE
[back] security: upgrade Django to 3.2.12

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.11
+Django==3.2.12
 django-computed-property==0.3.0
 django-cors-headers==3.7.0
 django-countries==7.2.1


### PR DESCRIPTION
It fixes:
- CVE-2022-22818
- CVE-2022-23833

see: https://docs.djangoproject.com/en/3.2/releases/3.2.12