### PR TITLE
[backend] Upgrade to Django 4.0 (#348)

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -4,10 +4,3 @@ markers =
 
 DJANGO_SETTINGS_MODULE = settings.settings
 python_files = tests.py test_*.py *_tests.py
-
-filterwarnings =
-    # TODO: could fix the issues instead of ignoring the warning here: 
-    # https://github.com/audiolion/django-language-field 
-    ignore:django.utils.translation.ugettext_lazy\(\) is deprecated:DeprecationWarning
-    ignore::django.utils.deprecation.RemovedInDjango41Warning
-    ignore::django.utils.deprecation.RemovedInDjango40Warning

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,22 +1,21 @@
-Django==3.2.12
+Django==4.0.1
 django-computed-property==0.3.0
-django-cors-headers==3.7.0
+django-cors-headers==3.11.0
 django-countries==7.2.1
 django-filter==2.4.0
-django-language-field==0.0.3
-django-oauth-toolkit==1.5.0
-django-prometheus==2.1.0
+django-oauth-toolkit==1.7.0
+django-prometheus==2.2.0
 django-rest-registration==0.7.0
-djangorestframework==3.12.4
-drf-spectacular==0.21.0
+djangorestframework==3.13.1
+drf-spectacular==0.21.2
 fuzzysearch==0.7.3
 numpy==1.21.2
 Pillow==9.0.0
-psycopg2-binary==2.9.1
+psycopg2-binary==2.9.3
 PyYAML==5.4.1
 tqdm==4.62.1
-langdetect==1.0.8
+langdetect==1.0.9
 
 #API Youtube data
-google-api-python-client==2.15.0
+google-api-python-client==2.36.0
 google-auth-httplib2==0.1.0

--- a/backend/tests/requirements.txt
+++ b/backend/tests/requirements.txt
@@ -14,7 +14,7 @@ pytest-html==3.1.1
 pytest-mock==3.6.1
 
 # Pytest for django
-pytest-django==4.4.0
+pytest-django==4.5.2
 
 # Factory tools
 factory-boy==3.2.1

--- a/backend/tournesol/models/video.py
+++ b/backend/tournesol/models/video.py
@@ -12,7 +12,6 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.html import format_html
-from languages.languages import LANGUAGES
 from tqdm.auto import tqdm
 
 from core.models import User
@@ -23,7 +22,7 @@ from tournesol.models.tags import Tag
 from tournesol.utils import VideoSearchEngine
 
 CRITERIAS = settings.CRITERIAS
-
+LANGUAGES = settings.LANGUAGES
 
 class Video(models.Model, WithFeatures, WithEmbedding):
     """One video."""

--- a/backend/tournesol/models/video.py
+++ b/backend/tournesol/models/video.py
@@ -24,6 +24,7 @@ from tournesol.utils import VideoSearchEngine
 CRITERIAS = settings.CRITERIAS
 LANGUAGES = settings.LANGUAGES
 
+
 class Video(models.Model, WithFeatures, WithEmbedding):
     """One video."""
 


### PR DESCRIPTION
I also updated a few other libraries, even that was not required.

The reason why django-language-field was replaced is discussed in #348 (use of the obsolete function ugettext_lazy)

tested with python 3.8 and 3.9

You may have to delete the tournesol-dev-api image first for it to work.