### PR TITLE
[back] security: upgrade Django to 4.0.2

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.0.1
+Django==4.0.2
 django-computed-property==0.3.0
 django-cors-headers==3.11.0
 django-countries==7.2.1


### PR DESCRIPTION
It fixes two security flaws re-introduced by the upgrade to Django 4.0.1
- CVE-2022-22818
- CVE-2022-23833

and several other regressions introduced by Django 4.0

see: https://docs.djangoproject.com/en/4.0/releases/4.0.2/