### PR TITLE
reduce uninteresting test logs

### DIFF
--- a/backend/core/tests/factories/user.py
+++ b/backend/core/tests/factories/user.py
@@ -1,6 +1,10 @@
+import logging
+
 import factory
 
 from core.models import User
+
+logging.getLogger('faker').setLevel(logging.INFO)
 
 
 class UserFactory(factory.django.DjangoModelFactory):

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -364,7 +364,7 @@ LOGGING = {
     },
     "root": {
         "handlers": ["console"],
-        "level": os.environ.get("DJANGO_LOG_LEVEL", "DEBUG"),
+        "level": os.environ.get("DJANGO_LOG_LEVEL", "INFO"),
     },
 }
 

--- a/backend/tournesol/tests/factories/video.py
+++ b/backend/tournesol/tests/factories/video.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import random
 import string
 
@@ -7,6 +8,7 @@ import factory
 from core.tests.factories.user import UserFactory
 from tournesol.models import video as video_models
 
+logging.getLogger('factory').setLevel(logging.WARN)
 
 def generate_youtube_id():
     return ''.join(random.choices(string.ascii_uppercase + string.digits, k=11))


### PR DESCRIPTION
Initially, when running `python manage.py test`, I had 1690 lines of log, mostly useless:
[log1.txt](https://github.com/tournesol-app/tournesol/files/8008430/log1.txt)

The use of "logging.getLogger('factory').setLevel(logging.WARN)" reduces the amount of logs to 157 lines:
[log2.txt](https://github.com/tournesol-app/tournesol/files/8008431/log2.txt)

The use of "logging.getLogger('faker').setLevel(logging.INFO)" reduces the amount of logs to 118 lines:
[log3.txt](https://github.com/tournesol-app/tournesol/files/8008439/log3.txt)

To further remove the last useless logs, I had to set the Django log level to "INFO". This is more controversial, maybe there is a better way to do it. I could also have modified the settings-tournesol.yaml instead. The only logs that remain (45 lines) look pretty meaningful:
[log4.txt](https://github.com/tournesol-app/tournesol/files/8008449/log4.txt)

