### PR TITLE
pytest warnings

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -4,3 +4,6 @@ markers =
 
 DJANGO_SETTINGS_MODULE = settings.settings
 python_files = tests.py test_*.py *_tests.py
+
+filterwarnings =
+    ignore::django.utils.deprecation.RemovedInDjango41Warning

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -218,8 +218,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 


### PR DESCRIPTION
In the previous PR (#544), I missed those pytest warnings because I was using `python manage.py test` instead of pytest

The first warning is because USE_L10N is getting deprecated. It is set to true by default anyway.

The second warning (RemovedInDjango41Warning) comes from django-rest-registration. It is not solved yet in the latest version of django-rest-registration, so I just muted the warning.