### PR TITLE
fix: ignore detected language if not in allowed choices

### DIFF
--- a/backend/tournesol/utils/video_language.py
+++ b/backend/tournesol/utils/video_language.py
@@ -1,9 +1,13 @@
 import re
 from collections import Counter
 
+from django.conf import settings
 from langdetect import DetectorFactory, detect, lang_detect_exception
 
 from ..models import Video
+
+ACCEPTED_LANGUAGE_CODES = {lang[0] for lang in settings.LANGUAGES}
+
 
 # Enforce consistent results with a constant seed,
 # as the language detection algorithm is non-deterministic.
@@ -39,4 +43,7 @@ def compute_video_language(uploader, title, description):
         if len(lang_list) > 4 and main_uploader_lang_cnt/len(lang_list) > 0.9:
             return main_uploader_lang[0]
 
-    return languages_detection(title, description)
+    lang = languages_detection(title, description)
+    if lang in ACCEPTED_LANGUAGE_CODES:
+        return lang
+    return None


### PR DESCRIPTION
Following #348, the language detection mechanism could insert languages that are not included in the field "choices".  
Let's ignore these languages. (This should be marginal, it represents only 1 video in the current database in production).