### PR TITLE
Fix requests not considered 'secure' when proxied via nginx + gunicorn

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -42,8 +42,8 @@ SECRET_KEY = server_settings.get(
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = server_settings.get("DEBUG", False)
-
 ALLOWED_HOSTS = server_settings.get("ALLOWED_HOSTS", ["127.0.0.1", "localhost"])
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 STATIC_URL = "/static/"
 MEDIA_URL = "/media/"


### PR DESCRIPTION
After upgrading to Django 4.0, CSRF checks failed due to bad "Origin" in requests, e.g when logging into the admin.

This is related to [a change related to CSRF in Django](https://docs.djangoproject.com/en/4.0/releases/4.0/#csrf). However `CSRF_TRUSTED_ORIGINS` should not be required in our case, as we are not using cross-origin requests with CSRF. 

The root cause seems to be that requests using HTTPS are not considered "secure" by Django, as they are proxied via Nginx / Gunicorn / Uvicorn.

As verified on staging, setting `SECURE_PROXY_SSL_HEADER` fixes this issue.

---
See the origin verification in Django implementation:
https://github.com/django/django/blob/4.0.2/django/middleware/csrf.py#L252-L264

And the headers set by Nginx in the current configuration
https://github.com/tournesol-app/tournesol/blob/main/infra/ansible/roles/django/templates/tournesol.j2#L67

