### PR TITLE
[front] feat: comparison on Home page for logged users

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -259,7 +259,10 @@
     "extensionNotAvailableOnYourBrowser": "The extension is not available on your web browser. You may use it on <2>Firefox</2>, <4>Google Chrome</4> or <6>Chromium</6>.",
     "collaborativeContentRecommendations": "Collaborative Content Recommendations",
     "whatIsTournesol": "What is Tournesol?",
-    "tournesolPlatformDescription": "Tournesol is an <1>open source</1> platform which aims to <3>collaboratively</3> identify top videos of public utility by eliciting contributors' judgements on content quality. We hope to contribute to making today's and tomorrow's large-scale algorithms <6>robustly beneficial</6> for all of humanity."
+    "tournesolPlatformDescription": "Tournesol is an <1>open source</1> platform which aims to <3>collaboratively</3> identify top videos of public utility by eliciting contributors' judgements on content quality. We hope to contribute to making today's and tomorrow's large-scale algorithms <6>robustly beneficial</6> for all of humanity.",
+    "giveYourOpinionNow": "Give your opinion now",
+    "and": "and",
+    "makeTheRecommendationsBetter": "make the recommendations better"
   },
   "reset": {
     "ifUserExistsResetLinkWillBeSent": "Done!<1></1>If this user exists, an email will be sent with a reset link.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -27,7 +27,7 @@
   },
   "submit": "submit",
   "lightComparison": {
-    "notEnoughVideos": "Sorry, Tournesol hasn't been able to retrieve videos."
+    "notEnoughVideos": "Sorry, Tournesol hasn't been able to display videos."
   },
   "footer": {
     "wiki": "wiki",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -26,6 +26,9 @@
     "goToComparison": "Go to comparison"
   },
   "submit": "submit",
+  "lightComparison": {
+    "notEnoughVideos": "Sorry, Tournesol hasn't been able to retrieve videos."
+  },
   "footer": {
     "wiki": "wiki",
     "privacyPolicy": "privacy policy",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -27,8 +27,8 @@
   },
   "submit": "submit",
   "lightComparison": {
-    "copyLink": "copy link",
-    "done": "done!",
+    "shareLink": "share link",
+    "copied": "copied!",
     "notEnoughVideos": "Sorry, Tournesol hasn't been able to display videos."
   },
   "footer": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -27,6 +27,8 @@
   },
   "submit": "submit",
   "lightComparison": {
+    "copyLink": "copy link",
+    "done": "done!",
     "notEnoughVideos": "Sorry, Tournesol hasn't been able to display videos."
   },
   "footer": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -263,7 +263,10 @@
     "extensionNotAvailableOnYourBrowser": "L'extension n'est malheureusement pas disponible pour votre navigateur web. Elle est compatible avec <2>Mozilla Firefox</2>, et <4>Google Chrome</4> ou <6>Chromium</6>.",
     "collaborativeContentRecommendations": "Recommandations collaboratives de contenus",
     "whatIsTournesol": "Qu'est-ce que Tournesol ?",
-    "tournesolPlatformDescription": "Tournesol est une plateforme <1>libre et open source</1> dont le but est d'identifier les vidéos d'utilité publique de grande qualité, de <3>manière collaborative</3>, en s'appuyant sur le jugement de contributeurs. Nous espérons rendre les algorithmes d'aujourd'hui et de demain <6>robustement bénéfique</6> à grande échelle, pour toute l'humanité."
+    "tournesolPlatformDescription": "Tournesol est une plateforme <1>libre et open source</1> dont le but est d'identifier les vidéos d'utilité publique de grande qualité, de <3>manière collaborative</3>, en s'appuyant sur le jugement de contributeurs. Nous espérons rendre les algorithmes d'aujourd'hui et de demain <6>robustement bénéfique</6> à grande échelle, pour toute l'humanité.",
+    "giveYourOpinionNow": "Donnez votre avis maintenant",
+    "and": "et",
+    "makeTheRecommendationsBetter": "améliorez les recommandations"
   },
   "reset": {
     "ifUserExistsResetLinkWillBeSent": "C'est fait !<1></1>Si l'identifiant existe, un courriel avec un lien de réinitialisation sera envoyé.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -27,8 +27,8 @@
   },
   "submit": "enregistrer",
   "lightComparison": {
-    "copyLink": "copier lien",
-    "done": "fait!",
+    "shareLink": "partager",
+    "copied": "copié !",
     "notEnoughVideos": "Désolé, Tournesol n'a pas été en mesure d'afficher des vidéos."
   },
   "footer": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -27,6 +27,8 @@
   },
   "submit": "enregistrer",
   "lightComparison": {
+    "copyLink": "copier lien",
+    "done": "fait!",
     "notEnoughVideos": "Désolé, Tournesol n'a pas été en mesure d'afficher des vidéos."
   },
   "footer": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -27,7 +27,7 @@
   },
   "submit": "enregistrer",
   "lightComparison": {
-    "notEnoughVideos": "Désolé, Tournesol n'a pas été en mesure de trouver des vidéos."
+    "notEnoughVideos": "Désolé, Tournesol n'a pas été en mesure d'afficher des vidéos."
   },
   "footer": {
     "wiki": "wiki",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -26,6 +26,9 @@
     "goToComparison": "Voir la comparaison"
   },
   "submit": "enregistrer",
+  "lightComparison": {
+    "notEnoughVideos": "Désolé, Tournesol n'a pas été en mesure de trouver des vidéos."
+  },
   "footer": {
     "wiki": "wiki",
     "privacyPolicy": "politique de confidentialité",

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -188,6 +188,7 @@ const Comparison = () => {
               initialComparison={initialComparison}
               videoA={videoA}
               videoB={videoB}
+              enableOptional
               isComparisonPublic={
                 selectorA.rating.is_public && selectorB.rating.is_public
               }

--- a/frontend/src/features/comparisons/ComparisonSliders.tsx
+++ b/frontend/src/features/comparisons/ComparisonSliders.tsx
@@ -42,12 +42,14 @@ const ComparisonSliders = ({
   initialComparison,
   videoA,
   videoB,
+  enableOptional,
   isComparisonPublic,
 }: {
   submit: (c: ComparisonRequest) => Promise<void>;
   initialComparison: ComparisonRequest | null;
   videoA: string;
   videoB: string;
+  enableOptional: boolean;
   isComparisonPublic?: boolean;
 }) => {
   const { t } = useTranslation();
@@ -139,19 +141,24 @@ const ComparisonSliders = ({
               handleSliderChange={handleSliderChange}
             />
           ))}
-        <Button
-          onClick={handleCollapseCriterias}
-          startIcon={showOptionalCriterias ? <ExpandLess /> : <ExpandMore />}
-          size="small"
-          color="secondary"
-          style={{ marginBottom: 8, color: showOptionalCriterias ? 'red' : '' }}
-        >
-          {showOptionalCriterias
-            ? t('comparison.removeOptionalCriterias')
-            : t('comparison.addOptionalCriterias')}
-        </Button>
+        {enableOptional && (
+          <Button
+            onClick={handleCollapseCriterias}
+            startIcon={showOptionalCriterias ? <ExpandLess /> : <ExpandMore />}
+            size="small"
+            color="secondary"
+            style={{
+              marginBottom: 8,
+              color: showOptionalCriterias ? 'red' : '',
+            }}
+          >
+            {showOptionalCriterias
+              ? t('comparison.removeOptionalCriterias')
+              : t('comparison.addOptionalCriterias')}
+          </Button>
+        )}
         <Collapse
-          in={showOptionalCriterias}
+          in={showOptionalCriterias && enableOptional}
           timeout="auto"
           style={{ width: '100%' }}
         >

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -72,7 +72,6 @@ const LightComparison = () => {
 
   const [videoIdA, setVideoIdA] = useState('');
   const [videoIdB, setVideoIdB] = useState('');
-  const [comparisonUrl, setComparisonUrl] = useState('');
 
   /**
    * Get an array of two random and distinct video IDs from the Tournesol
@@ -150,7 +149,6 @@ const LightComparison = () => {
 
       setVideoIdA(displayedVideos[0]);
       setVideoIdB(displayedVideos[1]);
-      setComparisonUrl(`/comparison/?videoA=${videoIdA}&videoB=${videoIdB}`);
       getUserComparison(displayedVideos[0], displayedVideos[1]);
       setIsLoading(false);
     };
@@ -176,8 +174,10 @@ const LightComparison = () => {
 
   const renderTopItem = () => {
     if (isLoggedIn && videoIdA !== '' && videoIdB !== '') {
-      const url =
-        `${window.location.protocol}//${window.location.host}` + comparisonUrl;
+      const comparisonPath =
+        '/comparison?videoA=' + videoIdA + '&videoB=' + videoIdB;
+      const comparisonUri =
+        `${window.location.protocol}//${window.location.host}` + comparisonPath;
 
       return (
         <Grid
@@ -191,7 +191,7 @@ const LightComparison = () => {
             <Button
               variant="text"
               onClick={() => {
-                navigator.clipboard.writeText(url);
+                navigator.clipboard.writeText(comparisonUri);
               }}
             >
               copy link
@@ -199,7 +199,7 @@ const LightComparison = () => {
             <IconButton
               aria-label="open-comparison"
               onClick={() => {
-                history.push(comparisonUrl);
+                history.push(comparisonPath);
               }}
             >
               <OpenInNewIcon />

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -144,7 +144,7 @@ const LightComparison = () => {
 
       // use videos from this year if the recent are not enough
       if (displayedVideos.some(empty)) {
-        const year = await getRecommendations('');
+        const year = await getRecommendations('?date=Year');
 
         if (displayedVideos[0] === '') {
           displayedVideos[0] = year[0];

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -127,16 +127,16 @@ const LightComparison = () => {
       const recent = await getRecommendations('?date=Month');
       const displayedVideos = [...recent];
 
-      // use all time recommendations if the recent videos < 2
+      // use videos from this year if the recent are not enough
       if (displayedVideos.some(empty)) {
-        const allTime = await getRecommendations('');
+        const year = await getRecommendations('?date=Year');
 
         if (displayedVideos[0] === '') {
-          displayedVideos[0] = allTime[0];
+          displayedVideos[0] = year[0];
         }
 
         if (displayedVideos[1] === '') {
-          displayedVideos[1] = allTime[1];
+          displayedVideos[1] = year[1];
         }
       }
 

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -10,9 +10,10 @@ import {
   Box,
   Theme,
   Button,
-  IconButton,
+  Stack,
 } from '@mui/material';
-import Stack from '@mui/material/Stack';
+
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 import { useLoginState, useNotifications } from 'src/hooks';
@@ -38,6 +39,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   cardTitle: {
     color: theme.palette.text.secondary,
+  },
+  yellow: {
+    color: theme.palette.primary.main,
   },
 }));
 
@@ -73,8 +77,8 @@ const LightComparison = () => {
   const [videoIdA, setVideoIdA] = useState('');
   const [videoIdB, setVideoIdB] = useState('');
 
-  const copyTextInitial = t('lightComparison.copyLink');
-  const copyTextCopied = t('lightComparison.done');
+  const copyTextInitial = t('lightComparison.shareLink');
+  const copyTextCopied = t('lightComparison.copied');
   const [copyText, setCopyText] = useState(copyTextInitial);
 
   /**
@@ -176,7 +180,7 @@ const LightComparison = () => {
     showSuccessAlert(t('comparison.successfullySubmitted'));
   };
 
-  const renderTopItem = () => {
+  const comparisonTopMenu = () => {
     if (isLoggedIn && videoIdA !== '' && videoIdB !== '') {
       const comparisonPath =
         '/comparison?videoA=' + videoIdA + '&videoB=' + videoIdB;
@@ -200,17 +204,22 @@ const LightComparison = () => {
           alignItems="center"
         >
           <Stack direction="row" spacing={1}>
-            <Button variant="text" onClick={copyToClipBoard}>
+            <Button
+              variant="text"
+              onClick={copyToClipBoard}
+              endIcon={<ContentCopyIcon />}
+            >
               {copyText}
             </Button>
-            <IconButton
-              aria-label="open-comparison"
+            <Button
+              variant="text"
               onClick={() => {
                 history.push(comparisonPath);
               }}
+              endIcon={<OpenInNewIcon />}
             >
-              <OpenInNewIcon />
-            </IconButton>
+              open
+            </Button>
           </Stack>
         </Grid>
       );
@@ -219,7 +228,7 @@ const LightComparison = () => {
 
   return (
     <Grid container className={classes.content}>
-      {renderTopItem()}
+      {comparisonTopMenu()}
       <Grid item xs component={Card} className={classes.card}>
         <Box m={0.5}>
           <Typography variant="h5" className={classes.cardTitle}>

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -73,6 +73,10 @@ const LightComparison = () => {
   const [videoIdA, setVideoIdA] = useState('');
   const [videoIdB, setVideoIdB] = useState('');
 
+  const copyTextInitial = t('lightComparison.copyLink');
+  const copyTextCopied = t('lightComparison.done');
+  const [copyText, setCopyText] = useState(copyTextInitial);
+
   /**
    * Get an array of two random and distinct video IDs from the Tournesol
    * recommendations.
@@ -179,6 +183,14 @@ const LightComparison = () => {
       const comparisonUri =
         `${window.location.protocol}//${window.location.host}` + comparisonPath;
 
+      const copyToClipBoard = () => {
+        navigator.clipboard.writeText(comparisonUri);
+        setCopyText(copyTextCopied);
+        setTimeout(() => {
+          setCopyText(copyTextInitial);
+        }, 2000);
+      };
+
       return (
         <Grid
           container
@@ -188,13 +200,8 @@ const LightComparison = () => {
           alignItems="center"
         >
           <Stack direction="row" spacing={1}>
-            <Button
-              variant="text"
-              onClick={() => {
-                navigator.clipboard.writeText(comparisonUri);
-              }}
-            >
-              copy link
+            <Button variant="text" onClick={copyToClipBoard}>
+              {copyText}
             </Button>
             <IconButton
               aria-label="open-comparison"

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -70,7 +70,7 @@ const LightComparison = () => {
   const [videoIdB, setVideoIdB] = useState('');
 
   const getRecentReco = async () => {
-    const searchString = '?limit=20date=Month';
+    const searchString = '';
     return await getRecommendedVideos(searchString);
   };
 
@@ -171,6 +171,7 @@ const LightComparison = () => {
               initialComparison={initialComparison}
               videoA={videoIdA}
               videoB={videoIdB}
+              enableOptional={false}
               isComparisonPublic={false}
             />
           )

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -10,13 +10,17 @@ import {
   Box,
   Theme,
   Button,
+  IconButton,
 } from '@mui/material';
+import Stack from '@mui/material/Stack';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 import { useLoginState, useNotifications } from 'src/hooks';
 import { ComparisonRequest, UsersService } from 'src/services/openapi';
 import ComparisonSliders from 'src/features/comparisons/ComparisonSliders';
 import { getRecommendedVideos } from 'src/features/recommendation/RecommendationApi';
 import { VideoCardFromId } from 'src/features/videos/VideoCard';
+import { useHistory } from 'react-router';
 
 const useStyles = makeStyles((theme: Theme) => ({
   centering: {
@@ -58,6 +62,7 @@ const LightComparison = () => {
   const classes = useStyles();
 
   const { isLoggedIn } = useLoginState();
+  const history = useHistory();
   const { t } = useTranslation();
   const { showSuccessAlert } = useNotifications();
 
@@ -132,7 +137,7 @@ const LightComparison = () => {
 
       // use videos from this year if the recent are not enough
       if (displayedVideos.some(empty)) {
-        const year = await getRecommendations('?date=Year');
+        const year = await getRecommendations('');
 
         if (displayedVideos[0] === '') {
           displayedVideos[0] = year[0];
@@ -145,9 +150,7 @@ const LightComparison = () => {
 
       setVideoIdA(displayedVideos[0]);
       setVideoIdB(displayedVideos[1]);
-      setComparisonUrl(
-        `https://tournesol.app/comparison/?videoA=${videoIdA}&videoB=${videoIdB}`
-      );
+      setComparisonUrl(`/comparison/?videoA=${videoIdA}&videoB=${videoIdB}`);
       getUserComparison(displayedVideos[0], displayedVideos[1]);
       setIsLoading(false);
     };
@@ -173,6 +176,9 @@ const LightComparison = () => {
 
   const renderTopItem = () => {
     if (isLoggedIn && videoIdA !== '' && videoIdB !== '') {
+      const url =
+        `${window.location.protocol}//${window.location.host}` + comparisonUrl;
+
       return (
         <Grid
           container
@@ -181,14 +187,24 @@ const LightComparison = () => {
           justifyContent="flex-end"
           alignItems="center"
         >
-          <Button
-            variant="outlined"
-            onClick={() => {
-              navigator.clipboard.writeText(comparisonUrl);
-            }}
-          >
-            copy link
-          </Button>
+          <Stack direction="row" spacing={1}>
+            <Button
+              variant="text"
+              onClick={() => {
+                navigator.clipboard.writeText(url);
+              }}
+            >
+              copy link
+            </Button>
+            <IconButton
+              aria-label="open-comparison"
+              onClick={() => {
+                history.push(comparisonUrl);
+              }}
+            >
+              <OpenInNewIcon />
+            </IconButton>
+          </Stack>
         </Grid>
       );
     }

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -9,9 +9,10 @@ import {
   Card,
   Box,
   Theme,
+  Button,
 } from '@mui/material';
 
-import { useNotifications } from 'src/hooks';
+import { useLoginState, useNotifications } from 'src/hooks';
 import { ComparisonRequest, UsersService } from 'src/services/openapi';
 import ComparisonSliders from 'src/features/comparisons/ComparisonSliders';
 import { getRecommendedVideos } from 'src/features/recommendation/RecommendationApi';
@@ -56,6 +57,7 @@ function getRandomInt(min: number, max: number): number {
 const LightComparison = () => {
   const classes = useStyles();
 
+  const { isLoggedIn } = useLoginState();
   const { t } = useTranslation();
   const { showSuccessAlert } = useNotifications();
 
@@ -65,6 +67,7 @@ const LightComparison = () => {
 
   const [videoIdA, setVideoIdA] = useState('');
   const [videoIdB, setVideoIdB] = useState('');
+  const [comparisonUrl, setComparisonUrl] = useState('');
 
   /**
    * Get an array of two random and distinct video IDs from the Tournesol
@@ -142,6 +145,9 @@ const LightComparison = () => {
 
       setVideoIdA(displayedVideos[0]);
       setVideoIdB(displayedVideos[1]);
+      setComparisonUrl(
+        `https://tournesol.app/comparison/?videoA=${videoIdA}&videoB=${videoIdB}`
+      );
       getUserComparison(displayedVideos[0], displayedVideos[1]);
       setIsLoading(false);
     };
@@ -165,8 +171,32 @@ const LightComparison = () => {
     showSuccessAlert(t('comparison.successfullySubmitted'));
   };
 
+  const renderTopItem = () => {
+    if (isLoggedIn && videoIdA !== '' && videoIdB !== '') {
+      return (
+        <Grid
+          container
+          item
+          direction="row"
+          justifyContent="flex-end"
+          alignItems="center"
+        >
+          <Button
+            variant="outlined"
+            onClick={() => {
+              navigator.clipboard.writeText(comparisonUrl);
+            }}
+          >
+            copy link
+          </Button>
+        </Grid>
+      );
+    }
+  };
+
   return (
     <Grid container className={classes.content}>
+      {renderTopItem()}
       <Grid item xs component={Card} className={classes.card}>
         <Box m={0.5}>
           <Typography variant="h5" className={classes.cardTitle}>

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -1,0 +1,187 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import makeStyles from '@mui/styles/makeStyles';
+import {
+  CircularProgress,
+  Grid,
+  Typography,
+  Card,
+  Box,
+  Theme,
+} from '@mui/material';
+
+import { useNotifications } from 'src/hooks';
+import {
+  ComparisonRequest,
+  PaginatedVideoSerializerWithCriteriaList,
+  UsersService,
+} from 'src/services/openapi';
+import ComparisonSliders from 'src/features/comparisons/ComparisonSliders';
+import { VideoCardFromId } from '../videos/VideoCard';
+import { getRecommendedVideos } from '../recommendation/RecommendationApi';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  centering: {
+    display: 'flex',
+    alignItems: 'center',
+    flexDirection: 'column',
+    paddingTop: 16,
+  },
+  content: {
+    maxWidth: '880px',
+    gap: '8px',
+  },
+  card: {
+    alignSelf: 'start',
+  },
+  cardTitle: {
+    color: theme.palette.text.secondary,
+  },
+}));
+
+function getRandomInt(min: number, max: number): number {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min)) + min;
+}
+
+/**
+ * A light comparison UI.
+ *
+ * This comparison UI is intended to be used by both anonymous and logged
+ * users. For now, only comparisons for logged users are supported.
+ *
+ * Contrary to the standard comparison UI, it only displays two videos without
+ * extraneous control. Users can't select videos, nor to set the comparison
+ * public.
+ */
+const LightComparison = () => {
+  const classes = useStyles();
+
+  const { t } = useTranslation();
+  const { showSuccessAlert } = useNotifications();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [initialComparison, setInitialComparison] =
+    useState<ComparisonRequest | null>(null);
+
+  const [videoIdA, setVideoIdA] = useState('');
+  const [videoIdB, setVideoIdB] = useState('');
+
+  const getRecentReco = async () => {
+    const searchString = '?limit=20date=Month';
+    return await getRecommendedVideos(searchString);
+  };
+
+  const getUserComparison = (idA: string, idB: string) => {
+    UsersService.usersMeComparisonsRetrieve({
+      videoIdA: idA,
+      videoIdB: idB,
+    })
+      .then((comparison) => {
+        setInitialComparison(comparison);
+      })
+      .catch((err) => {
+        console.error(err);
+        setInitialComparison(null);
+      });
+  };
+
+  useEffect(() => {
+    let idA = '';
+    let idB = '';
+
+    getRecentReco().then(
+      (response: PaginatedVideoSerializerWithCriteriaList) => {
+        const count = response && response.count ? response.count : 0;
+        const max =
+          response && response.results && response.results.length > 0
+            ? response.results.length
+            : 0;
+
+        if (count >= 2 && response.results) {
+          const randA = getRandomInt(0, max);
+          let randB = getRandomInt(0, max);
+          while (randA === randB) {
+            randB = getRandomInt(0, max);
+          }
+
+          idA = response.results[randA]['video_id'];
+          idB = response.results[randB]['video_id'];
+        } else if (count >= 1 && response.results) {
+          idA = response.results[0]['video_id'];
+        }
+
+        if (idA) setVideoIdA(idA);
+        if (idB) setVideoIdB(idB);
+        getUserComparison(idA, idB);
+
+        setIsLoading(false);
+      }
+    );
+  }, []);
+
+  const onSubmitComparison = async (c: ComparisonRequest) => {
+    if (initialComparison) {
+      const { video_a, video_b, criteria_scores, duration_ms } = c;
+      await UsersService.usersMeComparisonsUpdate({
+        videoIdA: video_a.video_id,
+        videoIdB: video_b.video_id,
+        requestBody: { criteria_scores, duration_ms },
+      });
+    } else {
+      await UsersService.usersMeComparisonsCreate({ requestBody: c });
+      setInitialComparison(c);
+    }
+
+    showSuccessAlert(t('comparison.successfullySubmitted'));
+  };
+
+  return (
+    <Grid container className={classes.content}>
+      <Grid item xs component={Card} className={classes.card}>
+        <Box m={0.5}>
+          <Typography variant="h5" className={classes.cardTitle}>
+            Video 1
+          </Typography>
+        </Box>
+        <VideoCardFromId videoId={videoIdA} compact />
+      </Grid>
+      <Grid item xs component={Card} className={classes.card}>
+        <Box m={0.5}>
+          <Typography variant="h5" className={classes.cardTitle}>
+            Video 2
+          </Typography>
+        </Box>
+        <VideoCardFromId videoId={videoIdB} compact />
+      </Grid>
+      <Grid
+        item
+        xs={12}
+        className={classes.centering}
+        style={{ marginTop: '16px' }}
+      >
+        {videoIdA && videoIdB ? (
+          isLoading ? (
+            <CircularProgress />
+          ) : (
+            <ComparisonSliders
+              submit={onSubmitComparison}
+              initialComparison={initialComparison}
+              videoA={videoIdA}
+              videoB={videoIdB}
+              isComparisonPublic={false}
+            />
+          )
+        ) : (
+          <Typography paragraph>
+            {t('lightComparison.notEnoughVideos')}
+          </Typography>
+        )}
+      </Grid>
+    </Grid>
+  );
+};
+
+export default LightComparison;

--- a/frontend/src/features/comparisons/LightComparison.tsx
+++ b/frontend/src/features/comparisons/LightComparison.tsx
@@ -129,7 +129,6 @@ const LightComparison = () => {
         setInitialComparison(comparison);
       })
       .catch((err) => {
-        console.error(err);
         setInitialComparison(null);
       });
   };
@@ -205,6 +204,7 @@ const LightComparison = () => {
         >
           <Stack direction="row" spacing={1}>
             <Button
+              data-testid="comparison-btn-share"
               variant="text"
               onClick={copyToClipBoard}
               endIcon={<ContentCopyIcon />}
@@ -212,6 +212,7 @@ const LightComparison = () => {
               {copyText}
             </Button>
             <Button
+              data-testid="comparison-btn-open"
               variant="text"
               onClick={() => {
                 history.push(comparisonPath);

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -5,6 +5,7 @@ import { Grid, Typography, Box } from '@mui/material';
 
 import ExtensionSection from './ExtensionSection';
 import ContributeSection from './ContributeSection';
+import Comparison from 'src/features/comparisons/Comparison';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -94,6 +95,38 @@ const HomePage = () => {
               </Trans>
             </Typography>
           </Box>
+        </Grid>
+        <Grid
+          item
+          xs={12}
+          className={classes.container}
+          sx={{ background: '#1282B2', color: 'white' }}
+        >
+          <Grid
+            container
+            direction="column"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Grid item>
+              <Typography variant="h1" component="h1">
+                Give your opinion now
+              </Typography>
+            </Grid>
+            <Grid item>
+              <Typography variant="h3" component="h3">
+                and
+              </Typography>
+            </Grid>
+            <Grid item>
+              <Typography variant="h3" component="h3">
+                make the recommendations better
+              </Typography>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item xs={12} className={classes.container}>
+          <Comparison />
         </Grid>
         <Grid
           item

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -6,6 +6,7 @@ import { Grid, Typography, Box } from '@mui/material';
 import ExtensionSection from './ExtensionSection';
 import ContributeSection from './ContributeSection';
 import LightComparison from 'src/features/comparisons/LightComparison';
+import { useLoginState } from '../../hooks';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -62,6 +63,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const HomePage = () => {
+  const { isLoggedIn } = useLoginState();
   const { t } = useTranslation();
   const classes = useStyles();
 
@@ -96,38 +98,42 @@ const HomePage = () => {
             </Typography>
           </Box>
         </Grid>
-        <Grid
-          item
-          xs={12}
-          className={classes.container}
-          sx={{ background: '#1282B2', color: 'white' }}
-        >
-          <Grid
-            container
-            direction="column"
-            justifyContent="center"
-            alignItems="center"
-          >
-            <Grid item>
-              <Typography variant="h1" component="h1">
-                Give your opinion now
-              </Typography>
+        {isLoggedIn && (
+          <>
+            <Grid
+              item
+              xs={12}
+              className={classes.container}
+              sx={{ background: '#1282B2', color: 'white' }}
+            >
+              <Grid
+                container
+                direction="column"
+                justifyContent="center"
+                alignItems="center"
+              >
+                <Grid item>
+                  <Typography variant="h1" component="h1">
+                    Give your opinion now
+                  </Typography>
+                </Grid>
+                <Grid item>
+                  <Typography variant="h3" component="h3">
+                    and
+                  </Typography>
+                </Grid>
+                <Grid item>
+                  <Typography variant="h3" component="h3">
+                    make the recommendations better
+                  </Typography>
+                </Grid>
+              </Grid>
             </Grid>
-            <Grid item>
-              <Typography variant="h3" component="h3">
-                and
-              </Typography>
+            <Grid item xs={12} className={classes.container}>
+              <LightComparison />
             </Grid>
-            <Grid item>
-              <Typography variant="h3" component="h3">
-                make the recommendations better
-              </Typography>
-            </Grid>
-          </Grid>
-        </Grid>
-        <Grid item xs={12} className={classes.container}>
-          <LightComparison />
-        </Grid>
+          </>
+        )}
         <Grid
           item
           xs={12}

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -114,17 +114,17 @@ const HomePage = () => {
               >
                 <Grid item>
                   <Typography variant="h1" component="h1">
-                    Give your opinion now
+                    {t('home.giveYourOpinionNow')}
                   </Typography>
                 </Grid>
                 <Grid item>
                   <Typography variant="h3" component="h3">
-                    and
+                    {t('home.and')}
                   </Typography>
                 </Grid>
                 <Grid item>
                   <Typography variant="h3" component="h3">
-                    make the recommendations better
+                    {t('home.makeTheRecommendationsBetter')}
                   </Typography>
                 </Grid>
               </Grid>

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -5,7 +5,7 @@ import { Grid, Typography, Box } from '@mui/material';
 
 import ExtensionSection from './ExtensionSection';
 import ContributeSection from './ContributeSection';
-import Comparison from 'src/features/comparisons/Comparison';
+import LightComparison from 'src/features/comparisons/LightComparison';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -126,7 +126,7 @@ const HomePage = () => {
           </Grid>
         </Grid>
         <Grid item xs={12} className={classes.container}>
-          <Comparison />
+          <LightComparison />
         </Grid>
         <Grid
           item

--- a/tests/cypress/integration/tournesolHomePage.spec.ts
+++ b/tests/cypress/integration/tournesolHomePage.spec.ts
@@ -1,0 +1,20 @@
+describe('Home page comparison feature - anonymous', () => {
+  it('doesn\'t display the comparison UI for anonymous users', () => {
+    cy.visit('/');
+    cy.contains('give your opinion now', {matchCase: false}).should('not.exist');
+  })
+});
+
+describe('Home page comparison feature - logged', () => {
+  it('displays the comparison UI for logged users', () => {
+    cy.visit('/login')
+    cy.focused().type('user');
+    cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+
+    cy.contains('give your opinion now', {matchCase: false}).should('be.visible');
+    cy.contains('should be largely recommended', {matchCase: false}).should('be.visible');
+
+    cy.get('#expert_submit_btn').click();
+    cy.get('#expert_submit_btn').contains('edit comparison', {matchCase: false});
+  })
+});

--- a/tests/cypress/integration/tournesolHomePage.spec.ts
+++ b/tests/cypress/integration/tournesolHomePage.spec.ts
@@ -17,4 +17,25 @@ describe('Home page comparison feature - logged', () => {
     cy.get('#expert_submit_btn').click();
     cy.get('#expert_submit_btn').contains('edit comparison', {matchCase: false});
   });
+
+  it('displays the share button', () => {
+    cy.visit('/login')
+    cy.focused().type('user');
+    cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+
+    cy.get('main').scrollTo(0, 400);
+    cy.get('button[data-testid="comparison-btn-share"]').should('be.visible');
+  });
+
+  it('allows to go to the comparison page', () => {
+    cy.visit('/login')
+    cy.focused().type('user');
+    cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+
+    cy.get('main').scrollTo(0, 400);
+    cy.get('button[data-testid="comparison-btn-open"]').should('be.visible');
+
+    cy.get('button[data-testid="comparison-btn-open"]').click();
+    cy.location('pathname').should('equal', '/comparison');
+  });
 });

--- a/tests/cypress/integration/tournesolHomePage.spec.ts
+++ b/tests/cypress/integration/tournesolHomePage.spec.ts
@@ -2,7 +2,7 @@ describe('Home page comparison feature - anonymous', () => {
   it('doesn\'t display the comparison UI for anonymous users', () => {
     cy.visit('/');
     cy.contains('give your opinion now', {matchCase: false}).should('not.exist');
-  })
+  });
 });
 
 describe('Home page comparison feature - logged', () => {
@@ -16,5 +16,5 @@ describe('Home page comparison feature - logged', () => {
 
     cy.get('#expert_submit_btn').click();
     cy.get('#expert_submit_btn').contains('edit comparison', {matchCase: false});
-  })
+  });
 });


### PR DESCRIPTION
**related to** #327 

---

This pull request aims to create the foundations of the comparison feature on the Home page.

It partially addresses the issue #327 as currently only logged users are able to make comparisons.

It adds a "light" comparison feature on the Home page, with two extra secondary menu for logged users allowing to:
- go to the comparison page
- copy the comparison URL to the clipboard

I didn't update the Home page layout yet as we didn't agree on a precise order for the different sections. It looks fine for a first pull request, but should be enhanced by moving the comparison section higher in the page before making the comparison available for anonymous users.

See a layout proposition in the PR #564 of @amatissart . Could be merged in this branch. 

**new component** `<LightComparison>`
- [x] the comparison is displayed on the Home page, logged users only for now
- [x] no option criteria
- [x] no video selector
- [x] no public / private toggle
- [x] no mention of the number of comparison
- [ ] submitting should redirect the logged user to the comparison page?

The redirection to the comparison page doesn't seem to be required. There is already a button allowing the logged users to go directly to the comparison page, and no automatic redirection allows users to edit they comparison.

**how videos are selected**

- [x] two random videos are picked from the top 20 of the last month
- [x] missing videos are completed by videos from the top 20 of the last year

The top 20 of monthly recommendations corresponds to the recommendations displayed by default in the recommendations page of the front end. This top 20 can be reduced to top 10 if needed.

**to-do**
- [x] add an error message when there is not enough video to compare
- [x] add end-to-end tests

**questions**
- [x] should we add a button allowing **logged users** to copy the URL of the comparison in order to share it with others **logged users**?
- [x] should we add a way for logged users to directly go to the comparison page, to have access to all optional criteria?

I used the `text` variant of the mui `<Button>` component to make a very light secondary menu containing these actions.

## preview

![screencapture-localhost-3000-2022-02-09-14_55_24](https://user-images.githubusercontent.com/39056254/153216037-def3dfbf-ec73-4045-a8a0-b476302d78a7.png)
