### PR TITLE
Add 'criteria' validation on comparison creation and update

### DIFF
--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -135,6 +135,14 @@ class ComparisonCriteriaScoreSerializer(ModelSerializer):
         model = ComparisonCriteriaScore
         fields = ["criteria", "score", "weight"]
 
+    def validate_criteria(self, value):
+        current_poll = self.context["poll"]
+        if value not in current_poll.criterias_list:
+            raise ValidationError(
+                f"'{value}' is not a valid criteria for poll '{current_poll.name}'"
+            )
+        return value
+
 
 class ComparisonSerializerMixin:
     def reverse_criteria_scores(self, criteria_scores):

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -9,7 +9,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, generics, mixins, status
 from rest_framework.response import Response
 
-from ..models import Comparison, ContributorRating
+from ..models import Comparison, ContributorRating, Poll
 from ..serializers import ComparisonSerializer, ComparisonUpdateSerializer
 
 
@@ -84,6 +84,10 @@ class ComparisonListApi(
     List all or a filtered list of comparisons made by the logged user, or
     create a new one.
     """
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["poll"] = Poll.default_poll()
+        return context
 
     def get(self, request, *args, **kwargs):
         """List all comparisons made by the logged user."""
@@ -129,8 +133,6 @@ class ComparisonDetailApi(mixins.RetrieveModelMixin,
     Retrieve, update or delete a comparison between two videos made by the
     logged user.
     """
-    serializer_class = ComparisonSerializer
-
     DEFAULT_SERIALIZER = ComparisonSerializer
     UPDATE_SERIALIZER = ComparisonUpdateSerializer
 
@@ -186,6 +188,7 @@ class ComparisonDetailApi(mixins.RetrieveModelMixin,
     def get_serializer_context(self):
         context = super(ComparisonDetailApi, self).get_serializer_context()
         context["reverse"] = self.currently_reversed
+        context["poll"] = Poll.default_poll()
         return context
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Comes after #556 and closes #526 

- [x] validation in the API, rejecting requests that contain criteria not available in the current poll 