### PR TITLE
[#482] Add link to /signup on the login page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -61,7 +61,8 @@
   "login": {
     "loginToTournesol": "Log in to Tournesol",
     "logInAction": "Log In",
-    "forgotYourPassword": "Forgot your password?"
+    "forgotYourPassword": "Forgot your password?",
+    "signUp": "Join us"
   },
   "usernameOrEmail": "Username or Email address",
   "password": "Password",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -61,7 +61,8 @@
   "login": {
     "loginToTournesol": "Se connecter à Tournesol",
     "logInAction": "Connexion",
-    "forgotYourPassword": "Mot de passe oublié ?"
+    "forgotYourPassword": "Mot de passe oublié ?",
+    "signUp": "Inscription"
   },
   "usernameOrEmail": "Nom d'utilisateur ou E-mail",
   "password": "Mot de passe",

--- a/frontend/src/features/login/Login.spec.tsx
+++ b/frontend/src/features/login/Login.spec.tsx
@@ -247,4 +247,12 @@ describe('login feature', () => {
       store.getActions()[1].meta.requestId
     );
   });
+  it('renders a link to sign up', async () => {
+    const state = { token: initialState };
+    const store = mockStore(state);
+    const { getByText } = component({ store: store });
+    const button = getByText('login.signUp');
+    const href = button.getAttribute('href');
+    expect(href).toEqual('/signup');
+  });
 });

--- a/frontend/src/features/login/Login.tsx
+++ b/frontend/src/features/login/Login.tsx
@@ -111,6 +111,17 @@ const Login = () => {
             {t('login.forgotYourPassword')}
           </Link>
         </Box>
+        <Box my={2}>
+          <Button
+            color="secondary"
+            fullWidth
+            variant="outlined"
+            component={RouterLink}
+            to="/signup"
+          >
+            {t('login.signUp')}
+          </Button>
+        </Box>
       </ContentBox>
     </>
   );


### PR DESCRIPTION
Linked issue: #482 

I chose the first alternative from the suggested UI. The link to the demo doesn't seem very useful here but I don't know (and I don't know where it should link to).

In English I used the same label as the header button, but the suggested French label is different from the header so you may want something else.

I used the outlined variant to differentiate it from the submit button, but the confusion can still happen I guess. It looks like that:
![image](https://user-images.githubusercontent.com/28259/153270954-721f7ba4-3310-4a2f-8d75-40b56541ca0d.png)
