### PR TITLE
refactor: use `uid` in comparisons URL instead of `video_id`

### DIFF
--- a/backend/tournesol/models/comparisons.py
+++ b/backend/tournesol/models/comparisons.py
@@ -79,7 +79,7 @@ class Comparison(models.Model):
         return f"{a}_{b}"
 
     @staticmethod
-    def get_comparison(user, poll_id, video_id_1, video_id_2):
+    def get_comparison(user, poll_id, uid_a, uid_b):
         """
         Return a tuple with the user's comparison between two videos in the
         given poll, and True is the comparison is made in the reverse way,
@@ -91,8 +91,8 @@ class Comparison(models.Model):
             comparison = Comparison.objects.get(
                 user=user,
                 poll_id=poll_id,
-                entity_1__video_id=video_id_1,
-                entity_2__video_id=video_id_2,
+                entity_1__uid=uid_a,
+                entity_2__uid=uid_b,
             )
         except ObjectDoesNotExist:
             pass
@@ -102,8 +102,8 @@ class Comparison(models.Model):
         comparison = Comparison.objects.get(
             user=user,
             poll_id=poll_id,
-            entity_1__video_id=video_id_2,
-            entity_2__video_id=video_id_1,
+            entity_1__uid=uid_b,
+            entity_2__uid=uid_a,
         )
 
         return comparison, True

--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -34,6 +34,7 @@ class Entity(models.Model):
     class Meta:
         verbose_name_plural = "entities"
 
+    UID_DELIMITER = ':'
     UID_YT_NAMESPACE = 'yt'
 
     uid = models.CharField(
@@ -271,7 +272,9 @@ class Entity(models.Model):
         return video
 
     def save(self, *args, **kwargs):
-        self.uid = '{}:{}'.format(Entity.UID_YT_NAMESPACE, self.video_id)
+        self.uid = '{}{}{}'.format(
+            Entity.UID_YT_NAMESPACE, Entity.UID_DELIMITER, self.video_id
+        )
         self.type = TYPE_VIDEO
         super().save(*args, **kwargs)
 

--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -165,14 +165,14 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
     Use `ComparisonUpdateSerializer` for the update operation.
     """
 
-    video_a = RelatedVideoSerializer(source="entity_1")
-    video_b = RelatedVideoSerializer(source="entity_2")
+    entity_a = RelatedVideoSerializer(source="entity_1")
+    entity_b = RelatedVideoSerializer(source="entity_2")
     criteria_scores = ComparisonCriteriaScoreSerializer(many=True)
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
     class Meta:
         model = Comparison
-        fields = ["user", "video_a", "video_b", "criteria_scores", "duration_ms"]
+        fields = ["user", "entity_a", "entity_b", "criteria_scores", "duration_ms"]
 
     def to_representation(self, instance):
         """
@@ -182,7 +182,7 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
         ret = super(ComparisonSerializer, self).to_representation(instance)
 
         if self.context.get("reverse", False):
-            ret["video_a"], ret["video_b"] = ret["video_b"], ret["video_a"]
+            ret["entity_a"], ret["entity_b"] = ret["entity_b"], ret["entity_a"]
             ret["criteria_scores"] = self.reverse_criteria_scores(
                 ret["criteria_scores"]
             )
@@ -225,31 +225,31 @@ class ComparisonUpdateSerializer(ComparisonSerializerMixin, ModelSerializer):
     """
 
     criteria_scores = ComparisonCriteriaScoreSerializer(many=True)
-    video_a = VideoSerializer(source="entity_1", read_only=True)
-    video_b = VideoSerializer(source="entity_2", read_only=True)
+    entity_a = VideoSerializer(source="entity_1", read_only=True)
+    entity_b = VideoSerializer(source="entity_2", read_only=True)
 
     class Meta:
         model = Comparison
-        fields = ["criteria_scores", "duration_ms", "video_a", "video_b"]
+        fields = ["criteria_scores", "duration_ms", "entity_a", "entity_b"]
 
     def to_representation(self, instance):
         """
         Display the opposite of each criteria scores if the comparison is
         requested in the reverse order.
 
-        Also add `video_a` and `video_b` fields to make the representation
+        Also add `entity_a` and `entity_b` fields to make the representation
         consistent across all comparison serializers.
         """
         ret = super(ComparisonUpdateSerializer, self).to_representation(instance)
 
         if self.context.get("reverse", False):
-            ret["video_a"], ret["video_b"] = ret["video_b"], ret["video_a"]
+            ret["entity_a"], ret["entity_b"] = ret["entity_b"], ret["entity_a"]
             ret["criteria_scores"] = self.reverse_criteria_scores(
                 ret["criteria_scores"]
             )
 
-        ret.move_to_end("video_b", last=False)
-        ret.move_to_end("video_a", last=False)
+        ret.move_to_end("entity_b", last=False)
+        ret.move_to_end("entity_a", last=False)
         return ret
 
     def to_internal_value(self, data):

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -432,7 +432,7 @@ class ComparisonApiTestCase(TestCase):
         client.force_authenticate(user=self.user)
 
         response = client.get(
-            "{}/{}/".format(self.comparisons_base_url, self._uid_02.split(":")[1]),
+            "{}/{}/".format(self.comparisons_base_url, self._uid_02),
             format="json",
         )
 

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -41,8 +41,8 @@ class ComparisonApiTestCase(TestCase):
     _video_id_07 = "video_id_07"
 
     non_existing_comparison = {
-        "video_a": {"video_id": _video_id_01},
-        "video_b": {"video_id": _video_id_03},
+        "entity_a": {"video_id": _video_id_01},
+        "entity_b": {"video_id": _video_id_03},
         "criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}],
         "duration_ms": 103,
     }
@@ -166,8 +166,8 @@ class ComparisonApiTestCase(TestCase):
         ).get(
             user=self.user,
             poll=self.poll_videos,
-            entity_1__video_id=data["video_a"]["video_id"],
-            entity_2__video_id=data["video_b"]["video_id"],
+            entity_1__video_id=data["entity_a"]["video_id"],
+            entity_2__video_id=data["entity_b"]["video_id"],
         )
         comparisons_nbr = Comparison.objects.filter(user=self.user).count()
 
@@ -176,8 +176,8 @@ class ComparisonApiTestCase(TestCase):
 
         self.assertEqual(comparison.poll, self.poll_videos)
         self.assertEqual(comparison.user, self.user)
-        self.assertEqual(comparison.entity_1.video_id, data["video_a"]["video_id"])
-        self.assertEqual(comparison.entity_2.video_id, data["video_b"]["video_id"])
+        self.assertEqual(comparison.entity_1.video_id, data["entity_a"]["video_id"])
+        self.assertEqual(comparison.entity_2.video_id, data["entity_b"]["video_id"])
         self.assertEqual(comparison.duration_ms, data["duration_ms"])
 
         comparison_criteria_scores = comparison.criteria_scores.all()
@@ -197,10 +197,10 @@ class ComparisonApiTestCase(TestCase):
 
         # check the representation integrity
         self.assertEqual(
-            response.data["video_a"]["video_id"], data["video_a"]["video_id"]
+            response.data["entity_a"]["video_id"], data["entity_a"]["video_id"]
         )
         self.assertEqual(
-            response.data["video_b"]["video_id"], data["video_b"]["video_id"]
+            response.data["entity_b"]["video_id"], data["entity_b"]["video_id"]
         )
         self.assertEqual(response.data["duration_ms"], data["duration_ms"])
 
@@ -246,8 +246,8 @@ class ComparisonApiTestCase(TestCase):
         ).get(
             poll=self.poll_videos,
             user=self.user,
-            entity_1__video_id=data["video_a"]["video_id"],
-            entity_2__video_id=data["video_b"]["video_id"],
+            entity_1__video_id=data["entity_a"]["video_id"],
+            entity_2__video_id=data["entity_b"]["video_id"],
         )
         comparisons_nbr = Comparison.objects.filter(user=self.user).count()
 
@@ -350,9 +350,9 @@ class ComparisonApiTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # swap the video id
-        data["video_a"]["video_id"], data["video_b"]["video_id"] = (
-            data["video_b"]["video_id"],
-            data["video_a"]["video_id"],
+        data["entity_a"]["video_id"], data["entity_b"]["video_id"] = (
+            data["entity_b"]["video_id"],
+            data["entity_a"]["video_id"],
         )
 
         response = client.post(
@@ -402,18 +402,18 @@ class ComparisonApiTestCase(TestCase):
         comparison2 = response.data["results"][1]
 
         self.assertEqual(
-            comparison1["video_a"]["video_id"], self.comparisons[1].entity_1.video_id
+            comparison1["entity_a"]["video_id"], self.comparisons[1].entity_1.video_id
         )
         self.assertEqual(
-            comparison1["video_b"]["video_id"], self.comparisons[1].entity_2.video_id
+            comparison1["entity_b"]["video_id"], self.comparisons[1].entity_2.video_id
         )
         self.assertEqual(comparison1["duration_ms"], self.comparisons[1].duration_ms)
 
         self.assertEqual(
-            comparison2["video_a"]["video_id"], self.comparisons[0].entity_1.video_id
+            comparison2["entity_a"]["video_id"], self.comparisons[0].entity_1.video_id
         )
         self.assertEqual(
-            comparison2["video_b"]["video_id"], self.comparisons[0].entity_2.video_id
+            comparison2["entity_b"]["video_id"], self.comparisons[0].entity_2.video_id
         )
         self.assertEqual(comparison2["duration_ms"], self.comparisons[0].duration_ms)
 
@@ -445,8 +445,8 @@ class ComparisonApiTestCase(TestCase):
         # currently the GET API returns an unordered list, so the assertions
         # are made unordered too
         for comparison in response.data["results"]:
-            if comparison["video_a"]["video_id"] != self._video_id_02:
-                self.assertEqual(comparison["video_b"]["video_id"], self._video_id_02)
+            if comparison["entity_a"]["video_id"] != self._video_id_02:
+                self.assertEqual(comparison["entity_b"]["video_id"], self._video_id_02)
 
             self.assertEqual(comparison["duration_ms"], 102)
 
@@ -468,7 +468,7 @@ class ComparisonApiTestCase(TestCase):
         """
         An authenticated user can read one of its comparisons.
 
-        The `video_a` and  `video_b` fields in the response must respectively
+        The `entity_a` and  `entity_b` fields in the response must respectively
         match the positional arguments of the URL requested.
         """
         client = APIClient()
@@ -482,8 +482,8 @@ class ComparisonApiTestCase(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(response.data["video_a"]["video_id"], self._video_id_01)
-        self.assertEqual(response.data["video_b"]["video_id"], self._video_id_02)
+        self.assertEqual(response.data["entity_a"]["video_id"], self._video_id_01)
+        self.assertEqual(response.data["entity_b"]["video_id"], self._video_id_02)
         self.assertEqual(response.data["duration_ms"], 102)
 
     def test_authenticated_can_read_reverse(self):
@@ -491,7 +491,7 @@ class ComparisonApiTestCase(TestCase):
         An authenticated user can read one of its comparisons, even if the
         video id are reversed in the URL requested.
 
-        The `video_a` and  `video_b` fields in the response must respectively
+        The `entity_a` and  `entity_b` fields in the response must respectively
         match the positional arguments of the URL requested.
         """
         client = APIClient()
@@ -517,8 +517,8 @@ class ComparisonApiTestCase(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(response.data["video_a"]["video_id"], self._video_id_02)
-        self.assertEqual(response.data["video_b"]["video_id"], self._video_id_01)
+        self.assertEqual(response.data["entity_a"]["video_id"], self._video_id_02)
+        self.assertEqual(response.data["entity_b"]["video_id"], self._video_id_01)
         self.assertEqual(response.data["duration_ms"], 102)
 
     def test_anonymous_cant_update(self):
@@ -636,16 +636,16 @@ class ComparisonApiTestCase(TestCase):
         result_comparison1 = response.data["results"][0]
         result_comparison2 = response.data["results"][1]
         self.assertEqual(
-            result_comparison1["video_a"]["video_id"], comparison1.entity_1.video_id
+            result_comparison1["entity_a"]["video_id"], comparison1.entity_1.video_id
         )
         self.assertEqual(
-            result_comparison1["video_b"]["video_id"], comparison1.entity_2.video_id
+            result_comparison1["entity_b"]["video_id"], comparison1.entity_2.video_id
         )
         self.assertEqual(
-            result_comparison2["video_a"]["video_id"], comparison2.entity_1.video_id
+            result_comparison2["entity_a"]["video_id"], comparison2.entity_1.video_id
         )
         self.assertEqual(
-            result_comparison2["video_b"]["video_id"], comparison2.entity_2.video_id
+            result_comparison2["entity_b"]["video_id"], comparison2.entity_2.video_id
         )
 
     def test_n_ratings_from_video(self):
@@ -657,8 +657,8 @@ class ComparisonApiTestCase(TestCase):
         VideoFactory(video_id=self._video_id_07)
 
         data1 = {
-            "video_a": {"video_id": self._video_id_05},
-            "video_b": {"video_id": self._video_id_06},
+            "entity_a": {"video_id": self._video_id_05},
+            "entity_b": {"video_id": self._video_id_06},
             "criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}],
             "duration_ms": 103,
         }
@@ -670,8 +670,8 @@ class ComparisonApiTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         data2 = {
-            "video_a": {"video_id": self._video_id_05},
-            "video_b": {"video_id": self._video_id_07},
+            "entity_a": {"video_id": self._video_id_05},
+            "entity_b": {"video_id": self._video_id_07},
             "criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}],
             "duration_ms": 103,
         }
@@ -685,8 +685,8 @@ class ComparisonApiTestCase(TestCase):
         client.force_authenticate(user=self.other)
 
         data3 = {
-            "video_a": {"video_id": self._video_id_05},
-            "video_b": {"video_id": self._video_id_06},
+            "entity_a": {"video_id": self._video_id_05},
+            "entity_b": {"video_id": self._video_id_06},
             "criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}],
             "duration_ms": 103,
         }
@@ -725,8 +725,8 @@ class ComparisonApiTestCase(TestCase):
         video03.save()
 
         data = {
-            "video_a": {"video_id": self._video_id_01},
-            "video_b": {"video_id": self._video_id_02},
+            "entity_a": {"video_id": self._video_id_01},
+            "entity_b": {"video_id": self._video_id_02},
             "criteria_scores": [
                 {"criteria": "largely_recommended", "score": 10, "weight": 10}
             ],
@@ -736,8 +736,8 @@ class ComparisonApiTestCase(TestCase):
         self.assertEqual(len(mock_get_video_metadata.mock_calls), 2)
 
         data = {
-            "video_a": {"video_id": self._video_id_01},
-            "video_b": {"video_id": self._video_id_03},
+            "entity_a": {"video_id": self._video_id_01},
+            "entity_b": {"video_id": self._video_id_03},
             "criteria_scores": [
                 {"criteria": "largely_recommended", "score": 10, "weight": 10}
             ],

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -30,19 +30,19 @@ class ComparisonApiTestCase(TestCase):
     _other = "other_username"
 
     # videos available in all tests
-    _video_id_01 = "video_id_01"
-    _video_id_02 = "video_id_02"
-    _video_id_03 = "video_id_03"
-    _video_id_04 = "video_id_04"
+    _uid_01 = "yt:video_id_01"
+    _uid_02 = "yt:video_id_02"
+    _uid_03 = "yt:video_id_03"
+    _uid_04 = "yt:video_id_04"
 
     # non existing videos that can be created
-    _video_id_05 = "video_id_05"
-    _video_id_06 = "video_id_06"
-    _video_id_07 = "video_id_07"
+    _uid_05 = "yt:video_id_05"
+    _uid_06 = "yt:video_id_06"
+    _uid_07 = "yt:video_id_07"
 
     non_existing_comparison = {
-        "entity_a": {"video_id": _video_id_01},
-        "entity_b": {"video_id": _video_id_03},
+        "entity_a": {"video_id": _uid_01.split(":")[1]},
+        "entity_b": {"video_id": _uid_03.split(":")[1]},
         "criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}],
         "duration_ms": 103,
     }
@@ -63,10 +63,10 @@ class ComparisonApiTestCase(TestCase):
         now = datetime.datetime.now()
 
         self.videos = [
-            VideoFactory(video_id=self._video_id_01),
-            VideoFactory(video_id=self._video_id_02),
-            VideoFactory(video_id=self._video_id_03),
-            VideoFactory(video_id=self._video_id_04),
+            VideoFactory(video_id=self._uid_01.split(":")[1]),
+            VideoFactory(video_id=self._uid_02.split(":")[1]),
+            VideoFactory(video_id=self._uid_03.split(":")[1]),
+            VideoFactory(video_id=self._uid_04.split(":")[1]),
         ]
 
         self.comparisons = [
@@ -127,12 +127,12 @@ class ComparisonApiTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         comparisons = Comparison.objects.filter(
-            entity_1__video_id=self._video_id_01, entity_2__video_id=self._video_id_03
+            entity_1__uid=self._uid_01, entity_2__uid=self._uid_03
         )
         self.assertFalse(comparisons.exists())
 
         comparisons = Comparison.objects.filter(
-            entity_1__video_id=self._video_id_03, entity_2__video_id=self._video_id_01
+            entity_1__uid=self._uid_03, entity_2__uid=self._uid_01
         )
         self.assertFalse(comparisons.exists())
         self.assertEqual(Comparison.objects.all().count(), initial_comparisons_nbr)
@@ -424,8 +424,7 @@ class ComparisonApiTestCase(TestCase):
         client = APIClient()
 
         comparisons_made = Comparison.objects.filter(
-            Q(entity_1__video_id=self._video_id_02)
-            | Q(entity_2__video_id=self._video_id_02),
+            Q(entity_1__uid=self._uid_02) | Q(entity_2__uid=self._uid_02),
             poll=self.poll_videos,
             user=self.user,
         )
@@ -433,7 +432,7 @@ class ComparisonApiTestCase(TestCase):
         client.force_authenticate(user=self.user)
 
         response = client.get(
-            "{}/{}/".format(self.comparisons_base_url, self._video_id_02),
+            "{}/{}/".format(self.comparisons_base_url, self._uid_02.split(":")[1]),
             format="json",
         )
 
@@ -445,8 +444,10 @@ class ComparisonApiTestCase(TestCase):
         # currently the GET API returns an unordered list, so the assertions
         # are made unordered too
         for comparison in response.data["results"]:
-            if comparison["entity_a"]["video_id"] != self._video_id_02:
-                self.assertEqual(comparison["entity_b"]["video_id"], self._video_id_02)
+            if comparison["entity_a"]["video_id"] != self._uid_02.split(":")[1]:
+                self.assertEqual(
+                    comparison["entity_b"]["video_id"], self._uid_02.split(":")[1]
+                )
 
             self.assertEqual(comparison["duration_ms"], 102)
 
@@ -457,9 +458,7 @@ class ComparisonApiTestCase(TestCase):
         client = APIClient()
 
         response = client.get(
-            "{}/{}/{}/".format(
-                self.comparisons_base_url, self._video_id_01, self._video_id_02
-            ),
+            "{}/{}/{}/".format(self.comparisons_base_url, self._uid_01, self._uid_02),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
@@ -475,15 +474,17 @@ class ComparisonApiTestCase(TestCase):
         client.force_authenticate(user=self.user)
 
         response = client.get(
-            "{}/{}/{}/".format(
-                self.comparisons_base_url, self._video_id_01, self._video_id_02
-            ),
+            "{}/{}/{}/".format(self.comparisons_base_url, self._uid_01, self._uid_02),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(response.data["entity_a"]["video_id"], self._video_id_01)
-        self.assertEqual(response.data["entity_b"]["video_id"], self._video_id_02)
+        self.assertEqual(
+            response.data["entity_a"]["video_id"], self._uid_01.split(":")[1]
+        )
+        self.assertEqual(
+            response.data["entity_b"]["video_id"], self._uid_02.split(":")[1]
+        )
         self.assertEqual(response.data["duration_ms"], 102)
 
     def test_authenticated_can_read_reverse(self):
@@ -503,22 +504,26 @@ class ComparisonApiTestCase(TestCase):
             Comparison.objects.get(
                 poll=self.poll_videos,
                 user=self.user,
-                entity_1__video_id=self._video_id_02,
-                entity_2__video_id=self._video_id_01,
+                entity_1__uid=self._uid_02,
+                entity_2__uid=self._uid_01,
             )
 
         response = client.get(
             "{}/{}/{}/".format(
                 self.comparisons_base_url,
-                self._video_id_02,
-                self._video_id_01,
+                self._uid_02,
+                self._uid_01,
             ),
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(response.data["entity_a"]["video_id"], self._video_id_02)
-        self.assertEqual(response.data["entity_b"]["video_id"], self._video_id_01)
+        self.assertEqual(
+            response.data["entity_a"]["video_id"], self._uid_02.split(":")[1]
+        )
+        self.assertEqual(
+            response.data["entity_b"]["video_id"], self._uid_01.split(":")[1]
+        )
         self.assertEqual(response.data["duration_ms"], 102)
 
     def test_anonymous_cant_update(self):
@@ -530,8 +535,8 @@ class ComparisonApiTestCase(TestCase):
         response = client.put(
             "{}/{}/{}/".format(
                 self.comparisons_base_url,
-                self._video_id_01,
-                self._video_id_02,
+                self._uid_01,
+                self._uid_02,
             ),
             {"criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}]},
             format="json",
@@ -555,8 +560,8 @@ class ComparisonApiTestCase(TestCase):
         response = client.delete(
             "{}/{}/{}/".format(
                 self.comparisons_base_url,
-                self._video_id_01,
-                self._video_id_02,
+                self._uid_01,
+                self._uid_02,
             ),
             format="json",
         )
@@ -588,8 +593,8 @@ class ComparisonApiTestCase(TestCase):
         response = client.delete(
             "{}/{}/{}/".format(
                 self.comparisons_base_url,
-                self._video_id_01,
-                self._video_id_02,
+                self._uid_01,
+                self._uid_02,
             ),
             format="json",
         )
@@ -621,8 +626,8 @@ class ComparisonApiTestCase(TestCase):
         client.put(
             "{}/{}/{}/".format(
                 self.comparisons_base_url,
-                self._video_id_03,
-                self._video_id_04,
+                self._uid_03,
+                self._uid_04,
             ),
             {"criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}]},
             format="json",
@@ -652,13 +657,13 @@ class ComparisonApiTestCase(TestCase):
         client = APIClient()
         client.force_authenticate(user=self.user)
 
-        VideoFactory(video_id=self._video_id_05)
-        VideoFactory(video_id=self._video_id_06)
-        VideoFactory(video_id=self._video_id_07)
+        VideoFactory(video_id=self._uid_05.split(":")[1])
+        VideoFactory(video_id=self._uid_06.split(":")[1])
+        VideoFactory(video_id=self._uid_07.split(":")[1])
 
         data1 = {
-            "entity_a": {"video_id": self._video_id_05},
-            "entity_b": {"video_id": self._video_id_06},
+            "entity_a": {"video_id": self._uid_05.split(":")[1]},
+            "entity_b": {"video_id": self._uid_06.split(":")[1]},
             "criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}],
             "duration_ms": 103,
         }
@@ -670,8 +675,8 @@ class ComparisonApiTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         data2 = {
-            "entity_a": {"video_id": self._video_id_05},
-            "entity_b": {"video_id": self._video_id_07},
+            "entity_a": {"video_id": self._uid_05.split(":")[1]},
+            "entity_b": {"video_id": self._uid_07.split(":")[1]},
             "criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}],
             "duration_ms": 103,
         }
@@ -685,8 +690,8 @@ class ComparisonApiTestCase(TestCase):
         client.force_authenticate(user=self.other)
 
         data3 = {
-            "entity_a": {"video_id": self._video_id_05},
-            "entity_b": {"video_id": self._video_id_06},
+            "entity_a": {"video_id": self._uid_05.split(":")[1]},
+            "entity_b": {"video_id": self._uid_06.split(":")[1]},
             "criteria_scores": [{"criteria": "pedagogy", "score": 10, "weight": 10}],
             "duration_ms": 103,
         }
@@ -697,9 +702,9 @@ class ComparisonApiTestCase(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        video5 = Entity.objects.get(video_id=self._video_id_05)
-        video6 = Entity.objects.get(video_id=self._video_id_06)
-        video7 = Entity.objects.get(video_id=self._video_id_07)
+        video5 = Entity.objects.get(uid=self._uid_05)
+        video6 = Entity.objects.get(uid=self._uid_06)
+        video7 = Entity.objects.get(uid=self._uid_07)
 
         self.assertEqual(video5.rating_n_contributors, 2)
         self.assertEqual(video5.rating_n_ratings, 3)
@@ -725,8 +730,8 @@ class ComparisonApiTestCase(TestCase):
         video03.save()
 
         data = {
-            "entity_a": {"video_id": self._video_id_01},
-            "entity_b": {"video_id": self._video_id_02},
+            "entity_a": {"video_id": self._uid_01.split(":")[1]},
+            "entity_b": {"video_id": self._uid_02.split(":")[1]},
             "criteria_scores": [
                 {"criteria": "largely_recommended", "score": 10, "weight": 10}
             ],
@@ -736,8 +741,8 @@ class ComparisonApiTestCase(TestCase):
         self.assertEqual(len(mock_get_video_metadata.mock_calls), 2)
 
         data = {
-            "entity_a": {"video_id": self._video_id_01},
-            "entity_b": {"video_id": self._video_id_03},
+            "entity_a": {"video_id": self._uid_01.split(":")[1]},
+            "entity_b": {"video_id": self._uid_03.split(":")[1]},
             "criteria_scores": [
                 {"criteria": "largely_recommended", "score": 10, "weight": 10}
             ],

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -60,7 +60,7 @@ urlpatterns = [
         name="poll_comparisons_me_list_filtered",
     ),
     path(
-        "users/me/comparisons/<str:poll_name>/<str:video_id_a>/<str:video_id_b>/",
+        "users/me/comparisons/<str:poll_name>/<str:uid_a>/<str:uid_b>/",
         ComparisonDetailApi.as_view(),
         name="poll_comparisons_me_detail",
     ),

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -55,7 +55,7 @@ urlpatterns = [
         name="poll_comparisons_me_list",
     ),
     path(
-        "users/me/comparisons/<str:poll_name>/<str:video_id>/",
+        "users/me/comparisons/<str:poll_name>/<str:uid>/",
         ComparisonListFilteredApi.as_view(),
         name="poll_comparisons_me_list_filtered",
     ),

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -9,12 +9,13 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, generics, mixins, status
 from rest_framework.response import Response
 
-from ..models import Comparison, ContributorRating, Poll
+from ..models import Comparison, ContributorRating, Entity, Poll
 from ..serializers import ComparisonSerializer, ComparisonUpdateSerializer
 
 
 class ComparisonApiMixin:
     """A mixin used to factorize behaviours common to all API views."""
+
     # used to avoid multiple similar database queries in a single HTTP request
     poll_from_url: Poll
 
@@ -27,14 +28,20 @@ class ComparisonApiMixin:
         # make the requested poll available at any time in the view
         self.poll_from_url = self.poll_from_kwargs_or_404(kwargs)
 
-    def comparison_already_exists(self, request, poll_id):
+    def comparison_already_exists(self, poll_id, request):
         """Return True if the comparison already exist, False instead."""
         try:
             comparison = Comparison.get_comparison(
                 request.user,
                 poll_id,
-                request.data['entity_a']['video_id'],
-                request.data['entity_b']['video_id']
+                "{}{}{}".format(
+                    Entity.UID_YT_NAMESPACE, Entity.UID_DELIMITER,
+                    request.data["entity_a"]["video_id"]
+                ),
+                "{}{}{}".format(
+                    Entity.UID_YT_NAMESPACE, Entity.UID_DELIMITER,
+                    request.data["entity_b"]["video_id"]
+                ),
             )
         # if one field is missing, do not raise error yet and let django rest
         # framework checks the request integrity
@@ -57,17 +64,15 @@ class ComparisonApiMixin:
     def response_404_poll_doesnt_exist(self, poll_name):
         return Response(
             {
-                "detail": "The requested poll {0} doesn't exist.".format(
-                    poll_name
-                ),
+                "detail": "The requested poll {0} doesn't exist.".format(poll_name),
             },
             status=status.HTTP_404_NOT_FOUND,
         )
 
 
-class ComparisonListBaseApi(ComparisonApiMixin,
-                            mixins.ListModelMixin,
-                            generics.GenericAPIView):
+class ComparisonListBaseApi(
+    ComparisonApiMixin, mixins.ListModelMixin, generics.GenericAPIView
+):
     """
     Base class of the ComparisonList API.
     """
@@ -84,9 +89,8 @@ class ComparisonListBaseApi(ComparisonApiMixin,
         uid -- the entity uid used to filter the results (default None)
         """
         queryset = Comparison.objects.filter(
-            poll=self.poll_from_url,
-            user=self.request.user
-        ).order_by('-datetime_lastedit')
+            poll=self.poll_from_url, user=self.request.user
+        ).order_by("-datetime_lastedit")
 
         if self.kwargs.get("uid"):
             video_id = self.kwargs.get("uid")
@@ -97,10 +101,7 @@ class ComparisonListBaseApi(ComparisonApiMixin,
         return queryset
 
 
-class ComparisonListApi(
-    mixins.CreateModelMixin,
-    ComparisonListBaseApi
-):
+class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
     """
     List all or a filtered list of comparisons made by the logged user, or
     create a new one.
@@ -126,13 +127,13 @@ class ComparisonListApi(
 
     @transaction.atomic
     def perform_create(self, serializer):
-        poll = serializer.context['poll']
+        poll = serializer.context["poll"]
 
-        if self.comparison_already_exists(self.request, poll.pk):
+        if self.comparison_already_exists(poll.pk, self.request):
             raise exceptions.ValidationError(
                 "You've already compared {0} with {1}.".format(
-                    self.request.data['entity_a']['video_id'],
-                    self.request.data['entity_b']['video_id']
+                    self.request.data["entity_a"]["video_id"],
+                    self.request.data["entity_b"]["video_id"],
                 )
             )
         comparison: Comparison = serializer.save()
@@ -141,14 +142,10 @@ class ComparisonListApi(
         comparison.entity_2.update_n_ratings()
         comparison.entity_2.refresh_youtube_metadata()
         ContributorRating.objects.get_or_create(
-            poll=poll,
-            user=self.request.user,
-            entity=comparison.entity_1
+            poll=poll, user=self.request.user, entity=comparison.entity_1
         )
         ContributorRating.objects.get_or_create(
-            poll=poll,
-            user=self.request.user,
-            entity=comparison.entity_2
+            poll=poll, user=self.request.user, entity=comparison.entity_2
         )
 
 
@@ -156,7 +153,8 @@ class ComparisonListFilteredApi(ComparisonListBaseApi):
     """
     List all or a filtered list of comparisons made by the logged user.
     """
-    @extend_schema(operation_id='users_me_comparisons_list_filtered')
+
+    @extend_schema(operation_id="users_me_comparisons_list_filtered")
     def get(self, request, *args, **kwargs):
         """
         Retrieve a filtered list of comparisons made by the logged user, in
@@ -165,15 +163,18 @@ class ComparisonListFilteredApi(ComparisonListBaseApi):
         return self.list(request, *args, **kwargs)
 
 
-class ComparisonDetailApi(ComparisonApiMixin,
-                          mixins.RetrieveModelMixin,
-                          mixins.UpdateModelMixin,
-                          mixins.DestroyModelMixin,
-                          generics.GenericAPIView):
+class ComparisonDetailApi(
+    ComparisonApiMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    generics.GenericAPIView,
+):
     """
     Retrieve, update or delete a comparison between two videos made by the
     logged user.
     """
+
     DEFAULT_SERIALIZER = ComparisonSerializer
     UPDATE_SERIALIZER = ComparisonUpdateSerializer
 
@@ -201,8 +202,8 @@ class ComparisonDetailApi(ComparisonApiMixin,
             comparison, reverse = Comparison.get_comparison(
                 self.request.user,
                 self.poll_from_url.pk,
-                self.kwargs['uid_a'],
-                self.kwargs['uid_b']
+                self.kwargs["uid_a"],
+                self.kwargs["uid_b"],
             )
         except ObjectDoesNotExist:
             raise Http404

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -93,9 +93,9 @@ class ComparisonListBaseApi(
         ).order_by("-datetime_lastedit")
 
         if self.kwargs.get("uid"):
-            video_id = self.kwargs.get("uid")
+            uid = self.kwargs.get("uid")
             queryset = queryset.filter(
-                Q(entity_1__video_id=video_id) | Q(entity_2__video_id=video_id)
+                Q(entity_1__uid=uid) | Q(entity_2__uid=uid)
             )
 
         return queryset

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -81,15 +81,15 @@ class ComparisonListBaseApi(ComparisonApiMixin,
         for a given poll.
 
         Keyword arguments:
-        video_id -- the video_id used to filter the results (default None)
+        uid -- the entity uid used to filter the results (default None)
         """
         queryset = Comparison.objects.filter(
             poll=self.poll_from_url,
             user=self.request.user
         ).order_by('-datetime_lastedit')
 
-        if self.kwargs.get("video_id"):
-            video_id = self.kwargs.get("video_id")
+        if self.kwargs.get("uid"):
+            video_id = self.kwargs.get("uid")
             queryset = queryset.filter(
                 Q(entity_1__video_id=video_id) | Q(entity_2__video_id=video_id)
             )

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -33,8 +33,8 @@ class ComparisonApiMixin:
             comparison = Comparison.get_comparison(
                 request.user,
                 poll_id,
-                request.data['video_a']['video_id'],
-                request.data['video_b']['video_id']
+                request.data['entity_a']['video_id'],
+                request.data['entity_b']['video_id']
             )
         # if one field is missing, do not raise error yet and let django rest
         # framework checks the request integrity
@@ -131,8 +131,8 @@ class ComparisonListApi(
         if self.comparison_already_exists(self.request, poll.pk):
             raise exceptions.ValidationError(
                 "You've already compared {0} with {1}.".format(
-                    self.request.data['video_a']['video_id'],
-                    self.request.data['video_b']['video_id']
+                    self.request.data['entity_a']['video_id'],
+                    self.request.data['entity_b']['video_id']
                 )
             )
         comparison: Comparison = serializer.save()
@@ -217,7 +217,7 @@ class ComparisonDetailApi(ComparisonApiMixin,
         Determine the appropriate serializer based on the request's method.
 
         Updating a comparison requires a different serializer because the
-        fields `video_a` and `video_b` are not editable anymore once the
+        fields `entity_a` and `entity_b` are not editable anymore once the
         comparison has been created. Discarding those two fields ensures
         their immutability and thus prevent the falsification of comparisons
         by video id swap.

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -187,23 +187,22 @@ class ComparisonDetailApi(ComparisonApiMixin,
 
     def get_object(self):
         """
-        Return a comparison made by the logged user between two videos, or
+        Return a comparison made by the logged user between two entities, or
         raise HTTP 404 nothing is found.
 
-        If the comparison `video_id_a` / `video_id_b` is not found, the
-        method will try to return the comparison `video_id_b` / `video_id_a`
-        before raising HTTP 404.
+        If the comparison `uid_a` / `uid_b` is not found, the method will try
+        to return the comparison `uid_b` / `uid_a` before raising HTTP 404.
 
         Query parameters:
-        video_id_a -- the video_id of a video
-        video_id_b -- the video_id of an other video
+        uid_a -- the uid of an entity
+        uid_b -- the uid of another entity
         """
         try:
             comparison, reverse = Comparison.get_comparison(
                 self.request.user,
                 self.poll_from_url.pk,
-                self.kwargs['video_id_a'],
-                self.kwargs['video_id_b']
+                self.kwargs['uid_a'],
+                self.kwargs['uid_b']
             )
         except ObjectDoesNotExist:
             raise Http404

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -28,8 +28,8 @@ def write_comparisons_file(request, write_target):
 
     writer.writerows(
         {
-            "video_a": comparison["video_a"]["video_id"],
-            "video_b": comparison["video_b"]["video_id"],
+            "video_a": comparison["entity_a"]["video_id"],
+            "video_b": comparison["entity_b"]["video_id"],
             **criteria_score
         }
         for comparison in serialized_comparisons
@@ -60,8 +60,8 @@ def write_public_comparisons_file(request, write_target):
     writer.writerows(
         {
             "public_username": public_username,
-            "video_a": comparison["video_a"]["video_id"],
-            "video_b": comparison["video_b"]["video_id"],
+            "video_a": comparison["entity_a"]["video_id"],
+            "video_b": comparison["entity_b"]["video_id"],
             **criteria_score
         }
         for (public_username, comparison) in zip(public_usernames, serialized_comparisons)

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -591,7 +591,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Comparison'
           description: ''
-  /users/me/comparisons/{poll_name}/{video_id_a}/{video_id_b}/:
+  /users/me/comparisons/{poll_name}/{uid_a}/{uid_b}/:
     get:
       operationId: users_me_comparisons_retrieve
       description: Retrieve a comparison made by the logged user, in the given poll.
@@ -602,12 +602,12 @@ paths:
           type: string
         required: true
       - in: path
-        name: video_id_a
+        name: uid_a
         schema:
           type: string
         required: true
       - in: path
-        name: video_id_b
+        name: uid_b
         schema:
           type: string
         required: true
@@ -633,12 +633,12 @@ paths:
           type: string
         required: true
       - in: path
-        name: video_id_a
+        name: uid_a
         schema:
           type: string
         required: true
       - in: path
-        name: video_id_b
+        name: uid_b
         schema:
           type: string
         required: true
@@ -676,12 +676,12 @@ paths:
           type: string
         required: true
       - in: path
-        name: video_id_a
+        name: uid_a
         schema:
           type: string
         required: true
       - in: path
-        name: video_id_b
+        name: uid_b
         schema:
           type: string
         required: true

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1248,9 +1248,9 @@ components:
 
         Use `ComparisonUpdateSerializer` for the update operation.
       properties:
-        video_a:
+        entity_a:
           $ref: '#/components/schemas/RelatedVideo'
-        video_b:
+        entity_b:
           $ref: '#/components/schemas/RelatedVideo'
         criteria_scores:
           type: array
@@ -1263,8 +1263,8 @@ components:
           description: Time it took to rate the videos (in milliseconds)
       required:
       - criteria_scores
-      - video_a
-      - video_b
+      - entity_a
+      - entity_b
     ComparisonCriteriaScore:
       type: object
       properties:
@@ -1316,9 +1316,9 @@ components:
 
         Use `ComparisonUpdateSerializer` for the update operation.
       properties:
-        video_a:
+        entity_a:
           $ref: '#/components/schemas/RelatedVideoRequest'
-        video_b:
+        entity_b:
           $ref: '#/components/schemas/RelatedVideoRequest'
         criteria_scores:
           type: array
@@ -1331,8 +1331,8 @@ components:
           description: Time it took to rate the videos (in milliseconds)
       required:
       - criteria_scores
-      - video_a
-      - video_b
+      - entity_a
+      - entity_b
     ComparisonUpdate:
       type: object
       description: |-
@@ -1352,18 +1352,18 @@ components:
           format: float
           nullable: true
           description: Time it took to rate the videos (in milliseconds)
-        video_a:
+        entity_a:
           allOf:
           - $ref: '#/components/schemas/Video'
           readOnly: true
-        video_b:
+        entity_b:
           allOf:
           - $ref: '#/components/schemas/Video'
           readOnly: true
       required:
       - criteria_scores
-      - video_a
-      - video_b
+      - entity_a
+      - entity_b
     ComparisonUpdateRequest:
       type: object
       description: |-

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -693,7 +693,7 @@ paths:
       responses:
         '204':
           description: No response body
-  /users/me/comparisons/{poll_name}/{video_id}/:
+  /users/me/comparisons/{poll_name}/{uid}/:
     get:
       operationId: users_me_comparisons_list_filtered
       description: |-
@@ -706,7 +706,7 @@ paths:
           type: string
         required: true
       - in: path
-        name: video_id
+        name: uid
         schema:
           type: string
         required: true

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -18,7 +18,7 @@ import ComparisonSliders from 'src/features/comparisons/ComparisonSliders';
 import VideoSelector, {
   VideoSelectorValue,
 } from 'src/features/video_selector/VideoSelector';
-import { YT_UID_PREFIX, YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { UID_YT_NAMESPACE, YOUTUBE_POLL_NAME } from 'src/utils/constants';
 
 const useStyles = makeStyles((theme: Theme) => ({
   centering: {
@@ -108,8 +108,8 @@ const Comparison = () => {
     if (videoA && videoB)
       UsersService.usersMeComparisonsRetrieve({
         pollName: YOUTUBE_POLL_NAME,
-        uidA: YT_UID_PREFIX + videoA,
-        uidB: YT_UID_PREFIX + videoB,
+        uidA: UID_YT_NAMESPACE + videoA,
+        uidB: UID_YT_NAMESPACE + videoB,
       })
         .then((comparison) => {
           setInitialComparison(comparison);
@@ -129,8 +129,8 @@ const Comparison = () => {
       const { entity_a, entity_b, criteria_scores, duration_ms } = c;
       await UsersService.usersMeComparisonsUpdate({
         pollName: YOUTUBE_POLL_NAME,
-        uidA: YT_UID_PREFIX + entity_a.video_id,
-        uidB: YT_UID_PREFIX + entity_b.video_id,
+        uidA: UID_YT_NAMESPACE + entity_a.video_id,
+        uidB: UID_YT_NAMESPACE + entity_b.video_id,
         requestBody: { criteria_scores, duration_ms },
       });
     } else {

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -108,8 +108,8 @@ const Comparison = () => {
     if (videoA && videoB)
       UsersService.usersMeComparisonsRetrieve({
         pollName: YOUTUBE_POLL_NAME,
-        videoIdA: videoA,
-        videoIdB: videoB,
+        uidA: videoA,
+        uidB: videoB,
       })
         .then((comparison) => {
           setInitialComparison(comparison);
@@ -126,11 +126,11 @@ const Comparison = () => {
 
   const onSubmitComparison = async (c: ComparisonRequest) => {
     if (initialComparison) {
-      const { video_a, video_b, criteria_scores, duration_ms } = c;
+      const { entity_a, entity_b, criteria_scores, duration_ms } = c;
       await UsersService.usersMeComparisonsUpdate({
         pollName: YOUTUBE_POLL_NAME,
-        videoIdA: video_a.video_id,
-        videoIdB: video_b.video_id,
+        uidA: entity_a.video_id,
+        uidB: entity_b.video_id,
         requestBody: { criteria_scores, duration_ms },
       });
     } else {

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -108,8 +108,8 @@ const Comparison = () => {
     if (videoA && videoB)
       UsersService.usersMeComparisonsRetrieve({
         pollName: YOUTUBE_POLL_NAME,
-        uidA: UID_YT_NAMESPACE + videoA,
-        uidB: UID_YT_NAMESPACE + videoB,
+        uidA: encodeURIComponent(UID_YT_NAMESPACE) + videoA,
+        uidB: encodeURIComponent(UID_YT_NAMESPACE) + videoB,
       })
         .then((comparison) => {
           setInitialComparison(comparison);
@@ -129,8 +129,8 @@ const Comparison = () => {
       const { entity_a, entity_b, criteria_scores, duration_ms } = c;
       await UsersService.usersMeComparisonsUpdate({
         pollName: YOUTUBE_POLL_NAME,
-        uidA: UID_YT_NAMESPACE + entity_a.video_id,
-        uidB: UID_YT_NAMESPACE + entity_b.video_id,
+        uidA: encodeURIComponent(UID_YT_NAMESPACE) + entity_a.video_id,
+        uidB: encodeURIComponent(UID_YT_NAMESPACE) + entity_b.video_id,
         requestBody: { criteria_scores, duration_ms },
       });
     } else {

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -18,7 +18,7 @@ import ComparisonSliders from 'src/features/comparisons/ComparisonSliders';
 import VideoSelector, {
   VideoSelectorValue,
 } from 'src/features/video_selector/VideoSelector';
-import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { YT_UID_PREFIX, YOUTUBE_POLL_NAME } from 'src/utils/constants';
 
 const useStyles = makeStyles((theme: Theme) => ({
   centering: {
@@ -108,8 +108,8 @@ const Comparison = () => {
     if (videoA && videoB)
       UsersService.usersMeComparisonsRetrieve({
         pollName: YOUTUBE_POLL_NAME,
-        uidA: videoA,
-        uidB: videoB,
+        uidA: YT_UID_PREFIX + videoA,
+        uidB: YT_UID_PREFIX + videoB,
       })
         .then((comparison) => {
           setInitialComparison(comparison);
@@ -129,8 +129,8 @@ const Comparison = () => {
       const { entity_a, entity_b, criteria_scores, duration_ms } = c;
       await UsersService.usersMeComparisonsUpdate({
         pollName: YOUTUBE_POLL_NAME,
-        uidA: entity_a.video_id,
-        uidB: entity_b.video_id,
+        uidA: YT_UID_PREFIX + entity_a.video_id,
+        uidB: YT_UID_PREFIX + entity_b.video_id,
         requestBody: { criteria_scores, duration_ms },
       });
     } else {

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -33,10 +33,10 @@ const useStyles = makeStyles((theme: Theme) => ({
 const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
   const { t } = useTranslation();
   const classes = useStyles();
-  const { video_a, video_b } = comparison;
+  const { entity_a, entity_b } = comparison;
   return (
     <Box className={classes.comparisonContainer}>
-      <VideoCard compact video={video_a} />
+      <VideoCard compact video={entity_a} />
       <Box className={classes.centering} style={{ position: 'relative' }}>
         <div
           style={{
@@ -49,7 +49,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
         <Tooltip title={`${t('comparisons.goToComparison')}`} placement="top">
           <Fab
             component="a"
-            href={`/comparison/?videoA=${video_a.video_id}&videoB=${video_b.video_id}`}
+            href={`/comparison/?videoA=${entity_a.video_id}&videoB=${entity_b.video_id}`}
             style={{ backgroundColor: '#F1EFE7' }}
             size="small"
           >
@@ -57,7 +57,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
           </Fab>
         </Tooltip>
       </Box>
-      <VideoCard compact video={video_b} />
+      <VideoCard compact video={entity_b} />
     </Box>
   );
 };
@@ -76,7 +76,7 @@ const Comparisons = ({
           {comparisons &&
             comparisons.map((c) => (
               <ComparisonThumbnail
-                key={`${c.video_a.video_id}${c.video_b.video_id}`}
+                key={`${c.entity_a.video_id}${c.entity_b.video_id}`}
                 comparison={c}
               />
             ))}

--- a/frontend/src/features/comparisons/ComparisonSliders.tsx
+++ b/frontend/src/features/comparisons/ComparisonSliders.tsx
@@ -56,8 +56,8 @@ const ComparisonSliders = ({
     return c
       ? c
       : {
-          video_a: { video_id: videoA },
-          video_b: { video_id: videoB },
+          entity_a: { video_id: videoA },
+          entity_b: { video_id: videoB },
           criteria_scores: allCriterias
             .filter((c) => !optionalCriterias[c])
             .map((criteria) => ({ criteria, score: 0 })),

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -6,7 +6,7 @@ import { ContentHeader, Pagination } from 'src/components';
 import ComparisonList from 'src/features/comparisons/ComparisonList';
 import type { Comparison } from 'src/services/openapi';
 import { UsersService } from 'src/services/openapi';
-import { YOUTUBE_POLL_NAME } from '../../utils/constants';
+import { UID_YT_NAMESPACE, YOUTUBE_POLL_NAME } from 'src/utils/constants';
 
 function ComparisonsPage() {
   const { t } = useTranslation();
@@ -32,7 +32,7 @@ function ComparisonsPage() {
       const comparisonsRequest = await (filteredVideo
         ? UsersService.usersMeComparisonsListFiltered({
             pollName: YOUTUBE_POLL_NAME,
-            uid: filteredVideo,
+            uid: UID_YT_NAMESPACE + filteredVideo,
             limit,
             offset,
           })

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -32,7 +32,7 @@ function ComparisonsPage() {
       const comparisonsRequest = await (filteredVideo
         ? UsersService.usersMeComparisonsListFiltered({
             pollName: YOUTUBE_POLL_NAME,
-            videoId: filteredVideo,
+            uid: filteredVideo,
             limit,
             offset,
           })

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -32,7 +32,7 @@ function ComparisonsPage() {
       const comparisonsRequest = await (filteredVideo
         ? UsersService.usersMeComparisonsListFiltered({
             pollName: YOUTUBE_POLL_NAME,
-            uid: UID_YT_NAMESPACE + filteredVideo,
+            uid: encodeURIComponent(UID_YT_NAMESPACE) + filteredVideo,
             limit,
             offset,
           })

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -44,7 +44,9 @@ export const getCriteriaName = (t: TFunction, criteria: string) => {
 };
 
 export const YOUTUBE_POLL_NAME = 'videos';
-export const YT_UID_PREFIX = 'yt%3A';
+
+const UID_DELIMITER = '%3A';
+export const UID_YT_NAMESPACE = 'yt' + UID_DELIMITER;
 
 export const recommendationFilters = {
   date: 'date',

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -44,6 +44,7 @@ export const getCriteriaName = (t: TFunction, criteria: string) => {
 };
 
 export const YOUTUBE_POLL_NAME = 'videos';
+export const YT_UID_PREFIX = 'yt%3A';
 
 export const recommendationFilters = {
   date: 'date',

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -45,7 +45,7 @@ export const getCriteriaName = (t: TFunction, criteria: string) => {
 
 export const YOUTUBE_POLL_NAME = 'videos';
 
-const UID_DELIMITER = '%3A';
+const UID_DELIMITER = ':';
 export const UID_YT_NAMESPACE = 'yt' + UID_DELIMITER;
 
 export const recommendationFilters = {

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -84,8 +84,8 @@ export async function getVideoFromPreviousComparisons(
   });
   const cl = comparisonVideoResult?.results || [];
   const comparisonVideoList = [
-    ...cl.map((v) => v.video_a.video_id),
-    ...cl.map((v) => v.video_b.video_id),
+    ...cl.map((v) => v.entity_a.video_id),
+    ...cl.map((v) => v.entity_b.video_id),
   ];
   const comparisonVideoId = retryRandomPick(
     5,


### PR DESCRIPTION
**related to** #527 

**follows the work of pull request** https://github.com/tournesol-app/tournesol/pull/563

---

This pull request refactors the comparisons API, to use entity UID in its URLs and make the front end compatible. It also changes the JSON representation of a comparison by replacing `video_a` and `video_b` keys by `entity_a` and `entity_b`.

This pull request doesn't replace the usage of `video_id` in the JSON representation of a comparison yet, I'd prefer doing this in a distinct PR as it might require few tweaks of the video serializers and maybe other part of the application. 

**back end**
- [x] in URL replace occurrences of `video_id_a` / `video_id_b` by `uid_a` / `uid_b`
- [x] in URL replace occurrences of `video_id` by `uid`
- [x] in the serializers, replace fields `video_a`  / `video_b` by `entity_a` / `entity_b`
- [x] `uid` URL parameters now contain the entity UID value instead of the previous video ID
- [ ] the video serializers still use `video_id` for now...

**front end**
- [x] in the schema URLs replace `video_id_a` / `video_id_b` by `uid_a` / `uid_b`
- [x] in the schema URLs replace `video_id` by `uid`
- [x] update services usage, replace fields `videoIdA`  / `videoIdB` by `uidA` / `uidB`
- [x] update services usage, replace fields `video_id_a`  / `video_id_b` by `entity_a` / `entity_b`
- [x] update services usage, replace fields `videoId` by `uid`
- [x] now use "namespaced" UID in `/comparisons/` URLs
- [ ] the video serializers still use `video_id` for now...

### new API design

![capture](https://user-images.githubusercontent.com/39056254/153875572-397d0992-1f4c-4ef8-88ca-8aa021720749.png)