### PR TITLE
Implement minimal version of poll recommendations API

### DIFF
--- a/backend/tournesol/entities/__init__.py
+++ b/backend/tournesol/entities/__init__.py
@@ -1,0 +1,11 @@
+from .video import VideoEntity
+
+ENTITY_CLASSES = [VideoEntity]
+
+ENTITY_TYPE_CHOICES = [
+    (VideoEntity.name, 'Video'),
+]
+
+ENTITY_TYPE_NAME_TO_CLASS = {
+    k.name: k for k in ENTITY_CLASSES
+}

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -2,6 +2,10 @@ from abc import ABC, abstractclassmethod
 
 
 class EntityType(ABC):
+
+    # The 'name' of this entity type corresponds
+    # to the `type` field in Entity,
+    # and to the `entity_type` in Poll.
     name: str
 
     @classmethod

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractclassmethod
+
+
+class EntityType(ABC):
+    name: str
+
+    @classmethod
+    def filter_date_lte(cls, qs, dt):
+        return qs.filter(add_time__lte=dt)
+
+    @classmethod
+    def filter_date_gte(cls, qs, dt):
+        return qs.filter(add_time__gte=dt)
+
+    @abstractclassmethod
+    def filter_search(cls, qs, query: str):
+        raise NotImplementedError

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -1,0 +1,29 @@
+from django.db.models import Q
+
+from .base import EntityType
+
+TYPE_VIDEO = "video"
+
+
+class VideoEntity(EntityType):
+    name = TYPE_VIDEO
+
+    @classmethod
+    def filter_date_lte(cls, qs, dt):
+        return qs.filter(publication_date__lte=dt)
+
+    @classmethod
+    def filter_date_gte(cls, qs, dt):
+        return qs.filter(publication_date__gte=dt)
+
+    @classmethod
+    def filter_search(cls, qs, query):
+        from tournesol.models import Entity
+
+        # Filtering in a nested queryset is necessary here, to be able to annotate
+        # each entity without duplicated scores, due to the m2m field 'tags'.
+        return qs.filter(pk__in=Entity.objects.filter(
+            Q(name__icontains=query) |
+            Q(description__icontains=query) |
+            Q(tags__name__icontains=query)
+        ))

--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -16,6 +16,8 @@ from tqdm.auto import tqdm
 
 from core.models import User
 from core.utils.constants import YOUTUBE_VIDEO_ID_REGEX
+from tournesol.entities import ENTITY_TYPE_CHOICES, ENTITY_TYPE_NAME_TO_CLASS
+from tournesol.entities.video import TYPE_VIDEO
 from tournesol.models.tags import Tag
 
 LANGUAGES = settings.LANGUAGES
@@ -34,11 +36,6 @@ class Entity(models.Model):
 
     UID_YT_NAMESPACE = 'yt'
 
-    TYPE_VIDEO = 'video'
-    ENTITY_TYPE = [
-        (TYPE_VIDEO, 'Video'),
-    ]
-
     uid = models.CharField(
         unique=True,
         max_length=144,
@@ -47,7 +44,7 @@ class Entity(models.Model):
 
     type = models.CharField(
         max_length=32,
-        choices=ENTITY_TYPE,
+        choices=ENTITY_TYPE_CHOICES,
     )
 
     metadata = models.JSONField(
@@ -138,6 +135,10 @@ class Entity(models.Model):
             .count()
         )
         self.save(update_fields=["rating_n_ratings", "rating_n_contributors"])
+
+    @property
+    def entity_cls(self):
+        return ENTITY_TYPE_NAME_TO_CLASS[self.type]
 
     @property
     def best_text(self, min_len=5):
@@ -271,7 +272,7 @@ class Entity(models.Model):
 
     def save(self, *args, **kwargs):
         self.uid = '{}:{}'.format(Entity.UID_YT_NAMESPACE, self.video_id)
-        self.type = Entity.TYPE_VIDEO
+        self.type = TYPE_VIDEO
         super().save(*args, **kwargs)
 
 

--- a/backend/tournesol/models/poll.py
+++ b/backend/tournesol/models/poll.py
@@ -3,7 +3,7 @@ from typing import List
 from django.db import models
 from django.utils.functional import cached_property
 
-from .entity import Entity
+from tournesol.entities import ENTITY_TYPE_CHOICES, ENTITY_TYPE_NAME_TO_CLASS, VideoEntity
 
 DEFAULT_POLL_NAME = "videos"
 
@@ -15,14 +15,14 @@ class Poll(models.Model):
     """
 
     name = models.SlugField(unique=True)
-    entity_type = models.CharField(max_length=32, choices=Entity.ENTITY_TYPE)
+    entity_type = models.CharField(max_length=32, choices=ENTITY_TYPE_CHOICES)
     criterias = models.ManyToManyField("Criteria", through="CriteriaRank")
 
     @classmethod
     def default_poll(cls) -> "Poll":
         poll, _created = cls.objects.get_or_create(
             name=DEFAULT_POLL_NAME,
-            defaults={"entity_type": Entity.TYPE_VIDEO}
+            defaults={"entity_type": VideoEntity.name}
         )
         return poll
 
@@ -33,6 +33,10 @@ class Poll(models.Model):
     @cached_property
     def criterias_list(self) -> List[str]:
         return list(self.criterias.values_list("name", flat=True))
+
+    @property
+    def entity_cls(self):
+        return ENTITY_TYPE_NAME_TO_CLASS[self.entity_type]
 
     def __str__(self) -> str:
         return f'Poll "{self.name}"'

--- a/backend/tournesol/query_serializers.py
+++ b/backend/tournesol/query_serializers.py
@@ -4,5 +4,11 @@ from rest_framework import serializers
 class RecommendationsFilterSerializer(serializers.Serializer):
     date_lte = serializers.DateTimeField(default=None)
     date_gte = serializers.DateTimeField(default=None)
-    search = serializers.CharField(default=None)
-    unsafe = serializers.BooleanField(default=False)
+    search = serializers.CharField(
+        default=None, help_text="A search query to filter entities"
+    )
+    unsafe = serializers.BooleanField(
+        default=False,
+        help_text="If true, entities considered as unsafe recommendations because of a"
+        " low score or due to too few contributions will be included.",
+    )

--- a/backend/tournesol/query_serializers.py
+++ b/backend/tournesol/query_serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+
+
+class RecommendationsFilterSerializer(serializers.Serializer):
+    date_lte = serializers.DateTimeField(default=None)
+    date_gte = serializers.DateTimeField(default=None)
+    search = serializers.CharField(default=None)
+    unsafe = serializers.BooleanField(default=False)

--- a/backend/tournesol/serializers.py
+++ b/backend/tournesol/serializers.py
@@ -95,14 +95,14 @@ class RelatedVideoSerializer(VideoSerializer):
         return value
 
 
-class VideoCriteriaScoreSerializer(ModelSerializer):
+class EntityCriteriaScoreSerializer(ModelSerializer):
     class Meta:
         model = EntityCriteriaScore
-        fields = ["criteria", "score", "uncertainty", "quantile"]
+        fields = ["criteria", "score"]
 
 
 class VideoSerializerWithCriteria(VideoSerializer):
-    criteria_scores = VideoCriteriaScoreSerializer(many=True)
+    criteria_scores = EntityCriteriaScoreSerializer(many=True)
 
     class Meta(VideoSerializer.Meta):
         fields = VideoSerializer.Meta.fields + ['criteria_scores']
@@ -357,3 +357,21 @@ class PollSerializer(ModelSerializer):
     class Meta:
         model = Poll
         fields = ["name", "criterias"]
+
+
+class RecommendationSerializer(ModelSerializer):
+    n_comparisons = serializers.IntegerField(source="rating_n_ratings")
+    n_contributors = serializers.IntegerField(source="rating_n_contributors")
+    criteria_scores = EntityCriteriaScoreSerializer(many=True)
+    total_score = serializers.FloatField()
+
+    class Meta:
+        model = Entity
+        fields = [
+            "uid",
+            "n_comparisons",
+            "n_contributors",
+            "metadata",
+            "total_score",
+            "criteria_scores",
+        ]

--- a/backend/tournesol/tests/test_api_polls.py
+++ b/backend/tournesol/tests/test_api_polls.py
@@ -1,5 +1,12 @@
+from datetime import date
+
 from django.test import TestCase
+from rest_framework import status
 from rest_framework.test import APIClient
+
+from tournesol.models import Poll
+
+from .factories.video import VideoCriteriaScoreFactory, VideoFactory
 
 
 class PollsApi(TestCase):
@@ -16,3 +23,91 @@ class PollsApi(TestCase):
             "label": "Devrait être largement recommandé",
             "optional": False,
         })
+
+
+class PollsRecommendationsApi(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+        self.video_1 = VideoFactory(
+            publication_date=date(2021, 1, 1),
+            rating_n_contributors=2,
+        )
+        self.video_2 = VideoFactory(
+            publication_date=date(2021, 1, 2),
+            rating_n_contributors=3,
+        )
+        self.video_3 = VideoFactory(
+            publication_date=date(2021, 1, 3),
+            rating_n_contributors=4,
+        )
+        self.video_4 = VideoFactory(
+            publication_date=date(2021, 1, 4),
+            rating_n_contributors=5,
+        )
+
+        VideoCriteriaScoreFactory(entity=self.video_1, criteria="reliability", score=-0.1)
+        VideoCriteriaScoreFactory(entity=self.video_2, criteria="reliability", score=0.2)
+        VideoCriteriaScoreFactory(entity=self.video_3, criteria="importance", score=0.3)
+        VideoCriteriaScoreFactory(entity=self.video_4, criteria="importance", score=0.4)
+
+    def test_anonymous_can_list_recommendations(self):
+        response = self.client.get("/polls/videos/recommendations/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 3)
+
+    def test_ignore_score_attached_to_another_poll(self):
+        other_poll = Poll.objects.create(name="other")
+        video_5 = VideoFactory(
+            publication_date=date(2021, 1, 5),
+            rating_n_contributors=6,
+        )
+        VideoCriteriaScoreFactory(poll=other_poll, entity=video_5, criteria="importance", score=0.5)
+        response = self.client.get("/polls/videos/recommendations/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 3)
+
+    def test_anonymous_can_list_unsafe_recommendations(self):
+        response = self.client.get("/polls/videos/recommendations/?unsafe=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 4)
+
+    def test_anonymous_can_list_with_offset(self):
+        """
+        An anonymous user can list a subset of videos by using the `offset`
+        query parameter.
+        """
+        response = self.client.get("/polls/videos/recommendations/?offset=2")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+
+
+    def test_list_videos_with_criteria_weights(self):
+        # Default weights: all criterias contribute equally
+        resp = self.client.get("/polls/videos/recommendations/")
+        self.assertEqual(
+            [r["uid"] for r in resp.data["results"]],
+            [self.video_4.uid, self.video_3.uid, self.video_2.uid],
+        )
+
+        # Disable reliability
+        resp = self.client.get("/polls/videos/recommendations/?weights[reliability]=0")
+        self.assertEqual(
+            [r["uid"] for r in resp.data["results"]],
+            [self.video_4.uid, self.video_3.uid],
+        )
+
+        # Disable both reliability and importance
+        resp = self.client.get(
+            "/polls/videos/recommendations/?weights[reliability]=0&weights[importance]=0"
+        )
+        self.assertEqual([r["uid"] for r in resp.data["results"]], [])
+
+        # More weight to reliability should change the order
+        resp = self.client.get(
+            "/polls/videos/recommendations/?weights[reliability]=100&weights[importance]=10"
+        )
+        self.assertEqual(
+            [r["uid"] for r in resp.data["results"]],
+            [self.video_2.uid, self.video_4.uid, self.video_3.uid],
+        )

--- a/backend/tournesol/tests/test_api_video.py
+++ b/backend/tournesol/tests/test_api_video.py
@@ -357,7 +357,7 @@ class VideoApi(TestCase):
 
         # ensure newly created entities are considered videos from YT
         self.assertEqual(new_video.uid, '{}:{}'.format(Entity.UID_YT_NAMESPACE, "NeADlWSDFAQ"))
-        self.assertEqual(new_video.type, Entity.TYPE_VIDEO)
+        self.assertEqual(new_video.type, "video")
 
     def test_authenticated_cant_create_twice(self):
         """

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -10,7 +10,7 @@ from rest_framework import routers
 from .views import ComparisonDetailApi, ComparisonListApi, ComparisonListFilteredApi
 from .views.email_domains import EmailDomainsList
 from .views.exports import ExportAllView, ExportComparisonsView, ExportPublicComparisonsView
-from .views.polls import PollsView
+from .views.polls import PollsRecommendationsView, PollsView
 from .views.ratings import (
     ContributorRatingDetail,
     ContributorRatingList,
@@ -108,5 +108,10 @@ urlpatterns = [
         "polls/<str:name>/",
         PollsView.as_view(),
         name="polls_detail"
+    ),
+    path(
+        "polls/<str:name>/recommendations/",
+        PollsRecommendationsView.as_view(),
+        name="polls_recommendations"
     )
 ]

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -1,9 +1,17 @@
 import logging
 
-from rest_framework.generics import RetrieveAPIView
+from django.conf import settings
+from django.db.models import Case, F, Prefetch, Q, Sum, When
+from django.shortcuts import get_object_or_404
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from rest_framework import serializers
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.pagination import LimitOffsetPagination
 
-from tournesol.models import Poll
-from tournesol.serializers import PollSerializer
+from tournesol.models import Entity, EntityCriteriaScore, Poll
+from tournesol.query_serializers import RecommendationsFilterSerializer
+from tournesol.serializers import PollSerializer, RecommendationSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +20,84 @@ class PollsView(RetrieveAPIView):
     """
     Retrieve a poll and its related criteria.
     """
+
     permission_classes = []
     queryset = Poll.objects.prefetch_related("criteriarank_set__criteria")
     lookup_field = "name"
     serializer_class = PollSerializer
+
+
+@extend_schema_view(
+    get=extend_schema(
+        description="Retrieve a list of recommended videos, sorted by decreasing total score.",
+        parameters=[
+            RecommendationsFilterSerializer,
+            OpenApiParameter("weights", OpenApiTypes.OBJECT, style="deepObject"),
+        ],
+    )
+)
+class PollsRecommendationsView(ListAPIView):
+    permission_classes = []
+    pagination_class = LimitOffsetPagination
+    serializer_class = RecommendationSerializer
+    queryset = Entity.objects.none()
+
+    def get_queryset(self):
+        request = self.request
+        poll = get_object_or_404(Poll, name=self.kwargs["name"])
+        criterias = poll.criterias_list
+
+        queryset = Entity.objects.all()
+
+        filter_serializer = RecommendationsFilterSerializer(data=request.query_params)
+        filter_serializer.is_valid(raise_exception=True)
+        recommendations_filter = filter_serializer.validated_data
+
+        search = recommendations_filter["search"]
+        if search:
+            queryset = poll.entity_cls.filter_search(queryset, search)
+
+        date_lte = recommendations_filter["date_lte"]
+        if date_lte:
+            queryset = poll.entity_cls.filter_date_lte(queryset, date_lte)
+
+        date_gte = recommendations_filter["date_gte"]
+        if date_gte:
+            queryset = poll.entity_cls.filter_date_gte(queryset, date_gte)
+
+        criteria_cases = []
+        for crit in criterias:
+            raw_weight = request.query_params.get(f"weights[{crit}]")
+            if raw_weight is not None:
+                try:
+                    weight = int(raw_weight)
+                except ValueError:
+                    raise serializers.ValidationError(
+                        f"Invalid weight value for criteria '{crit}'"
+                    )
+            else:
+                weight = 10
+            criteria_cases.append(When(criteria_scores__criteria=crit, then=weight))
+        criteria_weight = Case(*criteria_cases, default=0)
+
+        queryset = queryset.annotate(
+            total_score=Sum(
+                F("criteria_scores__score") * criteria_weight,
+                filter=Q(criteria_scores__poll=poll),
+            )
+        )
+
+        show_unsafe = recommendations_filter["unsafe"]
+        if show_unsafe:
+            queryset = queryset.filter(total_score__isnull=False)
+        else:
+            queryset = queryset.filter(
+                rating_n_contributors__gte=settings.RECOMMENDATIONS_MIN_CONTRIBUTORS
+            ).filter(total_score__gt=0)
+
+        return queryset.prefetch_related(
+            Prefetch(
+                "criteria_scores",
+                queryset=EntityCriteriaScore.objects.filter(poll=poll),
+            )
+        ).order_by("-total_score", "-pk")

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -12,7 +12,6 @@ from drf_spectacular.utils import (
 )
 from rest_framework import serializers
 from rest_framework.generics import ListAPIView, RetrieveAPIView
-from rest_framework.pagination import LimitOffsetPagination
 
 from tournesol.models import Entity, EntityCriteriaScore, Poll
 from tournesol.query_serializers import RecommendationsFilterSerializer
@@ -59,7 +58,6 @@ class PollsView(RetrieveAPIView):
 )
 class PollsRecommendationsView(ListAPIView):
     permission_classes = []
-    pagination_class = LimitOffsetPagination
     serializer_class = RecommendationSerializer
     queryset = Entity.objects.none()
 

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -4,7 +4,12 @@ from django.conf import settings
 from django.db.models import Case, F, Prefetch, Q, Sum, When
 from django.shortcuts import get_object_or_404
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework import serializers
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.pagination import LimitOffsetPagination
@@ -32,7 +37,23 @@ class PollsView(RetrieveAPIView):
         description="Retrieve a list of recommended videos, sorted by decreasing total score.",
         parameters=[
             RecommendationsFilterSerializer,
-            OpenApiParameter("weights", OpenApiTypes.OBJECT, style="deepObject"),
+            OpenApiParameter(
+                "weights",
+                OpenApiTypes.OBJECT,
+                style="deepObject",
+                description="Weights for criterias in this poll."
+                " The default weight is 10 for each criteria.",
+                examples=[
+                    OpenApiExample(
+                        name="weights example",
+                        value={
+                            "reliability": 10,
+                            "importance": 10,
+                            "ignored_criteria": 0,
+                        }
+                    )
+                ]
+            ),
         ],
     )
 )


### PR DESCRIPTION
Implements item **(2)** in https://github.com/tournesol-app/tournesol/issues/529

Similar to `GET /video/` to fetch a list of recommendation, with a few differences

In the **response**: 
  * fields specific to a video are not present. Instead a `metadata` dict is returned (empty for now)
  * `total_score` is present in the output (as a `FloatField`) and computed with a default weight of 10 for each criteria (instead of 50 in the /video/ route, to be consistent with the score currently computed by the frontend).

In the **query parameters**:
  * `?criteria=50` is replaced with `?weights[criteria]=10`, as the name of the criterias are now dynamic
  * filters based on video metadata (language, uploader, etc.) are not implemented.  
  Maybe a generic `?metadata[key]=value` could be used instead in the future?
