### PR TITLE
[#463][front] : adds language icon in the collapsed navigation bar

### DIFF
--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -7,7 +7,7 @@ import MenuButton from './MenuButton';
 import makeStyles from '@mui/styles/makeStyles';
 
 interface LanguageSelectorProps {
-  hideLanguageName?: boolean;
+  languageName?: boolean;
 }
 
 const useStyles = makeStyles({
@@ -20,9 +20,7 @@ const codeToLanguage = Object.fromEntries(
   SUPPORTED_LANGUAGES.map((l) => [l.code, l])
 );
 
-const LanguageSelector = ({
-  hideLanguageName = false,
-}: LanguageSelectorProps) => {
+const LanguageSelector = ({ languageName = true }: LanguageSelectorProps) => {
   const { i18n } = useTranslation();
   const currentLanguage = i18n.resolvedLanguage;
   const classes = useStyles();
@@ -65,7 +63,7 @@ const LanguageSelector = ({
           },
         }}
       >
-        {!hideLanguageName && (
+        {languageName && (
           <Box
             flexGrow={1}
             textAlign="left"

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -29,7 +29,7 @@ const LanguageSelector = ({ languageName = true }: LanguageSelectorProps) => {
     <Box color="neutral.main">
       <MenuButton
         startIcon={<Language />}
-        sx={{ width: '100%', px: 3 }}
+        sx={{ width: '100%', px: '20px' }}
         className={classes.HideLanguageNameContainer}
         menuContent={SUPPORTED_LANGUAGES.map(({ code, name }) => (
           <MenuItem

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -4,20 +4,35 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from 'src/i18n';
 import MenuButton from './MenuButton';
+import makeStyles from '@mui/styles/makeStyles';
+
+interface LanguageSelectorProps {
+  hideLanguageName?: boolean;
+}
+
+const useStyles = makeStyles({
+  HideLanguageNameContainer: {
+    justifyContent: 'flex-start',
+  },
+});
 
 const codeToLanguage = Object.fromEntries(
   SUPPORTED_LANGUAGES.map((l) => [l.code, l])
 );
 
-const LanguageSelector = () => {
+const LanguageSelector = ({
+  hideLanguageName = false,
+}: LanguageSelectorProps) => {
   const { i18n } = useTranslation();
   const currentLanguage = i18n.resolvedLanguage;
+  const classes = useStyles();
 
   return (
     <Box color="neutral.main">
       <MenuButton
         startIcon={<Language />}
         sx={{ width: '100%', px: 3 }}
+        className={classes.HideLanguageNameContainer}
         menuContent={SUPPORTED_LANGUAGES.map(({ code, name }) => (
           <MenuItem
             key={code}
@@ -50,14 +65,16 @@ const LanguageSelector = () => {
           },
         }}
       >
-        <Box
-          flexGrow={1}
-          textAlign="left"
-          fontWeight="bold"
-          sx={{ textTransform: 'capitalize' }}
-        >
-          {codeToLanguage[currentLanguage]?.name ?? currentLanguage}
-        </Box>
+        {!hideLanguageName && (
+          <Box
+            flexGrow={1}
+            textAlign="left"
+            fontWeight="bold"
+            sx={{ textTransform: 'capitalize' }}
+          >
+            {codeToLanguage[currentLanguage]?.name ?? currentLanguage}
+          </Box>
+        )}
       </MenuButton>
     </Box>
   );

--- a/frontend/src/features/frame/components/sidebar/Footer.tsx
+++ b/frontend/src/features/frame/components/sidebar/Footer.tsx
@@ -5,7 +5,6 @@ import makeStyles from '@mui/styles/makeStyles';
 import { Box, Divider, Theme } from '@mui/material';
 
 import { getWikiBaseUrl } from 'src/utils/url';
-import { LanguageSelector } from 'src/components';
 
 const useStyles = makeStyles((theme: Theme) => ({
   linksContainer: {
@@ -77,7 +76,6 @@ const Footer = () => {
         </a>
       </div>
       <Divider />
-      <LanguageSelector />
     </Box>
   );
 };

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -157,6 +157,7 @@ const SideBar = () => {
       <List
         disablePadding
         onClick={isSmallScreen ? () => dispatch(closeDrawer()) : undefined}
+        sx={{ flexGrow: 1 }}
       >
         {menuItems.map(({ targetUrl, IconComponent, displayText }) => {
           if (!IconComponent || !targetUrl)

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -202,7 +202,7 @@ const SideBar = () => {
         })}
       </List>
       {drawerOpen && <Footer />}
-      {!drawerOpen && <LanguageSelector hideLanguageName={true} />}
+      <LanguageSelector languageName={drawerOpen} />
     </Drawer>
   );
 };

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -32,6 +32,7 @@ import {
 import { useAppDispatch } from '../../../../app/hooks';
 import { closeDrawer } from '../../drawerOpenSlice';
 import Footer from './Footer';
+import { LanguageSelector } from 'src/components';
 
 export const sideBarWidth = 264;
 
@@ -201,6 +202,7 @@ const SideBar = () => {
         })}
       </List>
       {drawerOpen && <Footer />}
+      {!drawerOpen && <LanguageSelector hideLanguageName={true} />}
     </Drawer>
   );
 };


### PR DESCRIPTION
Context:
Language Icon is missing on the sidepanel when it is collapsed.
This PR fixes it by adding the LanguageSelector component when it is collapsed and hides the text when collapsed.

Fixes #463 