### PR TITLE
[front] refactor: `Comparison` now uses UIDs (and more)

### DIFF
--- a/backend/tournesol/serializers/entity.py
+++ b/backend/tournesol/serializers/entity.py
@@ -19,7 +19,7 @@ class VideoSerializer(ModelSerializer):
     class Meta:
         model = Entity
         fields = [
-            "video_id",
+            "uid",
             "name",
             "description",
             "publication_date",
@@ -29,8 +29,11 @@ class VideoSerializer(ModelSerializer):
             "rating_n_ratings",
             "rating_n_contributors",
             "duration",
+            # backward compatibility
+            "video_id",
         ]
         read_only_fields = [
+            "uid",
             "name",
             "description",
             "publication_date",

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -2836,9 +2836,11 @@ components:
         and having the constraint to ensure that video instances exist before
         they can be saved properly.
       properties:
-        video_id:
+        uid:
           type: string
-          pattern: ^[A-Za-z0-9-_]{11}$
+          readOnly: true
+          description: A unique identifier, build with a namespace and an external
+            id.
         name:
           type: string
           readOnly: true
@@ -2884,6 +2886,9 @@ components:
           type: integer
           nullable: true
           readOnly: true
+        video_id:
+          type: string
+          pattern: ^[A-Za-z0-9-_]{11}$
       required:
       - description
       - duration
@@ -2892,6 +2897,7 @@ components:
       - publication_date
       - rating_n_contributors
       - rating_n_ratings
+      - uid
       - uploader
       - video_id
       - views
@@ -3599,11 +3605,11 @@ components:
     Video:
       type: object
       properties:
-        video_id:
+        uid:
           type: string
-          description: Video ID from YouTube URL, matches ^[A-Za-z0-9-_]{11}$
-          pattern: ^[A-Za-z0-9-_]{11}$
-          maxLength: 20
+          readOnly: true
+          description: A unique identifier, build with a namespace and an external
+            id.
         name:
           type: string
           readOnly: true
@@ -3649,6 +3655,11 @@ components:
           type: integer
           nullable: true
           readOnly: true
+        video_id:
+          type: string
+          description: Video ID from YouTube URL, matches ^[A-Za-z0-9-_]{11}$
+          pattern: ^[A-Za-z0-9-_]{11}$
+          maxLength: 20
       required:
       - description
       - duration
@@ -3657,6 +3668,7 @@ components:
       - publication_date
       - rating_n_contributors
       - rating_n_ratings
+      - uid
       - uploader
       - video_id
       - views
@@ -3688,11 +3700,11 @@ components:
     VideoSerializerWithCriteria:
       type: object
       properties:
-        video_id:
+        uid:
           type: string
-          description: Video ID from YouTube URL, matches ^[A-Za-z0-9-_]{11}$
-          pattern: ^[A-Za-z0-9-_]{11}$
-          maxLength: 20
+          description: A unique identifier, build with a namespace and an external
+            id.
+          maxLength: 144
         name:
           type: string
           description: Video Title
@@ -3740,6 +3752,11 @@ components:
           type: integer
           nullable: true
           readOnly: true
+        video_id:
+          type: string
+          description: Video ID from YouTube URL, matches ^[A-Za-z0-9-_]{11}$
+          pattern: ^[A-Za-z0-9-_]{11}$
+          maxLength: 20
         criteria_scores:
           type: array
           items:
@@ -3747,6 +3764,7 @@ components:
       required:
       - criteria_scores
       - duration
+      - uid
       - video_id
   securitySchemes:
     oauth2:

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -98,7 +98,15 @@ const Comparison = () => {
     (videoKey: string) => (newValue: VideoSelectorValue) => {
       const searchParams = new URLSearchParams(location.search);
       const videoId = newValue.videoId;
-      if (searchParams.get(videoKey) !== videoId) {
+
+      let idInUrl;
+      if (Object.values(uidParams).includes(videoKey)) {
+        idInUrl = idFromUid(searchParams.get(videoKey) || '');
+      } else {
+        idInUrl = searchParams.get(videoKey);
+      }
+
+      if (idInUrl !== videoId) {
         searchParams.delete(videoKey);
         if (videoId) {
           if (Object.values(uidParams).includes(videoKey)) {

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -53,10 +53,12 @@ const rewriteLegacyParameters = (
   searchParams.append(paramVidB, uidB);
 
   if (legacyA && uidA === '') {
+    searchParams.delete(paramVidA);
     searchParams.append(paramVidA, UID_YT_NAMESPACE + legacyA);
   }
 
   if (legacyB && uidB === '') {
+    searchParams.delete(paramVidB);
     searchParams.append(paramVidB, UID_YT_NAMESPACE + legacyB);
   }
 
@@ -98,19 +100,12 @@ const Comparison = () => {
     };
   }, []);
 
-  // step 1: try to read UIDs from the URL...
   const uidA: string = searchParams.get(uidParams.vidA) || '';
   const uidB: string = searchParams.get(uidParams.vidB) || '';
+  const videoA: string = idFromUid(uidA);
+  const videoB: string = idFromUid(uidB);
 
-  // step 2: if they are empty, try the legacy videoA/videoB parameters
-  const videoA: string = uidA
-    ? idFromUid(uidA)
-    : searchParams.get(legacyParams.vidA) || '';
-  const videoB: string = uidB
-    ? idFromUid(uidB)
-    : searchParams.get(legacyParams.vidB) || '';
-
-  // step 3: Clean the URL by replacing legacy parameters by UIDs.
+  // clean the URL by replacing legacy parameters by UIDs
   const legacyA = searchParams.get(legacyParams.vidA);
   const legacyB = searchParams.get(legacyParams.vidB);
   searchParams.delete(legacyParams.vidA);

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -19,6 +19,7 @@ import VideoSelector, {
   VideoSelectorValue,
 } from 'src/features/video_selector/VideoSelector';
 import { UID_YT_NAMESPACE, YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { idFromUid } from 'src/utils/video';
 
 const useStyles = makeStyles((theme: Theme) => ({
   centering: {
@@ -61,8 +62,18 @@ const Comparison = () => {
     useState<ComparisonRequest | null>(null);
 
   const searchParams = new URLSearchParams(location.search);
-  const videoA: string = searchParams.get('videoA') || '';
-  const videoB: string = searchParams.get('videoB') || '';
+
+  // try to read UIDs from the URL...
+  const uidA: string = searchParams.get('uidA') || '';
+  const uidB: string = searchParams.get('uidB') || '';
+
+  // ... if they are empty, try the legacy videoA/videoB parameters
+  const videoA: string = uidA
+    ? idFromUid(uidA)
+    : searchParams.get('videoA') || '';
+  const videoB: string = uidB
+    ? idFromUid(uidB)
+    : searchParams.get('videoB') || '';
 
   const [selectorA, setSelectorA] = useState<VideoSelectorValue>({
     videoId: videoA,

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -62,10 +62,12 @@ const Comparison = () => {
     useState<ComparisonRequest | null>(null);
 
   const searchParams = new URLSearchParams(location.search);
-  const uidParams: { uidA: string; uidB: string } = {
-    uidA: 'uidA',
-    uidB: 'uidB',
-  };
+  const uidParams: { uidA: string; uidB: string } = useMemo(() => {
+    return {
+      uidA: 'uidA',
+      uidB: 'uidB',
+    };
+  }, []);
 
   // try to read UIDs from the URL...
   const encodedUidA: string = searchParams.get(uidParams.uidA) || '';

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -70,10 +70,8 @@ const Comparison = () => {
   }, []);
 
   // try to read UIDs from the URL...
-  const encodedUidA: string = searchParams.get(uidParams.uidA) || '';
-  const encodedUidB: string = searchParams.get(uidParams.uidB) || '';
-  const uidA: string = encodedUidA ? decodeURIComponent(encodedUidA) : '';
-  const uidB: string = encodedUidB ? decodeURIComponent(encodedUidB) : '';
+  const uidA: string = searchParams.get(uidParams.uidA) || '';
+  const uidB: string = searchParams.get(uidParams.uidB) || '';
 
   // ... if they are empty, try the legacy videoA/videoB parameters
   const videoA: string = uidA

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -40,6 +40,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+/**
+ * Return an URLSearchParams without legacy parameters.
+ */
 const rewriteLegacyParameters = (
   uidA: string,
   uidB: string,
@@ -108,8 +111,6 @@ const Comparison = () => {
   // clean the URL by replacing legacy parameters by UIDs
   const legacyA = searchParams.get(legacyParams.vidA);
   const legacyB = searchParams.get(legacyParams.vidB);
-  searchParams.delete(legacyParams.vidA);
-  searchParams.delete(legacyParams.vidB);
   const newSearchParams = rewriteLegacyParameters(
     uidA,
     uidB,

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -98,11 +98,11 @@ const Comparison = () => {
     };
   }, []);
 
-  // step1: try to read UIDs from the URL...
+  // step 1: try to read UIDs from the URL...
   const uidA: string = searchParams.get(uidParams.vidA) || '';
   const uidB: string = searchParams.get(uidParams.vidB) || '';
 
-  // step2: if they are empty, try the legacy videoA/videoB parameters
+  // step 2: if they are empty, try the legacy videoA/videoB parameters
   const videoA: string = uidA
     ? idFromUid(uidA)
     : searchParams.get(legacyParams.vidA) || '';
@@ -141,13 +141,6 @@ const Comparison = () => {
       if (idFromUid(searchParams.get(videoKey) || '') !== videoId) {
         searchParams.delete(videoKey);
 
-        if (videoKey === uidParams.vidA) {
-          searchParams.delete(legacyParams.vidA);
-        }
-        if (videoKey === uidParams.vidB) {
-          searchParams.delete(legacyParams.vidB);
-        }
-
         if (videoId) {
           searchParams.append(videoKey, UID_YT_NAMESPACE + videoId);
         }
@@ -160,7 +153,7 @@ const Comparison = () => {
       }
       setSubmitted(false);
     },
-    [history, location.search, uidParams, legacyParams]
+    [history, location.search, uidParams]
   );
 
   const onChangeA = useMemo(

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -49,7 +49,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
         <Tooltip title={`${t('comparisons.goToComparison')}`} placement="top">
           <Fab
             component="a"
-            href={`/comparison/?videoA=${entity_a.video_id}&videoB=${entity_b.video_id}`}
+            href={`/comparison/?uidA=${entity_a.uid}&uidB=${entity_b.uid}`}
             style={{ backgroundColor: '#F1EFE7' }}
             size="small"
           >

--- a/frontend/src/features/videos/PublicStatusAction.tsx
+++ b/frontend/src/features/videos/PublicStatusAction.tsx
@@ -3,6 +3,7 @@ import { useTranslation, Trans } from 'react-i18next';
 import { Tooltip, Typography, Box, Switch, Link } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import { UsersService, ContributorRating } from 'src/services/openapi';
+import { idFromUid } from 'src/utils/video';
 
 const setPublicStatus = async (videoId: string, isPublic: boolean) => {
   return await UsersService.usersMeContributorRatingsPartialUpdate({
@@ -94,7 +95,8 @@ interface RatingsContextValue {
 
 export const RatingsContext = React.createContext<RatingsContextValue>({});
 
-export const PublicStatusAction = ({ videoId }: { videoId: string }) => {
+export const PublicStatusAction = ({ uid }: { uid: string }) => {
+  const videoId = idFromUid(uid);
   const { getContributorRating, onChange } = useContext(RatingsContext);
   const contributorRating = getContributorRating?.(videoId);
   if (contributorRating == null || contributorRating.is_public == null) {

--- a/frontend/src/features/videos/VideoApi.tsx
+++ b/frontend/src/features/videos/VideoApi.tsx
@@ -23,8 +23,9 @@ export const getVideoInformation = async (videoId: string): Promise<Video> => {
   if (_inMemoryCache[videoId] == undefined) {
     const promise = VideoService.videoRetrieve({ videoId }).catch((err) => {
       console.log(err);
-      const defautVideo: Video = {
+      const defaultVideo: Video = {
         name: 'Missing Information',
+        uid: '',
         publication_date: '',
         uploader: '',
         views: 0,
@@ -36,7 +37,7 @@ export const getVideoInformation = async (videoId: string): Promise<Video> => {
         criteria_scores: [],
         duration: null,
       };
-      return defautVideo;
+      return defaultVideo;
     });
     _inMemoryCache[videoId] = promise;
   }

--- a/frontend/src/features/videos/VideoCard.spec.tsx
+++ b/frontend/src/features/videos/VideoCard.spec.tsx
@@ -20,7 +20,7 @@ const renderVideoCard = (video: VideoObject) =>
 describe('VideoCard content', () => {
   it('shows video metadata without criterias', () => {
     const video: VideoObject = {
-      video_id: 'xSqqXN0D4fY',
+      uid: 'yt:xSqqXN0D4fY',
       name: 'Video title',
       description: 'Video description',
       views: 154988,
@@ -30,6 +30,7 @@ describe('VideoCard content', () => {
       duration: 120,
       publication_date: '',
       language: LanguageEnum.FR,
+      video_id: 'xSqqXN0D4fY',
     };
     renderVideoCard(video);
 
@@ -49,7 +50,7 @@ describe('VideoCard content', () => {
 
   it('shows video card with single criteria', () => {
     const video: VideoObject = {
-      video_id: 'xSqqXN0D4fY',
+      uid: 'yt:xSqqXN0D4fY',
       name: 'Video title',
       description: 'Video description',
       views: 154988,
@@ -63,6 +64,7 @@ describe('VideoCard content', () => {
         },
       ],
       duration: 4200,
+      video_id: 'xSqqXN0D4fY',
     };
     renderVideoCard(video);
 
@@ -85,7 +87,7 @@ describe('VideoCard content', () => {
 
   it('shows video card with multiple criteria', () => {
     const video: VideoObject = {
-      video_id: 'xSqqXN0D4fY',
+      uid: 'yt:xSqqXN0D4fY',
       name: 'Video title',
       description: 'Video description',
       views: 154988,
@@ -103,6 +105,7 @@ describe('VideoCard content', () => {
         },
       ],
       duration: 120,
+      video_id: 'xSqqXN0D4fY',
     };
     renderVideoCard(video);
 

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -25,7 +25,7 @@ import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
 } from '@mui/icons-material';
-import { convertDurationToClockDuration, idFromUid } from 'src/utils/video';
+import { convertDurationToClockDuration, idFromEntity } from 'src/utils/video';
 
 const useStyles = makeStyles((theme) => ({
   main: {
@@ -217,7 +217,7 @@ function VideoCard({
   const theme = useTheme();
   const classes = useStyles();
 
-  const videoId = idFromUid(video);
+  const videoId = idFromEntity(video);
   let total_score = 0;
   let max_score = -Infinity;
   let min_score = Infinity;
@@ -428,7 +428,7 @@ function VideoCard({
       >
         {actions.map((Action, index) =>
           typeof Action === 'function' ? (
-            <Action key={index} videoId={videoId} />
+            <Action key={index} uid={video.uid} />
           ) : (
             Action
           )
@@ -458,7 +458,7 @@ function VideoCard({
             >
               {settings.map((Action, index) =>
                 typeof Action === 'function' ? (
-                  <Action key={index} videoId={videoId} />
+                  <Action key={index} uid={video.uid} />
                 ) : (
                   Action
                 )

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -25,7 +25,10 @@ import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
 } from '@mui/icons-material';
-import { convertDurationToClockDuration, idFromEntity } from 'src/utils/video';
+import {
+  convertDurationToClockDuration,
+  videoIdFromEntity,
+} from 'src/utils/video';
 
 const useStyles = makeStyles((theme) => ({
   main: {
@@ -217,7 +220,7 @@ function VideoCard({
   const theme = useTheme();
   const classes = useStyles();
 
-  const videoId = idFromEntity(video);
+  const videoId = videoIdFromEntity(video);
   let total_score = 0;
   let max_score = -Infinity;
   let min_score = Infinity;

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -25,7 +25,7 @@ import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
 } from '@mui/icons-material';
-import { convertDurationToClockDuration } from 'src/utils/video';
+import { convertDurationToClockDuration, idFromUid } from 'src/utils/video';
 
 const useStyles = makeStyles((theme) => ({
   main: {
@@ -217,15 +217,7 @@ function VideoCard({
   const theme = useTheme();
   const classes = useStyles();
 
-  let id = '';
-  if (video.uid && video.uid.split(':')[0] === '') {
-    id = video.uid.split(':')[1];
-  } else {
-    id = video.video_id;
-  }
-
-  const videoId = id.slice();
-
+  const videoId = idFromUid(video);
   let total_score = 0;
   let max_score = -Infinity;
   let min_score = Infinity;

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -216,7 +216,16 @@ function VideoCard({
   const { t, i18n } = useTranslation();
   const theme = useTheme();
   const classes = useStyles();
-  const videoId = video.video_id;
+
+  let id = '';
+  if (video.uid && video.uid.split(':')[0] === '') {
+    id = video.uid.split(':')[1];
+  } else {
+    id = video.video_id;
+  }
+
+  const videoId = id.slice();
+
   let total_score = 0;
   let max_score = -Infinity;
   let min_score = Infinity;

--- a/frontend/src/features/videos/VideoList.tsx
+++ b/frontend/src/features/videos/VideoList.tsx
@@ -31,7 +31,7 @@ function VideoList({
     <>
       {videos.length ? (
         videos.map((video: VideoObject) => (
-          <Box key={video.video_id} mx={1} my={2}>
+          <Box key={video.uid} mx={1} my={2}>
             <VideoCard
               video={video}
               actions={actions ?? defaultActions}

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -11,12 +11,11 @@ import { idFromUid } from './video';
 
 export const CompareNowAction = ({ uid }: { uid: string }) => {
   const { t } = useTranslation();
-  const videoId = idFromUid(uid);
   return (
     <Tooltip title={`${t('actions.compareNow')}`} placement="left">
       <IconButton
         size="medium"
-        href={`/comparison/?videoA=${videoId}`}
+        href={`/comparison/?uidA=${uid}`}
         style={{ color: '#CDCABC' }}
       >
         <CompareIcon />

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -7,9 +7,11 @@ import DeleteIcon from '@mui/icons-material/Delete';
 
 import { Video, UsersService } from 'src/services/openapi';
 import { useNotifications } from 'src/hooks';
+import { idFromUid } from './video';
 
-export const CompareNowAction = ({ videoId }: { videoId: string }) => {
+export const CompareNowAction = ({ uid }: { uid: string }) => {
   const { t } = useTranslation();
+  const videoId = idFromUid(uid);
   return (
     <Tooltip title={`${t('actions.compareNow')}`} placement="left">
       <IconButton
@@ -23,14 +25,14 @@ export const CompareNowAction = ({ videoId }: { videoId: string }) => {
   );
 };
 
-export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
+export const AddToRateLaterList = ({ uid }: { uid: string }) => {
   const { t } = useTranslation();
   const { showSuccessAlert, showInfoAlert } = useNotifications();
   const handleCreation = async () => {
     try {
       await UsersService.usersMeVideoRateLaterCreate({
         requestBody: {
-          video: { video_id: videoId } as Video,
+          video: { video_id: idFromUid(uid) } as Video,
         },
       });
       showSuccessAlert(t('actions.videoAddedToRateLaterList'));
@@ -53,9 +55,11 @@ export const AddToRateLaterList = ({ videoId }: { videoId: string }) => {
 };
 
 export const RemoveFromRateLater = (asyncCallback?: () => void) => {
-  const RemoveFromRateLaterComponnent = ({ videoId }: { videoId: string }) => {
+  const RemoveFromRateLaterComponnent = ({ uid }: { uid: string }) => {
     const { t } = useTranslation();
     const { showSuccessAlert } = useNotifications();
+    const videoId = idFromUid(uid);
+
     return (
       <Tooltip title={`${t('actions.remove')}`} placement="left">
         <IconButton

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -14,7 +14,7 @@ export interface JSONObject {
 }
 
 export type ActionList = Array<
-  (({ videoId }: { videoId: string }) => JSX.Element) | React.ReactNode
+  (({ uid }: { uid: string }) => JSX.Element) | React.ReactNode
 >;
 
 export type VideoObject = Video | VideoSerializerWithCriteria;

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -31,7 +31,7 @@ export function isVideoIdValid(videoId: string) {
  *     yt:videoABCDEF -> videoABCDEF
  *     yt:video:ABCDE -> video:ABCDE
  */
-export function idFromUid(entity: VideoObject): string {
+export function idFromEntity(entity: VideoObject): string {
   if (entity.uid) {
     const uid = entity.uid.split(':');
 
@@ -41,6 +41,18 @@ export function idFromUid(entity: VideoObject): string {
   }
 
   return entity.video_id;
+}
+
+export function idFromUid(uid: string): string {
+  if (uid) {
+    const uidSplit = uid.split(':');
+
+    if (uidSplit[0] !== '' && uidSplit[1] !== '') {
+      return uidSplit.slice(1).join();
+    }
+  }
+
+  return '';
 }
 
 function pick(arr: string[]): string | null {

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -18,7 +18,7 @@ export function isVideoIdValid(videoId: string) {
 }
 
 /**
- * Return the id of an entity.
+ * Return the video id of an entity.
  *
  * If no field `uid` is found, return the value of the legacy `video_id`
  * field instead.
@@ -31,13 +31,10 @@ export function isVideoIdValid(videoId: string) {
  *     yt:videoABCDEF -> videoABCDEF
  *     yt:video:ABCDE -> video:ABCDE
  */
-export function idFromEntity(entity: VideoObject): string {
+export function videoIdFromEntity(entity: VideoObject): string {
   if (entity.uid) {
-    const uid = entity.uid.split(':');
-
-    if (uid[0] !== '' && uid[1] !== '') {
-      return uid.slice(1).join();
-    }
+    const id = idFromUid(entity.uid);
+    if (id) return id;
   }
 
   return entity.video_id;

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -1,5 +1,6 @@
 import { VideoService, UsersService } from 'src/services/openapi';
 import { YOUTUBE_POLL_NAME } from './constants';
+import { VideoObject } from './types';
 
 export function extractVideoId(idOrUrl: string) {
   const matchUrl = idOrUrl.match(
@@ -14,6 +15,32 @@ export function extractVideoId(idOrUrl: string) {
 
 export function isVideoIdValid(videoId: string) {
   return !!videoId.match(/^[A-Za-z0-9-_]{11}$/);
+}
+
+/**
+ * Return the id of an entity.
+ *
+ * If no field `uid` is found, return the value of the legacy `video_id`
+ * field instead.
+ *
+ * The `uid` is expected to have the form `{namespace}:{id}`. The potential
+ * occurrences of the delimiter `:` in the identifier are considered part of it.
+ *
+ * Example with different `uid`:
+ *
+ *     yt:videoABCDEF -> videoABCDEF
+ *     yt:video:ABCDE -> video:ABCDE
+ */
+export function idFromUid(entity: VideoObject): string {
+  if (entity.uid) {
+    const uid = entity.uid.split(':');
+
+    if (uid[0] !== '' && uid[1] !== '') {
+      return uid.slice(1).join();
+    }
+  }
+
+  return entity.video_id;
 }
 
 function pick(arr: string[]): string | null {


### PR DESCRIPTION
**related to** #527 

---

This pull request make some front end components compatible with the new entity `uid` instead of the previous `video_id`. The main change is in the `<Comparison>` component which is now able to handle URLs containing UIDs (it's still compatible with the old `videoA` / `videoB` parameters, this keeps all previously shared comparison links valid).

To keep the back end backward compatible, its API responses include the `uid` field **in addition** to `video_id`.

To keep the front end backward compatible, the components **fallback** to `video_id` if there is no `uid` field in a video object.

### details

`features.videos.VideoCard.VideoCard`
- [x] now uses `uid`
- [x] is backward compatible

`features.comparisons.Comparison.Comparison`
- [x] now compatible with URL parameters `uidA` / `uidB`
- [x] still compatible with legacy URL parameters `videoA` / `videoB`
- [x] also works with mixed `uidA` / `videoB` and  `videoA` / `uidB`
- [x] when conflicting parameters co-exist, the couple `uidA` / `uidB` prevail 

`utils.action`
- [x] `AddToRateLaterList` is now compatible with `uid`
- [x] `RemoveFromRateLater` is now compatible with `uid`
- [x] `CompareNowAction` is now compatible with `uid`

`features.videos.PublicStatusAction.PublicStatusAction`
- [x] now compatible with `uid`