### PR TITLE
dev-env: longer timeout when waiting for frontend initialization

### DIFF
--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -35,7 +35,7 @@ function wait_for() {
       return 0
     fi
     echo "Waiting for $service_name to be ready..."
-    sleep 2
+    sleep 3
   done
   echo "$service_name is unreachable."
   exit 1


### PR DESCRIPTION
Sometimes, the pipeline for e2e tests fails because the dev-env (especially the frontend container) does not start in time.

This PR sets the delay to wait for containers from 2 minutes (**2** * 60) to  3 minutes (**3** * 60)