### PR TITLE
fix missing padding above recommendation filter,

### DIFF
--- a/frontend/src/components/ContentBox.tsx
+++ b/frontend/src/components/ContentBox.tsx
@@ -4,19 +4,19 @@ import { Box, Container } from '@mui/material';
 interface Props {
   maxWidth?: false | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   children: React.ReactNode;
-  noMinPadding?: boolean;
+  noMinPaddingX?: boolean;
 }
 
 const ContentBox = ({
   children,
   maxWidth = false,
-  noMinPadding = false,
+  noMinPaddingX = false,
 }: Props) => {
   if (!children) {
     return null;
   }
   return (
-    <Box p={[noMinPadding ? 0 : 2, 2, 3]}>
+    <Box px={[noMinPaddingX ? 0 : 2, 2, 3]} py={2}>
       <Container maxWidth={maxWidth} disableGutters>
         {children}
       </Container>

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -113,7 +113,7 @@ const RateLaterPage = () => {
   return (
     <>
       <ContentHeader title={t('myRateLaterListPage.title')} />
-      <ContentBox noMinPadding maxWidth="md">
+      <ContentBox noMinPaddingX maxWidth="md">
         <Card className={classes.rateLaterIntro} elevation={4}>
           <CardContent>
             <Typography variant="h6">

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -120,7 +120,7 @@ const VideoRatingsPage = () => {
       }}
     >
       <ContentHeader title={t('myRatedVideosPage.title')} />
-      <ContentBox noMinPadding maxWidth="md">
+      <ContentBox noMinPaddingX maxWidth="md">
         <Box px={{ xs: 2, sm: 0 }}>
           <RatingsFilter />
         </Box>

--- a/frontend/src/pages/videos/VideoRecommendation.tsx
+++ b/frontend/src/pages/videos/VideoRecommendation.tsx
@@ -45,7 +45,7 @@ function VideoRecommendationPage() {
   return (
     <>
       <ContentHeader title={t('recommendationsPage.title')} />
-      <ContentBox noMinPadding maxWidth="lg">
+      <ContentBox noMinPaddingX maxWidth="lg">
         <Box px={{ xs: 2, sm: 0 }}>
           <SearchFilter />
         </Box>


### PR DESCRIPTION
This PR defines a fixed non-zero paddingY in ContentBox. The `noMinPadding` prop (used on list views where no gutter should be visible on mobile) is renamed to `noMinPaddingX`.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/4726554/154498184-6738eb43-b942-4c4e-9ca8-559ad2724d20.png)|![image](https://user-images.githubusercontent.com/4726554/154497982-aee1086e-19c0-4c27-992c-593ae7981f61.png)|
 