### PR TITLE
Correct logic for highlighted component in navbar

### DIFF
--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -99,7 +99,10 @@ const SideBar = () => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
   const location = useLocation();
 
-  const isItemSelected = (url: string) => url === location.pathname;
+  // parameter 'url', which corresponds to the target url, may contain some url parameters
+  // we make sure that we highlight the component the user loaded
+  const isItemSelected = (url: string) =>
+    url.split('?')[0] === location.pathname;
 
   const menuItems = [
     { targetUrl: '/', IconComponent: HomeIcon, displayText: t('menu.home') },


### PR DESCRIPTION
Related issue: https://github.com/tournesol-app/tournesol/issues/565

The problem was that the target url beneath selecting "Recommendations" has the url parameter `date=Month`
I choose to correct the logic by deleting all possibles url params when checking for the component to highlight