### PR TITLE
[back] fix: `EntityAdmin.update_metadata` failing because of wrong import

### DIFF
--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -4,6 +4,8 @@ Defines Tournesol's backend admin interface
 
 from django.contrib import admin
 
+from tournesol.entities.video import TYPE_VIDEO
+
 from .models import (
     Comparison,
     ComparisonCriteriaScore,
@@ -40,7 +42,7 @@ class EntityAdmin(admin.ModelAdmin):
     @admin.action(description="Force metadata refresh of selected videos")
     def update_metadata(self, request, queryset):
         for entity in queryset.iterator():
-            if entity.type == Entity.TYPE_VIDEO:
+            if entity.type == TYPE_VIDEO:
                 entity.refresh_youtube_metadata(force=True)
 
 


### PR DESCRIPTION
I found this bug in production, the metadata update action from the admin interface was failing. 

The log from `journalctl`: 

```
Feb 21 16:51:09 tournesol gunicorn[494242]:   File "/.../tournesol/admin.py", line 43, in update_metadata
Feb 21 16:51:09 tournesol gunicorn[494242]:     if entity.type == Entity.TYPE_VIDEO:
Feb 21 16:51:09 tournesol gunicorn[494242]: AttributeError: type object 'Entity' has no attribute 'TYPE_VIDEO'
```