### PR TITLE
Validate entity 'metadata' content in admin form

### DIFF
--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -8,6 +8,7 @@ from functools import cached_property
 
 import numpy as np
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
@@ -268,6 +269,12 @@ class Entity(models.Model):
         # That's why a default value is set here to handle correctly blank values in forms.
         if self.metadata is None:
             self.metadata = {}
+
+        if self.entity_cls.metadata_serializer_class:
+            serializer = self.entity_cls.metadata_serializer_class(data=self.metadata)
+            if not serializer.is_valid():
+                raise ValidationError({"metadata": str(serializer.errors)})
+            self.metadata = serializer.data
 
 
 class VideoRateLater(models.Model):


### PR DESCRIPTION
For example, it's no longer possible to update the "metadata" for a video without the "video_id" field (required).