### PR TITLE
Use frontend recommendations languages in extension

### DIFF
--- a/browser-extension/addTournesolRecommendations.css
+++ b/browser-extension/addTournesolRecommendations.css
@@ -26,20 +26,12 @@
   font-weight: normal;
 }
 
-.language_option {
+#tournesol_link {
   color: var(--yt-spec-text-primary);
   font-family: "Roboto", "Arial", sans-serif;
   float: right;
   margin-top: 3px;
   margin-left: 2px;
-}
-
-#tournesol_link {
-  color: var(--yt-spec-text-primary);
-  font-family: "Roboto", "Arial", sans-serif;
-  position: absolute;
-  right: 0px;
-  top: 15px;
 }
 
 #tournesol_refresh_button {

--- a/browser-extension/addTournesolRecommendations.js
+++ b/browser-extension/addTournesolRecommendations.js
@@ -272,16 +272,9 @@ function loadRecommandations() {
   if(areRecommandationsLoading) return;
   
   areRecommandationsLoading = true;
-  /*
-   ** Send message to background.js to get recommendations from the API of Tournesol.
-   ** I put video amount here because we can get the value of --ytd-rich-grid-posts-per-row (css) to know how many videos we should retreive from api
-   */
-  const language =
-    localStorage.getItem('tournesol_extension_config_language') || 'en';
   
   chrome.runtime.sendMessage({
     message: 'getTournesolRecommendations',
-    language: language,
     videosNumber: videosPerRow,
     additionalVideosNumber: videosPerRow * (rowsWhenExpanded - 1)
   }, handleResponse);

--- a/browser-extension/addTournesolRecommendations.js
+++ b/browser-extension/addTournesolRecommendations.js
@@ -83,24 +83,6 @@ const getTournesolComponent = () => {
     tournesol_title.append('Recommended by Tournesol');
     inline_div.append(tournesol_title);
 
-    // Language options
-    const makeLanguageLink = (lang) => {
-      lang_option = document.createElement('a');
-      lang_option.className = 'language_option';
-      lang_option.href = '#';
-      lang_option.setAttribute('role', 'button');
-      lang_option.append(lang);
-      lang_option.onclick = (event) => {
-        event.preventDefault();
-        localStorage.setItem('tournesol_extension_config_language', lang);
-        loadRecommandations();
-      };
-      return lang_option;
-    };
-    inline_div.append(makeLanguageLink('de'));
-    inline_div.append(makeLanguageLink('en'));
-    inline_div.append(makeLanguageLink('fr'));
-
     // Add title
     tournesol_link = document.createElement('a');
     tournesol_link.id = 'tournesol_link';

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -152,12 +152,20 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const process = async () => {
       const threeWeeksAgo = getDateThreeWeeksAgo()
 
+      const storedRecommendationsLanguages = () => new Promise(
+        (resolve) => chrome.storage.local.get(
+          "recommendationsLanguages",
+          ({recommendationsLanguages}) => resolve(recommendationsLanguages),
+        )
+      )
+      const language = await storedRecommendationsLanguages() || "en";
+
       // Only one request for both videos and additional videos
       const recent = await request_recommendations(
-        `date_gte=${threeWeeksAgo}&language=${request.language}&limit=${recentVideoToLoad+recentAdditionalVideoToLoad}`
+        `date_gte=${threeWeeksAgo}&language=${language}&limit=${recentVideoToLoad+recentAdditionalVideoToLoad}`
       );
       const old = await request_recommendations(
-        `date_lte=${threeWeeksAgo}&language=${request.language}&limit=${oldVideoToLoad+oldAdditionalVideoToLoad}`
+        `date_lte=${threeWeeksAgo}&language=${language}&limit=${oldVideoToLoad+oldAdditionalVideoToLoad}`
       );
       
       // Cut the response into the part for the videos and the one for the additional videos

--- a/browser-extension/fetchTournesolRecommendationsLanguages.js
+++ b/browser-extension/fetchTournesolRecommendationsLanguages.js
@@ -2,9 +2,25 @@
  * Save the recommendations languages from the Tournesol localStorage to the extension
  * local storage.
  */
+
+function saveRecommendationsLanguages(recommendationsLanguages) {
+  chrome.storage.local.set({ recommendationsLanguages });
+}
+
 function updateRecommendationsLanguages() {
   const recommendationsLanguages = localStorage.getItem('recommendationsLanguages')
-  chrome.storage.local.set({recommendationsLanguages});
+  saveRecommendationsLanguages(recommendationsLanguages);
+}
+
+function handleRecommendationsLanguagesChange(event) {
+  const { detail } = event;
+  const { recommendationsLanguages } = detail;
+  saveRecommendationsLanguages(recommendationsLanguages);
 }
 
 updateRecommendationsLanguages();
+
+document.addEventListener(
+  "tournesol:recommendationsLanguagesChange",
+  handleRecommendationsLanguagesChange
+);

--- a/browser-extension/fetchTournesolRecommendationsLanguages.js
+++ b/browser-extension/fetchTournesolRecommendationsLanguages.js
@@ -1,0 +1,10 @@
+/**
+ * Save the recommendations languages from the Tournesol localStorage to the extension
+ * local storage.
+ */
+function updateRecommendationsLanguages() {
+  const recommendationsLanguages = localStorage.getItem('recommendationsLanguages')
+  chrome.storage.local.set({recommendationsLanguages});
+}
+
+updateRecommendationsLanguages();

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -58,13 +58,10 @@
     },
     {
       "matches": ["https://tournesol.app/*"],
-      "js": ["fetchTournesolToken.js"],
-      "run_at": "document_end",
-      "all_frames": true
-    },
-    {
-      "matches": ["https://tournesol.app/*"],
-      "js": ["fetchTournesolRecommendationsLanguages.js"],
+      "js": [
+        "fetchTournesolToken.js",
+        "fetchTournesolRecommendationsLanguages.js"
+      ],
       "run_at": "document_end",
       "all_frames": true
     }

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -61,6 +61,12 @@
       "js": ["fetchTournesolToken.js"],
       "run_at": "document_end",
       "all_frames": true
+    },
+    {
+      "matches": ["https://tournesol.app/*"],
+      "js": ["fetchTournesolRecommendationsLanguages.js"],
+      "run_at": "document_end",
+      "all_frames": true
     }
   ],
   "web_accessible_resources": [

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -80,6 +80,7 @@ export const defaultRecommendationFilters = {
   backfire_risk: '50',
 };
 
+// This constant is also defined in the browser extension so it should be updated there too if it changes.
 export const availableRecommendationsLanguages = ['en', 'fr', 'de'];
 
 export const getLanguageName = (t: TFunction, language: string) => {

--- a/frontend/src/utils/recommendationsLanguages.spec.ts
+++ b/frontend/src/utils/recommendationsLanguages.spec.ts
@@ -1,4 +1,7 @@
-import { recommendationsLanguagesFromNavigator } from './recommendationsLanguages';
+import {
+  recommendationsLanguagesFromNavigator,
+  saveRecommendationsLanguages,
+} from './recommendationsLanguages';
 
 describe('recommendationsLanguagesFromNavigator', () => {
   const testCases = [
@@ -19,4 +22,21 @@ describe('recommendationsLanguagesFromNavigator', () => {
       expect(recommendationsLanguagesFromNavigator()).toEqual(expected);
     })
   );
+});
+
+describe('saveRecommendationsLanguages', () => {
+  it('dispatches an event for the extension', () => {
+    const eventHandler = jest.fn((event) => {
+      const { detail } = event;
+      expect(detail).toEqual({ recommendationsLanguages: 'fr,de' });
+    });
+    document.addEventListener(
+      'tournesol:recommendationsLanguagesChange',
+      eventHandler
+    );
+
+    saveRecommendationsLanguages('fr,de');
+
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/utils/recommendationsLanguages.ts
+++ b/frontend/src/utils/recommendationsLanguages.ts
@@ -13,6 +13,7 @@ export const loadRecommendationsLanguages = (): string | null =>
   localStorage.getItem('recommendationsLanguages');
 
 export const recommendationsLanguagesFromNavigator = (): string =>
+  // This function also exists in the browser extension so it should be updated there too if it changes here.
   uniq(
     navigator.languages
       .map((languageTag) => languageTag.split('-', 1)[0])

--- a/frontend/src/utils/recommendationsLanguages.ts
+++ b/frontend/src/utils/recommendationsLanguages.ts
@@ -3,6 +3,10 @@ import { uniq } from 'src/utils/array';
 
 export const saveRecommendationsLanguages = (value: string) => {
   localStorage.setItem('recommendationsLanguages', value);
+  const event = new CustomEvent('tournesol:recommendationsLanguagesChange', {
+    detail: { recommendationsLanguages: value },
+  });
+  document.dispatchEvent(event);
 };
 
 export const loadRecommendationsLanguages = (): string | null =>


### PR DESCRIPTION
Related to #349.

It requires either [!602](https://github.com/tournesol-app/tournesol/pull/602) to be deployed in production or a manual change of the local storage on tournsol.app.

For now this PR only includes the code that loads the recommendations languages from the website's localStorage and uses them in the recommendations request.

If the recommendations languages change on the website and you refresh the youtube home page the recommendations are still in the previous language because the iframe that refreshes the data hasn't finished yet when the recommendations are loaded. A second refresh will load recommendations in the updated languages. A solution may be to wait for the iframe to complete but it may be tricky and may add a delay. A better solution may be to trigger the extension's storage change immediatly when the website changes its own storage (with a custom event captured by the extension for example).

Another solution would be to store the recommendations languages in the backend and not care about it in the extension at all. The extension would omit the `language` parameter in the request and the backend would use the stored languages of the user.

Remaining to do:

- [x] Remove the language selection UI from the recommendations
- [x] Use the navigator languages when there's no stored languages
