### PR TITLE
feat: Display language names instead of codes in EntityAdmin

### DIFF
--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -98,7 +98,8 @@ class EntityAdmin(admin.ModelAdmin):
     @staticmethod
     @admin.display(description="language", ordering="metadata__language")
     def get_language(obj):
-        return LANGUAGE_CODE_TO_NAME_MATCHING.get(obj.metadata.get("language"))
+        language_code = obj.metadata.get("language")
+        return LANGUAGE_CODE_TO_NAME_MATCHING.get(language_code, language_code)
 
 
 @admin.register(EntityCriteriaScore)

--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -6,8 +6,7 @@ from django.contrib import admin
 from django.contrib.admin.filters import SimpleListFilter
 from django.db.models import Q
 
-from tournesol.entities.video import TYPE_VIDEO
-
+from .entities.video import TYPE_VIDEO
 from .models import (
     Comparison,
     ComparisonCriteriaScore,
@@ -20,6 +19,7 @@ from .models import (
     EntityCriteriaScore,
     Poll,
 )
+from .utils.video_language import LANGUAGE_CODE_TO_NAME_MATCHING
 
 
 class MetadataFieldFilter(SimpleListFilter):
@@ -98,7 +98,7 @@ class EntityAdmin(admin.ModelAdmin):
     @staticmethod
     @admin.display(description="language", ordering="metadata__language")
     def get_language(obj):
-        return obj.metadata.get("language")
+        return LANGUAGE_CODE_TO_NAME_MATCHING.get(obj.metadata.get("language"))
 
 
 @admin.register(EntityCriteriaScore)

--- a/backend/tournesol/utils/video_language.py
+++ b/backend/tournesol/utils/video_language.py
@@ -6,7 +6,8 @@ from langdetect import DetectorFactory, detect, lang_detect_exception
 
 from ..models.entity import Entity
 
-ACCEPTED_LANGUAGE_CODES = {lang[0] for lang in settings.LANGUAGES}
+LANGUAGE_CODE_TO_NAME_MATCHING = {code: name for code, name in settings.LANGUAGES}
+ACCEPTED_LANGUAGE_CODES = set(LANGUAGE_CODE_TO_NAME_MATCHING.keys())
 
 
 # Enforce consistent results with a constant seed,


### PR DESCRIPTION
As an admin, using the admin interface, I find more readable to see names of languages ("Spanish" and "Estonian") rather than codes ("es" and "et") so that I can identify and manually correct language assignments of video entities