### PR TITLE
WIP / [back][front] refactor: ratings API does not use `video_id` in body anymore 

### DIFF
--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -79,22 +79,16 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
     def create(self, validated_data):
         uid_1 = validated_data.pop("entity_1").get("uid")
         uid_2 = validated_data.pop("entity_2").get("uid")
-
-        # XXX: the following lines are still specific to `video` Entity. When
-        # the comparisons API will be used by more than one entity type, a
-        # type check will be needed here to avoid calling `get_from_video_id`
-        # on non-video Entity.
-
         # The validation performed by the `RelatedEntitySerializer` guarantees
         # that the submitted UIDs exist in the database.
-        video_1 = Entity.get_from_video_id(uid_1.split(Entity.UID_DELIMITER)[1])
-        video_2 = Entity.get_from_video_id(uid_2.split(Entity.UID_DELIMITER)[1])
+        entity_1 = Entity.objects.get(uid=uid_1)
+        entity_2 = Entity.objects.get(uid=uid_2)
         criteria_scores = validated_data.pop("criteria_scores")
 
         comparison = Comparison.objects.create(
             poll=self.context.get("poll"),
-            entity_1=video_1,
-            entity_2=video_2,
+            entity_1=entity_1,
+            entity_2=entity_2,
             **validated_data,
         )
 

--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -4,7 +4,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import ModelSerializer
 
 from tournesol.models import Comparison, ComparisonCriteriaScore, Entity
-from tournesol.serializers.entity import RelatedVideoSerializer, VideoSerializer
+from tournesol.serializers.entity import RelatedEntitySerializer, VideoSerializer
 
 
 class ComparisonCriteriaScoreSerializer(ModelSerializer):
@@ -31,12 +31,13 @@ class ComparisonSerializerMixin:
 
     def validate_criteria_scores(self, value):
         current_poll = self.context["poll"]
-        missing_criterias = (
-            set(current_poll.required_criterias_list)
-            - set(score["criteria"] for score in value)
+        missing_criterias = set(current_poll.required_criterias_list) - set(
+            score["criteria"] for score in value
         )
         if missing_criterias:
-            raise ValidationError(f"Missing required criteria: {','.join(missing_criterias)}")
+            raise ValidationError(
+                f"Missing required criteria: {','.join(missing_criterias)}"
+            )
         return value
 
 
@@ -50,8 +51,8 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
     Use `ComparisonUpdateSerializer` for the update operation.
     """
 
-    entity_a = RelatedVideoSerializer(source="entity_1")
-    entity_b = RelatedVideoSerializer(source="entity_2")
+    entity_a = RelatedEntitySerializer(source="entity_1")
+    entity_b = RelatedEntitySerializer(source="entity_2")
     criteria_scores = ComparisonCriteriaScoreSerializer(many=True)
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
@@ -76,12 +77,18 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
 
     @transaction.atomic
     def create(self, validated_data):
-        video_id_1 = validated_data.pop("entity_1").get("video_id")
-        video_id_2 = validated_data.pop("entity_2").get("video_id")
-        # the validation performed by the RelatedVideoSerializer guarantees
-        # that the videos submitted exist in the database
-        video_1 = Entity.get_from_video_id(video_id_1)
-        video_2 = Entity.get_from_video_id(video_id_2)
+        uid_1 = validated_data.pop("entity_1").get("uid")
+        uid_2 = validated_data.pop("entity_2").get("uid")
+
+        # XXX: the following lines are still specific to `video` Entity. When
+        # the comparisons API will be used by more than one entity type, a
+        # type check will be needed here to avoid calling `get_from_video_id`
+        # on non-video Entity.
+
+        # The validation performed by the RelatedEntitySerializer guarantees
+        # that the submitted UIDs exist in the database.
+        video_1 = Entity.get_from_video_id(uid_1.split(Entity.UID_DELIMITER)[1])
+        video_2 = Entity.get_from_video_id(uid_2.split(Entity.UID_DELIMITER)[1])
         criteria_scores = validated_data.pop("criteria_scores")
 
         comparison = Comparison.objects.create(

--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -4,7 +4,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import ModelSerializer
 
 from tournesol.models import Comparison, ComparisonCriteriaScore, Entity
-from tournesol.serializers.entity import RelatedEntitySerializer, VideoSerializer
+from tournesol.serializers.entity import RelatedEntitySerializer
 
 
 class ComparisonCriteriaScoreSerializer(ModelSerializer):
@@ -117,8 +117,8 @@ class ComparisonUpdateSerializer(ComparisonSerializerMixin, ModelSerializer):
     """
 
     criteria_scores = ComparisonCriteriaScoreSerializer(many=True)
-    entity_a = VideoSerializer(source="entity_1", read_only=True)
-    entity_b = VideoSerializer(source="entity_2", read_only=True)
+    entity_a = RelatedEntitySerializer(source="entity_1", read_only=True)
+    entity_b = RelatedEntitySerializer(source="entity_2", read_only=True)
 
     class Meta:
         model = Comparison

--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -85,7 +85,7 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
         # type check will be needed here to avoid calling `get_from_video_id`
         # on non-video Entity.
 
-        # The validation performed by the RelatedEntitySerializer guarantees
+        # The validation performed by the `RelatedEntitySerializer` guarantees
         # that the submitted UIDs exist in the database.
         video_1 = Entity.get_from_video_id(uid_1.split(Entity.UID_DELIMITER)[1])
         video_2 = Entity.get_from_video_id(uid_2.split(Entity.UID_DELIMITER)[1])

--- a/backend/tournesol/serializers/entity.py
+++ b/backend/tournesol/serializers/entity.py
@@ -142,11 +142,17 @@ class EntitySerializer(ModelSerializer):
 
     Use `EntityOnlySerializer` if you don't need the related polls.
     """
+
     polls = serializers.SerializerMethodField()
 
     class Meta:
         model = Entity
-        fields = ["uid", "type", "metadata", "polls"]
+        fields = [
+            "uid",
+            "type",
+            "metadata",
+            "polls",
+        ]
 
     @extend_schema_field(EntityPollSerializer(many=True))
     def get_polls(self, obj):
@@ -171,13 +177,29 @@ class RelatedEntitySerializer(EntitySerializer):
     and having the constraint to ensure that video instances exist before
     they can be saved properly.
     """
+
     # XXX: should not be tightly related to the video entity type
     uid = RegexField(rf"yt:{YOUTUBE_VIDEO_ID_REGEX[1:]}")
 
     class Meta:
         model = Entity
-        fields = ["uid", "type", "metadata"]
-        read_only_fields = ["type", "metadata"]
+
+        # XXX: fields `rating_n_ratings` and `rating_n_contributors` are used
+        # temporarily to make it possible for API consumers to fully rebuild
+        # a Video object from an Entity object
+        fields = [
+            "uid",
+            "type",
+            "rating_n_ratings",
+            "rating_n_contributors",
+            "metadata",
+        ]
+        read_only_fields = [
+            "type",
+            "rating_n_ratings",
+            "rating_n_contributors",
+            "metadata",
+        ]
 
     def validate_uid(self, value):
         split_uid = value.split(Entity.UID_DELIMITER)

--- a/backend/tournesol/serializers/entity.py
+++ b/backend/tournesol/serializers/entity.py
@@ -190,14 +190,10 @@ class RelatedEntitySerializer(EntitySerializer):
         fields = [
             "uid",
             "type",
-            "rating_n_ratings",
-            "rating_n_contributors",
             "metadata",
         ]
         read_only_fields = [
             "type",
-            "rating_n_ratings",
-            "rating_n_contributors",
             "metadata",
         ]
 

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -7,7 +7,7 @@ from rest_framework.serializers import ModelSerializer, Serializer
 
 from core.utils.constants import YOUTUBE_VIDEO_ID_REGEX
 from tournesol.models import ContributorRating, ContributorRatingCriteriaScore, Entity
-from tournesol.serializers.entity import RelatedVideoSerializer, VideoSerializer
+from tournesol.serializers.entity import RelatedEntitySerializer
 
 
 class ContributorCriteriaScore(ModelSerializer):
@@ -17,7 +17,7 @@ class ContributorCriteriaScore(ModelSerializer):
 
 
 class ContributorRatingSerializer(ModelSerializer):
-    video = VideoSerializer(source="entity", read_only=True)
+    entity = RelatedEntitySerializer(read_only=True)
     criteria_scores = ContributorCriteriaScore(many=True, read_only=True)
     n_comparisons = SerializerMethodField(
         help_text="Number of comparisons submitted by the current user about the current video",
@@ -25,7 +25,7 @@ class ContributorRatingSerializer(ModelSerializer):
 
     class Meta:
         model = ContributorRating
-        fields = ["video", "is_public", "criteria_scores", "n_comparisons"]
+        fields = ["entity", "is_public", "criteria_scores", "n_comparisons"]
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_n_comparisons(self, obj):
@@ -51,24 +51,24 @@ class ContributorRatingSerializer(ModelSerializer):
 
 
 class ContributorRatingCreateSerializer(ContributorRatingSerializer):
-    video_id = RegexField(YOUTUBE_VIDEO_ID_REGEX, write_only=True)
+    uid = RegexField(rf"yt:{YOUTUBE_VIDEO_ID_REGEX[1:]}", write_only=True)
 
     class Meta:
         model = ContributorRating
-        fields = ["video_id", "is_public", "video", "criteria_scores", "n_comparisons"]
+        fields = ["uid", "is_public", "entity", "criteria_scores", "n_comparisons"]
 
     def validate(self, attrs):
-        video_id = attrs.pop("video_id")
-        video_serializer = RelatedVideoSerializer(data={"video_id": video_id})
-        video_serializer.is_valid(raise_exception=True)
-        video = Entity.get_from_video_id(video_id)
+        uid = attrs.pop("uid")
+        entity_serializer = RelatedEntitySerializer(data={"uid": uid})
+        entity_serializer.is_valid(raise_exception=True)
+        entity = Entity.objects.get(uid=uid)
         user = self.context["request"].user
-        if user.contributorvideoratings.filter(entity=video).exists():
+        if user.contributorvideoratings.filter(entity=entity).exists():
             raise ValidationError(
-                "A ContributorRating already exists for this (user, video)",
+                "A ContributorRating already exists for this (user, entity)",
                 code="unique",
             )
-        attrs["entity"] = video
+        attrs["entity"] = entity
         attrs["user"] = user
         return attrs
 

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -41,8 +41,8 @@ class ComparisonApiTestCase(TestCase):
     _uid_07 = "yt:video_id_07"
 
     non_existing_comparison = {
-        "entity_a": {"video_id": _uid_01.split(":")[1]},
-        "entity_b": {"video_id": _uid_03.split(":")[1]},
+        "entity_a": {"uid": _uid_01},
+        "entity_b": {"uid": _uid_03},
         "criteria_scores": [
             {"criteria": "largely_recommended", "score": 10, "weight": 10}
         ],
@@ -164,8 +164,8 @@ class ComparisonApiTestCase(TestCase):
             ).get(
                 user=self.user,
                 poll__name=non_existing_poll,
-                entity_1__uid=f'yt:{data["entity_a"]["video_id"]}',
-                entity_2__uid=f'yt:{data["entity_b"]["video_id"]}',
+                entity_1__uid=data["entity_a"]["uid"],
+                entity_2__uid=data["entity_b"]["uid"],
             )
 
         # the default poll must not contain the comparison
@@ -175,8 +175,8 @@ class ComparisonApiTestCase(TestCase):
             ).get(
                 user=self.user,
                 poll=self.poll_videos,
-                entity_1__uid=f'yt:{data["entity_a"]["video_id"]}',
-                entity_2__uid=f'yt:{data["entity_b"]["video_id"]}',
+                entity_1__uid=data["entity_a"]["uid"],
+                entity_2__uid=data["entity_b"]["uid"],
             )
 
     def test_authenticated_can_create(self):
@@ -208,8 +208,8 @@ class ComparisonApiTestCase(TestCase):
         ).get(
             user=self.user,
             poll=self.poll_videos,
-            entity_1__uid=f'yt:{data["entity_a"]["video_id"]}',
-            entity_2__uid=f'yt:{data["entity_b"]["video_id"]}',
+            entity_1__uid=data["entity_a"]["uid"],
+            entity_2__uid=data["entity_b"]["uid"],
         )
         comparisons_nbr = Comparison.objects.filter(user=self.user).count()
 
@@ -218,8 +218,8 @@ class ComparisonApiTestCase(TestCase):
 
         self.assertEqual(comparison.poll, self.poll_videos)
         self.assertEqual(comparison.user, self.user)
-        self.assertEqual(comparison.entity_1.video_id, data["entity_a"]["video_id"])
-        self.assertEqual(comparison.entity_2.video_id, data["entity_b"]["video_id"])
+        self.assertEqual(comparison.entity_1.uid, data["entity_a"]["uid"])
+        self.assertEqual(comparison.entity_2.uid, data["entity_b"]["uid"])
         self.assertEqual(comparison.duration_ms, data["duration_ms"])
 
         comparison_criteria_scores = comparison.criteria_scores.all()
@@ -238,12 +238,8 @@ class ComparisonApiTestCase(TestCase):
         )
 
         # check the representation integrity
-        self.assertEqual(
-            response.data["entity_a"]["video_id"], data["entity_a"]["video_id"]
-        )
-        self.assertEqual(
-            response.data["entity_b"]["video_id"], data["entity_b"]["video_id"]
-        )
+        self.assertEqual(response.data["entity_a"]["uid"], data["entity_a"]["uid"])
+        self.assertEqual(response.data["entity_b"]["uid"], data["entity_b"]["uid"])
         self.assertEqual(response.data["duration_ms"], data["duration_ms"])
 
         self.assertEqual(
@@ -288,8 +284,8 @@ class ComparisonApiTestCase(TestCase):
         ).get(
             poll=self.poll_videos,
             user=self.user,
-            entity_1__uid=f'yt:{data["entity_a"]["video_id"]}',
-            entity_2__uid=f'yt:{data["entity_b"]["video_id"]}',
+            entity_1__uid=data["entity_a"]["uid"],
+            entity_2__uid=data["entity_b"]["uid"],
         )
         comparisons_nbr = Comparison.objects.filter(user=self.user).count()
 
@@ -403,10 +399,10 @@ class ComparisonApiTestCase(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        # swap the video id
-        data["entity_a"]["video_id"], data["entity_b"]["video_id"] = (
-            data["entity_b"]["video_id"],
-            data["entity_a"]["video_id"],
+        # swap the uid
+        data["entity_a"]["uid"], data["entity_b"]["uid"] = (
+            data["entity_b"]["uid"],
+            data["entity_a"]["uid"],
         )
 
         response = client.post(
@@ -471,18 +467,18 @@ class ComparisonApiTestCase(TestCase):
         comparison2 = response.data["results"][1]
 
         self.assertEqual(
-            comparison1["entity_a"]["video_id"], self.comparisons[1].entity_1.video_id
+            comparison1["entity_a"]["uid"], self.comparisons[1].entity_1.uid
         )
         self.assertEqual(
-            comparison1["entity_b"]["video_id"], self.comparisons[1].entity_2.video_id
+            comparison1["entity_b"]["uid"], self.comparisons[1].entity_2.uid
         )
         self.assertEqual(comparison1["duration_ms"], self.comparisons[1].duration_ms)
 
         self.assertEqual(
-            comparison2["entity_a"]["video_id"], self.comparisons[0].entity_1.video_id
+            comparison2["entity_a"]["uid"], self.comparisons[0].entity_1.uid
         )
         self.assertEqual(
-            comparison2["entity_b"]["video_id"], self.comparisons[0].entity_2.video_id
+            comparison2["entity_b"]["uid"], self.comparisons[0].entity_2.uid
         )
         self.assertEqual(comparison2["duration_ms"], self.comparisons[0].duration_ms)
 
@@ -513,10 +509,8 @@ class ComparisonApiTestCase(TestCase):
         # currently the GET API returns an unordered list, so the assertions
         # are made unordered too
         for comparison in response.data["results"]:
-            if comparison["entity_a"]["video_id"] != self._uid_02.split(":")[1]:
-                self.assertEqual(
-                    comparison["entity_b"]["video_id"], self._uid_02.split(":")[1]
-                )
+            if comparison["entity_a"]["uid"] != self._uid_02:
+                self.assertEqual(comparison["entity_b"]["uid"], self._uid_02)
 
             self.assertEqual(comparison["duration_ms"], 102)
 
@@ -565,12 +559,8 @@ class ComparisonApiTestCase(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(
-            response.data["entity_a"]["video_id"], self._uid_01.split(":")[1]
-        )
-        self.assertEqual(
-            response.data["entity_b"]["video_id"], self._uid_02.split(":")[1]
-        )
+        self.assertEqual(response.data["entity_a"]["uid"], self._uid_01)
+        self.assertEqual(response.data["entity_b"]["uid"], self._uid_02)
         self.assertEqual(response.data["duration_ms"], 102)
 
     def test_authenticated_can_read_reverse(self):
@@ -603,13 +593,8 @@ class ComparisonApiTestCase(TestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        self.assertEqual(
-            response.data["entity_a"]["video_id"], self._uid_02.split(":")[1]
-        )
-        self.assertEqual(
-            response.data["entity_b"]["video_id"], self._uid_01.split(":")[1]
-        )
+        self.assertEqual(response.data["entity_a"]["uid"], self._uid_02)
+        self.assertEqual(response.data["entity_b"]["uid"], self._uid_01)
         self.assertEqual(response.data["duration_ms"], 102)
 
     def test_anonymous_cant_update(self):
@@ -773,16 +758,16 @@ class ComparisonApiTestCase(TestCase):
         result_comparison1 = response.data["results"][0]
         result_comparison2 = response.data["results"][1]
         self.assertEqual(
-            result_comparison1["entity_a"]["video_id"], comparison1.entity_1.video_id
+            result_comparison1["entity_a"]["uid"], comparison1.entity_1.uid
         )
         self.assertEqual(
-            result_comparison1["entity_b"]["video_id"], comparison1.entity_2.video_id
+            result_comparison1["entity_b"]["uid"], comparison1.entity_2.uid
         )
         self.assertEqual(
-            result_comparison2["entity_a"]["video_id"], comparison2.entity_1.video_id
+            result_comparison2["entity_a"]["uid"], comparison2.entity_1.uid
         )
         self.assertEqual(
-            result_comparison2["entity_b"]["video_id"], comparison2.entity_2.video_id
+            result_comparison2["entity_b"]["uid"], comparison2.entity_2.uid
         )
 
     def test_n_ratings_from_video(self):
@@ -794,8 +779,8 @@ class ComparisonApiTestCase(TestCase):
         VideoFactory(metadata__video_id=self._uid_07.split(":")[1])
 
         data1 = {
-            "entity_a": {"video_id": self._uid_05.split(":")[1]},
-            "entity_b": {"video_id": self._uid_06.split(":")[1]},
+            "entity_a": {"uid": self._uid_05},
+            "entity_b": {"uid": self._uid_06},
             "criteria_scores": [
                 {"criteria": "largely_recommended", "score": 10, "weight": 10}
             ],
@@ -809,8 +794,8 @@ class ComparisonApiTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         data2 = {
-            "entity_a": {"video_id": self._uid_05.split(":")[1]},
-            "entity_b": {"video_id": self._uid_07.split(":")[1]},
+            "entity_a": {"uid": self._uid_05},
+            "entity_b": {"uid": self._uid_07},
             "criteria_scores": [
                 {"criteria": "largely_recommended", "score": 10, "weight": 10}
             ],
@@ -826,8 +811,8 @@ class ComparisonApiTestCase(TestCase):
         client.force_authenticate(user=self.other)
 
         data3 = {
-            "entity_a": {"video_id": self._uid_05.split(":")[1]},
-            "entity_b": {"video_id": self._uid_06.split(":")[1]},
+            "entity_a": {"uid": self._uid_05},
+            "entity_b": {"uid": self._uid_06},
             "criteria_scores": [
                 {"criteria": "largely_recommended", "score": 10, "weight": 10}
             ],
@@ -868,26 +853,26 @@ class ComparisonApiTestCase(TestCase):
         video03.save()
 
         data = {
-            "entity_a": {"video_id": self._uid_01.split(":")[1]},
-            "entity_b": {"video_id": self._uid_02.split(":")[1]},
+            "entity_a": {"uid": self._uid_01},
+            "entity_b": {"uid": self._uid_02},
             "criteria_scores": [
                 {"criteria": "largely_recommended", "score": 10, "weight": 10}
             ],
         }
         response = client.post(self.comparisons_base_url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
         self.assertEqual(len(mock_get_video_metadata.mock_calls), 2)
 
         data = {
-            "entity_a": {"video_id": self._uid_01.split(":")[1]},
-            "entity_b": {"video_id": self._uid_03.split(":")[1]},
+            "entity_a": {"uid": self._uid_01},
+            "entity_b": {"uid": self._uid_03},
             "criteria_scores": [
                 {"criteria": "largely_recommended", "score": 10, "weight": 10}
             ],
         }
 
         response = client.post(self.comparisons_base_url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
         # Video01 has been refreshed and video03 was already up-to-date.
         # No additional call to YouTube API should be visible.
         self.assertEqual(len(mock_get_video_metadata.mock_calls), 2)

--- a/backend/tournesol/tests/test_api_entities.py
+++ b/backend/tournesol/tests/test_api_entities.py
@@ -48,6 +48,7 @@ class EntitiesApi(TestCase):
                     },
                 ],
             },
+            response.json()
         )
 
     def test_anonymous_can_list_filter_by_type(self):

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -141,7 +141,7 @@ class ComparisonDetailApi(
     generics.GenericAPIView,
 ):
     """
-    Retrieve, update or delete a comparison between two videos made by the
+    Retrieve, update or delete a comparison between two entities made by the
     logged user.
     """
 
@@ -191,7 +191,7 @@ class ComparisonDetailApi(
         fields `entity_a` and `entity_b` are not editable anymore once the
         comparison has been created. Discarding those two fields ensures
         their immutability and thus prevent the falsification of comparisons
-        by video id swap.
+        by uid swap.
         """
         if self.request.method == "PUT":
             return self.UPDATE_SERIALIZER

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -22,16 +22,8 @@ class ComparisonApiMixin:
             comparison = Comparison.get_comparison(
                 request.user,
                 poll_id,
-                "{}{}{}".format(
-                    Entity.UID_YT_NAMESPACE,
-                    Entity.UID_DELIMITER,
-                    request.data["entity_a"]["video_id"],
-                ),
-                "{}{}{}".format(
-                    Entity.UID_YT_NAMESPACE,
-                    Entity.UID_DELIMITER,
-                    request.data["entity_b"]["video_id"],
-                ),
+                request.data["entity_a"]["uid"],
+                request.data["entity_b"]["uid"],
             )
         # if one field is missing, do not raise error yet and let django rest
         # framework checks the request integrity
@@ -109,8 +101,8 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
         if self.comparison_already_exists(poll.pk, self.request):
             raise exceptions.ValidationError(
                 "You've already compared {0} with {1}.".format(
-                    self.request.data["entity_a"]["video_id"],
-                    self.request.data["entity_b"]["video_id"],
+                    self.request.data["entity_a"]["uid"],
+                    self.request.data["entity_b"]["uid"],
                 )
             )
         comparison: Comparison = serializer.save()

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -8,7 +8,7 @@ from django.http import Http404
 from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, generics, mixins
 
-from tournesol.models import Comparison, ContributorRating, Entity
+from tournesol.models import Comparison, ContributorRating
 from tournesol.serializers.comparison import ComparisonSerializer, ComparisonUpdateSerializer
 from tournesol.views.mixins.poll import PollScopedViewMixin
 

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -8,7 +8,7 @@ from drf_spectacular.utils import OpenApiTypes, extend_schema
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.views import APIView
 
-from tournesol.models import Comparison, ContributorRating
+from tournesol.models import Comparison, ContributorRating, Entity
 from tournesol.serializers.comparison import ComparisonSerializer
 from tournesol.utils.cache import cache_page_no_i18n
 
@@ -30,8 +30,8 @@ def write_comparisons_file(request, write_target):
 
     writer.writerows(
         {
-            "video_a": comparison["entity_a"]["video_id"],
-            "video_b": comparison["entity_b"]["video_id"],
+            "video_a": comparison["entity_a"]["uid"].split(Entity.UID_DELIMITER)[1],
+            "video_b": comparison["entity_b"]["uid"].split(Entity.UID_DELIMITER)[1],
             **criteria_score,
         }
         for comparison in serialized_comparisons
@@ -77,8 +77,8 @@ def write_public_comparisons_file(request, write_target):
     writer.writerows(
         {
             "public_username": public_username,
-            "video_a": comparison["entity_a"]["video_id"],
-            "video_b": comparison["entity_b"]["video_id"],
+            "video_a": comparison["entity_a"]["uid"].split(Entity.UID_DELIMITER)[1],
+            "video_b": comparison["entity_b"]["uid"].split(Entity.UID_DELIMITER)[1],
             **criteria_score,
         }
         for (public_username, comparison) in zip(

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1634,9 +1634,9 @@ components:
     ContributorRating:
       type: object
       properties:
-        video:
+        entity:
           allOf:
-          - $ref: '#/components/schemas/Video'
+          - $ref: '#/components/schemas/RelatedEntity'
           readOnly: true
         is_public:
           type: boolean
@@ -1653,17 +1653,17 @@ components:
             current video
       required:
       - criteria_scores
+      - entity
       - n_comparisons
-      - video
     ContributorRatingCreate:
       type: object
       properties:
         is_public:
           type: boolean
           description: Should the rating be public?
-        video:
+        entity:
           allOf:
-          - $ref: '#/components/schemas/Video'
+          - $ref: '#/components/schemas/RelatedEntity'
           readOnly: true
         criteria_scores:
           type: array
@@ -1677,21 +1677,21 @@ components:
             current video
       required:
       - criteria_scores
+      - entity
       - n_comparisons
-      - video
     ContributorRatingCreateRequest:
       type: object
       properties:
-        video_id:
+        uid:
           type: string
           writeOnly: true
           minLength: 1
-          pattern: ^[A-Za-z0-9-_]{11}$
+          pattern: yt:[A-Za-z0-9-_]{11}$
         is_public:
           type: boolean
           description: Should the rating be public?
       required:
-      - video_id
+      - uid
     ContributorRatingRequest:
       type: object
       properties:

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1460,9 +1460,9 @@ components:
         Use `ComparisonUpdateSerializer` for the update operation.
       properties:
         entity_a:
-          $ref: '#/components/schemas/RelatedVideo'
+          $ref: '#/components/schemas/RelatedEntity'
         entity_b:
-          $ref: '#/components/schemas/RelatedVideo'
+          $ref: '#/components/schemas/RelatedEntity'
         criteria_scores:
           type: array
           items:
@@ -1528,9 +1528,9 @@ components:
         Use `ComparisonUpdateSerializer` for the update operation.
       properties:
         entity_a:
-          $ref: '#/components/schemas/RelatedVideoRequest'
+          $ref: '#/components/schemas/RelatedEntityRequest'
         entity_b:
-          $ref: '#/components/schemas/RelatedVideoRequest'
+          $ref: '#/components/schemas/RelatedEntityRequest'
         criteria_scores:
           type: array
           items:
@@ -1565,11 +1565,11 @@ components:
           description: Time it took to rate the videos (in milliseconds)
         entity_a:
           allOf:
-          - $ref: '#/components/schemas/Video'
+          - $ref: '#/components/schemas/RelatedEntity'
           readOnly: true
         entity_b:
           allOf:
-          - $ref: '#/components/schemas/Video'
+          - $ref: '#/components/schemas/RelatedEntity'
           readOnly: true
       required:
       - criteria_scores
@@ -1755,6 +1755,10 @@ components:
       - domain
     Entity:
       type: object
+      description: |-
+        An Entity serializer that also includes polls.
+
+        Use `EntityOnlySerializer` if you don't need the related polls.
       properties:
         uid:
           type: string
@@ -2860,6 +2864,62 @@ components:
       - password
       - password_confirm
       - username
+    RelatedEntity:
+      type: object
+      description: |-
+        An Entity serializer that will create the Entity object on validation
+        if it does not exist in the database yet.
+
+        Only the field `uid` is provided when using write HTTP methods.
+
+        Used by ModelSerializer(s) having one or more nested relations with Entity,
+        and having the constraint to ensure that video instances exist before
+        they can be saved properly.
+      properties:
+        uid:
+          type: string
+          pattern: yt:[A-Za-z0-9-_]{11}$
+        type:
+          allOf:
+          - $ref: '#/components/schemas/TypeEnum'
+          readOnly: true
+        rating_n_ratings:
+          type: integer
+          readOnly: true
+          description: Total number of pairwise comparisons for this videofrom certified
+            contributors
+        rating_n_contributors:
+          type: integer
+          readOnly: true
+          description: Total number of certified contributors who rated the video
+        metadata:
+          type: object
+          additionalProperties: {}
+          readOnly: true
+      required:
+      - metadata
+      - rating_n_contributors
+      - rating_n_ratings
+      - type
+      - uid
+    RelatedEntityRequest:
+      type: object
+      description: |-
+        An Entity serializer that will create the Entity object on validation
+        if it does not exist in the database yet.
+
+        Only the field `uid` is provided when using write HTTP methods.
+
+        Used by ModelSerializer(s) having one or more nested relations with Entity,
+        and having the constraint to ensure that video instances exist before
+        they can be saved properly.
+      properties:
+        uid:
+          type: string
+          minLength: 1
+          pattern: yt:[A-Za-z0-9-_]{11}$
+      required:
+      - uid
     RelatedVideo:
       type: object
       description: |-

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -2883,23 +2883,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/TypeEnum'
           readOnly: true
-        rating_n_ratings:
-          type: integer
-          readOnly: true
-          description: Total number of pairwise comparisons for this videofrom certified
-            contributors
-        rating_n_contributors:
-          type: integer
-          readOnly: true
-          description: Total number of certified contributors who rated the video
         metadata:
           type: object
           additionalProperties: {}
           readOnly: true
       required:
       - metadata
-      - rating_n_contributors
-      - rating_n_ratings
       - type
       - uid
     RelatedEntityRequest:

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -164,8 +164,8 @@ const Comparison = () => {
       const { entity_a, entity_b, criteria_scores, duration_ms } = c;
       await UsersService.usersMeComparisonsUpdate({
         pollName: YOUTUBE_POLL_NAME,
-        uidA: UID_YT_NAMESPACE + entity_a.video_id,
-        uidB: UID_YT_NAMESPACE + entity_b.video_id,
+        uidA: entity_a.uid,
+        uidB: entity_b.uid,
         requestBody: { criteria_scores, duration_ms },
       });
     } else {

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -256,8 +256,8 @@ const Comparison = () => {
             <ComparisonSliders
               submit={onSubmitComparison}
               initialComparison={initialComparison}
-              videoA={videoA}
-              videoB={videoB}
+              uidA={uidA}
+              uidB={uidB}
               isComparisonPublic={
                 selectorA.rating.is_public && selectorB.rating.is_public
               }

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -12,13 +12,8 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
   const { t } = useTranslation();
   const { entity_a, entity_b } = comparison;
 
-  const videoA: VideoObject = {
-    ...videoFromRelatedEntity(entity_a),
-  };
-
-  const videoB: VideoObject = {
-    ...videoFromRelatedEntity(entity_b),
-  };
+  const videoA: VideoObject = videoFromRelatedEntity(entity_a);
+  const videoB: VideoObject = videoFromRelatedEntity(entity_b);
 
   return (
     <Box

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -5,10 +5,23 @@ import { Compare as CompareIcon } from '@mui/icons-material';
 
 import type { Comparison } from 'src/services/openapi';
 import VideoCard from '../videos/VideoCard';
+import { VideoObject } from 'src/utils/types';
+import { videoFromRelatedEntity } from 'src/utils/entity';
 
 const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
   const { t } = useTranslation();
   const { entity_a, entity_b } = comparison;
+
+  const videoA: VideoObject = {
+    ...videoFromRelatedEntity(entity_a),
+    criteria_scores: comparison.criteria_scores,
+  };
+
+  const videoB: VideoObject = {
+    ...videoFromRelatedEntity(entity_b),
+    criteria_scores: comparison.criteria_scores,
+  };
+
   return (
     <Box
       sx={{
@@ -20,7 +33,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
         gap: '16px',
       }}
     >
-      <VideoCard compact video={entity_a} />
+      <VideoCard compact video={videoA} />
       <Box
         sx={{
           position: 'relative',
@@ -48,7 +61,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
           </Fab>
         </Tooltip>
       </Box>
-      <VideoCard compact video={entity_b} />
+      <VideoCard compact video={videoB} />
     </Box>
   );
 };
@@ -75,7 +88,7 @@ const Comparisons = ({
           {comparisons &&
             comparisons.map((c) => (
               <ComparisonThumbnail
-                key={`${c.entity_a.video_id}${c.entity_b.video_id}`}
+                key={`${c.entity_a.metadata.video_id}${c.entity_b.metadata.video_id}`}
                 comparison={c}
               />
             ))}

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -14,12 +14,10 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
 
   const videoA: VideoObject = {
     ...videoFromRelatedEntity(entity_a),
-    criteria_scores: comparison.criteria_scores,
   };
 
   const videoB: VideoObject = {
     ...videoFromRelatedEntity(entity_b),
-    criteria_scores: comparison.criteria_scores,
   };
 
   return (

--- a/frontend/src/features/comparisons/ComparisonSliders.tsx
+++ b/frontend/src/features/comparisons/ComparisonSliders.tsx
@@ -40,14 +40,14 @@ const useStyles = makeStyles(() => ({
 const ComparisonSliders = ({
   submit,
   initialComparison,
-  videoA,
-  videoB,
+  uidA,
+  uidB,
   isComparisonPublic,
 }: {
   submit: (c: ComparisonRequest) => Promise<void>;
   initialComparison: ComparisonRequest | null;
-  videoA: string;
-  videoB: string;
+  uidA: string;
+  uidB: string;
   isComparisonPublic?: boolean;
 }) => {
   const { t } = useTranslation();
@@ -56,8 +56,8 @@ const ComparisonSliders = ({
     return c
       ? c
       : {
-          entity_a: { uid: videoA },
-          entity_b: { uid: videoB },
+          entity_a: { uid: uidA },
+          entity_b: { uid: uidB },
           criteria_scores: allCriterias
             .filter((c) => !optionalCriterias[c])
             .map((criteria) => ({ criteria, score: 0 })),
@@ -113,7 +113,7 @@ const ComparisonSliders = ({
     );
   };
 
-  if (videoA == videoB) {
+  if (uidA == uidB) {
     return (
       <div className={classes.root}>
         <Typography paragraph sx={{ textAlign: 'center' }}>

--- a/frontend/src/features/comparisons/ComparisonSliders.tsx
+++ b/frontend/src/features/comparisons/ComparisonSliders.tsx
@@ -56,8 +56,8 @@ const ComparisonSliders = ({
     return c
       ? c
       : {
-          entity_a: { video_id: videoA },
-          entity_b: { video_id: videoB },
+          entity_a: { uid: videoA },
+          entity_b: { uid: videoB },
           criteria_scores: allCriterias
             .filter((c) => !optionalCriterias[c])
             .map((criteria) => ({ criteria, score: 0 })),

--- a/frontend/src/features/video_selector/VideoSelector.tsx
+++ b/frontend/src/features/video_selector/VideoSelector.tsx
@@ -14,10 +14,12 @@ import { ActionList } from 'src/utils/types';
 import {
   extractVideoId,
   getVideoForComparison,
+  idFromUid,
   isVideoIdValid,
 } from 'src/utils/video';
 import { UsersService, ContributorRating } from 'src/services/openapi';
 import { UID_YT_NAMESPACE, YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { videoFromRelatedEntity } from '../../utils/entity';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -79,7 +81,7 @@ const VideoSelector = ({
             await UsersService.usersMeContributorRatingsCreate({
               pollName: YOUTUBE_POLL_NAME,
               requestBody: {
-                video_id: videoId,
+                uid: UID_YT_NAMESPACE + videoId,
                 is_public: true,
               },
             });
@@ -124,7 +126,7 @@ const VideoSelector = ({
   const handleRatingUpdate = useCallback(
     (newValue: ContributorRating) => {
       onChange({
-        videoId: newValue.video.video_id,
+        videoId: idFromUid(newValue.entity.uid),
         rating: newValue,
       });
     },
@@ -152,7 +154,7 @@ const VideoSelector = ({
       ? [
           <UserRatingPublicToggle
             key="isPublicToggle"
-            videoId={rating.video.video_id}
+            videoId={idFromUid(rating.entity.uid)}
             nComparisons={rating.n_comparisons}
             isPublic={rating.is_public}
             onChange={handleRatingUpdate}
@@ -186,7 +188,11 @@ const VideoSelector = ({
         </Tooltip>
       </div>
       {rating ? (
-        <VideoCard compact video={rating.video} settings={toggleAction} />
+        <VideoCard
+          compact
+          video={videoFromRelatedEntity(rating.entity)}
+          settings={toggleAction}
+        />
       ) : (
         <EmptyVideoCard compact loading={loading} />
       )}

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -16,8 +16,10 @@ import {
   RatingsContext,
 } from 'src/features/videos/PublicStatusAction';
 import RatingsFilter from 'src/features/ratings/RatingsFilter';
+import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { videoFromRelatedEntity } from 'src/utils/entity';
 import { scrollToTop } from 'src/utils/ui';
-import { YOUTUBE_POLL_NAME } from '../../utils/constants';
+import { idFromUid } from 'src/utils/video';
 
 const NoRatingMessage = ({ hasFilter }: { hasFilter: boolean }) => {
   const { t } = useTranslation();
@@ -83,11 +85,14 @@ const VideoRatingsPage = () => {
     loadData();
   }, [loadData]);
 
-  const videos = (ratings.results || []).map(
-    (rating: ContributorRating) => rating.video
+  const entities = (ratings.results || []).map(
+    (rating: ContributorRating) => rating.entity
   );
   const idToRating = Object.fromEntries(
-    (ratings.results || []).map((rating) => [rating.video.video_id, rating])
+    (ratings.results || []).map((rating) => [
+      idFromUid(rating.entity.uid),
+      rating,
+    ])
   );
   const getRating = (videoId: string) => idToRating[videoId];
 
@@ -95,9 +100,7 @@ const VideoRatingsPage = () => {
     if (newRating) {
       setRatings((prevRatings) => {
         const updatedResults = (prevRatings.results || []).map((rating) =>
-          rating.video.video_id === newRating.video.video_id
-            ? newRating
-            : rating
+          rating.entity.uid === newRating.entity.uid ? newRating : rating
         );
         return { ...prevRatings, results: updatedResults };
       });
@@ -128,7 +131,7 @@ const VideoRatingsPage = () => {
         </Box>
         <LoaderWrapper isLoading={isLoading}>
           <VideoList
-            videos={videos}
+            videos={entities.map((ent) => videoFromRelatedEntity(ent))}
             settings={[PublicStatusAction]}
             emptyMessage={<NoRatingMessage hasFilter={hasFilter} />}
           />

--- a/frontend/src/utils/entity.ts
+++ b/frontend/src/utils/entity.ts
@@ -1,0 +1,18 @@
+import { RelatedEntityObject } from './types';
+import { Video } from 'src/services/openapi';
+
+export const videoFromRelatedEntity = (entity: RelatedEntityObject): Video => {
+  return {
+    uid: entity.uid,
+    name: entity.metadata.name,
+    description: entity.metadata.description,
+    publication_date: entity.metadata.publication_date,
+    views: entity.metadata.views,
+    uploader: entity.metadata.uploader,
+    language: entity.metadata.language,
+    rating_n_ratings: entity.rating_n_ratings || 0,
+    rating_n_contributors: entity.rating_n_contributors || 0,
+    duration: entity.metadata.duration,
+    video_id: entity.metadata.video_id,
+  };
+};

--- a/frontend/src/utils/entity.ts
+++ b/frontend/src/utils/entity.ts
@@ -10,8 +10,8 @@ export const videoFromRelatedEntity = (entity: RelatedEntityObject): Video => {
     views: entity.metadata.views,
     uploader: entity.metadata.uploader,
     language: entity.metadata.language,
-    rating_n_ratings: entity.rating_n_ratings || 0,
-    rating_n_contributors: entity.rating_n_contributors || 0,
+    rating_n_ratings: 0,
+    rating_n_contributors: 0,
     duration: entity.metadata.duration,
     video_id: entity.metadata.video_id,
   };

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,5 +1,9 @@
 import React from 'react';
-import { Video, VideoSerializerWithCriteria } from 'src/services/openapi';
+import {
+  RelatedEntity,
+  Video,
+  VideoSerializerWithCriteria,
+} from 'src/services/openapi';
 
 export type JSONValue =
   | string
@@ -17,4 +21,5 @@ export type ActionList = Array<
   (({ uid }: { uid: string }) => JSX.Element) | React.ReactNode
 >;
 
+export type RelatedEntityObject = RelatedEntity;
 export type VideoObject = Video | VideoSerializerWithCriteria;

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -120,8 +120,8 @@ export async function getVideoFromPreviousComparisons(
   });
   const cl = comparisonVideoResult?.results || [];
   const comparisonVideoList = [
-    ...cl.map((v) => v.entity_a.video_id),
-    ...cl.map((v) => v.entity_b.video_id),
+    ...cl.map((v) => v.entity_a.metadata.video_id),
+    ...cl.map((v) => v.entity_b.metadata.video_id),
   ];
   const comparisonVideoId = retryRandomPick(
     5,


### PR DESCRIPTION
**related to** #597

**follows the work of the pull request** #623

based on branch `597`, will be rebased on `main` when #623  is merged

---

should be reviewed after #623 