### PR TITLE
[back][front] refactor: ratings API uses `RelatedEntitySerializer`

### DIFF
--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -79,22 +79,16 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
     def create(self, validated_data):
         uid_1 = validated_data.pop("entity_1").get("uid")
         uid_2 = validated_data.pop("entity_2").get("uid")
-
-        # XXX: the following lines are still specific to `video` Entity. When
-        # the comparisons API will be used by more than one entity type, a
-        # type check will be needed here to avoid calling `get_from_video_id`
-        # on non-video Entity.
-
         # The validation performed by the `RelatedEntitySerializer` guarantees
         # that the submitted UIDs exist in the database.
-        video_1 = Entity.get_from_video_id(uid_1.split(Entity.UID_DELIMITER)[1])
-        video_2 = Entity.get_from_video_id(uid_2.split(Entity.UID_DELIMITER)[1])
+        entity_1 = Entity.objects.get(uid=uid_1)
+        entity_2 = Entity.objects.get(uid=uid_2)
         criteria_scores = validated_data.pop("criteria_scores")
 
         comparison = Comparison.objects.create(
             poll=self.context.get("poll"),
-            entity_1=video_1,
-            entity_2=video_2,
+            entity_1=entity_1,
+            entity_2=entity_2,
             **validated_data,
         )
 

--- a/backend/tournesol/serializers/entity.py
+++ b/backend/tournesol/serializers/entity.py
@@ -178,6 +178,7 @@ class EntityNoExtraFieldSerializer(EntitySerializer):
             "metadata",
         ]
         read_only_fields = [
+            "uid",
             "type",
             "metadata",
         ]

--- a/backend/tournesol/serializers/entity.py
+++ b/backend/tournesol/serializers/entity.py
@@ -140,7 +140,7 @@ class EntitySerializer(ModelSerializer):
     """
     An Entity serializer that also includes polls.
 
-    Use `EntityOnlySerializer` if you don't need the related polls.
+    Use `EntityNoExtraFieldSerializer` if you don't need the related polls.
     """
 
     polls = serializers.SerializerMethodField()
@@ -164,6 +164,23 @@ class EntitySerializer(ModelSerializer):
             for (name, scores) in poll_to_scores.items()
         ]
         return EntityPollSerializer(items, many=True).data
+
+
+class EntityNoExtraFieldSerializer(EntitySerializer):
+    """
+    An Entity serializer that doesn't include extra fields.
+    """
+    class Meta:
+        model = Entity
+        fields = [
+            "uid",
+            "type",
+            "metadata",
+        ]
+        read_only_fields = [
+            "type",
+            "metadata",
+        ]
 
 
 class RelatedEntitySerializer(EntitySerializer):

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -7,7 +7,7 @@ from rest_framework.serializers import ModelSerializer, Serializer
 
 from core.utils.constants import YOUTUBE_VIDEO_ID_REGEX
 from tournesol.models import ContributorRating, ContributorRatingCriteriaScore, Entity
-from tournesol.serializers.entity import RelatedVideoSerializer, VideoSerializer
+from tournesol.serializers.entity import RelatedEntitySerializer
 
 
 class ContributorCriteriaScore(ModelSerializer):
@@ -17,7 +17,7 @@ class ContributorCriteriaScore(ModelSerializer):
 
 
 class ContributorRatingSerializer(ModelSerializer):
-    video = VideoSerializer(source="entity", read_only=True)
+    entity = RelatedEntitySerializer(read_only=True)
     criteria_scores = ContributorCriteriaScore(many=True, read_only=True)
     n_comparisons = SerializerMethodField(
         help_text="Number of comparisons submitted by the current user about the current video",
@@ -25,7 +25,7 @@ class ContributorRatingSerializer(ModelSerializer):
 
     class Meta:
         model = ContributorRating
-        fields = ["video", "is_public", "criteria_scores", "n_comparisons"]
+        fields = ["entity", "is_public", "criteria_scores", "n_comparisons"]
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_n_comparisons(self, obj):
@@ -51,24 +51,24 @@ class ContributorRatingSerializer(ModelSerializer):
 
 
 class ContributorRatingCreateSerializer(ContributorRatingSerializer):
-    video_id = RegexField(YOUTUBE_VIDEO_ID_REGEX, write_only=True)
+    uid = RegexField(rf"yt:{YOUTUBE_VIDEO_ID_REGEX[1:]}", write_only=True)
 
     class Meta:
         model = ContributorRating
-        fields = ["video_id", "is_public", "video", "criteria_scores", "n_comparisons"]
+        fields = ["uid", "is_public", "entity", "criteria_scores", "n_comparisons"]
 
     def validate(self, attrs):
-        video_id = attrs.pop("video_id")
-        video_serializer = RelatedVideoSerializer(data={"video_id": video_id})
-        video_serializer.is_valid(raise_exception=True)
-        video = Entity.get_from_video_id(video_id)
+        uid = attrs.pop("uid")
+        entity_serializer = RelatedEntitySerializer(data={"uid": uid})
+        entity_serializer.is_valid(raise_exception=True)
+        entity = Entity.objects.get(uid=uid)
         user = self.context["request"].user
-        if user.contributorvideoratings.filter(entity=video).exists():
+        if user.contributorvideoratings.filter(entity=entity).exists():
             raise ValidationError(
-                "A ContributorRating already exists for this (user, video)",
+                "A ContributorRating already exists for this (user, entity)",
                 code="unique",
             )
-        attrs["entity"] = video
+        attrs["entity"] = entity
         attrs["user"] = user
         return attrs
 

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -7,7 +7,7 @@ from rest_framework.serializers import ModelSerializer, Serializer
 
 from core.utils.constants import YOUTUBE_VIDEO_ID_REGEX
 from tournesol.models import ContributorRating, ContributorRatingCriteriaScore, Entity
-from tournesol.serializers.entity import RelatedEntitySerializer
+from tournesol.serializers.entity import EntityNoExtraFieldSerializer, RelatedEntitySerializer
 
 
 class ContributorCriteriaScore(ModelSerializer):
@@ -17,7 +17,7 @@ class ContributorCriteriaScore(ModelSerializer):
 
 
 class ContributorRatingSerializer(ModelSerializer):
-    entity = RelatedEntitySerializer(read_only=True)
+    entity = EntityNoExtraFieldSerializer(read_only=True)
     criteria_scores = ContributorCriteriaScore(many=True, read_only=True)
     n_comparisons = SerializerMethodField(
         help_text="Number of comparisons submitted by the current user about the current video",

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -5,7 +5,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import BooleanField, CharField, SerializerMethodField
 from rest_framework.serializers import ModelSerializer, Serializer
 
-from core.utils.constants import YOUTUBE_VIDEO_ID_REGEX
 from tournesol.models import ContributorRating, ContributorRatingCriteriaScore, Entity
 from tournesol.serializers.entity import EntityNoExtraFieldSerializer, RelatedEntitySerializer
 
@@ -51,10 +50,7 @@ class ContributorRatingSerializer(ModelSerializer):
 
 
 class ContributorRatingCreateSerializer(ContributorRatingSerializer):
-    uid = CharField(
-        write_only=True,
-        max_length=144,
-    )
+    uid = CharField(max_length=144, write_only=True)
 
     class Meta:
         model = ContributorRating

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1631,9 +1631,9 @@ components:
     ContributorRating:
       type: object
       properties:
-        video:
+        entity:
           allOf:
-          - $ref: '#/components/schemas/Video'
+          - $ref: '#/components/schemas/RelatedEntity'
           readOnly: true
         is_public:
           type: boolean
@@ -1650,17 +1650,17 @@ components:
             current video
       required:
       - criteria_scores
+      - entity
       - n_comparisons
-      - video
     ContributorRatingCreate:
       type: object
       properties:
         is_public:
           type: boolean
           description: Should the rating be public?
-        video:
+        entity:
           allOf:
-          - $ref: '#/components/schemas/Video'
+          - $ref: '#/components/schemas/RelatedEntity'
           readOnly: true
         criteria_scores:
           type: array
@@ -1674,21 +1674,21 @@ components:
             current video
       required:
       - criteria_scores
+      - entity
       - n_comparisons
-      - video
     ContributorRatingCreateRequest:
       type: object
       properties:
-        video_id:
+        uid:
           type: string
           writeOnly: true
           minLength: 1
-          pattern: ^[A-Za-z0-9-_]{11}$
+          pattern: yt:[A-Za-z0-9-_]{11}$
         is_public:
           type: boolean
           description: Should the rating be public?
       required:
-      - video_id
+      - uid
     ContributorRatingRequest:
       type: object
       properties:

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1633,7 +1633,7 @@ components:
       properties:
         entity:
           allOf:
-          - $ref: '#/components/schemas/RelatedEntity'
+          - $ref: '#/components/schemas/EntityNoExtraField'
           readOnly: true
         is_public:
           type: boolean
@@ -1660,7 +1660,7 @@ components:
           description: Should the rating be public?
         entity:
           allOf:
-          - $ref: '#/components/schemas/RelatedEntity'
+          - $ref: '#/components/schemas/EntityNoExtraField'
           readOnly: true
         criteria_scores:
           type: array
@@ -1755,7 +1755,7 @@ components:
       description: |-
         An Entity serializer that also includes polls.
 
-        Use `EntityOnlySerializer` if you don't need the related polls.
+        Use `EntityNoExtraFieldSerializer` if you don't need the related polls.
       properties:
         uid:
           type: string
@@ -1789,6 +1789,39 @@ components:
           description: Score of the given criteria
       required:
       - criteria
+    EntityNoExtraField:
+      type: object
+      description: An Entity serializer that doesn't include extra fields.
+      properties:
+        uid:
+          type: string
+          description: A unique identifier, build with a namespace and an external
+            id.
+          maxLength: 144
+        type:
+          allOf:
+          - $ref: '#/components/schemas/TypeEnum'
+          readOnly: true
+        metadata:
+          type: object
+          additionalProperties: {}
+          readOnly: true
+      required:
+      - metadata
+      - type
+      - uid
+    EntityNoExtraFieldRequest:
+      type: object
+      description: An Entity serializer that doesn't include extra fields.
+      properties:
+        uid:
+          type: string
+          minLength: 1
+          description: A unique identifier, build with a namespace and an external
+            id.
+          maxLength: 144
+      required:
+      - uid
     EntityPoll:
       type: object
       properties:

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1683,7 +1683,7 @@ components:
           type: string
           writeOnly: true
           minLength: 1
-          pattern: yt:[A-Za-z0-9-_]{11}$
+          maxLength: 144
         is_public:
           type: boolean
           description: Should the rating be public?
@@ -1795,9 +1795,9 @@ components:
       properties:
         uid:
           type: string
+          readOnly: true
           description: A unique identifier, build with a namespace and an external
             id.
-          maxLength: 144
         type:
           allOf:
           - $ref: '#/components/schemas/TypeEnum'
@@ -1809,18 +1809,6 @@ components:
       required:
       - metadata
       - type
-      - uid
-    EntityNoExtraFieldRequest:
-      type: object
-      description: An Entity serializer that doesn't include extra fields.
-      properties:
-        uid:
-          type: string
-          minLength: 1
-          description: A unique identifier, build with a namespace and an external
-            id.
-          maxLength: 144
-      required:
       - uid
     EntityPoll:
       type: object

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -12,13 +12,8 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
   const { t } = useTranslation();
   const { entity_a, entity_b } = comparison;
 
-  const videoA: VideoObject = {
-    ...videoFromRelatedEntity(entity_a),
-  };
-
-  const videoB: VideoObject = {
-    ...videoFromRelatedEntity(entity_b),
-  };
+  const videoA: VideoObject = videoFromRelatedEntity(entity_a);
+  const videoB: VideoObject = videoFromRelatedEntity(entity_b);
 
   return (
     <Box

--- a/frontend/src/features/video_selector/VideoSelector.tsx
+++ b/frontend/src/features/video_selector/VideoSelector.tsx
@@ -14,10 +14,12 @@ import { ActionList } from 'src/utils/types';
 import {
   extractVideoId,
   getVideoForComparison,
+  idFromUid,
   isVideoIdValid,
 } from 'src/utils/video';
 import { UsersService, ContributorRating } from 'src/services/openapi';
 import { UID_YT_NAMESPACE, YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { videoFromRelatedEntity } from '../../utils/entity';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -79,7 +81,7 @@ const VideoSelector = ({
             await UsersService.usersMeContributorRatingsCreate({
               pollName: YOUTUBE_POLL_NAME,
               requestBody: {
-                video_id: videoId,
+                uid: UID_YT_NAMESPACE + videoId,
                 is_public: true,
               },
             });
@@ -124,7 +126,7 @@ const VideoSelector = ({
   const handleRatingUpdate = useCallback(
     (newValue: ContributorRating) => {
       onChange({
-        videoId: newValue.video.video_id,
+        videoId: idFromUid(newValue.entity.uid),
         rating: newValue,
       });
     },
@@ -152,7 +154,7 @@ const VideoSelector = ({
       ? [
           <UserRatingPublicToggle
             key="isPublicToggle"
-            videoId={rating.video.video_id}
+            videoId={idFromUid(rating.entity.uid)}
             nComparisons={rating.n_comparisons}
             isPublic={rating.is_public}
             onChange={handleRatingUpdate}
@@ -186,7 +188,11 @@ const VideoSelector = ({
         </Tooltip>
       </div>
       {rating ? (
-        <VideoCard compact video={rating.video} settings={toggleAction} />
+        <VideoCard
+          compact
+          video={videoFromRelatedEntity(rating.entity)}
+          settings={toggleAction}
+        />
       ) : (
         <EmptyVideoCard compact loading={loading} />
       )}

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -16,8 +16,10 @@ import {
   RatingsContext,
 } from 'src/features/videos/PublicStatusAction';
 import RatingsFilter from 'src/features/ratings/RatingsFilter';
+import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { videoFromRelatedEntity } from 'src/utils/entity';
 import { scrollToTop } from 'src/utils/ui';
-import { YOUTUBE_POLL_NAME } from '../../utils/constants';
+import { idFromUid } from 'src/utils/video';
 
 const NoRatingMessage = ({ hasFilter }: { hasFilter: boolean }) => {
   const { t } = useTranslation();
@@ -83,11 +85,14 @@ const VideoRatingsPage = () => {
     loadData();
   }, [loadData]);
 
-  const videos = (ratings.results || []).map(
-    (rating: ContributorRating) => rating.video
+  const entities = (ratings.results || []).map(
+    (rating: ContributorRating) => rating.entity
   );
   const idToRating = Object.fromEntries(
-    (ratings.results || []).map((rating) => [rating.video.video_id, rating])
+    (ratings.results || []).map((rating) => [
+      idFromUid(rating.entity.uid),
+      rating,
+    ])
   );
   const getRating = (videoId: string) => idToRating[videoId];
 
@@ -95,9 +100,7 @@ const VideoRatingsPage = () => {
     if (newRating) {
       setRatings((prevRatings) => {
         const updatedResults = (prevRatings.results || []).map((rating) =>
-          rating.video.video_id === newRating.video.video_id
-            ? newRating
-            : rating
+          rating.entity.uid === newRating.entity.uid ? newRating : rating
         );
         return { ...prevRatings, results: updatedResults };
       });
@@ -128,7 +131,7 @@ const VideoRatingsPage = () => {
         </Box>
         <LoaderWrapper isLoading={isLoading}>
           <VideoList
-            videos={videos}
+            videos={entities.map((ent) => videoFromRelatedEntity(ent))}
             settings={[PublicStatusAction]}
             emptyMessage={<NoRatingMessage hasFilter={hasFilter} />}
           />

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  EntityNoExtraField,
   RelatedEntity,
   Video,
   VideoSerializerWithCriteria,
@@ -21,5 +22,5 @@ export type ActionList = Array<
   (({ uid }: { uid: string }) => JSX.Element) | React.ReactNode
 >;
 
-export type RelatedEntityObject = RelatedEntity;
+export type RelatedEntityObject = EntityNoExtraField | RelatedEntity;
 export type VideoObject = Video | VideoSerializerWithCriteria;


### PR DESCRIPTION
**related to** #597

**follows the work of the pull request** #623