### PR TITLE
[tests] tests: add end-to-end tests related to the comparison page

### DIFF
--- a/frontend/src/features/video_selector/VideoSelector.tsx
+++ b/frontend/src/features/video_selector/VideoSelector.tsx
@@ -182,6 +182,7 @@ const VideoSelector = ({
         >
           <IconButton
             aria-label="new_video"
+            data-testid="new-video"
             onClick={loadNewVideo}
             size="large"
           >

--- a/tests/cypress/integration/frontend/comparePage.ts
+++ b/tests/cypress/integration/frontend/comparePage.ts
@@ -1,4 +1,4 @@
-describe('Compare page', () => {
+describe('Comparison page', () => {
     describe('authorization', () => {
         it('is not accessible by anonymous users', () => {
             cy.visit('/comparison');
@@ -14,6 +14,62 @@ describe('Compare page', () => {
 
             cy.location('pathname').should('equal', '/comparison');
             cy.contains('submit a comparison', {matchCase: false}).should('be.visible');
+        })
+    });
+
+    describe('video selectors', () => {
+        const videoAUrl = 'https://www.youtube.com/watch?v=u83A7DUNMHs';
+        const videoBUrl = 'https://www.youtube.com/watch?v=m9APFfDGRuk';
+
+        it('support pasting YouTube URLs', () => {
+            cy.visit('/comparison');
+
+            cy.focused().type('user1');
+            cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+
+            cy.contains('video 1', {matchCase: false}).should('be.visible');
+            cy.contains('video 2', {matchCase: false}).should('be.visible');
+
+            // TODO: write the test
+        })
+
+        it('support pasting YouTube video ID', () => {
+            cy.visit('/comparison');
+
+            cy.focused().type('user1');
+            cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+
+            const inputs = cy.get('input[placeholder="Paste URL or Video ID"]');
+            inputs.should('have.length', 2);
+
+            inputs.first().type(videoAUrl.split('?v=')[1], {delay: 0});
+            inputs.first().get('div[data-testid=video-card-info]').within(() => {
+                // the video title is displayed
+                cy.contains(
+                    'Science4VeryAll : Lê fait enfin un effort de vulgarisation sur Étincelles !!',
+                    {matchCase: false}
+                ).should('be.visible');
+                // the upload date is displayed
+                cy.contains('2021-11-22', {matchCase: false}).should('be.visible');
+                // the number of view is displayed
+                cy.contains('views', {matchCase: false}).should('be.visible');
+            });
+
+            cy.get('input[placeholder="Paste URL or Video ID"]')
+                .last().type(videoBUrl.split('?v=')[1], {delay: 0});
+
+            cy.get('input[placeholder="Paste URL or Video ID"]')
+                .last().get('div[data-testid=video-card-info]').within(() => {
+                // the video title is displayed
+                cy.contains(
+                    'Pourquoi les réseaux sociaux sont si clivants ?',
+                    {matchCase: false}
+                ).should('be.visible');
+                // the upload date is displayed
+                cy.contains('2022-02-03', {matchCase: false}).should('be.visible');
+                // the number of view is displayed
+                cy.contains('views', {matchCase: false}).should('be.visible');
+            });
         })
     });
 });

--- a/tests/cypress/integration/frontend/comparePage.ts
+++ b/tests/cypress/integration/frontend/comparePage.ts
@@ -67,8 +67,16 @@ describe('Comparison page', () => {
 
   describe('submit a comparison', () => {
     const videoAUrl = 'https://www.youtube.com/watch?v=u83A7DUNMHs';
-    const videoBUrl = 'https://www.youtube.com/watch?v=6jK9bFWE--g';
 
+    /**
+     * Select a video in the first VideoSelector then click on the new video
+     * button in the second VideoSelector.
+     *
+     * The test ensures:
+     * - only the main criteria is visible
+     * - the add optional criteria button is displayed
+     * - success hints are visible (edit button and success alert)
+     */
     it('with only the main criteria', () => {
       cy.visit('/comparison');
 
@@ -79,11 +87,10 @@ describe('Comparison page', () => {
       cy.get('input[placeholder="Paste URL or Video ID"]').first()
         .type(videoAUrl.split('?v=')[1], {delay: 0});
 
-      // TODO: click on the New Video button instead to guarantee
-      //       the comparison doesn't already exist
-      cy.get('input[placeholder="Paste URL or Video ID"]').last()
-        .type(videoBUrl.split('?v=')[1], {delay: 0});
+      cy.get('button[data-testid=new-video').last().click()
 
+      cy.contains('add optional criteria', {matchCase: false})
+          .should('be.visible');
       cy.contains('should be largely recommended', {matchCase: false})
         .should('be.visible');
 
@@ -92,6 +99,8 @@ describe('Comparison page', () => {
 
       cy.get('button#expert_submit_btn').click();
 
+      cy.contains('successfully submitted', {matchCase: false})
+          .should('be.visible');
       cy.contains('edit comparison', {matchCase: false})
         .should('be.visible');
     })

--- a/tests/cypress/integration/frontend/comparePage.ts
+++ b/tests/cypress/integration/frontend/comparePage.ts
@@ -68,6 +68,18 @@ describe('Comparison page', () => {
   describe('submit a comparison', () => {
     const videoAUrl = 'https://www.youtube.com/watch?v=u83A7DUNMHs';
 
+    const criteriaSliders = [
+      "slider_expert_reliability",
+      "slider_expert_pedagogy",
+      "slider_expert_importance",
+      "slider_expert_layman_friendly",
+      "slider_expert_entertaining_relaxing",
+      "slider_expert_engaging",
+      "slider_expert_diversity_inclusion",
+      "slider_expert_better_habits",
+      "slider_expert_backfire_risk",
+    ]
+
     /**
      * Select a video in the first VideoSelector then click on the new video
      * button in the second VideoSelector.
@@ -107,6 +119,42 @@ describe('Comparison page', () => {
           .should('be.visible');
       cy.contains('successfully submitted', {matchCase: false})
           .should('be.visible');
-    })
+    });
+
+    /**
+     * A user can submit a comparison with all criteria.
+     */
+    it('with all the criteria', () => {
+      cy.visit('/comparison');
+
+      cy.focused().type('user1');
+      cy.get('input[name="password"]').click()
+          .type('tournesol').type('{enter}');
+
+      cy.get('input[placeholder="Paste URL or Video ID"]').first()
+          .type(videoAUrl.split('?v=')[1], {delay: 0});
+      cy.get('button[data-testid=new-video').last().click()
+
+      cy.contains('add optional criteria', {matchCase: false}).click()
+
+      cy.get('#slider_expert_largely_recommended').within(() => {
+        cy.get('span[data-index=12]').click();
+      })
+
+      criteriaSliders.forEach((slider) => {
+        cy.get('#' + slider).within(() => {
+          cy.get('span[data-index=12]').click();
+        })
+      });
+
+      cy.contains('submit', {matchCase: false})
+          .should('be.visible');
+      cy.get('button#expert_submit_btn').click();
+
+      cy.contains('edit comparison', {matchCase: false})
+          .should('be.visible');
+      cy.contains('successfully submitted', {matchCase: false})
+          .should('be.visible');
+    });
   });
 });

--- a/tests/cypress/integration/frontend/comparePage.ts
+++ b/tests/cypress/integration/frontend/comparePage.ts
@@ -84,25 +84,29 @@ describe('Comparison page', () => {
       cy.get('input[name="password"]').click()
         .type('tournesol').type('{enter}');
 
+      // add one video, and ask for a second one
       cy.get('input[placeholder="Paste URL or Video ID"]').first()
         .type(videoAUrl.split('?v=')[1], {delay: 0});
-
       cy.get('button[data-testid=new-video').last().click()
 
+      // only one criteria must be visible by default
       cy.contains('add optional criteria', {matchCase: false})
           .should('be.visible');
       cy.contains('should be largely recommended', {matchCase: false})
         .should('be.visible');
 
+      cy.get('#slider_expert_largely_recommended').within(() => {
+        cy.get('span[data-index=12]').click();
+      })
+
       cy.contains('submit', {matchCase: false})
         .should('be.visible');
-
       cy.get('button#expert_submit_btn').click();
 
+      cy.contains('edit comparison', {matchCase: false})
+          .should('be.visible');
       cy.contains('successfully submitted', {matchCase: false})
           .should('be.visible');
-      cy.contains('edit comparison', {matchCase: false})
-        .should('be.visible');
     })
   });
 });

--- a/tests/cypress/integration/frontend/comparePage.ts
+++ b/tests/cypress/integration/frontend/comparePage.ts
@@ -51,7 +51,7 @@ describe('Comparison page', () => {
         .should('have.length', 2);
 
       cy.get('input[placeholder="Paste URL or Video ID"]').first()
-        .type(videoAUrl.split('?v=')[1]);
+        .type(videoAUrl.split('?v=')[1], {delay: 0});
 
       // the video title, upload date, and the number of views must be displayed
       cy.get('div[data-testid=video-card-info]').first().within(() => {
@@ -62,6 +62,38 @@ describe('Comparison page', () => {
         cy.contains('2021-11-22', {matchCase: false}).should('be.visible');
         cy.contains('views', {matchCase: false}).should('be.visible');
       });
+    })
+  });
+
+  describe('submit a comparison', () => {
+    const videoAUrl = 'https://www.youtube.com/watch?v=u83A7DUNMHs';
+    const videoBUrl = 'https://www.youtube.com/watch?v=6jK9bFWE--g';
+
+    it('with only the main criteria', () => {
+      cy.visit('/comparison');
+
+      cy.focused().type('user1');
+      cy.get('input[name="password"]').click()
+        .type('tournesol').type('{enter}');
+
+      cy.get('input[placeholder="Paste URL or Video ID"]').first()
+        .type(videoAUrl.split('?v=')[1], {delay: 0});
+
+      // TODO: click on the New Video button instead to guarantee
+      //       the comparison doesn't already exist
+      cy.get('input[placeholder="Paste URL or Video ID"]').last()
+        .type(videoBUrl.split('?v=')[1], {delay: 0});
+
+      cy.contains('should be largely recommended', {matchCase: false})
+        .should('be.visible');
+
+      cy.contains('submit', {matchCase: false})
+        .should('be.visible');
+
+      cy.get('button#expert_submit_btn').click();
+
+      cy.contains('edit comparison', {matchCase: false})
+        .should('be.visible');
     })
   });
 });

--- a/tests/cypress/integration/frontend/comparePage.ts
+++ b/tests/cypress/integration/frontend/comparePage.ts
@@ -1,75 +1,67 @@
 describe('Comparison page', () => {
-    describe('authorization', () => {
-        it('is not accessible by anonymous users', () => {
-            cy.visit('/comparison');
-            cy.location('pathname').should('equal', '/login');
-            cy.contains('log in to tournesol', {matchCase: false}).should('be.visible');
-        })
+  describe('authorization', () => {
+    it('is not accessible by anonymous users', () => {
+      cy.visit('/comparison');
+      cy.location('pathname').should('equal', '/login');
+      cy.contains('log in to tournesol', {matchCase: false}).should('be.visible');
+    })
 
-        it('is accessible by authenticated users', () => {
-            cy.visit('/comparison');
+    it('is accessible by authenticated users', () => {
+      cy.visit('/comparison');
 
-            cy.focused().type('user1');
-            cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+      cy.focused().type('user1');
+      cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
 
-            cy.location('pathname').should('equal', '/comparison');
-            cy.contains('submit a comparison', {matchCase: false}).should('be.visible');
-        })
-    });
+      cy.location('pathname').should('equal', '/comparison');
+      cy.contains('submit a comparison', {matchCase: false}).should('be.visible');
+    })
+  });
 
-    describe('video selectors', () => {
-        const videoAUrl = 'https://www.youtube.com/watch?v=u83A7DUNMHs';
-        const videoBUrl = 'https://www.youtube.com/watch?v=m9APFfDGRuk';
+  describe('video selectors', () => {
+    const videoAUrl = 'https://www.youtube.com/watch?v=u83A7DUNMHs';
 
-        it('support pasting YouTube URLs', () => {
-            cy.visit('/comparison');
+    it('support pasting YouTube URLs', () => {
+      cy.visit('/comparison');
 
-            cy.focused().type('user1');
-            cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+      cy.focused().type('user1');
+      cy.get('input[name="password"]').click()
+        .type('tournesol').type('{enter}');
 
-            cy.contains('video 1', {matchCase: false}).should('be.visible');
-            cy.contains('video 2', {matchCase: false}).should('be.visible');
+      cy.contains('video 1', {matchCase: false}).should('be.visible');
+      cy.contains('video 2', {matchCase: false}).should('be.visible');
 
-            // TODO: write the test
-        })
+      // TODO: a little help is required to write the tests
 
-        it('support pasting YouTube video ID', () => {
-            cy.visit('/comparison');
+      // I didn't find a proper way to paste the URL into the `VideoCard` input field,
+      // and to trigger its `onChange` method to extract the video ID from the URL.
+      // .type() didn't work
+      // .invoke('val', url) didn't work neither
+      // .invoke('val', url).trigger('change') / trigger('input') neither
+    })
 
-            cy.focused().type('user1');
-            cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+    it('support pasting YouTube video ID', () => {
+      cy.visit('/comparison');
 
-            const inputs = cy.get('input[placeholder="Paste URL or Video ID"]');
-            inputs.should('have.length', 2);
+      cy.focused().type('user1');
+      cy.get('input[name="password"]').click()
+        .type('tournesol').type('{enter}');
 
-            inputs.first().type(videoAUrl.split('?v=')[1], {delay: 0});
-            inputs.first().get('div[data-testid=video-card-info]').within(() => {
-                // the video title is displayed
-                cy.contains(
-                    'Science4VeryAll : Lê fait enfin un effort de vulgarisation sur Étincelles !!',
-                    {matchCase: false}
-                ).should('be.visible');
-                // the upload date is displayed
-                cy.contains('2021-11-22', {matchCase: false}).should('be.visible');
-                // the number of view is displayed
-                cy.contains('views', {matchCase: false}).should('be.visible');
-            });
+      // two cards must be displayed
+      cy.get('input[placeholder="Paste URL or Video ID"]')
+        .should('have.length', 2);
 
-            cy.get('input[placeholder="Paste URL or Video ID"]')
-                .last().type(videoBUrl.split('?v=')[1], {delay: 0});
+      cy.get('input[placeholder="Paste URL or Video ID"]').first()
+        .type(videoAUrl.split('?v=')[1]);
 
-            cy.get('input[placeholder="Paste URL or Video ID"]')
-                .last().get('div[data-testid=video-card-info]').within(() => {
-                // the video title is displayed
-                cy.contains(
-                    'Pourquoi les réseaux sociaux sont si clivants ?',
-                    {matchCase: false}
-                ).should('be.visible');
-                // the upload date is displayed
-                cy.contains('2022-02-03', {matchCase: false}).should('be.visible');
-                // the number of view is displayed
-                cy.contains('views', {matchCase: false}).should('be.visible');
-            });
-        })
-    });
+      // the video title, upload date, and the number of views must be displayed
+      cy.get('div[data-testid=video-card-info]').first().within(() => {
+        cy.contains(
+          'Science4VeryAll : Lê fait enfin un effort de vulgarisation sur Étincelles !!',
+          {matchCase: false}
+        ).should('be.visible');
+        cy.contains('2021-11-22', {matchCase: false}).should('be.visible');
+        cy.contains('views', {matchCase: false}).should('be.visible');
+      });
+    })
+  });
 });

--- a/tests/cypress/integration/frontend/comparePage.ts
+++ b/tests/cypress/integration/frontend/comparePage.ts
@@ -1,0 +1,19 @@
+describe('Compare page', () => {
+    describe('authorization', () => {
+        it('is not accessible by anonymous users', () => {
+            cy.visit('/comparison');
+            cy.location('pathname').should('equal', '/login');
+            cy.contains('log in to tournesol', {matchCase: false}).should('be.visible');
+        })
+
+        it('is accessible by authenticated users', () => {
+            cy.visit('/comparison');
+
+            cy.focused().type('user1');
+            cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+
+            cy.location('pathname').should('equal', '/comparison');
+            cy.contains('submit a comparison', {matchCase: false}).should('be.visible');
+        })
+    });
+});

--- a/tests/cypress/integration/frontend/comparisonPage.ts
+++ b/tests/cypress/integration/frontend/comparisonPage.ts
@@ -1,4 +1,29 @@
 describe('Comparison page', () => {
+
+  const deleteComparison = (idA, idB) => {
+    cy.sql(`
+        DELETE FROM tournesol_comparisoncriteriascore
+        WHERE comparison_id = (
+            SELECT id
+            FROM tournesol_comparison
+            WHERE entity_1_id = (
+                SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${idA}'
+            ) AND entity_2_id = (
+                SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${idB}'
+            )
+        );
+      `);
+
+    cy.sql(`
+        DELETE FROM tournesol_comparison
+            WHERE entity_1_id = (
+                SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${idA}'
+            ) AND entity_2_id = (
+                SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${idB}'
+            );
+      `);
+  };
+
   describe('authorization', () => {
     it('is not accessible by anonymous users', () => {
       cy.visit('/comparison');
@@ -80,30 +105,6 @@ describe('Comparison page', () => {
       "slider_expert_better_habits",
       "slider_expert_backfire_risk",
     ];
-
-    const deleteComparison = (idA, idB) => {
-      cy.sql(`
-        DELETE FROM tournesol_comparisoncriteriascore
-        WHERE comparison_id = (
-            SELECT id
-            FROM tournesol_comparison
-            WHERE entity_1_id = (
-                SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${videoAId}'
-            ) AND entity_2_id = (
-                SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${videoBId}'
-            )
-        );
-      `);
-
-      cy.sql(`
-        DELETE FROM tournesol_comparison
-            WHERE entity_1_id = (
-                SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${videoAId}'
-            ) AND entity_2_id = (
-                SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${videoBId}'
-            );
-      `);
-    };
 
     beforeEach(() => {
       deleteComparison(videoAId, videoBId);

--- a/tests/cypress/integration/frontend/comparisonPage.ts
+++ b/tests/cypress/integration/frontend/comparisonPage.ts
@@ -68,7 +68,7 @@ describe('Comparison page', () => {
   describe('submit a comparison', () => {
     const videoAUrl = 'https://www.youtube.com/watch?v=u83A7DUNMHs';
 
-    const criteriaSliders = [
+    const optionalCriteriaSliders = [
       "slider_expert_reliability",
       "slider_expert_pedagogy",
       "slider_expert_importance",
@@ -78,7 +78,7 @@ describe('Comparison page', () => {
       "slider_expert_diversity_inclusion",
       "slider_expert_better_habits",
       "slider_expert_backfire_risk",
-    ]
+    ];
 
     /**
      * Select a video in the first VideoSelector then click on the new video
@@ -141,7 +141,7 @@ describe('Comparison page', () => {
         cy.get('span[data-index=12]').click();
       })
 
-      criteriaSliders.forEach((slider) => {
+      optionalCriteriaSliders.forEach((slider) => {
         cy.get('#' + slider).within(() => {
           cy.get('span[data-index=12]').click();
         })

--- a/tests/cypress/integration/frontend/comparisonPage.ts
+++ b/tests/cypress/integration/frontend/comparisonPage.ts
@@ -122,7 +122,7 @@ describe('Comparison page', () => {
      * - the add optional criteria button is displayed
      * - success hints are visible (edit button and success alert)
      */
-    it('with only the main criteria', () => {
+    it('works with only the main criteria', () => {
       cy.visit('/comparison');
 
       cy.focused().type('user1');
@@ -155,7 +155,7 @@ describe('Comparison page', () => {
         .should('be.visible');
     });
 
-    it('with all the criteria', () => {
+    it('works with all the criteria', () => {
       cy.visit('/comparison');
 
       cy.focused().type('user1');

--- a/tests/cypress/integration/frontend/comparisonPage.ts
+++ b/tests/cypress/integration/frontend/comparisonPage.ts
@@ -1,6 +1,6 @@
 describe('Comparison page', () => {
 
-  const deleteComparison = (idA, idB) => {
+  const deleteComparison = (username, idA, idB) => {
     cy.sql(`
         DELETE FROM tournesol_comparisoncriteriascore
         WHERE comparison_id = (
@@ -10,6 +10,8 @@ describe('Comparison page', () => {
                 SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${idA}'
             ) AND entity_2_id = (
                 SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${idB}'
+            ) AND user_id = (
+                SELECT id FROM core_user WHERE username = '${username}'
             )
         );
       `);
@@ -20,6 +22,8 @@ describe('Comparison page', () => {
                 SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${idA}'
             ) AND entity_2_id = (
                 SELECT id FROM tournesol_entity WHERE metadata->>'video_id' = '${idB}'
+            ) AND user_id = (
+                SELECT id FROM core_user WHERE username = '${username}'
             );
       `);
   };
@@ -91,6 +95,7 @@ describe('Comparison page', () => {
   });
 
   describe('submit a comparison', () => {
+    const username = 'user1';
     const videoAId = 'u83A7DUNMHs';
     const videoBId = '6jK9bFWE--g';
 
@@ -107,11 +112,11 @@ describe('Comparison page', () => {
     ];
 
     beforeEach(() => {
-      deleteComparison(videoAId, videoBId);
+      deleteComparison(username, videoAId, videoBId);
     })
 
     after(() => {
-      deleteComparison(videoAId, videoBId);
+      deleteComparison(username, videoAId, videoBId);
     })
 
     /**
@@ -125,7 +130,7 @@ describe('Comparison page', () => {
     it('works with only the main criteria', () => {
       cy.visit('/comparison');
 
-      cy.focused().type('user1');
+      cy.focused().type(username);
       cy.get('input[name="password"]').click()
         .type('tournesol').type('{enter}');
 
@@ -158,7 +163,7 @@ describe('Comparison page', () => {
     it('works with all the criteria', () => {
       cy.visit('/comparison');
 
-      cy.focused().type('user1');
+      cy.focused().type(username);
       cy.get('input[name="password"]').click()
         .type('tournesol').type('{enter}');
 
@@ -192,7 +197,7 @@ describe('Comparison page', () => {
     it('doesn\'t allow comparing a video with itself', () => {
       cy.visit('/comparison');
 
-      cy.focused().type('user1');
+      cy.focused().type(username);
       cy.get('input[name="password"]').click()
           .type('tournesol').type('{enter}');
 

--- a/tests/cypress/integration/frontend/comparisonPage.ts
+++ b/tests/cypress/integration/frontend/comparisonPage.ts
@@ -39,6 +39,9 @@ describe('Comparison page', () => {
 
       cy.location('pathname').should('equal', '/comparison');
       cy.contains('submit a comparison', {matchCase: false}).should('be.visible');
+
+      cy.contains('video 1', {matchCase: false}).should('be.visible');
+      cy.contains('video 2', {matchCase: false}).should('be.visible');
     })
   });
 
@@ -51,9 +54,6 @@ describe('Comparison page', () => {
       cy.focused().type('user1');
       cy.get('input[name="password"]').click()
         .type('tournesol').type('{enter}');
-
-      cy.contains('video 1', {matchCase: false}).should('be.visible');
-      cy.contains('video 2', {matchCase: false}).should('be.visible');
 
       // TODO: a little help is required to write the tests
 
@@ -187,6 +187,28 @@ describe('Comparison page', () => {
         .should('be.visible');
       cy.contains('successfully submitted', {matchCase: false})
         .should('be.visible');
+    });
+
+    it('doesn\'t allow comparing a video with itself', () => {
+      cy.visit('/comparison');
+
+      cy.focused().type('user1');
+      cy.get('input[name="password"]').click()
+          .type('tournesol').type('{enter}');
+
+      cy.get('input[placeholder="Paste URL or Video ID"]').first()
+          .type(videoAId, {delay: 0});
+      cy.get('input[placeholder="Paste URL or Video ID"]').last()
+          .type(videoAId, {delay: 0});
+
+      cy.contains('These two videos are very similar', {matchCase: false})
+          .should('be.visible');
+
+      cy.contains('add optional criteria', {matchCase: false})
+          .should('not.exist');
+      cy.contains('should be largely recommended', {matchCase: false})
+          .should('not.exist');
+      cy.get('button#expert_submit_btn').should('not.exist');
     });
   });
 });

--- a/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
+++ b/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
@@ -5,7 +5,7 @@ describe('"My rated videos" page', () => {
     cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
 
     // All rated videos are listed.
-    cy.contains('/Showing videos 1 to 20 of \d+/').should('be.visible');
+    cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
 
     // Mark all videos as public.
     cy.contains('button', 'Options', {matchCase: false}).click();
@@ -25,7 +25,7 @@ describe('"My rated videos" page', () => {
 
     // Mark all videos as public, the filter is reset and all videos are listed
     cy.contains('button', 'Mark all as public').click();
-    cy.contains('/Showing videos 1 to 20 of \d+/').should('be.visible');
+    cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
   })
 
   it('visit ratings page with filter in URL', () => {

--- a/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
+++ b/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
@@ -5,7 +5,7 @@ describe('"My rated videos" page', () => {
     cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
 
     // All rated videos are listed.
-    cy.contains('Showing videos 1 to 20 of 263').should('be.visible');
+    cy.contains('/Showing videos 1 to 20 of \d+/').should('be.visible');
 
     // Mark all videos as public.
     cy.contains('button', 'Options', {matchCase: false}).click();
@@ -25,7 +25,7 @@ describe('"My rated videos" page', () => {
 
     // Mark all videos as public, the filter is reset and all videos are listed
     cy.contains('button', 'Mark all as public').click();
-    cy.contains('Showing videos 1 to 20 of 263').should('be.visible');
+    cy.contains('/Showing videos 1 to 20 of \d+/').should('be.visible');
   })
 
   it('visit ratings page with filter in URL', () => {


### PR DESCRIPTION
Here are few end-to-end tests ensuring the comparison UI is working properly.

This test case is not exhaustive yet, but is a good starting point. It should fail easily if the comparison UI is broken during the development. 

![capture](https://user-images.githubusercontent.com/39056254/157044565-ba3039fb-1f37-4673-bbcb-e02603d80797.png)

**use cases not covered by these tests**
- pasting video URLs directly in the video selectors input fields (more details in the code)
- requesting new video with the `new video` circular button (note: this feature is subject to change)