### PR TITLE
[front] feat: allow navigation between polls

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -82,6 +82,9 @@
   "private": "private",
   "filter": {
     "filterByVisibility": "Filter by visibility",
+    "includeAllVideos": "Include all videos",
+    "advanced": "Advanced",
+    "unsafeTooltip": "Also display videos with a low number of contributors and those with a negative score.",
     "ignore": "Ignore",
     "notImportant": "Not important",
     "neutral": "Neutral",
@@ -94,9 +97,6 @@
     "thisYear": "This year",
     "uploadDate": "Upload date",
     "language": "Language",
-    "includeAllVideos": "Include all videos",
-    "advanced": "Advanced",
-    "unsafeTooltip": "Also display videos with a low number of contributors and those with a negative score.",
     "uploader": "Uploader"
   },
   "ratings": {
@@ -110,11 +110,6 @@
     "compareVideosButton": "Compare videos"
   },
   "options": "Options",
-  "language": {
-    "english": "english",
-    "french": "french",
-    "german": "german"
-  },
   "settings": {
     "typeKeywordDeleteAccount": "Please type the words <1>{{DELETE_ACCOUNT_KEYWORD}}</1> in the text box below to enable deleting your account.",
     "deleteYourAccount": "Delete your account",
@@ -160,6 +155,8 @@
     "notYetComparedByYou": "Not yet compared by you",
     "contributionsArePublicMessage": "Your contributions about this video are currently public. Comparisons appear in the public data associated to your profile only if you tag both videos as public.",
     "contributionsArePrivateMessage": "Your contributions about this video are currently private. The details of your personal ratings are not published, but they may still be used to compute public aggregated scores about videos.",
+    "unsafeNotEnoughContributor": "The relevance of this score is uncertain, due to too few contributors.",
+    "unsafeNegativeRating": "This video score is below the average of the other videos added to Tournesol.",
     "nbViews": "{{nbViews}} views",
     "seeRecommendedVideosSameUploader": "See recommended videos of the same uploader",
     "nbComparisonsBy_one": "{{count}} comparison by",
@@ -168,10 +165,7 @@
     "nbContributors_other": "{{count}} contributors",
     "criteriaRatedHigh": "Rated high:",
     "criteriaRatedLow": "Rated low:",
-    "labelShowSettings": "Show settings related to this video",
-    "unsafeNotEnoughContributor": "The relevance of this score is uncertain, due to too few contributors.",
-    "unsafeNegativeRating" : "This video score is below the average of the other videos added to Tournesol."
-
+    "labelShowSettings": "Show settings related to this video"
   },
   "notifications": {
     "errorOccurred": "Sorry an error has occurred.",
@@ -307,16 +301,13 @@
     "remove": "Remove",
     "videoDeletedFromRateLaterList": "The video has been deleted from your rate later list."
   },
-  "criteria": {
-    "shouldBeLargelyRecommended": "Should be largely recommended",
-    "reliableAndNotMisleading": "Reliable & not misleading",
-    "clearAndPedagogical": "Clear & pedagogical",
-    "importantAndActionable": "Important and actionable",
-    "laymanFriendly": "Layman-friendly",
-    "entertainingAndRelaxing": "Entertaining and relaxing",
-    "engagingAndThoughtProvoking": "Engaging & thought-provoking",
-    "diversityAndInclusion": "Diversity & inclusion",
-    "encouragesBetterHabits": "Encourages better habits",
-    "resilienceToBackfiringRisks": "Resilience to backfiring risks"
+  "language": {
+    "english": "english",
+    "french": "french",
+    "german": "german"
+  },
+  "poll": {
+    "presidential2022": "election FR 2022",
+    "videos": "videos"
   }
 }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -83,6 +83,9 @@
   "private": "privée",
   "filter": {
     "filterByVisibility": "Filtrer par visibilité",
+    "includeAllVideos": "Inclure toutes les vidéos",
+    "advanced": "Avancés",
+    "unsafeTooltip": "Afficher aussi les vidéos avec peu de contributeurs et les vidéos avec des scores négatifs.",
     "ignore": "Ignoré",
     "notImportant": "Pas important",
     "neutral": "Neutre",
@@ -95,9 +98,6 @@
     "thisYear": "Cette année",
     "uploadDate": "Mises en ligne",
     "language": "Langues",
-    "includeAllVideos": "Inclure toutes les vidéos",
-    "advanced": "Avancés",
-    "unsafeTooltip": "Afficher aussi les vidéos avec peu de contributeurs et les vidéos avec des scores négatifs.",
     "uploader": "Chaîne"
   },
   "ratings": {
@@ -111,11 +111,6 @@
     "compareVideosButton": "Comparer des vidéos"
   },
   "options": "Options",
-  "language": {
-    "english": "anglais",
-    "french": "français",
-    "german": "allemand"
-  },
   "settings": {
     "typeKeywordDeleteAccount": "Écrivez les mots <1>{{DELETE_ACCOUNT_KEYWORD}}</1> dans le champ ci-dessous pour déverrouiller la suppression de votre compte.",
     "deleteYourAccount": "Supprimer votre compte",
@@ -162,6 +157,8 @@
     "notYetComparedByYou": "Vous ne l'avez pas encore comparée",
     "contributionsArePublicMessage": "Vos contributions impliquant cette vidéo sont actuellement publiques. Une comparaison n'est publiquement associée à votre profil que lorsque vous marquez explicitement ses deux vidéos comme publiques.",
     "contributionsArePrivateMessage": "Vos contributions impliquant cette vidéo sont actuellement privées. Les détails de vos jugements ne sont pas publiés, mais ils sont tout de même pris en compte pour calculer le score agréré public des vidéos.",
+    "unsafeNotEnoughContributor": "La pertinence de ce score est incertaine, en raison d'un trop faible nombre de contributeurs.",
+    "unsafeNegativeRating": "Cette vidéo a un score inférieur à la moyenne des autres vidéos ajoutées à Tournesol.",
     "nbViews": "{{nbViews}} vues",
     "seeRecommendedVideosSameUploader": "Voir les vidéos recommandées de cette chaîne",
     "nbComparisonsBy_one": "{{count}} comparaison par",
@@ -172,9 +169,7 @@
     "nbContributors_other": "{{count}} contributeurs",
     "criteriaRatedHigh": "Noté fortement :",
     "criteriaRatedLow": "Noté faiblement :",
-    "labelShowSettings": "Voir les paramètres de cette video",
-    "unsafeNotEnoughContributor": "La pertinence de ce score est incertaine, en raison d'un trop faible nombre de contributeurs.",
-    "unsafeNegativeRating" : "Cette vidéo a un score inférieur à la moyenne des autres vidéos ajoutées à Tournesol."
+    "labelShowSettings": "Voir les paramètres de cette video"
   },
   "notifications": {
     "errorOccurred": "Désolé, une erreur est survenue.",
@@ -310,16 +305,13 @@
     "remove": "Supprimer",
     "videoDeletedFromRateLaterList": "Vidéo bien supprimée de votre liste de vidéos à comparer plus tard."
   },
-  "criteria": {
-    "shouldBeLargelyRecommended": "Devrait être largement recommandé",
-    "reliableAndNotMisleading": "Fiable & non trompeur",
-    "clearAndPedagogical": "Clair & pédagogique",
-    "importantAndActionable": "Important & actionnable",
-    "laymanFriendly": "Accessible aux non-spécialistes",
-    "entertainingAndRelaxing": "Divertissant & relaxant",
-    "engagingAndThoughtProvoking": "Stimulant & suscite la réflexion",
-    "diversityAndInclusion": "Diversité & inclusion",
-    "encouragesBetterHabits": "Encourage de meilleures habitudes",
-    "resilienceToBackfiringRisks": "Résistant aux retours négatifs"
+  "language": {
+    "english": "anglais",
+    "french": "français",
+    "german": "allemand"
+  },
+  "poll": {
+    "presidential2022": "présidentielle FR 2022",
+    "videos": "vidéos"
   }
 }

--- a/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { MemoryRouter, Route, Switch } from 'react-router-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { HowToVote, YouTube } from '@mui/icons-material';
+import PollSelector from './PollSelector';
+import {
+  PRESIDENTIELLE_2022_POLL_NAME,
+  YOUTUBE_POLL_NAME,
+} from 'src/utils/constants';
+import { SelectablePolls } from 'src/utils/types';
+
+describe('change password feature', () => {
+  const polls: SelectablePolls = [
+    {
+      name: PRESIDENTIELLE_2022_POLL_NAME,
+      displayOrder: 20,
+      path: '/presidentielle2022/',
+      iconComponent: HowToVote,
+      withSearchBar: false,
+      topBarBackground:
+        'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
+    },
+    {
+      name: YOUTUBE_POLL_NAME,
+      displayOrder: 10,
+      path: '/',
+      iconComponent: YouTube,
+      withSearchBar: true,
+      topBarBackground: null,
+    },
+  ];
+
+  const component = () =>
+    render(
+      <MemoryRouter>
+        <Switch>
+          <Route path="/">
+            <PollSelector polls={polls} />
+          </Route>
+        </Switch>
+      </MemoryRouter>
+    );
+
+  const setup = () => {
+    const rendered = component();
+    const logos = screen.getAllByAltText('Tournesol logo');
+    const title = screen.getByText('Tournesol');
+    return { logos, title, rendered };
+  };
+
+  it('click on the logo displays the menu', async () => {
+    const { logos } = setup();
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+
+    fireEvent.click(logos[0]);
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+  });
+
+  it('click on the title displays the menu', async () => {
+    const { title } = setup();
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+
+    fireEvent.click(title);
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+  });
+
+  it('the menu is closed after a click on an item', async () => {
+    const { title } = setup();
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+
+    fireEvent.click(title);
+    // then click on item 1
+    fireEvent.click(screen.getAllByRole('menuitem')[0]);
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+
+    fireEvent.click(title);
+    // then click on item 2
+    fireEvent.click(screen.getAllByRole('menuitem')[1]);
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+  });
+});

--- a/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Switch } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { HowToVote, YouTube } from '@mui/icons-material';
 import PollSelector from './PollSelector';
+import { PollProvider } from 'src/hooks/useCurrentPoll';
 import {
   PRESIDENTIELLE_2022_POLL_NAME,
   YOUTUBE_POLL_NAME,
@@ -32,13 +33,15 @@ describe('change password feature', () => {
 
   const component = () =>
     render(
-      <MemoryRouter>
-        <Switch>
-          <Route path="/">
-            <PollSelector polls={polls} />
-          </Route>
-        </Switch>
-      </MemoryRouter>
+      <PollProvider>
+        <MemoryRouter>
+          <Switch>
+            <Route path="/">
+              <PollSelector polls={polls} />
+            </Route>
+          </Switch>
+        </MemoryRouter>
+      </PollProvider>
     );
 
   const setup = () => {
@@ -70,7 +73,7 @@ describe('change password feature', () => {
     expect(screen.getByTestId('ArrowDropUpIcon')).toBeInTheDocument();
   });
 
-  it('items can be selected', () => {
+  it('items can be selected, and poll changed', () => {
     const { title } = setup();
 
     fireEvent.click(title);
@@ -86,5 +89,9 @@ describe('change password feature', () => {
     // then click on item 2
     fireEvent.click(screen.getAllByRole('menuitem')[1]);
     expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+
+    expect(screen.getByRole('heading', { level: 6 })).toHaveTextContent(
+      'poll.presidential2022'
+    );
   });
 });

--- a/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
@@ -48,13 +48,13 @@ describe('change password feature', () => {
     return { logos, title, rendered };
   };
 
-  it("doesn't display the menu by default", async () => {
+  it("doesn't display the menu by default", () => {
     setup();
     expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
     expect(screen.getByTestId('ArrowDropDownIcon')).toBeInTheDocument();
   });
 
-  it('click on the logo displays the menu', async () => {
+  it('click on the logo displays the menu', () => {
     const { logos } = setup();
 
     fireEvent.click(logos[0]);
@@ -62,7 +62,7 @@ describe('change password feature', () => {
     expect(screen.getByTestId('ArrowDropUpIcon')).toBeInTheDocument();
   });
 
-  it('click on the title displays the menu', async () => {
+  it('click on the title displays the menu', () => {
     const { title } = setup();
 
     fireEvent.click(title);
@@ -70,13 +70,17 @@ describe('change password feature', () => {
     expect(screen.getByTestId('ArrowDropUpIcon')).toBeInTheDocument();
   });
 
-  it('the menu is closed after a click on an item', async () => {
+  it('items can be selected', () => {
     const { title } = setup();
 
     fireEvent.click(title);
     // then click on item 1
     fireEvent.click(screen.getAllByRole('menuitem')[0]);
     expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+
+    expect(screen.getByRole('heading', { level: 6 })).toHaveTextContent(
+      'poll.video'
+    );
 
     fireEvent.click(title);
     // then click on item 2

--- a/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
@@ -48,25 +48,30 @@ describe('change password feature', () => {
     return { logos, title, rendered };
   };
 
+  it("doesn't display the menu by default", async () => {
+    setup();
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+    expect(screen.getByTestId('ArrowDropDownIcon')).toBeInTheDocument();
+  });
+
   it('click on the logo displays the menu', async () => {
     const { logos } = setup();
-    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
 
     fireEvent.click(logos[0]);
     expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+    expect(screen.getByTestId('ArrowDropUpIcon')).toBeInTheDocument();
   });
 
   it('click on the title displays the menu', async () => {
     const { title } = setup();
-    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
 
     fireEvent.click(title);
     expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+    expect(screen.getByTestId('ArrowDropUpIcon')).toBeInTheDocument();
   });
 
   it('the menu is closed after a click on an item', async () => {
     const { title } = setup();
-    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
 
     fireEvent.click(title);
     // then click on item 1

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 import {
   Box,
@@ -13,10 +14,11 @@ import {
 } from '@mui/material';
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { polls } from 'src/utils/constants';
+import { getPollName, polls } from 'src/utils/constants';
 
 const PollSelector = () => {
   const history = useHistory();
+  const { t } = useTranslation();
   const { name: currentPoll, setPollName } = useCurrentPoll();
 
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<null | HTMLElement>(
@@ -77,7 +79,9 @@ const PollSelector = () => {
                   alignItems: 'center',
                 }}
               >
-                <Typography variant="subtitle1">{currentPoll}</Typography>
+                <Typography variant="subtitle1">
+                  {getPollName(t, currentPoll)}
+                </Typography>
                 {menuAnchorEl ? (
                   <ArrowDropUp sx={{ color: 'rgba(0, 0, 0, 0.32)' }} />
                 ) : (
@@ -109,7 +113,7 @@ const PollSelector = () => {
               <ListItemIcon>
                 <elem.iconComponent fontSize="small" />
               </ListItemIcon>
-              <ListItemText>{elem.displayName}</ListItemText>
+              <ListItemText>{getPollName(t, elem.name)}</ListItemText>
             </MenuItem>
           ))}
       </Menu>

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -41,21 +41,20 @@ const PollSelector = () => {
   return (
     <Box
       sx={{
-        padding: '8px',
-        paddingLeft: 0,
+        padding: '8px 4px',
         '&:hover': { backgroundColor: 'rgba(29, 26, 20, 0.08)' },
       }}
     >
-      <Hidden smDown>
-        {/* use Link to make the area clickable while preserving its accessibility */}
-        <Link
-          onClick={displayMenu}
-          underline="none"
-          sx={{
-            cursor: 'pointer',
-            color: 'text.primary',
-          }}
-        >
+      {/* use Link to make the area clickable while preserving its accessibility */}
+      <Link
+        onClick={displayMenu}
+        underline="none"
+        sx={{
+          cursor: 'pointer',
+          color: 'text.primary',
+        }}
+      >
+        <Hidden smDown>
           <Grid container alignItems="center" spacing={1}>
             <Grid item>
               <img src="/svg/LogoSmall.svg" alt="logo" />
@@ -83,11 +82,11 @@ const PollSelector = () => {
               </Box>
             </Grid>
           </Grid>
-        </Link>
-      </Hidden>
-      <Hidden smUp>
-        <img src="/svg/LogoSmall.svg" alt="logo" />
-      </Hidden>
+        </Hidden>
+        <Hidden smUp>
+          <img src="/svg/LogoSmall.svg" alt="logo" />
+        </Hidden>
+      </Link>
       <Menu
         anchorEl={menuAnchorEl}
         open={Boolean(menuAnchorEl)}

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -11,7 +11,7 @@ import {
   MenuItem,
   Typography,
 } from '@mui/material';
-import { ArrowLeft } from '@mui/icons-material';
+import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import { polls } from 'src/utils/constants';
 
@@ -78,7 +78,11 @@ const PollSelector = () => {
                 }}
               >
                 <Typography variant="subtitle1">{currentPoll}</Typography>
-                <ArrowLeft sx={{ color: 'rgba(0, 0, 0, 0.32)' }} />
+                {menuAnchorEl ? (
+                  <ArrowDropUp sx={{ color: 'rgba(0, 0, 0, 0.32)' }} />
+                ) : (
+                  <ArrowDropDown sx={{ color: 'rgba(0, 0, 0, 0.32)' }} />
+                )}
               </Box>
             </Grid>
           </Grid>

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -59,7 +59,7 @@ const PollSelector = ({ polls }: { polls: Array<SelectablePoll> }) => {
         <Box sx={{ display: { xs: 'none', sm: 'none', md: 'block' } }}>
           <Grid container alignItems="center" spacing={1}>
             <Grid item>
-              <img src="/svg/LogoSmall.svg" alt="logo" />
+              <img src="/svg/LogoSmall.svg" alt="Tournesol logo" />
             </Grid>
             <Grid item>
               <Typography
@@ -86,7 +86,7 @@ const PollSelector = ({ polls }: { polls: Array<SelectablePoll> }) => {
           </Grid>
         </Box>
         <Box sx={{ display: { sm: 'block', md: 'none' } }}>
-          <img src="/svg/LogoSmall.svg" alt="logo" />
+          <img src="/svg/LogoSmall.svg" alt="Tournesol logo" />
         </Box>
       </Link>
       <Menu

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Grid, Hidden, Typography } from '@mui/material';
+import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+
+const PollSelector = () => {
+  const { name: pollName } = useCurrentPoll();
+
+  return (
+    <Link to="/">
+      <Hidden smDown>
+        <Grid container alignItems="center" spacing={1}>
+          <Grid item>
+            <img src="/svg/LogoSmall.svg" alt="logo" />
+          </Grid>
+          <Grid item>
+            <Typography variant="h3" sx={{ fontSize: '1.4em !important' }}>
+              Tournesol
+            </Typography>
+            <Typography variant="subtitle1">{pollName}</Typography>
+          </Grid>
+        </Grid>
+      </Hidden>
+      <Hidden smUp>
+        <img src="/svg/LogoSmall.svg" alt="logo" />
+      </Hidden>
+    </Link>
+  );
+};
+
+export default PollSelector;

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useHistory } from 'react-router';
 import {
-  Button,
   Grid,
   Hidden,
+  Link,
   ListItemIcon,
   ListItemText,
   Menu,
@@ -21,7 +21,7 @@ const PollSelector = () => {
     null
   );
 
-  const displayMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const displayMenu = (event: React.MouseEvent<HTMLElement>) => {
     setMenuAnchorEl(event.currentTarget);
   };
 
@@ -30,6 +30,7 @@ const PollSelector = () => {
   };
 
   const onItemSelect = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
     setPollName(event.currentTarget.dataset.pollName || '');
     history.push(event.currentTarget.dataset.pollUrl || '');
     onMenuClose();
@@ -38,28 +39,31 @@ const PollSelector = () => {
   return (
     <>
       <Hidden smDown>
-        <Grid container alignItems="center" spacing={1}>
-          <Grid item>
-            <img src="/svg/LogoSmall.svg" alt="logo" />
+        {/* use Link to make the area clickable while preserving its accessibility */}
+        <Link
+          onClick={displayMenu}
+          underline="none"
+          sx={{ cursor: 'pointer', color: 'rgb(29, 26, 20)' }}
+        >
+          <Grid container alignItems="center" spacing={1}>
+            <Grid item>
+              <img src="/svg/LogoSmall.svg" alt="logo" />
+            </Grid>
+            <Grid item>
+              <Typography
+                variant="h3"
+                sx={{
+                  fontSize: '1.4em !important',
+                  fontWeight: 'bold',
+                  lineHeight: 1,
+                }}
+              >
+                Tournesol
+              </Typography>
+              <Typography variant="subtitle1">{currentPoll}</Typography>
+            </Grid>
           </Grid>
-          <Grid item>
-            <Button
-              onClick={displayMenu}
-              variant="text"
-              sx={{
-                color: 'black',
-                fontSize: '1.4em !important',
-                fontWeight: 'bold',
-                lineHeight: 1,
-                padding: 0,
-                textTransform: 'none',
-              }}
-            >
-              Tournesol
-            </Button>
-            <Typography variant="subtitle1">{currentPoll}</Typography>
-          </Grid>
-        </Grid>
+        </Link>
       </Hidden>
       <Hidden smUp>
         <img src="/svg/LogoSmall.svg" alt="logo" />

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -4,7 +4,6 @@ import { useHistory } from 'react-router';
 import {
   Box,
   Grid,
-  Hidden,
   Link,
   ListItemIcon,
   ListItemText,
@@ -56,7 +55,7 @@ const PollSelector = () => {
           color: 'text.primary',
         }}
       >
-        <Hidden smDown>
+        <Box sx={{ display: { xs: 'none', sm: 'none', md: 'block' } }}>
           <Grid container alignItems="center" spacing={1}>
             <Grid item>
               <img src="/svg/LogoSmall.svg" alt="logo" />
@@ -84,10 +83,10 @@ const PollSelector = () => {
               </Box>
             </Grid>
           </Grid>
-        </Hidden>
-        <Hidden smUp>
+        </Box>
+        <Box sx={{ display: { sm: 'block', md: 'none' } }}>
           <img src="/svg/LogoSmall.svg" alt="logo" />
-        </Hidden>
+        </Box>
       </Link>
       <Menu
         anchorEl={menuAnchorEl}

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -1,16 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Redirect } from 'react-router-dom';
 import {
   Button,
   Grid,
   Hidden,
+  ListItemIcon,
   Menu,
   MenuItem,
   Typography,
 } from '@mui/material';
+import { HowToVote, YouTube } from '@mui/icons-material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
 const PollSelector = () => {
-  const { name: pollName } = useCurrentPoll();
+  const { name: currentPoll } = useCurrentPoll();
+  const [selectedPoll, setSelectedPoll] = useState('');
 
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<null | HTMLElement>(
     null
@@ -23,6 +27,15 @@ const PollSelector = () => {
   const onMenuClose = () => {
     setMenuAnchorEl(null);
   };
+
+  const onItemSelect = (event: React.MouseEvent<HTMLElement>) => {
+    const poll = event.currentTarget.dataset.pollName || '';
+    setSelectedPoll(poll);
+  };
+
+  if (selectedPoll) {
+    return <Redirect push to={`/${selectedPoll}/`} />;
+  }
 
   return (
     <>
@@ -38,6 +51,7 @@ const PollSelector = () => {
               sx={{
                 color: 'black',
                 fontSize: '1.4em !important',
+                fontWeight: 'bold',
                 lineHeight: 1,
                 padding: 0,
                 textTransform: 'none',
@@ -45,7 +59,7 @@ const PollSelector = () => {
             >
               Tournesol
             </Button>
-            <Typography variant="subtitle1">{pollName}</Typography>
+            <Typography variant="subtitle1">{currentPoll}</Typography>
           </Grid>
         </Grid>
       </Hidden>
@@ -57,8 +71,28 @@ const PollSelector = () => {
         open={Boolean(menuAnchorEl)}
         onClose={onMenuClose}
       >
-        <MenuItem>videos</MenuItem>
-        <MenuItem>élection 2022</MenuItem>
+        {[
+          {
+            name: 'videos',
+            label: 'Vidéos',
+            icon: <YouTube fontSize="small" />,
+          },
+          {
+            name: 'elections_2022',
+            label: 'Élections 2022',
+            icon: <HowToVote fontSize="small" />,
+          },
+        ].map((elem) => (
+          <MenuItem
+            key={elem.name}
+            data-poll-name={elem.name}
+            onClick={onItemSelect}
+            selected={elem.name === currentPoll}
+          >
+            <ListItemIcon>{elem.icon}</ListItemIcon>
+            {elem.label}
+          </MenuItem>
+        ))}
       </Menu>
     </>
   );

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -42,8 +42,8 @@ const PollSelector = () => {
 
   return (
     <Box
+      padding="8px 4px"
       sx={{
-        padding: '8px 4px',
         '&:hover': { backgroundColor: 'rgba(29, 26, 20, 0.08)' },
       }}
     >
@@ -72,13 +72,7 @@ const PollSelector = () => {
               >
                 Tournesol
               </Typography>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                }}
-              >
+              <Box display="flex" flexDirection="row" alignItems="center">
                 <Typography variant="subtitle1">
                   {getPollName(t, currentPoll)}
                 </Typography>

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -1,22 +1,50 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Grid, Hidden, Typography } from '@mui/material';
+import {
+  Button,
+  Grid,
+  Hidden,
+  Menu,
+  MenuItem,
+  Typography,
+} from '@mui/material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
 const PollSelector = () => {
   const { name: pollName } = useCurrentPoll();
 
+  const [menuAnchorEl, setMenuAnchorEl] = React.useState<null | HTMLElement>(
+    null
+  );
+
+  const displayMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setMenuAnchorEl(event.currentTarget);
+  };
+
+  const onMenuClose = () => {
+    setMenuAnchorEl(null);
+  };
+
   return (
-    <Link to="/">
+    <>
       <Hidden smDown>
         <Grid container alignItems="center" spacing={1}>
           <Grid item>
             <img src="/svg/LogoSmall.svg" alt="logo" />
           </Grid>
           <Grid item>
-            <Typography variant="h3" sx={{ fontSize: '1.4em !important' }}>
+            <Button
+              onClick={displayMenu}
+              variant="text"
+              sx={{
+                color: 'black',
+                fontSize: '1.4em !important',
+                lineHeight: 1,
+                padding: 0,
+                textTransform: 'none',
+              }}
+            >
               Tournesol
-            </Typography>
+            </Button>
             <Typography variant="subtitle1">{pollName}</Typography>
           </Grid>
         </Grid>
@@ -24,7 +52,15 @@ const PollSelector = () => {
       <Hidden smUp>
         <img src="/svg/LogoSmall.svg" alt="logo" />
       </Hidden>
-    </Link>
+      <Menu
+        anchorEl={menuAnchorEl}
+        open={Boolean(menuAnchorEl)}
+        onClose={onMenuClose}
+      >
+        <MenuItem>videos</MenuItem>
+        <MenuItem>élection 2022</MenuItem>
+      </Menu>
+    </>
   );
 };
 

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useHistory } from 'react-router';
 import {
+  Box,
   Grid,
   Hidden,
   Link,
@@ -10,6 +11,7 @@ import {
   MenuItem,
   Typography,
 } from '@mui/material';
+import { ArrowLeft } from '@mui/icons-material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import { polls } from 'src/utils/constants';
 
@@ -37,13 +39,22 @@ const PollSelector = () => {
   };
 
   return (
-    <>
+    <Box
+      sx={{
+        padding: '8px',
+        paddingLeft: 0,
+        '&:hover': { backgroundColor: 'rgba(29, 26, 20, 0.08)' },
+      }}
+    >
       <Hidden smDown>
         {/* use Link to make the area clickable while preserving its accessibility */}
         <Link
           onClick={displayMenu}
           underline="none"
-          sx={{ cursor: 'pointer', color: 'rgb(29, 26, 20)' }}
+          sx={{
+            cursor: 'pointer',
+            color: 'text.primary',
+          }}
         >
           <Grid container alignItems="center" spacing={1}>
             <Grid item>
@@ -60,7 +71,16 @@ const PollSelector = () => {
               >
                 Tournesol
               </Typography>
-              <Typography variant="subtitle1">{currentPoll}</Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                }}
+              >
+                <Typography variant="subtitle1">{currentPoll}</Typography>
+                <ArrowLeft sx={{ color: 'rgba(0, 0, 0, 0.32)' }} />
+              </Box>
             </Grid>
           </Grid>
         </Link>
@@ -90,7 +110,7 @@ const PollSelector = () => {
             </MenuItem>
           ))}
       </Menu>
-    </>
+    </Box>
   );
 };
 

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -5,6 +5,7 @@ import {
   Grid,
   Hidden,
   ListItemIcon,
+  ListItemText,
   Menu,
   MenuItem,
   Typography,
@@ -14,7 +15,7 @@ import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
 const PollSelector = () => {
   const history = useHistory();
-  const { name: currentPoll } = useCurrentPoll();
+  const { name: currentPoll, setPollName } = useCurrentPoll();
 
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<null | HTMLElement>(
     null
@@ -29,8 +30,8 @@ const PollSelector = () => {
   };
 
   const onItemSelect = (event: React.MouseEvent<HTMLElement>) => {
-    const poll = event.currentTarget.dataset.pollUrl || '';
-    history.push(poll);
+    setPollName(event.currentTarget.dataset.pollName || '');
+    history.push(event.currentTarget.dataset.pollUrl || '');
     onMenuClose();
   };
 
@@ -77,7 +78,7 @@ const PollSelector = () => {
           },
           {
             name: 'presidentielle2022',
-            label: 'Élections 2022',
+            label: 'Élection FR 2022',
             url: '/presidentielle2022/',
             icon: <HowToVote fontSize="small" />,
           },
@@ -85,11 +86,12 @@ const PollSelector = () => {
           <MenuItem
             key={elem.name}
             data-poll-url={elem.url}
+            data-poll-name={elem.name}
             onClick={onItemSelect}
             selected={elem.name === currentPoll}
           >
             <ListItemIcon>{elem.icon}</ListItemIcon>
-            {elem.label}
+            <ListItemText>{elem.label}</ListItemText>
           </MenuItem>
         ))}
       </Menu>

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -13,9 +13,10 @@ import {
 } from '@mui/material';
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { getPollName, polls } from 'src/utils/constants';
+import { getPollName } from 'src/utils/constants';
+import { SelectablePoll } from 'src/utils/types';
 
-const PollSelector = () => {
+const PollSelector = ({ polls }: { polls: Array<SelectablePoll> }) => {
   const history = useHistory();
   const { t } = useTranslation();
   const { name: currentPoll, setPollName } = useCurrentPoll();
@@ -95,7 +96,7 @@ const PollSelector = () => {
       >
         {polls
           .sort((a, b) => a.displayOrder - b.displayOrder)
-          .map((elem) => (
+          .map((elem: SelectablePoll) => (
             <MenuItem
               key={elem.name}
               data-poll-url={elem.path}

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Redirect } from 'react-router-dom';
+import React from 'react';
+import { useHistory } from 'react-router';
 import {
   Button,
   Grid,
@@ -13,8 +13,8 @@ import { HowToVote, YouTube } from '@mui/icons-material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
 const PollSelector = () => {
+  const history = useHistory();
   const { name: currentPoll } = useCurrentPoll();
-  const [selectedPoll, setSelectedPoll] = useState('');
 
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<null | HTMLElement>(
     null
@@ -29,13 +29,10 @@ const PollSelector = () => {
   };
 
   const onItemSelect = (event: React.MouseEvent<HTMLElement>) => {
-    const poll = event.currentTarget.dataset.pollName || '';
-    setSelectedPoll(poll);
+    const poll = event.currentTarget.dataset.pollUrl || '';
+    history.push(poll);
+    onMenuClose();
   };
-
-  if (selectedPoll) {
-    return <Redirect push to={`/${selectedPoll}/`} />;
-  }
 
   return (
     <>
@@ -75,17 +72,19 @@ const PollSelector = () => {
           {
             name: 'videos',
             label: 'Vidéos',
+            url: '/',
             icon: <YouTube fontSize="small" />,
           },
           {
-            name: 'elections_2022',
+            name: 'presidentielle2022',
             label: 'Élections 2022',
+            url: '/presidentielle2022/',
             icon: <HowToVote fontSize="small" />,
           },
         ].map((elem) => (
           <MenuItem
             key={elem.name}
-            data-poll-name={elem.name}
+            data-poll-url={elem.url}
             onClick={onItemSelect}
             selected={elem.name === currentPoll}
           >

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -10,8 +10,8 @@ import {
   MenuItem,
   Typography,
 } from '@mui/material';
-import { HowToVote, YouTube } from '@mui/icons-material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import { polls } from 'src/utils/constants';
 
 const PollSelector = () => {
   const history = useHistory();
@@ -69,31 +69,22 @@ const PollSelector = () => {
         open={Boolean(menuAnchorEl)}
         onClose={onMenuClose}
       >
-        {[
-          {
-            name: 'videos',
-            label: 'Vidéos',
-            url: '/',
-            icon: <YouTube fontSize="small" />,
-          },
-          {
-            name: 'presidentielle2022',
-            label: 'Élection FR 2022',
-            url: '/presidentielle2022/',
-            icon: <HowToVote fontSize="small" />,
-          },
-        ].map((elem) => (
-          <MenuItem
-            key={elem.name}
-            data-poll-url={elem.url}
-            data-poll-name={elem.name}
-            onClick={onItemSelect}
-            selected={elem.name === currentPoll}
-          >
-            <ListItemIcon>{elem.icon}</ListItemIcon>
-            <ListItemText>{elem.label}</ListItemText>
-          </MenuItem>
-        ))}
+        {polls
+          .sort((a, b) => a.displayOrder - b.displayOrder)
+          .map((elem) => (
+            <MenuItem
+              key={elem.name}
+              data-poll-url={elem.path}
+              data-poll-name={elem.name}
+              onClick={onItemSelect}
+              selected={elem.name === currentPoll}
+            >
+              <ListItemIcon>
+                <elem.iconComponent fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>{elem.displayName}</ListItemText>
+            </MenuItem>
+          ))}
       </Menu>
     </>
   );

--- a/frontend/src/features/frame/components/topbar/PollSelector.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.tsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router';
 import {
   Box,
   Grid,
-  Link,
+  Button,
   ListItemIcon,
   ListItemText,
   Menu,
@@ -34,26 +34,28 @@ const PollSelector = ({ polls }: { polls: Array<SelectablePoll> }) => {
   };
 
   const onItemSelect = (event: React.MouseEvent<HTMLElement>) => {
-    event.stopPropagation();
     setPollName(event.currentTarget.dataset.pollName || '');
     history.push(event.currentTarget.dataset.pollUrl || '');
     onMenuClose();
   };
 
+  const isDisabled = polls.length <= 1;
+
   return (
-    <Box
-      padding="8px 4px"
-      sx={{
-        '&:hover': { backgroundColor: 'rgba(29, 26, 20, 0.08)' },
-      }}
-    >
-      {/* use Link to make the area clickable while preserving its accessibility */}
-      <Link
+    <Box>
+      {/* use Button to make the area clickable while preserving its accessibility */}
+      <Button
+        disabled={isDisabled}
         onClick={displayMenu}
-        underline="none"
         sx={{
           cursor: 'pointer',
           color: 'text.primary',
+          textTransform: 'initial',
+          textAlign: 'left',
+          padding: '8px 4px',
+          minWidth: 0,
+          '&:hover': { backgroundColor: 'rgba(29, 26, 20, 0.08)' },
+          '&:disabled': { color: 'text.primary' },
         }}
       >
         <Box sx={{ display: { xs: 'none', sm: 'none', md: 'block' } }}>
@@ -76,11 +78,12 @@ const PollSelector = ({ polls }: { polls: Array<SelectablePoll> }) => {
                 <Typography variant="subtitle1">
                   {getPollName(t, currentPoll)}
                 </Typography>
-                {menuAnchorEl ? (
-                  <ArrowDropUp sx={{ color: 'rgba(0, 0, 0, 0.32)' }} />
-                ) : (
-                  <ArrowDropDown sx={{ color: 'rgba(0, 0, 0, 0.32)' }} />
-                )}
+                {!isDisabled &&
+                  (menuAnchorEl ? (
+                    <ArrowDropUp sx={{ color: 'rgba(0, 0, 0, 0.32)' }} />
+                  ) : (
+                    <ArrowDropDown sx={{ color: 'rgba(0, 0, 0, 0.32)' }} />
+                  ))}
               </Box>
             </Grid>
           </Grid>
@@ -88,7 +91,7 @@ const PollSelector = ({ polls }: { polls: Array<SelectablePoll> }) => {
         <Box sx={{ display: { sm: 'block', md: 'none' } }}>
           <img src="/svg/LogoSmall.svg" alt="Tournesol logo" />
         </Box>
-      </Link>
+      </Button>
       <Menu
         anchorEl={menuAnchorEl}
         open={Boolean(menuAnchorEl)}

--- a/frontend/src/features/frame/components/topbar/TopBar.tsx
+++ b/frontend/src/features/frame/components/topbar/TopBar.tsx
@@ -16,6 +16,7 @@ import { openDrawer, closeDrawer, selectFrame } from '../../drawerOpenSlice';
 import AccountInfo from './AccountInfo';
 import { useTheme } from '@mui/material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import { polls } from 'src/utils/constants';
 import PollSelector from './PollSelector';
 
 export const topBarHeight = 80;
@@ -77,7 +78,7 @@ const Logo = () => {
       >
         <Menu />
       </IconButton>
-      <PollSelector />
+      <PollSelector polls={polls} />
     </Grid>
   );
 };

--- a/frontend/src/features/frame/components/topbar/TopBar.tsx
+++ b/frontend/src/features/frame/components/topbar/TopBar.tsx
@@ -14,7 +14,7 @@ import { Menu } from '@mui/icons-material';
 import { useAppSelector, useAppDispatch } from '../../../../app/hooks';
 import { openDrawer, closeDrawer, selectFrame } from '../../drawerOpenSlice';
 import AccountInfo from './AccountInfo';
-import { useTheme } from '@mui/material';
+import { Typography, useTheme } from '@mui/material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
 export const topBarHeight = 80;
@@ -58,6 +58,7 @@ const useStyles = makeStyles(() => ({
 const Logo = () => {
   const drawerOpen = useAppSelector(selectFrame);
   const dispatch = useAppDispatch();
+  const { name: pollName } = useCurrentPoll();
 
   return (
     <Grid
@@ -78,7 +79,15 @@ const Logo = () => {
       </IconButton>
       <Link to="/">
         <Hidden smDown>
-          <img src="/svg/Logo.svg" alt="logo" />
+          <Grid container>
+            <Grid item>
+              <img src="/svg/LogoSmall.svg" alt="logo" />
+            </Grid>
+            <Grid item>
+              <Typography variant="h3">Tournesol</Typography>
+              <Typography variant="subtitle1">{pollName}</Typography>
+            </Grid>
+          </Grid>
         </Hidden>
         <Hidden smUp>
           <img src="/svg/LogoSmall.svg" alt="logo" />

--- a/frontend/src/features/frame/components/topbar/TopBar.tsx
+++ b/frontend/src/features/frame/components/topbar/TopBar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import makeStyles from '@mui/styles/makeStyles';
@@ -14,8 +14,9 @@ import { Menu } from '@mui/icons-material';
 import { useAppSelector, useAppDispatch } from '../../../../app/hooks';
 import { openDrawer, closeDrawer, selectFrame } from '../../drawerOpenSlice';
 import AccountInfo from './AccountInfo';
-import { Typography, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import PollSelector from './PollSelector';
 
 export const topBarHeight = 80;
 
@@ -58,7 +59,6 @@ const useStyles = makeStyles(() => ({
 const Logo = () => {
   const drawerOpen = useAppSelector(selectFrame);
   const dispatch = useAppDispatch();
-  const { name: pollName } = useCurrentPoll();
 
   return (
     <Grid
@@ -77,22 +77,7 @@ const Logo = () => {
       >
         <Menu />
       </IconButton>
-      <Link to="/">
-        <Hidden smDown>
-          <Grid container>
-            <Grid item>
-              <img src="/svg/LogoSmall.svg" alt="logo" />
-            </Grid>
-            <Grid item>
-              <Typography variant="h3">Tournesol</Typography>
-              <Typography variant="subtitle1">{pollName}</Typography>
-            </Grid>
-          </Grid>
-        </Hidden>
-        <Hidden smUp>
-          <img src="/svg/LogoSmall.svg" alt="logo" />
-        </Hidden>
-      </Link>
+      <PollSelector />
     </Grid>
   );
 };

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,4 +1,5 @@
 import { TFunction } from 'react-i18next';
+import { HowToVote, YouTube } from '@mui/icons-material';
 
 export const YOUTUBE_POLL_NAME = 'videos';
 export const PRESIDENTIELLE_2022_POLL_NAME = 'presidentielle2022';
@@ -61,14 +62,22 @@ export const polls = [
   */
   {
     name: PRESIDENTIELLE_2022_POLL_NAME,
+    // could be translated by the back end
+    displayName: 'Élection FR 2022',
+    displayOrder: 20,
     path: '/presidentielle2022/',
+    iconComponent: HowToVote,
     withSearchBar: false,
     topBarBackground:
       'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
   },
   {
     name: YOUTUBE_POLL_NAME,
+    // could be translated by the back end
+    displayName: 'Videos',
+    displayOrder: 10,
     path: '/',
+    iconComponent: YouTube,
     withSearchBar: true,
     topBarBackground: null,
   },

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,5 +1,6 @@
 import { TFunction } from 'react-i18next';
 import { YouTube } from '@mui/icons-material';
+import { SelectablePolls } from './types';
 
 export const YOUTUBE_POLL_NAME = 'videos';
 export const PRESIDENTIELLE_2022_POLL_NAME = 'presidentielle2022';
@@ -70,7 +71,7 @@ export const getPollName = (t: TFunction, pollName: string) => {
   The most specific paths should be listed first,
   to be routed correctly.
 */
-export const polls = [
+export const polls: SelectablePolls = [
   /* disable the poll presidentielle2022 for now
      as it doesn't exist in the back end
   {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,5 +1,5 @@
 import { TFunction } from 'react-i18next';
-import { HowToVote, YouTube } from '@mui/icons-material';
+import { YouTube } from '@mui/icons-material';
 
 export const YOUTUBE_POLL_NAME = 'videos';
 export const PRESIDENTIELLE_2022_POLL_NAME = 'presidentielle2022';
@@ -55,11 +55,13 @@ export const getLanguageName = (t: TFunction, language: string) => {
   }
 };
 
+/*
+  The most specific paths should be listed first,
+  to be routed correctly.
+*/
 export const polls = [
-  /*
-    The most specific paths should be listed first,
-    to be routed correctly.
-  */
+  /* disable the poll presidentielle2022 for now
+     as it doesn't exist in the back end
   {
     name: PRESIDENTIELLE_2022_POLL_NAME,
     // could be translated by the back end
@@ -71,6 +73,7 @@ export const polls = [
     topBarBackground:
       'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
   },
+  */
   {
     name: YOUTUBE_POLL_NAME,
     // could be translated by the back end

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -55,6 +55,17 @@ export const getLanguageName = (t: TFunction, language: string) => {
   }
 };
 
+export const getPollName = (t: TFunction, pollName: string) => {
+  switch (pollName) {
+    case PRESIDENTIELLE_2022_POLL_NAME:
+      return t('poll.presidential2022');
+    case YOUTUBE_POLL_NAME:
+      return t('poll.videos');
+    default:
+      return pollName;
+  }
+};
+
 /*
   The most specific paths should be listed first,
   to be routed correctly.
@@ -64,8 +75,6 @@ export const polls = [
      as it doesn't exist in the back end
   {
     name: PRESIDENTIELLE_2022_POLL_NAME,
-    // could be translated by the back end
-    displayName: 'Élection FR 2022',
     displayOrder: 20,
     path: '/presidentielle2022/',
     iconComponent: HowToVote,
@@ -76,8 +85,6 @@ export const polls = [
   */
   {
     name: YOUTUBE_POLL_NAME,
-    // could be translated by the back end
-    displayName: 'Videos',
     displayOrder: 10,
     path: '/',
     iconComponent: YouTube,

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,6 +1,7 @@
 import { TFunction } from 'react-i18next';
 
 export const YOUTUBE_POLL_NAME = 'videos';
+export const PRESIDENTIELLE_2022_POLL_NAME = 'presidentielle2022';
 
 const UID_DELIMITER = ':';
 export const UID_YT_NAMESPACE = 'yt' + UID_DELIMITER;
@@ -58,13 +59,13 @@ export const polls = [
     The most specific paths should be listed first,
     to be routed correctly.
   */
-  // {
-  //   name: 'presidentielle',
-  //   path: '/presidentielle',
-  //   withSearchBar: false,
-  //   topBarBackground:
-  //     'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
-  // },
+  {
+    name: PRESIDENTIELLE_2022_POLL_NAME,
+    path: '/presidentielle2022/',
+    withSearchBar: false,
+    topBarBackground:
+      'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
+  },
   {
     name: YOUTUBE_POLL_NAME,
     path: '/',

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SvgIconComponent } from '@mui/icons-material';
 import {
   EntityNoExtraField,
   RelatedEntity,
@@ -24,3 +25,14 @@ export type ActionList = Array<
 
 export type RelatedEntityObject = EntityNoExtraField | RelatedEntity;
 export type VideoObject = Video | VideoSerializerWithCriteria;
+
+// a poll that can be displayed by <PollSelector>
+export type SelectablePoll = {
+  name: string;
+  displayOrder: number;
+  path: string;
+  iconComponent: SvgIconComponent;
+  withSearchBar: boolean;
+  topBarBackground: string | null;
+};
+export type SelectablePolls = Array<SelectablePoll>;


### PR DESCRIPTION
**related to** #647 

---

This pull request adds a `<PollSelector>` component allowing users to navigate between polls.

I didn't add the requested mui badge yet. I plan to do it in another pull request.

The menu on mobile is still very light. It works, but doesn't display the selected poll name. With @amatissart we considered using the side menu on the mobile instead of the `<PollSelector>`, or we can just display the poll name in the top bar.

**new component**
- [x] create a new component displaying logo + title + poll's name
- [x] display the title with `<Typography>` instead of hardcoding it in the logo's image
- [x] display the current poll's name 
- [x] a click on the title display the list of available polls
  - [x] should the list be hard-coded? **its already available as a component** 
- [x] translate the names of the available polls 
- [x] add isolation tests

**ux / ui**
- [x] make the title black
- [x] make the poll's name lighter than the title
- [x] remove the underline decoration
- [x] make the logo + title + poll's name clickable 
- [x] add a visual hint indicating the component is clickable
  - [x] `cursor: pointer` on hover
  - [x] also change the background color
  - [x] add a little arrow next to the poll's name
- [ ] add a mui badge only visible if the user has never clicked on the component 

**desktop / mobile**
- [x] display the title + poll's name only on desktop 

**further improvement**
- [x] `<Hidden>` component is deprecated in mui 5, should be replaced

## preview

### screenshot

![capture](https://user-images.githubusercontent.com/39056254/157412259-3616d50c-faff-4587-979c-109a5c316be6.png)

### video

https://user-images.githubusercontent.com/39056254/157412291-4b21cc39-0781-4845-bfab-a064497d748c.mp4


