### PR TITLE
Fix: legacy params in comparison URL should redirect to uids

### DIFF
--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -124,6 +124,12 @@ const Comparison = () => {
   useEffect(() => {
     setIsLoading(true);
     setInitialComparison(null);
+    if (selectorA.uid !== uidA) {
+      setSelectorA({ uid: uidA, rating: null });
+    }
+    if (selectorB.uid !== uidB) {
+      setSelectorB({ uid: uidB, rating: null });
+    }
     if (uidA && uidB)
       UsersService.usersMeComparisonsRetrieve({
         pollName,
@@ -139,7 +145,7 @@ const Comparison = () => {
           setInitialComparison(null);
           setIsLoading(false);
         });
-  }, [uidA, uidB, pollName]);
+  }, [pollName, uidA, uidB, selectorA.uid, selectorB.uid]);
 
   const onSubmitComparison = async (c: ComparisonRequest) => {
     if (initialComparison) {

--- a/tests/cypress/integration/frontend/comparisonPage.ts
+++ b/tests/cypress/integration/frontend/comparisonPage.ts
@@ -216,4 +216,23 @@ describe('Comparison page', () => {
       cy.get('button#expert_submit_btn').should('not.exist');
     });
   });
+
+  describe('access a comparison page', () => {
+    it('redirects legacy video params to corresponding uids', () => {
+      const videoAId = 'u83A7DUNMHs';
+      const videoBId = '6jK9bFWE--g';
+
+      cy.visit(`/comparison/?videoA=${videoAId}&videoB=${videoBId}`);
+      cy.focused().type('user1');
+      cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+
+      cy.location('search').should('contain', `uidA=yt%3A${videoAId}`)
+      cy.location('search').should('contain', `uidB=yt%3A${videoBId}`)
+
+      cy.get('input[placeholder="Paste URL or Video ID"]').first()
+        .should('have.value', `yt:${videoAId}`);
+      cy.get('input[placeholder="Paste URL or Video ID"]').last()
+        .should('have.value', `yt:${videoBId}`);
+    });
+  })
 });


### PR DESCRIPTION
A regression was introduced in #632  
An integration test has been added to cover this.