### PR TITLE
[front] feat: make sidebar aware of the selected poll

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -58,9 +58,9 @@
   "menu": {
     "home": "Home",
     "recommendations": "Recommendations",
-    "compare": "Compare videos",
+    "compare": "Compare 🌻",
     "myComparisons": "My comparisons",
-    "myRatedVideos": "My rated videos",
+    "comparedItems": "Compared items",
     "myRateLaterList": "My rate later list",
     "about": "About"
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -61,9 +61,9 @@
   "menu": {
     "home": "Accueil",
     "recommendations": "Recommandations",
-    "compare": "Comparer des vidéos",
+    "compare": "Comparer 🌻",
     "myComparisons": "Mes comparaisons",
-    "myRatedVideos": "Vidéos comparées",
+    "comparedItems": "Élements comparés",
     "myRateLaterList": "À comparer plus tard",
     "about": "À propos"
   },

--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -58,11 +58,11 @@ const PollRoutes = ({ pollName, disableRecommendations = false }: Props) => {
       page: RateLaterPage,
     },
     {
-      id: 'myRatedVideo',
+      id: 'myRatedVideos',
       url: 'ratings',
       page: VideoRatingsPage,
     },
-  ];
+  ] as const;
 
   return (
     <Switch>

--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -12,10 +12,9 @@ import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
 interface Props {
   pollName: string;
-  disableRecommendations?: boolean;
 }
 
-const PollRoutes = ({ pollName, disableRecommendations = false }: Props) => {
+const PollRoutes = ({ pollName }: Props) => {
   const { path } = useRouteMatch();
   const basePath = path.replace(/\/+$/g, '');
 
@@ -42,6 +41,12 @@ const PollRoutes = ({ pollName, disableRecommendations = false }: Props) => {
   }
 
   const routes = [
+    {
+      id: 'recommendations',
+      url: 'recommendations',
+      page: VideoRecommendationPage,
+      type: PublicRoute,
+    },
     {
       id: 'myComparisons',
       url: 'comparisons',
@@ -70,11 +75,6 @@ const PollRoutes = ({ pollName, disableRecommendations = false }: Props) => {
 
   return (
     <Switch>
-      {!disableRecommendations && (
-        <PublicRoute path={`${basePath}/recommendations`}>
-          <VideoRecommendationPage />
-        </PublicRoute>
-      )}
       {routes.map((route) => {
         if (disabledItems.includes(route.id)) {
           return;

--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { Switch, useRouteMatch } from 'react-router-dom';
-import { CircularProgress, Box } from '@mui/material';
+import { Box, CircularProgress } from '@mui/material';
 import PublicRoute from 'src/features/login/PublicRoute';
 import PrivateRoute from 'src/features/login/PrivateRoute';
 import ComparisonListPage from 'src/pages/comparisons/ComparisonList';
@@ -9,6 +9,7 @@ import VideoRatingsPage from 'src/pages/videos/VideoRatings';
 import ComparisonPage from 'src/pages/comparisons/Comparison';
 import RateLaterPage from 'src/pages/rateLater/RateLater';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import { RouteID } from 'src/utils/types';
 
 interface Props {
   pollName: string;
@@ -42,36 +43,36 @@ const PollRoutes = ({ pollName }: Props) => {
 
   const routes = [
     {
-      id: 'recommendations',
+      id: RouteID.Recommendations,
       url: 'recommendations',
       page: VideoRecommendationPage,
       type: PublicRoute,
     },
     {
-      id: 'myComparisons',
-      url: 'comparisons',
-      page: ComparisonListPage,
-      type: PrivateRoute,
-    },
-    {
-      id: 'comparison',
+      id: RouteID.Comparison,
       url: 'comparison',
       page: ComparisonPage,
       type: PrivateRoute,
     },
     {
-      id: 'myRateLaterList',
-      url: 'rate_later',
-      page: RateLaterPage,
+      id: RouteID.MyComparisons,
+      url: 'comparisons',
+      page: ComparisonListPage,
       type: PrivateRoute,
     },
     {
-      id: 'myRatedVideos',
+      id: RouteID.MyComparedItems,
       url: 'ratings',
       page: VideoRatingsPage,
       type: PrivateRoute,
     },
-  ] as const;
+    {
+      id: RouteID.MyRateLaterList,
+      url: 'rate_later',
+      page: RateLaterPage,
+      type: PrivateRoute,
+    },
+  ];
 
   return (
     <Switch>

--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -46,21 +46,25 @@ const PollRoutes = ({ pollName, disableRecommendations = false }: Props) => {
       id: 'myComparisons',
       url: 'comparisons',
       page: ComparisonListPage,
+      type: PrivateRoute,
     },
     {
       id: 'comparison',
       url: 'comparison',
       page: ComparisonPage,
+      type: PrivateRoute,
     },
     {
       id: 'myRateLaterList',
       url: 'rate_later',
       page: RateLaterPage,
+      type: PrivateRoute,
     },
     {
       id: 'myRatedVideos',
       url: 'ratings',
       page: VideoRatingsPage,
+      type: PrivateRoute,
     },
   ] as const;
 
@@ -76,9 +80,9 @@ const PollRoutes = ({ pollName, disableRecommendations = false }: Props) => {
           return;
         }
         return (
-          <PrivateRoute key={route.id} path={`${basePath}/${route.url}`}>
+          <route.type key={route.id} path={`${basePath}/${route.url}`}>
             <route.page />
-          </PrivateRoute>
+          </route.type>
         );
       })}
       <PublicRoute>Page not found</PublicRoute>

--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -19,7 +19,13 @@ const PollRoutes = ({ pollName, disableRecommendations = false }: Props) => {
   const { path } = useRouteMatch();
   const basePath = path.replace(/\/+$/g, '');
 
-  const { setPollName, name: currentPollName, isReady } = useCurrentPoll();
+  const {
+    setPollName,
+    name: currentPollName,
+    options,
+    isReady,
+  } = useCurrentPoll();
+  const disabledItems = options?.disabledRouteIds ?? [];
 
   useEffect(() => {
     if (currentPollName !== pollName || !isReady) {
@@ -35,6 +41,29 @@ const PollRoutes = ({ pollName, disableRecommendations = false }: Props) => {
     );
   }
 
+  const routes = [
+    {
+      id: 'myComparisons',
+      url: 'comparisons',
+      page: ComparisonListPage,
+    },
+    {
+      id: 'comparison',
+      url: 'comparison',
+      page: ComparisonPage,
+    },
+    {
+      id: 'myRateLaterList',
+      url: 'rate_later',
+      page: RateLaterPage,
+    },
+    {
+      id: 'myRatedVideo',
+      url: 'ratings',
+      page: VideoRatingsPage,
+    },
+  ];
+
   return (
     <Switch>
       {!disableRecommendations && (
@@ -42,18 +71,16 @@ const PollRoutes = ({ pollName, disableRecommendations = false }: Props) => {
           <VideoRecommendationPage />
         </PublicRoute>
       )}
-      <PrivateRoute path={`${basePath}/comparisons`}>
-        <ComparisonListPage />
-      </PrivateRoute>
-      <PrivateRoute path={`${basePath}/comparison`}>
-        <ComparisonPage />
-      </PrivateRoute>
-      <PrivateRoute path={`${basePath}/rate_later`}>
-        <RateLaterPage />
-      </PrivateRoute>
-      <PrivateRoute path={`${basePath}/ratings`}>
-        <VideoRatingsPage />
-      </PrivateRoute>
+      {routes.map((route) => {
+        if (disabledItems.includes(route.id)) {
+          return;
+        }
+        return (
+          <PrivateRoute key={route.id} path={`${basePath}/${route.url}`}>
+            <route.page />
+          </PrivateRoute>
+        );
+      })}
       <PublicRoute>Page not found</PublicRoute>
     </Switch>
   );

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -33,6 +33,7 @@ import { closeDrawer } from '../../drawerOpenSlice';
 import { useAppDispatch } from 'src/app/hooks';
 import { LanguageSelector } from 'src/components';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import { RouteID } from 'src/utils/types';
 import Footer from './Footer';
 
 export const sideBarWidth = 264;
@@ -116,45 +117,45 @@ const SideBar = () => {
 
   const menuItems = [
     {
-      id: 'home' as const,
+      id: RouteID.Home,
       targetUrl: path,
       IconComponent: HomeIcon,
       displayText: t('menu.home'),
     },
     {
-      id: 'recommendations' as const,
+      id: RouteID.Recommendations,
       targetUrl: `${path}recommendations?date=Month`,
       IconComponent: VideoLibrary,
       displayText: t('menu.recommendations'),
     },
     { displayText: 'divider_1' },
     {
-      id: 'comparison' as const,
+      id: RouteID.Comparison,
       targetUrl: `${path}comparison`,
       IconComponent: CompareIcon,
       displayText: t('menu.compare'),
     },
     {
-      id: 'myComparisons' as const,
+      id: RouteID.MyComparisons,
       targetUrl: `${path}comparisons`,
       IconComponent: ListIcon,
       displayText: t('menu.myComparisons'),
     },
     {
-      id: 'myRatedVideos' as const,
+      id: RouteID.MyComparedItems,
       targetUrl: `${path}ratings`,
       IconComponent: StarsIcon,
       displayText: t('menu.comparedItems'),
     },
     {
-      id: 'myRateLaterList' as const,
+      id: RouteID.MyRateLaterList,
       targetUrl: `${path}rate_later`,
       IconComponent: WatchLaterIcon,
       displayText: t('menu.myRateLaterList'),
     },
     { displayText: 'divider_2' },
     {
-      id: 'about' as const,
+      id: RouteID.About,
       targetUrl: '/about',
       IconComponent: InfoIcon,
       displayText: t('menu.about'),

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -29,10 +29,11 @@ import {
   VideoLibrary,
 } from '@mui/icons-material';
 
-import { useAppDispatch } from '../../../../app/hooks';
 import { closeDrawer } from '../../drawerOpenSlice';
-import Footer from './Footer';
+import { useAppDispatch } from 'src/app/hooks';
 import { LanguageSelector } from 'src/components';
+import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import Footer from './Footer';
 
 export const sideBarWidth = 264;
 
@@ -91,13 +92,18 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 const SideBar = () => {
-  const { t } = useTranslation();
   const classes = useStyles();
-  const drawerOpen = useAppSelector(selectFrame);
-  const dispatch = useAppDispatch();
   const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+
+  const { t } = useTranslation();
   const location = useLocation();
+  const dispatch = useAppDispatch();
+
+  const { options } = useCurrentPoll();
+  const path = options && options.path ? options.path : '';
+
+  const drawerOpen = useAppSelector(selectFrame);
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
   // parameter 'url', which corresponds to the target url, may contain some url parameters
   // we make sure that we highlight the component the user loaded
@@ -105,36 +111,36 @@ const SideBar = () => {
     url.split('?')[0] === location.pathname;
 
   const menuItems = [
-    { targetUrl: '/', IconComponent: HomeIcon, displayText: t('menu.home') },
+    { targetUrl: path, IconComponent: HomeIcon, displayText: t('menu.home') },
     {
-      targetUrl: '/recommendations?date=Month',
+      targetUrl: `${path}recommendations?date=Month`,
       IconComponent: VideoLibrary,
       displayText: t('menu.recommendations'),
     },
     { displayText: 'divider_1' },
     {
-      targetUrl: '/comparison',
+      targetUrl: `${path}comparison`,
       IconComponent: CompareIcon,
       displayText: t('menu.compare'),
     },
     {
-      targetUrl: '/comparisons',
+      targetUrl: `${path}comparisons`,
       IconComponent: ListIcon,
       displayText: t('menu.myComparisons'),
     },
     {
-      targetUrl: '/ratings',
+      targetUrl: `${path}ratings`,
       IconComponent: StarsIcon,
       displayText: t('menu.myRatedVideos'),
     },
     {
-      targetUrl: '/rate_later',
+      targetUrl: `${path}rate_later`,
       IconComponent: WatchLaterIcon,
       displayText: t('menu.myRateLaterList'),
     },
     { displayText: 'divider_2' },
     {
-      targetUrl: '/about',
+      targetUrl: `/about`,
       IconComponent: InfoIcon,
       displayText: t('menu.about'),
     },

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -113,45 +113,45 @@ const SideBar = () => {
 
   const menuItems = [
     {
-      id: 'home',
+      id: 'home' as const,
       targetUrl: path,
       IconComponent: HomeIcon,
       displayText: t('menu.home'),
     },
     {
-      id: 'recommendations',
+      id: 'recommendations' as const,
       targetUrl: `${path}recommendations?date=Month`,
       IconComponent: VideoLibrary,
       displayText: t('menu.recommendations'),
     },
     { displayText: 'divider_1' },
     {
-      id: 'comparison',
+      id: 'comparison' as const,
       targetUrl: `${path}comparison`,
       IconComponent: CompareIcon,
       displayText: t('menu.compare'),
     },
     {
-      id: 'myComparisons',
+      id: 'myComparisons' as const,
       targetUrl: `${path}comparisons`,
       IconComponent: ListIcon,
       displayText: t('menu.myComparisons'),
     },
     {
-      id: 'myRatedVideo',
+      id: 'myRatedVideos' as const,
       targetUrl: `${path}ratings`,
       IconComponent: StarsIcon,
       displayText: t('menu.myRatedVideos'),
     },
     {
-      id: 'myRateLaterList',
+      id: 'myRateLaterList' as const,
       targetUrl: `${path}rate_later`,
       IconComponent: WatchLaterIcon,
       displayText: t('menu.myRateLaterList'),
     },
     { displayText: 'divider_2' },
     {
-      id: 'about',
+      id: 'about' as const,
       targetUrl: '/about',
       IconComponent: InfoIcon,
       displayText: t('menu.about'),

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -100,7 +100,9 @@ const SideBar = () => {
   const dispatch = useAppDispatch();
 
   const { options } = useCurrentPoll();
-  const path = options && options.path ? options.path : '';
+  const path = options && options.path ? options.path : '/';
+  const disabledItems =
+    options && options.disabledMenuItems ? options.disabledMenuItems : [];
 
   const drawerOpen = useAppSelector(selectFrame);
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
@@ -111,36 +113,47 @@ const SideBar = () => {
     url.split('?')[0] === location.pathname;
 
   const menuItems = [
-    { targetUrl: path, IconComponent: HomeIcon, displayText: t('menu.home') },
     {
+      id: 'home',
+      targetUrl: path,
+      IconComponent: HomeIcon,
+      displayText: t('menu.home'),
+    },
+    {
+      id: 'recommendations',
       targetUrl: `${path}recommendations?date=Month`,
       IconComponent: VideoLibrary,
       displayText: t('menu.recommendations'),
     },
     { displayText: 'divider_1' },
     {
+      id: 'comparison',
       targetUrl: `${path}comparison`,
       IconComponent: CompareIcon,
       displayText: t('menu.compare'),
     },
     {
+      id: 'myComparisons',
       targetUrl: `${path}comparisons`,
       IconComponent: ListIcon,
       displayText: t('menu.myComparisons'),
     },
     {
+      id: 'myRatedVideo',
       targetUrl: `${path}ratings`,
       IconComponent: StarsIcon,
       displayText: t('menu.myRatedVideos'),
     },
     {
+      id: 'myRateLater',
       targetUrl: `${path}rate_later`,
       IconComponent: WatchLaterIcon,
       displayText: t('menu.myRateLaterList'),
     },
     { displayText: 'divider_2' },
     {
-      targetUrl: `/about`,
+      id: 'about',
+      targetUrl: '/about',
       IconComponent: InfoIcon,
       displayText: t('menu.about'),
     },
@@ -168,9 +181,12 @@ const SideBar = () => {
         onClick={isSmallScreen ? () => dispatch(closeDrawer()) : undefined}
         sx={{ flexGrow: 1 }}
       >
-        {menuItems.map(({ targetUrl, IconComponent, displayText }) => {
+        {menuItems.map(({ id, targetUrl, IconComponent, displayText }) => {
           if (!IconComponent || !targetUrl)
             return <Divider key={displayText} />;
+          if (id && disabledItems.includes(id)) {
+            return;
+          }
           const selected = isItemSelected(targetUrl);
           return (
             <ListItem

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -88,6 +88,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   listItemText: {
     fontWeight: 'bold',
+    '&:first-letter': {
+      textTransform: 'capitalize',
+    },
   },
 }));
 
@@ -141,7 +144,7 @@ const SideBar = () => {
       id: 'myRatedVideos' as const,
       targetUrl: `${path}ratings`,
       IconComponent: StarsIcon,
-      displayText: t('menu.myRatedVideos'),
+      displayText: t('menu.comparedItems'),
     },
     {
       id: 'myRateLaterList' as const,
@@ -189,7 +192,7 @@ const SideBar = () => {
           const selected = isItemSelected(targetUrl);
           return (
             <ListItem
-              key={displayText}
+              key={id}
               button
               selected={selected}
               className={classes.listItem}

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -101,8 +101,7 @@ const SideBar = () => {
 
   const { options } = useCurrentPoll();
   const path = options && options.path ? options.path : '/';
-  const disabledItems =
-    options && options.disabledMenuItems ? options.disabledMenuItems : [];
+  const disabledItems = options?.disabledRouteIds ?? [];
 
   const drawerOpen = useAppSelector(selectFrame);
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
@@ -145,7 +144,7 @@ const SideBar = () => {
       displayText: t('menu.myRatedVideos'),
     },
     {
-      id: 'myRateLater',
+      id: 'myRateLaterList',
       targetUrl: `${path}rate_later`,
       IconComponent: WatchLaterIcon,
       displayText: t('menu.myRateLaterList'),

--- a/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
+++ b/frontend/src/features/frame/components/topbar/PollSelector.spec.tsx
@@ -8,10 +8,10 @@ import {
   PRESIDENTIELLE_2022_POLL_NAME,
   YOUTUBE_POLL_NAME,
 } from 'src/utils/constants';
-import { SelectablePolls } from 'src/utils/types';
+import { SelectablePoll } from 'src/utils/types';
 
 describe('change password feature', () => {
-  const polls: SelectablePolls = [
+  const polls: Array<SelectablePoll> = [
     {
       name: PRESIDENTIELLE_2022_POLL_NAME,
       displayOrder: 20,

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,6 +1,6 @@
 import { TFunction } from 'react-i18next';
 import { HowToVote, YouTube } from '@mui/icons-material';
-import { SelectablePolls } from './types';
+import { SelectablePoll } from './types';
 
 export const YOUTUBE_POLL_NAME = 'videos';
 export const PRESIDENTIELLE_2022_POLL_NAME = 'presidentielle2022';
@@ -133,11 +133,12 @@ export const getEntityName = (t: TFunction, pollName: string) => {
   The most specific paths should be listed first,
   to be routed correctly.
 */
-export const polls: SelectablePolls = [
+export const polls: Array<SelectablePoll> = [
   {
     name: PRESIDENTIELLE_2022_POLL_NAME,
     displayOrder: 20,
     path: '/presidentielle2022/',
+    disabledMenuItems: ['myRateLater'],
     iconComponent: HowToVote,
     withSearchBar: false,
     topBarBackground:

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -138,7 +138,7 @@ export const polls: Array<SelectablePoll> = [
     name: PRESIDENTIELLE_2022_POLL_NAME,
     displayOrder: 20,
     path: '/presidentielle2022/',
-    disabledMenuItems: ['myRateLater'],
+    disabledRouteIds: ['myRateLaterList'],
     iconComponent: HowToVote,
     withSearchBar: false,
     topBarBackground:

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,5 +1,5 @@
 import { TFunction } from 'react-i18next';
-import { YouTube } from '@mui/icons-material';
+import { HowToVote, YouTube } from '@mui/icons-material';
 import { SelectablePolls } from './types';
 
 export const YOUTUBE_POLL_NAME = 'videos';
@@ -134,8 +134,6 @@ export const getEntityName = (t: TFunction, pollName: string) => {
   to be routed correctly.
 */
 export const polls: SelectablePolls = [
-  /* disable the poll presidentielle2022 for now
-     as it doesn't exist in the back end
   {
     name: PRESIDENTIELLE_2022_POLL_NAME,
     displayOrder: 20,
@@ -145,7 +143,6 @@ export const polls: SelectablePolls = [
     topBarBackground:
       'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
   },
-  */
   {
     name: YOUTUBE_POLL_NAME,
     displayOrder: 10,

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -140,7 +140,7 @@ export const polls: Array<SelectablePoll> = [
     name: PRESIDENTIELLE_2022_POLL_NAME,
     displayOrder: 20,
     path: '/presidentielle2022/',
-    disabledRouteIds: ['myRateLaterList'],
+    disabledRouteIds: [RouteID.MyRateLaterList],
     iconComponent: HowToVote,
     withSearchBar: false,
     topBarBackground:

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,5 +1,5 @@
 import { TFunction } from 'react-i18next';
-import { HowToVote, YouTube } from '@mui/icons-material';
+import { YouTube } from '@mui/icons-material';
 import { SelectablePoll } from './types';
 
 export const YOUTUBE_POLL_NAME = 'videos';
@@ -134,6 +134,8 @@ export const getEntityName = (t: TFunction, pollName: string) => {
   to be routed correctly.
 */
 export const polls: Array<SelectablePoll> = [
+  /* disable the poll presidentielle2022 for now
+     as it doesn't exist in the back end
   {
     name: PRESIDENTIELLE_2022_POLL_NAME,
     displayOrder: 20,
@@ -144,6 +146,7 @@ export const polls: Array<SelectablePoll> = [
     topBarBackground:
       'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
   },
+  */
   {
     name: YOUTUBE_POLL_NAME,
     displayOrder: 10,

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -26,14 +26,29 @@ export type ActionList = Array<
 export type RelatedEntityObject = EntityNoExtraField | RelatedEntity;
 export type VideoObject = Video | VideoSerializerWithCriteria;
 
-// a poll that can be displayed by <PollSelector>
+/**
+ * An exhaustive list of route ids helping to enforce type checking in each
+ * place a routeId is required.
+ */
+export type routeId =
+  | 'home'
+  | 'recommendations'
+  | 'comparison'
+  | 'myComparisons'
+  | 'myRatedVideos'
+  | 'myRateLaterList'
+  | 'about';
+
+/**
+ * A poll that can be displayed by <PollSelector>
+ */
 export type SelectablePoll = {
   name: string;
   displayOrder: number;
   // the path used as URL prefix, must include leading and trailing slash
   path: string;
   // a list route id that will be disable in `PollRoutes` and `SideBar`
-  disabledRouteIds?: Array<string>;
+  disabledRouteIds?: Array<routeId>;
   iconComponent: SvgIconComponent;
   withSearchBar: boolean;
   topBarBackground: string | null;

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -32,8 +32,8 @@ export type SelectablePoll = {
   displayOrder: number;
   // the path used as URL prefix, must include leading and trailing slash
   path: string;
-  // a list of id used by `SideBar` items that won't be displayed
-  disabledMenuItems?: Array<string>;
+  // a list route id that will be disable in `PollRoutes` and `SideBar`
+  disabledRouteIds?: Array<string>;
   iconComponent: SvgIconComponent;
   withSearchBar: boolean;
   topBarBackground: string | null;

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -28,16 +28,17 @@ export type VideoObject = Video | VideoSerializerWithCriteria;
 
 /**
  * An exhaustive list of route ids helping to enforce type checking in each
- * place a routeId is required.
+ * place a route id is required.
  */
-export type routeId =
-  | 'home'
-  | 'recommendations'
-  | 'comparison'
-  | 'myComparisons'
-  | 'myRatedVideos'
-  | 'myRateLaterList'
-  | 'about';
+export enum RouteID {
+  Home = 'home',
+  Recommendations = 'recommendations',
+  Comparison = 'comparison',
+  MyComparisons = 'myComparisons',
+  MyComparedItems = 'myComparedItems',
+  MyRateLaterList = 'myRateLaterList',
+  About = 'about',
+}
 
 /**
  * A poll that can be displayed by <PollSelector>
@@ -48,7 +49,7 @@ export type SelectablePoll = {
   // the path used as URL prefix, must include leading and trailing slash
   path: string;
   // a list route id that will be disable in `PollRoutes` and `SideBar`
-  disabledRouteIds?: Array<routeId>;
+  disabledRouteIds?: Array<RouteID>;
   iconComponent: SvgIconComponent;
   withSearchBar: boolean;
   topBarBackground: string | null;

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -30,9 +30,11 @@ export type VideoObject = Video | VideoSerializerWithCriteria;
 export type SelectablePoll = {
   name: string;
   displayOrder: number;
+  // the path used as URL prefix, must include leading and trailing slash
   path: string;
+  // a list of id used by `SideBar` items that won't be displayed
+  disabledMenuItems?: Array<string>;
   iconComponent: SvgIconComponent;
   withSearchBar: boolean;
   topBarBackground: string | null;
 };
-export type SelectablePolls = Array<SelectablePoll>;


### PR DESCRIPTION
**related to** #659 

---

I temporarily activated the poll `presidentielle2022` in the front end configuration just to make the branch testable. I'll revert it before merging.

This pull request makes the router `<PollRoutes>` and the component `<SideBar>` aware of the currently selected poll and its configuration.

To achieve this, these components use ids allowing them to identify which routes must be enabled and which must be disabled.  

Making the sidebar items translations more generic simplified a lot the code, but as a drawback items are less precise than before.

- `Compare videos` becomes `Compare`
- `My rated videos` becomes `Compared items`

`Compare` is less appealing than `Compare videos` as the user may not be able to know what he/she is invited to compare. So as a proposition I added a wild sunflower to catch the eyes and to invite people to click. 

### further improvements

It looks like the `disableRecommendations` prop of the `<PollRoutes>` component is redundant with the constant property `utils.constants.polls.disableRoutesIds` . Should we delete the `disableRecommendations`?
- [x] fixed by 0b725025881baa5d2725cc025613d1d69fad615e

## preview

https://user-images.githubusercontent.com/39056254/158560674-17f095c2-f2bd-4df2-a159-7f849e0e2406.mp4
