### PR TITLE
Suggestion to adjust style of the comparison page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -19,7 +19,7 @@
     "comparisonInPublicDataset": "This comparison is included in the public dataset.",
     "comparisonInPublicDatasetAfterSubmission": "After submission, this comparison will be included in the public dataset.",
     "editComparison": "Edit comparison",
-    "criteriaSkipped": "Skipped",
+    "criteriaSkipped": "skipped",
     "submitAComparison": "Submit a comparison"
   },
   "comparisons": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -154,7 +154,7 @@
     "ratedVideos": "Rated videos"
   },
   "videoSelector": {
-    "newVideo": "New Video",
+    "newVideo": "Select a new video automatically",
     "autoEntityButton": "Auto",
     "pasteUrlOrVideoId": "Paste URL or Video ID"
   },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -9,14 +9,6 @@
     "nextButton": "Next {{limit}}",
     "comparisons": "comparisons"
   },
-  "metrics": {
-    "evolutionDuringTheLast30Days": "Evolution during the last 30 days."
-  },
-  "stats": {
-    "activeUsers": "Active users",
-    "comparisons": "Comparisons",
-    "ratedVideos": "Rated videos"
-  },
   "comparison": {
     "successfullySubmitted": "The comparison has been successfully submitted.",
     "pleaseSelectTwoVideos": "Please, enter two URLs or IDs of YouTube videos to compare them.",
@@ -24,9 +16,9 @@
     "removeOptionalCriterias": "Remove optional criterias",
     "addOptionalCriterias": "Add optional criterias",
     "changeOneVideo": "Change one of the video to submit a new comparison",
-    "editComparison": "Edit comparison",
     "comparisonInPublicDataset": "This comparison is included in the public dataset.",
     "comparisonInPublicDatasetAfterSubmission": "After submission, this comparison will be included in the public dataset.",
+    "editComparison": "Edit comparison",
     "criteriaSkipped": "Skipped",
     "submitAComparison": "Submit a comparison"
   },
@@ -153,9 +145,18 @@
   },
   "username": "Username",
   "profile": "Profile",
+  "metrics": {
+    "evolutionDuringTheLast30Days": "Evolution during the last 30 days."
+  },
+  "stats": {
+    "activeUsers": "Active users",
+    "comparisons": "Comparisons",
+    "ratedVideos": "Rated videos"
+  },
   "videoSelector": {
-    "pasteUrlOrVideoId": "Paste URL or Video ID",
-    "newVideo": "New Video"
+    "newVideo": "New Video",
+    "autoEntityButton": "Auto",
+    "pasteUrlOrVideoId": "Paste URL or Video ID"
   },
   "video": {
     "nComparisonsByYou_one": "{{count}} comparison by you",
@@ -163,17 +164,17 @@
     "notYetComparedByYou": "Not yet compared by you",
     "contributionsArePublicMessage": "Your contributions about this video are currently public. Comparisons appear in the public data associated to your profile only if you tag both videos as public.",
     "contributionsArePrivateMessage": "Your contributions about this video are currently private. The details of your personal ratings are not published, but they may still be used to compute public aggregated scores about videos.",
-    "unsafeNotEnoughContributor": "The relevance of this score is uncertain, due to too few contributors.",
-    "unsafeNegativeRating": "This video score is below the average of the other videos added to Tournesol.",
     "nbViews": "{{nbViews}} views",
     "seeRecommendedVideosSameUploader": "See recommended videos of the same uploader",
+    "labelShowSettings": "Show settings related to this video",
+    "unsafeNotEnoughContributor": "The relevance of this score is uncertain, due to too few contributors.",
+    "unsafeNegativeRating": "This video score is below the average of the other videos added to Tournesol.",
     "nbComparisonsBy_one": "{{count}} comparison by",
     "nbComparisonsBy_other": "{{count}} comparisons by",
     "nbContributors_one": "{{count}} contributor",
     "nbContributors_other": "{{count}} contributors",
     "criteriaRatedHigh": "Rated high:",
-    "criteriaRatedLow": "Rated low:",
-    "labelShowSettings": "Show settings related to this video"
+    "criteriaRatedLow": "Rated low:"
   },
   "notifications": {
     "errorOccurred": "Sorry an error has occurred.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -9,14 +9,6 @@
     "nextButton": "{{limit}} suiv.",
     "comparisons": "comparaisons"
   },
-  "metrics": {
-    "evolutionDuringTheLast30Days": "Evolution au cours des 30 derniers jours."
-  },
-  "stats": {
-    "activeUsers": "Utilisateurs actifs",
-    "comparisons": "Comparaisons",
-    "ratedVideos": "Vidéos notées"
-  },
   "comparison": {
     "successfullySubmitted": "Comparaison bien enregistrée.",
     "pleaseSelectTwoVideos": "Entrez deux URLs ou deux IDs de vidéo YouTube pour les comparer.",
@@ -24,9 +16,9 @@
     "removeOptionalCriterias": "Supprimer les critères optionnels",
     "addOptionalCriterias": "Ajouter les critères optionnels",
     "changeOneVideo": "Changez l'une des deux vidéos pour faire une nouvelle comparaison.",
-    "editComparison": "Modifier la comparaison",
     "comparisonInPublicDataset": "Cette comparaison fait partie des données publiques.",
     "comparisonInPublicDatasetAfterSubmission": "Après enregistrement, cette comparaison fera partie des données publiques.",
+    "editComparison": "Modifier la comparaison",
     "criteriaSkipped": "ignoré",
     "submitAComparison": "Comparer des vidéos"
   },
@@ -154,9 +146,18 @@
   },
   "username": "Nom d'utilisateur",
   "profile": "Profil",
+  "metrics": {
+    "evolutionDuringTheLast30Days": "Evolution au cours des 30 derniers jours."
+  },
+  "stats": {
+    "activeUsers": "Utilisateurs actifs",
+    "comparisons": "Comparaisons",
+    "ratedVideos": "Vidéos notées"
+  },
   "videoSelector": {
-    "pasteUrlOrVideoId": "Coller une URL ou un ID de vidéo",
-    "newVideo": "Nouvelle vidéo"
+    "newVideo": "Nouvelle vidéo",
+    "autoEntityButton": "Auto",
+    "pasteUrlOrVideoId": "Coller une URL ou un ID de vidéo"
   },
   "video": {
     "nComparisonsByYou_one": "{{count}} comparaison par vous",
@@ -165,10 +166,11 @@
     "notYetComparedByYou": "Vous ne l'avez pas encore comparée",
     "contributionsArePublicMessage": "Vos contributions impliquant cette vidéo sont actuellement publiques. Une comparaison n'est publiquement associée à votre profil que lorsque vous marquez explicitement ses deux vidéos comme publiques.",
     "contributionsArePrivateMessage": "Vos contributions impliquant cette vidéo sont actuellement privées. Les détails de vos jugements ne sont pas publiés, mais ils sont tout de même pris en compte pour calculer le score agréré public des vidéos.",
-    "unsafeNotEnoughContributor": "La pertinence de ce score est incertaine, en raison d'un trop faible nombre de contributeurs.",
-    "unsafeNegativeRating": "Cette vidéo a un score inférieur à la moyenne des autres vidéos ajoutées à Tournesol.",
     "nbViews": "{{nbViews}} vues",
     "seeRecommendedVideosSameUploader": "Voir les vidéos recommandées de cette chaîne",
+    "labelShowSettings": "Voir les paramètres de cette video",
+    "unsafeNotEnoughContributor": "La pertinence de ce score est incertaine, en raison d'un trop faible nombre de contributeurs.",
+    "unsafeNegativeRating": "Cette vidéo a un score inférieur à la moyenne des autres vidéos ajoutées à Tournesol.",
     "nbComparisonsBy_one": "{{count}} comparaison par",
     "nbComparisonsBy_many": "{{count}} comparaisons par",
     "nbComparisonsBy_other": "{{count}} comparaisons par",
@@ -176,8 +178,7 @@
     "nbContributors_many": "{{count}} contributeurs",
     "nbContributors_other": "{{count}} contributeurs",
     "criteriaRatedHigh": "Noté fortement :",
-    "criteriaRatedLow": "Noté faiblement :",
-    "labelShowSettings": "Voir les paramètres de cette video"
+    "criteriaRatedLow": "Noté faiblement :"
   },
   "notifications": {
     "errorOccurred": "Désolé, une erreur est survenue.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -155,7 +155,7 @@
     "ratedVideos": "Vidéos notées"
   },
   "videoSelector": {
-    "newVideo": "Nouvelle vidéo",
+    "newVideo": "Selectionner une nouvelle vidéo automatiquement",
     "autoEntityButton": "Auto",
     "pasteUrlOrVideoId": "Coller une URL ou un ID de vidéo"
   },

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -222,12 +222,14 @@ const Comparison = () => {
         item
         xs={12}
         sx={{
-          marginTop: '16px',
+          marginTop: 2,
           display: 'flex',
           alignItems: 'center',
           flexDirection: 'column',
-          paddingTop: '16px',
+          py: 3,
         }}
+        component={Card}
+        elevation={2}
       >
         {selectorA.rating && selectorB.rating ? (
           isLoading ? (
@@ -244,9 +246,7 @@ const Comparison = () => {
             />
           )
         ) : (
-          <Typography paragraph>
-            {t('comparison.pleaseSelectTwoVideos')}
-          </Typography>
+          <Typography>{t('comparison.pleaseSelectTwoVideos')}</Typography>
         )}
       </Grid>
     </Grid>

--- a/frontend/src/features/comparisons/ComparisonSliders.tsx
+++ b/frontend/src/features/comparisons/ComparisonSliders.tsx
@@ -19,14 +19,11 @@ const useStyles = makeStyles(() => ({
     width: '100%',
     display: 'flex',
     justifyContent: 'center',
-    overflow: 'hidden',
   },
   centered: {
-    paddingBottom: '32px',
-    width: '880px',
     flex: '0 0 auto',
-    maxWidth: '100%',
-
+    maxWidth: 660,
+    width: 'calc(100% - 64px)',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
@@ -138,9 +135,11 @@ const ComparisonSliders = ({
             />
           ))}
         <Button
+          fullWidth
+          disabled={!criterias.some((c) => c.optional)}
           onClick={handleCollapseCriterias}
           startIcon={showOptionalCriterias ? <ExpandLess /> : <ExpandMore />}
-          size="small"
+          size="medium"
           color="secondary"
           sx={{
             marginBottom: '8px',
@@ -174,6 +173,26 @@ const ComparisonSliders = ({
             <Typography>{t('comparison.changeOneVideo')}</Typography>
           </div>
         )}
+
+        <Box
+          display="flex"
+          alignItems="center"
+          gap="8px"
+          my={1}
+          color="text.hint"
+          minHeight="40px"
+        >
+          {isComparisonPublic && (
+            <>
+              <InfoIcon fontSize="small" color="inherit" />
+              <Typography variant="caption" color="textSecondary">
+                {initialComparison
+                  ? t('comparison.comparisonInPublicDataset')
+                  : t('comparison.comparisonInPublicDatasetAfterSubmission')}
+              </Typography>
+            </>
+          )}
+        </Box>
         <Button
           variant="contained"
           color="primary"
@@ -183,22 +202,6 @@ const ComparisonSliders = ({
         >
           {submitted ? t('comparison.editComparison') : t('submit')}
         </Button>
-        {isComparisonPublic && (
-          <Box
-            display="flex"
-            alignItems="center"
-            gap="8px"
-            m={2}
-            color="text.hint"
-          >
-            <InfoIcon fontSize="small" color="inherit" />
-            <Typography variant="caption" color="textSecondary">
-              {initialComparison
-                ? t('comparison.comparisonInPublicDataset')
-                : t('comparison.comparisonInPublicDatasetAfterSubmission')}
-            </Typography>
-          </Box>
-        )}
       </div>
     </div>
   );

--- a/frontend/src/features/comparisons/CriteriaSlider.tsx
+++ b/frontend/src/features/comparisons/CriteriaSlider.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import makeStyles from '@mui/styles/makeStyles';
 import Typography from '@mui/material/Typography';
-import { Box, Slider, Grid, Checkbox, Chip, Divider } from '@mui/material';
+import { Box, Slider, Grid, Checkbox, Chip } from '@mui/material';
 
 import { getWikiBaseUrl } from 'src/utils/url';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
@@ -18,7 +18,7 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    marginBottom: '12px',
+    marginBottom: '16px',
   },
   sliderContainer: {
     display: 'flex',
@@ -120,6 +120,7 @@ const CriteriaSlider = ({
             criteriaValue == undefined) && (
             <Checkbox
               id={`id_checkbox_skip_${criteria}`}
+              size="small"
               disabled={disabled}
               checked={criteriaValue !== undefined}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -164,7 +165,6 @@ const CriteriaSlider = ({
           }
         />
       </div>
-      <Divider light flexItem sx={{ minHeight: '12px' }} />
     </div>
   );
 };

--- a/frontend/src/features/comparisons/CriteriaSlider.tsx
+++ b/frontend/src/features/comparisons/CriteriaSlider.tsx
@@ -3,12 +3,11 @@ import { useTranslation } from 'react-i18next';
 
 import makeStyles from '@mui/styles/makeStyles';
 import Typography from '@mui/material/Typography';
-import Slider from '@mui/material/Slider';
-import Grid from '@mui/material/Grid';
-import Checkbox from '@mui/material/Checkbox';
+import { Box, Slider, Grid, Checkbox, Chip, Divider } from '@mui/material';
 
 import { getWikiBaseUrl } from 'src/utils/url';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import { Link } from '@mui/material';
 
 const SLIDER_MIN_STEP = -10;
 const SLIDER_MAX_STEP = 10;
@@ -19,12 +18,12 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+    marginBottom: '12px',
   },
   sliderContainer: {
     display: 'flex',
     flexDirection: 'row',
-    maxWidth: 660,
-    width: 'calc(100% - 64px)',
+    width: '100%',
     alignItems: 'center',
   },
   slider: {
@@ -33,10 +32,11 @@ const useStyles = makeStyles(() => ({
   criteriaNameDisplay: {
     display: 'flex',
     flexDirection: 'row',
-    alignItems: 'center',
+    alignSelf: 'flex-start',
+    width: '100%',
   },
   img_criteria: {
-    padding: 4,
+    marginRight: '8px',
   },
 }));
 
@@ -84,27 +84,38 @@ const CriteriaSlider = ({
           direction="row"
           justifyContent="center"
           alignItems="center"
+          flexWrap="nowrap"
           container
         >
           {criteria != 'largely_recommended' && (
             <img
               className={classes.img_criteria}
               src={`/svg/${criteria}.svg`}
+              width="18px"
             />
           )}
-          <Typography>
-            <a
+          <Typography fontSize={{ xs: '90%', sm: '100%' }}>
+            <Link
+              color="text.secondary"
               href={`${getWikiBaseUrl()}/wiki/Quality_criteria`}
               id={`id_explanation_${criteria}`}
               target="_blank"
               rel="noreferrer"
+              underline="hover"
             >
               {criteriaLabel}{' '}
-              {criteriaValue === undefined
-                ? `(${t('comparison.criteriaSkipped')})`
-                : ''}
-            </a>
+              {criteriaValue === undefined ? (
+                <Chip
+                  size="small"
+                  label={t('comparison.criteriaSkipped')}
+                  sx={{ height: '100%' }}
+                />
+              ) : (
+                ''
+              )}
+            </Link>
           </Typography>
+          <Box component="span" flexGrow={1} />
           {(criteriaByName[criteria]?.optional ||
             criteriaValue == undefined) && (
             <Checkbox
@@ -114,7 +125,7 @@ const CriteriaSlider = ({
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 handleSliderChange(criteria, e.target.checked ? 0 : undefined)
               }
-              color="primary"
+              color="secondary"
               sx={{
                 padding: 0,
                 marginLeft: '8px',
@@ -127,7 +138,14 @@ const CriteriaSlider = ({
         <Slider
           sx={{
             [`& span[data-index="${neutralPos}"].MuiSlider-mark`]: {
-              height: '12px',
+              height: '16px',
+            },
+            '& .MuiSlider-thumb:before': {
+              fontSize: '11px',
+              content: '"❰❱"',
+              color: 'white',
+              textAlign: 'center',
+              lineHeight: 1.6,
             },
           }}
           id={`slider_expert_${criteria}`}
@@ -146,6 +164,7 @@ const CriteriaSlider = ({
           }
         />
       </div>
+      <Divider light flexItem sx={{ minHeight: '12px' }} />
     </div>
   );
 };

--- a/frontend/src/features/video_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/video_selector/AutoEntityButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Tooltip, IconButton } from '@mui/material';
-import { AutoFixHigh as MagicWandIcon } from '@mui/icons-material';
+import { Tooltip, Button } from '@mui/material';
+import { Autorenew } from '@mui/icons-material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import { YOUTUBE_POLL_NAME, UID_YT_NAMESPACE } from 'src/utils/constants';
 import { getVideoForComparison, idFromUid } from 'src/utils/video';
@@ -41,9 +41,16 @@ const AutoEntityButton = ({
 
   return (
     <Tooltip title={`${t('videoSelector.newVideo')}`} aria-label="new_video">
-      <IconButton aria-label="new_video" onClick={askNewVideo}>
-        <MagicWandIcon fontSize="small" />
-      </IconButton>
+      <Button
+        color="secondary"
+        variant="outlined"
+        size="small"
+        onClick={askNewVideo}
+        startIcon={<Autorenew />}
+        sx={{ fontSize: { xs: '0.7rem', sm: '0.8rem' } }}
+      >
+        {t('videoSelector.autoEntityButton')}
+      </Button>
     </Tooltip>
   );
 };

--- a/frontend/src/features/video_selector/VideoInput.tsx
+++ b/frontend/src/features/video_selector/VideoInput.tsx
@@ -13,6 +13,7 @@ const VideoInput = ({ value, onChange }: Props) => {
   return (
     <Box>
       <TextField
+        color="secondary"
         fullWidth
         value={value}
         placeholder={t('videoSelector.pasteUrlOrVideoId')}

--- a/frontend/src/features/video_selector/VideoSelector.tsx
+++ b/frontend/src/features/video_selector/VideoSelector.tsx
@@ -166,7 +166,7 @@ const VideoSelector = ({
         flexDirection="row"
         alignItems="center"
       >
-        <Typography variant="h5" color="text.disabled" flexGrow={1}>
+        <Typography variant="h6" color="secondary" flexGrow={1}>
           {title}
         </Typography>
         <AutoEntityButton

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -1,34 +1,26 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-
-import makeStyles from '@mui/styles/makeStyles';
+import { Box } from '@mui/material';
 
 import { ContentHeader } from 'src/components';
 import Comparison from 'src/features/comparisons/Comparison';
 
-const useStyles = makeStyles(() => ({
-  root: {
-    width: '100%',
-    height: '100%',
-  },
-  centering: {
-    display: 'flex',
-    alignItems: 'center',
-    flexDirection: 'column',
-    paddingTop: 16,
-  },
-}));
-
 const ComparisonPage = () => {
   const { t } = useTranslation();
-  const classes = useStyles();
 
   return (
     <>
       <ContentHeader title={t('comparison.submitAComparison')} />
-      <div className={`${classes.root} ${classes.centering}`}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          flexDirection: 'column',
+          py: 2,
+        }}
+      >
         <Comparison />
-      </div>
+      </Box>
     </>
   );
 };

--- a/tests/cypress/integration/frontend/comparisonPage.ts
+++ b/tests/cypress/integration/frontend/comparisonPage.ts
@@ -142,6 +142,7 @@ describe('Comparison page', () => {
 
       // only one criteria must be visible by default
       cy.contains('add optional criteria', {matchCase: false})
+        .scrollIntoView()
         .should('be.visible');
       cy.contains('should be largely recommended', {matchCase: false})
         .should('be.visible');


### PR DESCRIPTION
* The "magic wand" button (used to select a new video automatically) is replaced with a more explicit button with text "Auto"

* The style of the criteria sliders is updated to be closer to the initial mockup.  
The name and logo of each criteria is aligned on the left.  
The checkbox used on each optional criteria is aligned on the right.  
It also makes the layout more consistent when criterias names are of different lengths.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/4726554/157901960-3f4a5680-20a3-4c7a-b573-1744258243d9.png)|![image](https://user-images.githubusercontent.com/4726554/157902235-c9e1580c-2706-46d9-9a79-4479411c344f.png)


Feedbacks are welcome :pray: 