### PR TITLE
Fix "active search filter" badge: empty string should not be considered as an active filter

### DIFF
--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -32,7 +32,7 @@ function SearchFilter() {
   const isFilterActive = () =>
     Object.entries(defaultRecommendationFilters).some(
       ([key, defaultValue]) =>
-        ![null, defaultValue].includes(filterParams.get(key))
+        ![null, '', defaultValue].includes(filterParams.get(key))
     );
 
   const handleLanguageChange = useCallback(


### PR DESCRIPTION
This is especially important for the "language" filter, as `?language=` parameter is explicitly used to disable the default filter based on the user languages.