### PR TITLE
Single component `VideoPlayer` with "controls" prop

### DIFF
--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -5,17 +5,21 @@ import { TypeEnum } from 'src/services/openapi';
 import { convertDurationToClockDuration } from 'src/utils/video';
 import { RelatedEntityObject } from 'src/utils/types';
 
-export const PlayerWrapper = React.forwardRef(function PlayerWrapper(
+const PlayerWrapper = React.forwardRef(function PlayerWrapper(
   {
     duration,
     children,
   }: {
-    duration?: string;
+    duration?: number;
     children: React.ReactNode;
   },
   ref
 ) {
   const [isDurationVisible, setIsDurationVisible] = useState(true);
+  const formattedDuration: string | null = duration
+    ? convertDurationToClockDuration(duration)
+    : null;
+
   return (
     <Box
       position="relative"
@@ -23,7 +27,7 @@ export const PlayerWrapper = React.forwardRef(function PlayerWrapper(
       onClick={() => setIsDurationVisible(false)}
       ref={ref}
     >
-      {isDurationVisible && duration && (
+      {isDurationVisible && formattedDuration && (
         <Box
           position="absolute"
           bottom={0}
@@ -36,7 +40,7 @@ export const PlayerWrapper = React.forwardRef(function PlayerWrapper(
           fontWeight="bold"
           sx={{ pointerEvents: 'none' }}
         >
-          {duration}
+          {formattedDuration}
         </Box>
       )}
       {children}
@@ -44,18 +48,35 @@ export const PlayerWrapper = React.forwardRef(function PlayerWrapper(
   );
 });
 
+export const VideoPlayer = ({
+  videoId,
+  duration,
+  controls = true,
+}: {
+  videoId: string;
+  duration?: number | null;
+  controls?: boolean;
+}) => {
+  return (
+    <ReactPlayer
+      url={`https://youtube.com/watch?v=${videoId}`}
+      playing
+      light
+      width="100%"
+      height="100%"
+      wrapper={PlayerWrapper}
+      duration={duration}
+      controls={controls}
+    />
+  );
+};
+
 const EntityImagery = ({ entity }: { entity: RelatedEntityObject }) => {
   if (entity.type === TypeEnum.VIDEO) {
-    const duration = entity.metadata.duration;
     return (
-      <ReactPlayer
-        url={`https://youtube.com/watch?v=${entity.metadata.video_id}`}
-        playing
-        light
-        width="100%"
-        height="100%"
-        wrapper={PlayerWrapper}
-        duration={!!duration && convertDurationToClockDuration(duration)}
+      <VideoPlayer
+        videoId={entity.metadata.video_id}
+        duration={entity.metadata.duration}
       />
     );
   }

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import ReactPlayer from 'react-player/youtube';
 import { useTranslation } from 'react-i18next';
 import makeStyles from '@mui/styles/makeStyles';
 import {
@@ -18,15 +17,12 @@ import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
 } from '@mui/icons-material';
-import {
-  convertDurationToClockDuration,
-  videoIdFromEntity,
-} from 'src/utils/video';
+import { videoIdFromEntity } from 'src/utils/video';
 import VideoCardScores from './VideoCardScores';
 import EntityCardTitle from 'src/components/entity/EntityCardTitle';
 import { entityCardMainSx } from 'src/components/entity/style';
 import EmptyEntityCard from 'src/components/entity/EmptyEntityCard';
-import { PlayerWrapper } from 'src/components/entity/EntityImagery';
+import { VideoPlayer } from 'src/components/entity/EntityImagery';
 import { VideoMetadata } from 'src/components/entity/EntityMetadata';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -86,16 +82,9 @@ function VideoCard({
         sm={compact ? 12 : 'auto'}
         sx={{ aspectRatio: '16 / 9', width: '240px !important' }}
       >
-        <ReactPlayer
-          url={`https://youtube.com/watch?v=${videoId}`}
-          playing
-          light
-          width="100%"
-          height="100%"
-          wrapper={PlayerWrapper}
-          duration={
-            !!video.duration && convertDurationToClockDuration(video.duration)
-          }
+        <VideoPlayer
+          videoId={videoId}
+          duration={video.duration}
           controls={controls}
         />
       </Grid>


### PR DESCRIPTION
Following #672  and #661, the player "controls" were not visible where created from the  `EntityCard`.  
Let's keep a single implementation of the player, where "controls" can be enabled/disabled.