### PR TITLE
Disable 'auto' button on loading and solve warnings related to MUI components

### DIFF
--- a/frontend/src/features/comparisons/CriteriaSlider.tsx
+++ b/frontend/src/features/comparisons/CriteriaSlider.tsx
@@ -106,6 +106,7 @@ const CriteriaSlider = ({
               {criteriaLabel}{' '}
               {criteriaValue === undefined ? (
                 <Chip
+                  component="span"
                   size="small"
                   label={t('comparison.criteriaSkipped')}
                   sx={{ height: '100%' }}

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -11,6 +11,7 @@ interface Props {
   otherUid: string | null;
   onResponse: (newUid: string | null) => void;
   onClick: () => void;
+  disabled?: boolean;
 }
 
 const AutoEntityButton = ({
@@ -18,6 +19,7 @@ const AutoEntityButton = ({
   otherUid,
   onResponse,
   onClick,
+  disabled = false,
 }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
@@ -41,16 +43,20 @@ const AutoEntityButton = ({
 
   return (
     <Tooltip title={`${t('videoSelector.newVideo')}`} aria-label="new_video">
-      <Button
-        color="secondary"
-        variant="outlined"
-        size="small"
-        onClick={askNewVideo}
-        startIcon={<Autorenew />}
-        sx={{ fontSize: { xs: '0.7rem', sm: '0.8rem' } }}
-      >
-        {t('videoSelector.autoEntityButton')}
-      </Button>
+      {/* A <span> element is required to allow wrapping a disabled button.  */}
+      <span>
+        <Button
+          disabled={disabled}
+          color="secondary"
+          variant="outlined"
+          size="small"
+          onClick={askNewVideo}
+          startIcon={<Autorenew />}
+          sx={{ fontSize: { xs: '0.7rem', sm: '0.8rem' } }}
+        >
+          {t('videoSelector.autoEntityButton')}
+        </Button>
+      </span>
     </Tooltip>
   );
 };

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -174,6 +174,7 @@ const EntitySelector = ({
           {title}
         </Typography>
         <AutoEntityButton
+          disabled={loading}
           currentUid={uid}
           otherUid={otherUid}
           onClick={() => {


### PR DESCRIPTION
* Disable the "auto" button to avoid repeated requests for new entities to compare (can also trigger unexpected flickers in the UI)
* Solve several warnings on this page:
  * the `Tooltip` child cannot be a disabled button, hence a "<span>" used as a wrapper
  * a `Chip` was used inside a `<p>` and should be inserted as a `<span>` instead of a `<div>` (by default)

