### PR TITLE
Add Bar chart on video analysis page

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -3,7 +3,7 @@ import Card from '@mui/material/Card';
 
 interface Props {
   children: React.ReactNode;
-  sx: object | undefined;
+  sx?: object;
   [props: string]: unknown;
 }
 

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Bar, BarChart, XAxis, YAxis, Cell } from 'recharts';
+import { VideoSerializerWithCriteria } from 'src/services/openapi';
+import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+
+const BAR_CHART_CRITERIA_SCORE_MIN = -1;
+const BAR_CHART_CRITERIA_SCORE_MAX = 1;
+
+interface Props {
+  video: VideoSerializerWithCriteria;
+}
+
+const between = (a: number, b: number, x: number | undefined): number => {
+  // clips x between a and b
+  return Math.min(b, Math.max(a, x || 0));
+};
+
+const criteriaColors: { [criteria: string]: string } = {
+  reliability: '#4F77DD',
+  importance: '#DC8A5D',
+  engaging: '#DFC642',
+  pedagogy: '#C28BED',
+  layman_friendly: '#4BB061',
+  diversity_inclusion: '#76C6CB',
+  backfire_risk: '#D37A80',
+  better_habits: '#9DD654',
+  entertaining_relaxing: '#D8B36D',
+  default: '#000000',
+};
+
+const CriteriaBarChart = ({ video }: Props) => {
+  const { getCriteriaLabel } = useCurrentPoll();
+
+  const renderCustomAxisTick = ({
+    x,
+    y,
+    payload,
+  }: {
+    x: number;
+    y: number;
+    payload: { value: string };
+  }) => {
+    return (
+      <svg
+        x={x - 42}
+        y={y - 21}
+        width="42"
+        height="42"
+        viewBox="0 0 42 42"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <image
+          x="0"
+          y="0"
+          width="42"
+          height="42"
+          href={`/svg/${payload.value}.svg`}
+        />
+        <title>{getCriteriaLabel(payload.value)}</title>
+      </svg>
+    );
+  };
+
+  const { criteria_scores } = video;
+  const shouldDisplayChart = criteria_scores && criteria_scores.length > 0;
+
+  if (!shouldDisplayChart) {
+    return <div></div>;
+  }
+
+  const data = criteria_scores
+    .filter((s) => s.criteria != 'largely_recommended')
+    .map((s) => ({
+      ...s,
+      score: between(
+        BAR_CHART_CRITERIA_SCORE_MIN,
+        BAR_CHART_CRITERIA_SCORE_MAX,
+        s.score
+      ),
+    }));
+
+  return (
+    <BarChart width={500} height={500} layout="vertical" data={data}>
+      <XAxis
+        type="number"
+        domain={[BAR_CHART_CRITERIA_SCORE_MIN, BAR_CHART_CRITERIA_SCORE_MAX]}
+        hide={true}
+      />
+      <YAxis
+        type="category"
+        dataKey="criteria"
+        tick={renderCustomAxisTick}
+        interval={0}
+        axisLine={false}
+        tickLine={false}
+      />
+      <Bar dataKey="score" barSize={16}>
+        {data.map((entry) => (
+          <Cell
+            key={entry.criteria}
+            fill={criteriaColors[entry.criteria] || criteriaColors['default']}
+          />
+        ))}
+      </Bar>
+    </BarChart>
+  );
+};
+
+export default CriteriaBarChart;

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Bar, BarChart, XAxis, YAxis, Cell } from 'recharts';
+import {
+  Bar,
+  BarChart,
+  XAxis,
+  YAxis,
+  Cell,
+  Tooltip,
+  TooltipProps,
+} from 'recharts';
 import { VideoSerializerWithCriteria } from 'src/services/openapi';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
@@ -42,17 +50,18 @@ const CriteriaBarChart = ({ video }: Props) => {
   }) => {
     return (
       <svg
-        x={x - 42}
-        y={y - 21}
-        width="42"
-        height="42"
-        viewBox="0 0 42 42"
+        x={x - 30 + 250}
+        y={y - 30}
+        width="60"
+        height="60"
+        viewBox="0 0 60 60"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
+        <rect x="0" y="15" width="60" height="30" fill="white" />
         <image
-          x="0"
-          y="0"
+          x="9"
+          y="9"
           width="42"
           height="42"
           href={`/svg/${payload.value}.svg`}
@@ -71,14 +80,17 @@ const CriteriaBarChart = ({ video }: Props) => {
 
   const data = criteria_scores
     .filter((s) => s.criteria != 'largely_recommended')
-    .map((s) => ({
-      ...s,
-      score: between(
+    .map((s) => {
+      const clipped_score = between(
         BAR_CHART_CRITERIA_SCORE_MIN,
         BAR_CHART_CRITERIA_SCORE_MAX,
         s.score
-      ),
-    }));
+      );
+      return {
+        ...s,
+        clipped_score,
+      };
+    });
 
   return (
     <BarChart width={500} height={500} layout="vertical" data={data}>
@@ -87,15 +99,8 @@ const CriteriaBarChart = ({ video }: Props) => {
         domain={[BAR_CHART_CRITERIA_SCORE_MIN, BAR_CHART_CRITERIA_SCORE_MAX]}
         hide={true}
       />
-      <YAxis
-        type="category"
-        dataKey="criteria"
-        tick={renderCustomAxisTick}
-        interval={0}
-        axisLine={false}
-        tickLine={false}
-      />
-      <Bar dataKey="score" barSize={16}>
+
+      <Bar dataKey="clipped_score" barSize={20}>
         {data.map((entry) => (
           <Cell
             key={entry.criteria}
@@ -103,6 +108,30 @@ const CriteriaBarChart = ({ video }: Props) => {
           />
         ))}
       </Bar>
+      <YAxis
+        type="category"
+        dataKey="criteria"
+        tick={renderCustomAxisTick}
+        interval={0}
+        axisLine={false}
+        tickLine={false}
+        width={6}
+      />
+      <Tooltip
+        cursor={{ stroke: 'black', strokeWidth: 2, fill: 'transparent' }}
+        content={(props: TooltipProps<number, string>) => {
+          const payload = props?.payload;
+          if (payload && payload[0]) {
+            const { criteria, score } = payload[0].payload;
+            return (
+              <pre>
+                {criteria}: {(10 * score).toFixed(2)}
+              </pre>
+            );
+          }
+          return null;
+        }}
+      />
     </BarChart>
   );
 };

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -125,7 +125,7 @@ const CriteriaBarChart = ({ video }: Props) => {
             const { criteria, score } = payload[0].payload;
             return (
               <pre>
-                {criteria}: {(10 * score).toFixed(2)}
+                {getCriteriaLabel(criteria)}: {(10 * score).toFixed(2)}
               </pre>
             );
           }

--- a/frontend/src/pages/videos/VideoAnalysis.tsx
+++ b/frontend/src/pages/videos/VideoAnalysis.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import makeStyles from '@mui/styles/makeStyles';
+import Grid from '@mui/material/Grid';
 
 import Card from 'src/components/Card';
 import VideoCard from 'src/features/videos/VideoCard';
 import { useVideoMetadata } from 'src/features/videos/VideoApi';
 import CriteriaRadarChart from 'src/components/CriteriaRadarChart';
+import CriteriaBarChart from 'src/components/CriteriaBarChart';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -26,9 +28,23 @@ function VideoAnalysis() {
   return (
     <div className={classes.root}>
       <VideoCard video={video} />
-      <Card sx={{ marginTop: 3 }}>
-        <CriteriaRadarChart video={video} />
-      </Card>
+      <Grid
+        container
+        spacing={2}
+        justifyContent="center"
+        sx={{ marginTop: 3, marginBottom: 3 }}
+      >
+        <Grid item xs="auto">
+          <Card>
+            <CriteriaRadarChart video={video} />
+          </Card>
+        </Grid>
+        <Grid item xs="auto">
+          <Card>
+            <CriteriaBarChart video={video} />
+          </Card>
+        </Grid>
+      </Grid>
     </div>
   );
 }


### PR DESCRIPTION
Related issue: #626

Initial attempt to add the Bar chart:

![image](https://user-images.githubusercontent.com/28259/159001144-b4bed6e7-a0f4-40f0-b1e5-16981c1bb40d.png)

Moving the ticks in the middle doesn't seem possible with recharts. It may be possible to solve that by making 2 aligned charts.

Most of the code is copied from the Radar chart. Some of it should be refactored if both charts are going to stay.