### PR TITLE
Fix a race condition when the 2 entity selectors are updated concurrently

### DIFF
--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -97,7 +97,10 @@ const Comparison = () => {
 
   const onChange = useCallback(
     (uidKey: string) => (newValue: SelectorValue) => {
-      const searchParams = new URLSearchParams(location.search);
+      // `window.location` is used here, to avoid memoizing the location
+      // defined in component state, which could be obsolete and cause a
+      // race condition when the 2 selectors are updated concurrently.
+      const searchParams = new URLSearchParams(window.location.search);
       const uid = newValue.uid;
 
       if ((searchParams.get(uidKey) || '') !== uid) {
@@ -106,7 +109,7 @@ const Comparison = () => {
         if (uid) {
           searchParams.append(uidKey, uid);
         }
-        history.push('?' + searchParams.toString());
+        history.push({ search: searchParams.toString() });
       }
       if (uidKey === UID_PARAMS.vidA) {
         setSelectorA(newValue);
@@ -115,7 +118,7 @@ const Comparison = () => {
       }
       setSubmitted(false);
     },
-    [history, location.search]
+    [history]
   );
 
   const onChangeA = useMemo(() => onChange(UID_PARAMS.vidA), [onChange]);


### PR DESCRIPTION
Due to how the location was memoized by the callback `onChange`, the URL change could fall in a race condition when the 2 "auto" buttons were activated simultaneously. Only one of the 2 changes would be persisted in the URL.

Reading `window.location` just in time should solve the issue.