### PR TITLE
fix: selected values appear in EntityInput when refreshing

### DIFF
--- a/frontend/src/features/entity_selector/EntityInput.tsx
+++ b/frontend/src/features/entity_selector/EntityInput.tsx
@@ -57,7 +57,7 @@ const VideoInput = ({ value, onChange }: Props) => {
   );
 };
 
-const CandidateInput = ({ onChange }: Props) => {
+const CandidateInput = ({ onChange, value }: Props) => {
   const [options, setOptions] = useState<Entity[]>([]);
 
   useEffect(() => {
@@ -66,6 +66,7 @@ const CandidateInput = ({ onChange }: Props) => {
 
   return (
     <Autocomplete
+      value={options.find((opt) => opt.uid == value) || null}
       selectOnFocus
       blurOnSelect
       onChange={(event, newValue) => {


### PR DESCRIPTION
Fix missing selected inputs after refreshing a comparison page

![Screenshot 2022-03-19 at 09 01 51](https://user-images.githubusercontent.com/8818081/159113094-f1e2d0b5-e5f9-45c6-a0da-3c6277a75372.png)
