### PR TITLE
chore: include Linux and JetBrains specific files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,33 @@
+# -- --
+# OS: Linux
+# see: https://github.com/github/gitignore/blob/main/Global/Linux.gitignore
+# -- --
+
+*~
+
+# temporary files which can be created if a process still has a handle open
+# of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being
+# accessed
+.nfs*
+
+# -- --
+# OS: macOS
+# -- --
+
 .DS_Store
+
+# --
+# JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# see: https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+# --
+
+.idea


### PR DESCRIPTION
I finally took the time to add more files to the  `.gitignore`. The `git diff` commands should be less talkative now, at last on my laptop.

All sources come from the https://github.com/github/gitignore project.

Concerning JetBrains, as we don't plan for now to share configurations and as we use different IDEs I simply ignored all files specific to JetBrains IDEs.