### PR TITLE
Explicit "everything" filter

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -118,6 +118,7 @@
     "thisWeek": "This week",
     "thisMonth": "This month",
     "thisYear": "This year",
+    "allTime": "All time",
     "uploadDate": "Upload date",
     "language": "Language",
     "allLanguages": "All languages",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -120,6 +120,7 @@
     "thisYear": "This year",
     "uploadDate": "Upload date",
     "language": "Language",
+    "allLanguages": "All languages",
     "uploader": "Uploader"
   },
   "ratings": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -124,6 +124,7 @@
     "thisYear": "Cette année",
     "uploadDate": "Mises en ligne",
     "language": "Langues",
+    "allLanguages": "Toutes",
     "uploader": "Chaîne"
   },
   "ratings": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -122,6 +122,7 @@
     "thisWeek": "Cette semaine",
     "thisMonth": "Ce mois-ci",
     "thisYear": "Cette année",
+    "allTime": "Depuis le début",
     "uploadDate": "Mises en ligne",
     "language": "Langues",
     "allLanguages": "Toutes",

--- a/frontend/src/features/recommendation/DateFilter.tsx
+++ b/frontend/src/features/recommendation/DateFilter.tsx
@@ -15,6 +15,7 @@ function DateFilter(props: Props) {
     Week: t('filter.thisWeek'),
     Month: t('filter.thisMonth'),
     Year: t('filter.thisYear'),
+    ['']: t('filter.allTime'),
   };
 
   return (

--- a/frontend/src/features/recommendation/LanguageFilter.tsx
+++ b/frontend/src/features/recommendation/LanguageFilter.tsx
@@ -40,6 +40,11 @@ function LanguageFilter({ value, onChange }: Props) {
     );
   }, [i18n.resolvedLanguage, getOptionLabel]);
 
+  const placeholder = useMemo(
+    () => (arrayValue.length === 0 ? t('filter.allLanguages') : undefined),
+    [arrayValue.length, t]
+  );
+
   return (
     <TitledSection title={t('filter.language')}>
       <Autocomplete
@@ -54,6 +59,7 @@ function LanguageFilter({ value, onChange }: Props) {
             variant="outlined"
             color="secondary"
             size="small"
+            placeholder={placeholder}
           />
         )}
         filterSelectedOptions

--- a/frontend/src/features/recommendation/SearchFilter.spec.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.spec.tsx
@@ -90,7 +90,7 @@ describe('Filters feature', () => {
     const dateFilter = document.querySelector(
       '[data-testid=search-date-safe-filter]'
     );
-    expect(queryAllByTestId(dateFilter, /checkbox-choice/i)).toHaveLength(5);
+    expect(queryAllByTestId(dateFilter, /checkbox-choice/i)).toHaveLength(6);
 
     // Check language filters presence
     const languageFilter = document.querySelector(


### PR DESCRIPTION
Related issue: #689 

I tried the small "x" but it doesn't look good when it's warped on a new line on some window widths, so I added an "All time" option instead.

For the languages I shortened the French version to "Toutes" because the input is not long enough for "Toutes les langues".

![image](https://user-images.githubusercontent.com/28259/159762504-6bd03ff4-6ecf-4580-bf6e-e159b3888138.png)
![image](https://user-images.githubusercontent.com/28259/159762849-385649a3-53a3-435e-adc2-ab3015d296d6.png)

