### PR TITLE
backend/tournesol/entities annotations, code layout and type homogenization

### DIFF
--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -47,10 +47,10 @@ class EntityType(ABC):
         serializer.is_valid(raise_exception=True)
         return serializer.validated_data
 
-    def metadata_needs_to_be_refreshed(self):
+    def metadata_needs_to_be_refreshed(self) -> bool:
         return False
 
-    def update_metadata_field(self):
+    def update_metadata_field(self) -> None:
         raise NotImplementedError
 
     def refresh_metadata(self, *, force=False, save=True):

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -37,7 +37,7 @@ class EntityType(ABC):
 
     @classmethod
     @abstractmethod
-    def get_uid_regex(cls, namespace: str):
+    def get_uid_regex(cls, namespace: str) -> str:
         """Get a regex able to validate the entity UID."""
         raise NotImplementedError
 

--- a/backend/tournesol/entities/candidate.py
+++ b/backend/tournesol/entities/candidate.py
@@ -27,7 +27,7 @@ class CandidateEntity(EntityType):
         )
 
     @classmethod
-    def get_uid_regex(cls, namespace):
+    def get_uid_regex(cls, namespace: str) -> str:
         return CANDIDATE_UID_REGEX
 
     @property

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -42,10 +42,10 @@ class VideoEntity(EntityType):
         )
 
     @classmethod
-    def get_uid_regex(cls, namespace):
+    def get_uid_regex(cls, namespace) -> str:
         if namespace == YOUTUBE_UID_NAMESPACE:
             return YOUTUBE_UID_REGEX
-        return None
+        return ''
 
     def update_metadata_field(self):
         from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -70,7 +70,6 @@ class VideoEntity(EntityType):
         are older than `VIDEO_METADATA_EXPIRE_SECONDS`.
         The request can be forced with `.refresh_metadata(force=True)`.
         """
-        return self.instance.last_metadata_request_at is None or (
-            timezone.now() - self.instance.last_metadata_request_at
-            >= timedelta(seconds=settings.VIDEO_METADATA_EXPIRE_SECONDS)
-        )
+        return self.instance.last_metadata_request_at is None \
+               or (timezone.now()-self.instance.last_metadata_request_at
+                   >= timedelta(seconds=settings.VIDEO_METADATA_EXPIRE_SECONDS))

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -70,6 +70,7 @@ class VideoEntity(EntityType):
         are older than `VIDEO_METADATA_EXPIRE_SECONDS`.
         The request can be forced with `.refresh_metadata(force=True)`.
         """
-        return self.instance.last_metadata_request_at is None \
-               or (timezone.now()-self.instance.last_metadata_request_at
-                   >= timedelta(seconds=settings.VIDEO_METADATA_EXPIRE_SECONDS))
+        return self.instance.last_metadata_request_at is None or (
+            timezone.now() - self.instance.last_metadata_request_at
+            >= timedelta(seconds=settings.VIDEO_METADATA_EXPIRE_SECONDS)
+        )

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -47,7 +47,7 @@ class VideoEntity(EntityType):
             return YOUTUBE_UID_REGEX
         return ''
 
-    def update_metadata_field(self):
+    def update_metadata_field(self) -> None:
         from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata
         try:
             metadata = get_video_metadata(
@@ -64,7 +64,7 @@ class VideoEntity(EntityType):
                 self.instance.metadata[metadata_key] = metadata_value
         self.instance.metadata_timestamp = timezone.now()
 
-    def metadata_needs_to_be_refreshed(self):
+    def metadata_needs_to_be_refreshed(self) -> bool:
         """
         Refresh will be executed only if the current metadata
         are older than `VIDEO_METADATA_EXPIRE_SECONDS`.

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -42,7 +42,7 @@ class VideoEntity(EntityType):
         )
 
     @classmethod
-    def get_uid_regex(cls, namespace) -> str:
+    def get_uid_regex(cls, namespace: str) -> str:
         if namespace == YOUTUBE_UID_NAMESPACE:
             return YOUTUBE_UID_REGEX
         return ''


### PR DESCRIPTION
First simple pr.
Almost nothing, I read the code and saw some stuff I can improve.

The only "big" change is the returned type of `get_uid_regex` that now return `str` instead of `str | None`.
AFAIK Only used in backend/tournesol/serializers/entity.py:L241, type truthiness is used.
I like simpler signature. PEP20, simple is better than complex. Optional[str] is more complex than str.