### PR TITLE
[front] feat: add translations for the `presidentielle2022` tuto

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -415,8 +415,8 @@
         },
         "title7": "Thanks a lot!",
         "message7": {
-          "p10": "One last comparison and you will be able to see your results.",
-          "p20": "We sincerely hope you've appreciated this new voting system."
+          "p10": "One last comparison and you will be able to see your current preferences.",
+          "p20": "We sincerely hope you appreciated this new voting system, which may have allowed you to better think about why you support some candidates."
         }
       }
     }

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -381,15 +381,15 @@
       "tutorial": {
         "title1": "Welcome on Tournesol 🌻",
         "message1": {
-          "p10": "In order to familiarize yourself with the comparison system, small messages like this one will be displayed.",
-          "p20": "Let's start with a first comparison between two candidates.",
-          "p30": "Move the blue handle below the candidates, then submit to select the person who should be president.",
-          "p40": "The more the handle is in the center, the more the candidates are considered similar."
+          "p10": "This tutorial will guide you step by step through a comparison series.",
+          "p20": "First, move the blue handles and adjust your preferences by moving them more or less far. Save when your choice is made.",
+          "p30": "The more your opinion is clear-but on a criterion, the more the handle should be close to the slider extremity.",
+          "p40": "If you find candidates similar, the handle should remain close to the center."
         },
         "title2": "Congratulations !",
         "message2": {
-          "p10": "Let's continue with other candidates.",
-          "p20": "Note that you can manually choose the candidates by using the drop down menu located just above the candidates' photos."
+          "p10": "You have made your first comparison \uD83E\uDD73",
+          "p20": "Note that you can manually choose the candidates by using the drop down menus located just above the candidates' photos."
         },
         "title3": "Tip",
         "message3": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -383,7 +383,7 @@
         "message1": {
           "p10": "This tutorial will guide you step by step through a comparison series.",
           "p20": "First, move the blue handles and adjust your preferences by moving them more or less far. Save when your choice is made.",
-          "p30": "The more your opinion is clear-but on a criterion, the more the handle should be close to the slider extremity.",
+          "p30": "The more your opinion is clear-cut on a criterion, the more the handle should be close to the slider extremity.",
           "p40": "If you find candidates similar, the handle should remain close to the center."
         },
         "title2": "Congratulations !",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -393,14 +393,14 @@
         },
         "title3": "Tip",
         "message3": {
-          "p10": "Don't worry if you are not confident. You will be able to update all comparisons later, at your own pace.",
-          "p20": ""
+          "p10": "Don't worry if the handles' position doesn't feel exact.",
+          "p20": "You will be able to update all comparisons later, at your own pace"
         },
         "title4": "Did you see?",
         "message4": {
           "p10": "There are also optional criteria under the main ones.",
           "p20": "Try to unfold and use the optional criteria to give a more complete opinion about the candidates.",
-          "p30": ""
+          "p30": "It's also possible to uncheck an optional criterion if you don't want to give your opinion on it."
         },
         "title5": "Is it better than voting for a single person?",
         "message5": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2,6 +2,9 @@
   "components": {
     "filtersButton": "filters"
   },
+  "dialogBox": {
+    "continue": "continue"
+  },
   "video": {
     "labelShowSettings": "Show settings related to this video",
     "nbViews": "{{nbViews}} views",
@@ -44,9 +47,6 @@
     "goToComparison": "Go to comparison"
   },
   "submit": "submit",
-  "dialogBox": {
-    "continue": "continue"
-  },
   "videoSelector": {
     "newVideo": "Select a new video automatically",
     "autoEntityButton": "Auto",
@@ -375,5 +375,49 @@
     "videos": "videos",
     "entityCandidate": "candidate",
     "entityVideo": "video"
+  },
+  "presidentielle2022": {
+    "dialogs": {
+      "tutorial": {
+        "title1": "",
+        "message1": {
+          "p10": "",
+          "p20": "",
+          "p30": "",
+          "p40": ""
+        },
+        "title2": "",
+        "message2": {
+          "p10": "",
+          "p20": ""
+        },
+        "title3": "",
+        "message3": {
+          "p10": ""
+        },
+        "title4": "",
+        "message4": {
+          "p10": "",
+          "p20": ""
+        },
+        "title5": "",
+        "message5": {
+          "p10": "",
+          "p20": "",
+          "p30": ""
+        },
+        "title6": "",
+        "message6": {
+          "p10": "",
+          "p20": "",
+          "p30": ""
+        },
+        "title7": "",
+        "message7": {
+          "p10": "",
+          "p20": ""
+        }
+      }
+    }
   }
 }

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -123,8 +123,8 @@
     "thisYear": "This year",
     "allTime": "All time",
     "uploadDate": "Upload date",
-    "language": "Language",
     "allLanguages": "All languages",
+    "language": "Language",
     "uploader": "Uploader"
   },
   "ratings": {
@@ -379,7 +379,7 @@
   "presidentielle2022": {
     "dialogs": {
       "tutorial": {
-        "title1": "Welcome on Tournesol \uD83C\uDF3B",
+        "title1": "Welcome on Tournesol 🌻",
         "message1": {
           "p10": "In order to familiarize yourself with the comparison system, small messages like this one will be displayed.",
           "p20": "Let's start with a first comparison between two candidates.",
@@ -393,18 +393,19 @@
         },
         "title3": "Tip",
         "message3": {
-          "p10": "Don't worry if you are not confident. You will be able to update all comparisons later, at your own pace."
+          "p10": "Don't worry if you are not confident. You will be able to update all comparisons later, at your own pace.",
+          "p20": ""
         },
         "title4": "Did you see?",
         "message4": {
           "p10": "There are also optional criteria under the main ones.",
-          "p20": "Try to unfold and use the optional criteria to give a more complete opinion about the candidates."
+          "p20": "Try to unfold and use the optional criteria to give a more complete opinion about the candidates.",
+          "p30": ""
         },
         "title5": "Is it better than voting for a single person?",
         "message5": {
           "p10": "Contrary to the current voting system in France, here you are invited to give your opinion on several candidates.",
-          "p20": "Thus it's possible to express your favourite choice, your second choice, the third one, etc.",
-          "p30": "This system avoids problem like « tactical vote », and doesn't encourage the polarization of political opinions."
+          "p20": "Thus it's possible to express your favourite choice, your second choice, the third one, etc."
         },
         "title6": "How does it work?",
         "message6": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -405,13 +405,13 @@
         "title5": "Is it better than voting for a single person?",
         "message5": {
           "p10": "Contrary to the current voting system in France, here you are invited to give your opinion on several candidates.",
-          "p20": "Thus it's possible to express your favourite choice, your second choice, the third one, etc."
+          "p20": "Thus it's possible to express your real opinion. This allows to avoid problems like the « tactical vote », and doesn't encourage the polarization of political opinions."
         },
         "title6": "How does it work?",
         "message6": {
-          "p10": "It's by aggregating comparisons of all users that Tournesol is able to understand their preferences.",
-          "p20": "It's not the candidate who received the most voices who is elected, but the one with the most favourable sum of opinions.",
-          "p30": "The objective is to get the results that fits the best the users' global opinion."
+          "p10": "Tournesol classifies the candidates by aggregating the preferences of all contributors.",
+          "p20": "It's not the person who received the highest number of votes who is elected, but the one // to complete //.",
+          "p30": "The objective is to get the results that fits the best the contributors' global opinion."
         },
         "title7": "Thanks a lot!",
         "message7": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -379,43 +379,43 @@
   "presidentielle2022": {
     "dialogs": {
       "tutorial": {
-        "title1": "",
+        "title1": "Welcome on Tournesol \uD83C\uDF3B",
         "message1": {
-          "p10": "",
-          "p20": "",
-          "p30": "",
-          "p40": ""
+          "p10": "In order to familiarize yourself with the comparison system, small messages like this one will be displayed.",
+          "p20": "Let's start with a first comparison between two candidates.",
+          "p30": "Move the blue handle below the candidates, then submit to select the person who should be president.",
+          "p40": "The more the handle is in the center, the more the candidates are considered similar."
         },
-        "title2": "",
+        "title2": "Congratulations !",
         "message2": {
-          "p10": "",
-          "p20": ""
+          "p10": "Let's continue with other candidates.",
+          "p20": "Note that you can manually choose the candidates by using the drop down menu located just above the candidates' photos."
         },
-        "title3": "",
+        "title3": "Tip",
         "message3": {
-          "p10": ""
+          "p10": "Don't worry if you are not confident. You will be able to update all comparisons later, at your own pace."
         },
-        "title4": "",
+        "title4": "Did you see?",
         "message4": {
-          "p10": "",
-          "p20": ""
+          "p10": "There are also optional criteria under the main ones.",
+          "p20": "Try to unfold and use the optional criteria to give a more complete opinion about the candidates."
         },
-        "title5": "",
+        "title5": "Is it better than voting for a single person?",
         "message5": {
-          "p10": "",
-          "p20": "",
-          "p30": ""
+          "p10": "Contrary to the current voting system in France, here you are invited to give your opinion on several candidates.",
+          "p20": "Thus it's possible to express your favourite choice, your second choice, the third one, etc.",
+          "p30": "This system avoids problem like « tactical vote », and doesn't encourage the polarization of political opinions."
         },
-        "title6": "",
+        "title6": "How does it work?",
         "message6": {
-          "p10": "",
-          "p20": "",
-          "p30": ""
+          "p10": "It's by aggregating comparisons of all users that Tournesol is able to understand their preferences.",
+          "p20": "It's not the candidate who received the most voices who is elected, but the one with the most favourable sum of opinions.",
+          "p30": "The objective is to get the results that fits the best the users' global opinion."
         },
-        "title7": "",
+        "title7": "Thanks a lot!",
         "message7": {
-          "p10": "",
-          "p20": ""
+          "p10": "One last comparison and you will be able to see your results.",
+          "p20": "We sincerely hope you've appreciated this new voting system."
         }
       }
     }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -393,7 +393,7 @@
         "title2": "Bravo !",
         "message2": {
           "p10": "Vous avez effectué votre première comparaison 🥳.",
-          "p20": "Notez que vous pouvez choisir vous même les candidat.es. en utilisant les menus déroulant qui se trouvent au dessus de leurs photos."
+          "p20": "Notez que vous pouvez choisir vous même les candidat.es. en utilisant les menus déroulants qui se trouvent au dessus de leurs photos."
         },
         "title3": "Un conseil",
         "message3": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -2,6 +2,9 @@
   "components": {
     "filtersButton": "filtres"
   },
+  "dialogBox": {
+    "continue": "continuer"
+  },
   "video": {
     "labelShowSettings": "Voir les paramètres de cette video",
     "nbViews": "{{nbViews}} vues",
@@ -47,9 +50,6 @@
     "goToComparison": "Voir la comparaison"
   },
   "submit": "enregistrer",
-  "dialogBox": {
-    "continue": "continuer"
-  },
   "videoSelector": {
     "newVideo": "Selectionner une nouvelle vidéo automatiquement",
     "autoEntityButton": "Auto",
@@ -379,5 +379,49 @@
     "videos": "vidéos",
     "entityCandidate": "candidat",
     "entityVideo": "vidéo"
+  },
+  "presidentielle2022": {
+    "dialogs": {
+      "tutorial": {
+        "title1": "Bienvenue dans Tournesol 🌻",
+        "message1": {
+          "p10": "Pour vous familiariser avec ce système de comparaison, des petits messages comme celui-ci apparaîtront pour vous guider pas à pas.",
+          "p20": "Commençons par faire une première comparaison entre deux candidat.es.",
+          "p30": "Faites coulisser la poignée bleu au dessous des candidat.es, puis enregistrez pour indiquer qui d'après vous devrait-être président.e.",
+          "p40": "Plus la poignée est au centre, plus les candidat.es sont considérés comme similaires."
+        },
+        "title2": "Bravo !",
+        "message2": {
+          "p10": "Continuons avec d'autres candidat.es.",
+          "p20": "Notez que vous pouvez choisir manuellement les candidat.es. en utilisant le menu déroulant qui se trouve au dessus de leurs photos."
+        },
+        "title3": "Un conseil",
+        "message3": {
+          "p10": "Ne vous en faites pas trop si vous n'etes pas sûr.e de vous. Il vous sera possible par la suite de modifier toutes vos comparaisons à votre rythme."
+        },
+        "title4": "Avez-vous remarqué ?",
+        "message4": {
+          "p10": "Il y a aussi des critères de comparaison optionnels sous les critères principaux.",
+          "p20": "Essayez de dérouler les critères optionnels pour donner un avis plus complet sur les candidat.es."
+        },
+        "title5": "Mieux que de voter pour une seule personne ?",
+        "message5": {
+          "p10": "Contrairement au système de vote classique en France, ici vous donnez votre avis sur plusieurs candidat.es.",
+          "p20": "Ainsi il est possible d'exprimer son choix préféré, puis son second, puis son troisième, etc.",
+          "p30": "Cela permet d'éviter des problèmes comme « le vote utile », et ne favorise pas la polarisation des opinions politiques."
+        },
+        "title6": "Comment ça fonctionne ?",
+        "message6": {
+          "p10": "C'est en aggrégeant les comparaisons de tous les utilisateurs que Tournesol est capable de comprendre leurs préférences.",
+          "p20": "Ce n'est donc pas la personne qui reçoit le plus de vote qui est élue mais celle dont la somme des avis est la plus favorable.",
+          "p30": "L'objectif est d'obtenir un résultat qui correspond le plus possible à l'opinion globale des utilisateurs."
+        },
+        "title7": "Merci beaucoup !",
+        "message7": {
+          "p10": "Encore une dernière comparaison et vous pourrez enfin voir vos résultats.",
+          "p20": "Nous espérons sincèrement que vous avez apprécié cette nouvelle manière de voter."
+        }
+      }
+    }
   }
 }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -413,7 +413,7 @@
         "title6": "Comment ça fonctionne ?",
         "message6": {
           "p10": "C'est en aggrégeant les comparaisons de tous les utilisateurs que Tournesol est capable de comprendre leurs préférences.",
-          "p20": "Ce n'est donc pas la personne qui reçoit le plus de vote qui est élue mais celle dont la somme des avis est la plus favorable.",
+          "p20": "Ce n'est donc pas la personne qui reçoit le plus de votes qui est élue mais celle dont la somme des avis est la plus favorable.",
           "p30": "L'objectif est d'obtenir un résultat qui correspond le plus possible à l'opinion globale des utilisateurs."
         },
         "title7": "Merci beaucoup !",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -386,7 +386,7 @@
         "title1": "Bienvenue dans Tournesol 🌻",
         "message1": {
           "p10": "Ce tutoriel va vous guider pas à pas à travers une série de comparaison.",
-          "p20": "D'abord, déplacez les curseurs bleu et ajustez vos préférences en les positionnant plus ou moins loin, puis enregistrez quand votre choix est fait.",
+          "p20": "D'abord, déplacez les curseurs bleus et ajustez vos préférences en les positionnant plus ou moins loin, puis enregistrez quand votre choix est fait.",
           "p30": "Plus votre avis est tranché sur un critère plus le curseur devrait être proche de l'extrémité.",
           "p40": "Si vous trouvez les candidat.es similaires, le curseur devrait rester proche du centre."
         },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -385,7 +385,7 @@
       "tutorial": {
         "title1": "Bienvenue dans Tournesol 🌻",
         "message1": {
-          "p10": "Ce tutorial va vous guider pas à pas à travers une série de comparaisons.",
+          "p10": "Ce tutoriel va vous guider pas à pas à travers une série de comparaison.",
           "p20": "D'abord, déplacez les curseurs bleu et ajustez vos préférences en les positionnant plus ou moins loin, puis enregistrez quand votre choix est fait.",
           "p30": "Plus votre avis est tranché sur un critère plus le curseur devrait être proche de l'extrémité.",
           "p40": "Si vous trouvez les candidat.es similaires, le curseur devrait rester proche du centre."

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -385,7 +385,7 @@
       "tutorial": {
         "title1": "Bienvenue dans Tournesol 🌻",
         "message1": {
-          "p10": "Ce tutoriel va vous guider pas à pas à travers une série de comparaison.",
+          "p10": "Ce tutoriel va vous guider pas à pas à travers une série de comparaisons.",
           "p20": "D'abord, déplacez les curseurs bleus et ajustez vos préférences en les positionnant plus ou moins loin, puis enregistrez quand votre choix est fait.",
           "p30": "Plus votre avis est tranché sur un critère plus le curseur devrait être proche de l'extrémité.",
           "p40": "Si vous trouvez les candidat.es similaires, le curseur devrait rester proche du centre."

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -127,8 +127,8 @@
     "thisYear": "Cette année",
     "allTime": "Depuis le début",
     "uploadDate": "Mises en ligne",
-    "language": "Langues",
     "allLanguages": "Toutes",
+    "language": "Langues",
     "uploader": "Chaîne"
   },
   "ratings": {
@@ -385,41 +385,42 @@
       "tutorial": {
         "title1": "Bienvenue dans Tournesol 🌻",
         "message1": {
-          "p10": "Pour vous familiariser avec ce système de comparaison, des petits messages comme celui-ci apparaîtront pour vous guider pas à pas.",
-          "p20": "Commençons par faire une première comparaison entre deux candidat.es.",
-          "p30": "Faites coulisser la poignée bleu au dessous des candidat.es, puis enregistrez pour indiquer qui d'après vous devrait-être président.e.",
-          "p40": "Plus la poignée est au centre, plus les candidat.es sont considérés comme similaires."
+          "p10": "Ce tutorial va vous guider pas à pas à travers une série de comparaisons.",
+          "p20": "D'abord, déplacez les curseurs bleu et ajustez vos préférences en les positionnant plus ou moins loin, puis enregistrez quand votre choix est fait.",
+          "p30": "Plus votre avis est tranché sur un critère plus le curseur devrait être proche de l'extrémité.",
+          "p40": "Si vous trouvez les candidat.es similaires, le curseur devrait rester proche du centre."
         },
         "title2": "Bravo !",
         "message2": {
-          "p10": "Continuons avec d'autres candidat.es.",
-          "p20": "Notez que vous pouvez choisir manuellement les candidat.es. en utilisant le menu déroulant qui se trouve au dessus de leurs photos."
+          "p10": "Vous avez effectué votre première comparaison 🥳.",
+          "p20": "Notez que vous pouvez choisir vous même les candidat.es. en utilisant les menus déroulant qui se trouvent au dessus de leurs photos."
         },
         "title3": "Un conseil",
         "message3": {
-          "p10": "Ne vous en faites pas trop si vous n'etes pas sûr.e de vous. Il vous sera possible par la suite de modifier toutes vos comparaisons à votre rythme."
+          "p10": "Ne vous en faites pas, ce n'est pas grave si la position des curseurs n'est pas exacte.",
+          "p20": "De plus, il vous sera possible par la suite de modifier toutes vos comparaisons à votre rythme."
         },
         "title4": "Avez-vous remarqué ?",
         "message4": {
           "p10": "Il y a aussi des critères de comparaison optionnels sous les critères principaux.",
-          "p20": "Essayez de dérouler les critères optionnels pour donner un avis plus complet sur les candidat.es."
+          "p20": "Essayez de dérouler les critères optionnels pour donner un avis plus complet sur les candidat.es.",
+          "p30": "Il est tout a fait possible de décocher un ou plusieurs critères optionnels si vous ne souhaitez pas vous exprimer à leurs sujets."
         },
         "title5": "Mieux que de voter pour une seule personne ?",
         "message5": {
           "p10": "Contrairement au système de vote classique en France, ici vous donnez votre avis sur plusieurs candidat.es.",
-          "p20": "Ainsi il est possible d'exprimer son choix préféré, puis son second, puis son troisième, etc.",
-          "p30": "Cela permet d'éviter des problèmes comme « le vote utile », et ne favorise pas la polarisation des opinions politiques."
+          "p20": "Ainsi il est possible d'exprimer ses véritables préférences. Cela permet d'éviter des problèmes comme « le vote utile », et ne favorise pas la polarisation des opinions politiques."
         },
         "title6": "Comment ça fonctionne ?",
         "message6": {
-          "p10": "C'est en aggrégeant les comparaisons de tous les utilisateurs que Tournesol est capable de comprendre leurs préférences.",
-          "p20": "Ce n'est donc pas la personne qui reçoit le plus de votes qui est élue mais celle dont la somme des avis est la plus favorable.",
-          "p30": "L'objectif est d'obtenir un résultat qui correspond le plus possible à l'opinion globale des utilisateurs."
+          "p10": "Tournesol classe les candidat.es en aggrégeant les préférences de tous les contributeurs.",
+          "p20": "Ce n'est donc pas la personne qui reçoit le plus de votes qui est élue mais celle // à compléter //.",
+          "p30": "L'objectif est d'obtenir un résultat qui correspond le plus possible à l'opinion globale des contributeurs."
         },
         "title7": "Merci beaucoup !",
         "message7": {
-          "p10": "Encore une dernière comparaison et vous pourrez enfin voir vos résultats.",
-          "p20": "Nous espérons sincèrement que vous avez apprécié cette nouvelle manière de voter."
+          "p10": "Encore une dernière comparaison et vous pourrez enfin voir vos préférences actuelles.",
+          "p20": "Nous espérons sincèrement que vous avez apprécié cette nouvelle manière de voter, qui vous a peut-être permis de mieux réfléchir aux raisons pour lequelles vous soutenez certains candidat.es."
         }
       }
     }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -398,7 +398,7 @@
         "title3": "Un conseil",
         "message3": {
           "p10": "Ne vous en faites pas, ce n'est pas grave si la position des curseurs n'est pas exacte.",
-          "p20": "De plus, il vous sera possible par la suite de modifier toutes vos comparaisons à votre rythme."
+          "p20": "Il vous sera possible par la suite de modifier toutes vos comparaisons à votre rythme."
         },
         "title4": "Avez-vous remarqué ?",
         "message4": {

--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -31,6 +31,7 @@ async function getUserComparisons(
 ): Promise<ComparisonModel[]> {
   const comparisons = await UsersService.usersMeComparisonsList({
     pollName,
+    limit: 100,
   });
 
   return comparisons.results || [];

--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -26,12 +26,14 @@ interface Props {
   length: number;
 }
 
-export function getUserComparisons(
+async function getUserComparisons(
   pollName: string
 ): Promise<ComparisonModel[]> {
-  return UsersService.usersMeComparisonsList({
+  const comparisons = await UsersService.usersMeComparisonsList({
     pollName,
-  }).then((data) => data.results ?? []);
+  });
+
+  return comparisons.results || [];
 }
 
 const generateSteps = (length: number) => {
@@ -109,6 +111,7 @@ const ComparisonSeries = ({
       const formattedComparisons = comparisons.map(
         (c) => c.entity_a.uid + '/' + c.entity_b.uid
       );
+
       setComparisonsMade(formattedComparisons);
       return formattedComparisons;
     }

--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -118,23 +118,21 @@ const ComparisonSeries = ({
     }
 
     if (length >= MIN_LENGTH) {
-      getUserComparisonsAsync(pollName).then((comparisons) => {
-        if (getAlternatives) {
-          getAlternativesAsync(getAlternatives).then((entities) => {
-            if (initialize.current && (uidA === '' || uidB === '')) {
-              setFirstComparisonParams(
-                genInitialComparisonParams(entities, comparisons, uidA, uidB)
-              );
-            }
-
-            // stop loading after the initial comparison params have been built
-            setIsLoading(false);
-          });
-        } else {
-          // stop loading if no alternatives have been provided
+      const comparisonsPromise = getUserComparisonsAsync(pollName);
+      const alternativesPromise = getAlternatives
+        ? getAlternativesAsync(getAlternatives)
+        : Promise.resolve();
+      Promise.all([comparisonsPromise, alternativesPromise])
+        .then(([comparisons, entities]) => {
+          if (entities && initialize.current && (uidA === '' || uidB === '')) {
+            setFirstComparisonParams(
+              genInitialComparisonParams(entities, comparisons, uidA, uidB)
+            );
+          }
+        })
+        .then(() => {
           setIsLoading(false);
-        }
-      });
+        });
     } else {
       // stop loading if no series is going to be rendered
       setIsLoading(false);

--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -138,7 +138,8 @@ const ComparisonSeries = ({
       // stop loading if no series is going to be rendered
       setIsLoading(false);
     }
-  }, [getAlternatives, length, pollName, setComparisonsMade, uidA, uidB]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const afterSubmitCallback = (
     uidA: string,

--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -10,6 +10,7 @@ import { OrderedDialogs } from 'src/utils/types';
 const MIN_LENGTH = 2;
 
 interface Props {
+  alreadyMadeComparisons?: Array<string>;
   dialogs?: OrderedDialogs;
   generateInitial?: boolean;
   getAlternatives?: () => Promise<Array<Entity>>;
@@ -32,10 +33,11 @@ const generateSteps = (length: number) => {
 };
 
 const ComparisonSeries = ({
+  alreadyMadeComparisons,
+  dialogs,
   generateInitial,
   getAlternatives,
   length,
-  dialogs,
 }: Props) => {
   // trigger the initialization on the first render only, to allow users to
   // freely clear entities without being redirected
@@ -50,13 +52,19 @@ const ComparisonSeries = ({
   const [refreshLeft, setRefreshLeft] = useState(false);
   // a limited list of entities that can be used to suggest new comparisons
   const [alternatives, setAlternatives] = useState<Array<Entity>>([]);
-  // a list of already made comparisons, allowing to not suggest two times the
-  // same comparison to a user
+  // an array of already made comparisons, allowing to not suggest two times the
+  // same comparison to a user, formatted like this ['uidA/uidB', 'uidA/uidC']
   const [comparisonsMade, setComparisonsMade] = useState<Array<string>>([]);
 
   const searchParams = new URLSearchParams(location.search);
   const uidA: string = searchParams.get(UID_PARAMS.vidA) || '';
   const uidB: string = searchParams.get(UID_PARAMS.vidB) || '';
+
+  useEffect(() => {
+    if (alreadyMadeComparisons !== undefined) {
+      setComparisonsMade(alreadyMadeComparisons);
+    }
+  }, [alreadyMadeComparisons, setComparisonsMade]);
 
   /**
    * Build the list of `alternatives`.

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -37,10 +37,7 @@ const ComparisonPage = () => {
     Array<string>
   >([]);
 
-  let dialogs;
-  if (tutorialDialogs) {
-    dialogs = tutorialDialogs(t);
-  }
+  const dialogs = tutorialDialogs ? tutorialDialogs(t) : undefined;
 
   /**
    * If 'series' is present in the URL parameters, retrieve the user's

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -20,6 +20,11 @@ const ComparisonPage = () => {
   const tutorialAlternatives = options?.tutorialAlternatives ?? undefined;
   const tutorialDialogs = options?.tutorialDialogs ?? undefined;
 
+  let dialogs;
+  if (tutorialDialogs) {
+    dialogs = tutorialDialogs(t);
+  }
+
   return (
     <>
       <ContentHeader title={t('comparison.submitAComparison')} />
@@ -33,7 +38,7 @@ const ComparisonPage = () => {
       >
         {series === 'true' ? (
           <ComparisonSeries
-            dialogs={tutorialDialogs}
+            dialogs={dialogs}
             generateInitial={true}
             getAlternatives={tutorialAlternatives}
             length={tutorialLength}

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
@@ -7,6 +7,20 @@ import { ContentHeader } from 'src/components';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import Comparison from 'src/features/comparisons/Comparison';
 import ComparisonSeries from 'src/features/comparisonSeries/ComparisonSeries';
+import {
+  Comparison as ComparisonModel,
+  UsersService,
+} from 'src/services/openapi';
+
+export function getUserComparisons(
+  pollName: string
+): Promise<ComparisonModel[]> {
+  const comparisons: Promise<ComparisonModel[]> =
+    UsersService.usersMeComparisonsList({
+      pollName,
+    }).then((data) => data.results ?? []);
+  return comparisons;
+}
 
 const ComparisonPage = () => {
   const { t } = useTranslation();
@@ -15,15 +29,36 @@ const ComparisonPage = () => {
   const searchParams = new URLSearchParams(location.search);
   const series: string = searchParams.get('series') || 'false';
 
-  const { options } = useCurrentPoll();
+  const { options, name: pollName } = useCurrentPoll();
   const tutorialLength = options?.tutorialLength ?? 0;
   const tutorialAlternatives = options?.tutorialAlternatives ?? undefined;
   const tutorialDialogs = options?.tutorialDialogs ?? undefined;
+  const [alreadyMadeComparisons, setAlreadyMadeComparisons] = useState<
+    Array<string>
+  >([]);
 
   let dialogs;
   if (tutorialDialogs) {
     dialogs = tutorialDialogs(t);
   }
+
+  /**
+   * If 'series' is present in the URL parameters, retrieve the user's
+   * comparisons to avoid suggesting couple of entities that have been already
+   * compared.
+   */
+  useEffect(() => {
+    async function getUserComparisonsAsync(pName: string) {
+      const comparisons = await getUserComparisons(pName);
+      setAlreadyMadeComparisons(
+        comparisons.map((c) => c.entity_a.uid + '/' + c.entity_b.uid)
+      );
+    }
+
+    if (series === 'true') {
+      getUserComparisonsAsync(pollName);
+    }
+  }, [pollName, series]);
 
   return (
     <>
@@ -38,6 +73,7 @@ const ComparisonPage = () => {
       >
         {series === 'true' ? (
           <ComparisonSeries
+            alreadyMadeComparisons={alreadyMadeComparisons}
             dialogs={dialogs}
             generateInitial={true}
             getAlternatives={tutorialAlternatives}

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
@@ -7,20 +7,6 @@ import { ContentHeader } from 'src/components';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import Comparison from 'src/features/comparisons/Comparison';
 import ComparisonSeries from 'src/features/comparisonSeries/ComparisonSeries';
-import {
-  Comparison as ComparisonModel,
-  UsersService,
-} from 'src/services/openapi';
-
-export function getUserComparisons(
-  pollName: string
-): Promise<ComparisonModel[]> {
-  const comparisons: Promise<ComparisonModel[]> =
-    UsersService.usersMeComparisonsList({
-      pollName,
-    }).then((data) => data.results ?? []);
-  return comparisons;
-}
 
 const ComparisonPage = () => {
   const { t } = useTranslation();
@@ -29,33 +15,12 @@ const ComparisonPage = () => {
   const searchParams = new URLSearchParams(location.search);
   const series: string = searchParams.get('series') || 'false';
 
-  const { options, name: pollName } = useCurrentPoll();
+  const { options } = useCurrentPoll();
   const tutorialLength = options?.tutorialLength ?? 0;
   const tutorialAlternatives = options?.tutorialAlternatives ?? undefined;
   const tutorialDialogs = options?.tutorialDialogs ?? undefined;
-  const [alreadyMadeComparisons, setAlreadyMadeComparisons] = useState<
-    Array<string>
-  >([]);
 
   const dialogs = tutorialDialogs ? tutorialDialogs(t) : undefined;
-
-  /**
-   * If 'series' is present in the URL parameters, retrieve the user's
-   * comparisons to avoid suggesting couple of entities that have been already
-   * compared.
-   */
-  useEffect(() => {
-    async function getUserComparisonsAsync(pName: string) {
-      const comparisons = await getUserComparisons(pName);
-      setAlreadyMadeComparisons(
-        comparisons.map((c) => c.entity_a.uid + '/' + c.entity_b.uid)
-      );
-    }
-
-    if (series === 'true') {
-      getUserComparisonsAsync(pollName);
-    }
-  }, [pollName, series]);
 
   return (
     <>
@@ -70,7 +35,6 @@ const ComparisonPage = () => {
       >
         {series === 'true' ? (
           <ComparisonSeries
-            alreadyMadeComparisons={alreadyMadeComparisons}
             dialogs={dialogs}
             generateInitial={true}
             getAlternatives={tutorialAlternatives}

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,10 +1,6 @@
 import { TFunction } from 'react-i18next';
-import { HowToVote, YouTube } from '@mui/icons-material';
-import { RouteID, SelectablePoll } from './types';
-import {
-  getAllCandidates,
-  getTutorialDialogs,
-} from './polls/presidentielle2022';
+import { YouTube } from '@mui/icons-material';
+import { SelectablePoll } from './types';
 
 export const YOUTUBE_POLL_NAME = 'videos';
 export const PRESIDENTIELLE_2022_POLL_NAME = 'presidentielle2022';
@@ -138,6 +134,7 @@ export const getEntityName = (t: TFunction, pollName: string) => {
   to be routed correctly.
 */
 export const polls: Array<SelectablePoll> = [
+  /*
   {
     name: PRESIDENTIELLE_2022_POLL_NAME,
     displayOrder: 20,
@@ -151,6 +148,7 @@ export const polls: Array<SelectablePoll> = [
     tutorialAlternatives: getAllCandidates,
     tutorialDialogs: getTutorialDialogs,
   },
+  */
   {
     name: YOUTUBE_POLL_NAME,
     displayOrder: 10,

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,6 +1,10 @@
 import { TFunction } from 'react-i18next';
-import { YouTube } from '@mui/icons-material';
-import { SelectablePoll } from './types';
+import { HowToVote, YouTube } from '@mui/icons-material';
+import { RouteID, SelectablePoll } from './types';
+import {
+  getAllCandidates,
+  getTutorialDialogs,
+} from './polls/presidentielle2022';
 
 export const YOUTUBE_POLL_NAME = 'videos';
 export const PRESIDENTIELLE_2022_POLL_NAME = 'presidentielle2022';
@@ -134,7 +138,6 @@ export const getEntityName = (t: TFunction, pollName: string) => {
   to be routed correctly.
 */
 export const polls: Array<SelectablePoll> = [
-  /*
   {
     name: PRESIDENTIELLE_2022_POLL_NAME,
     displayOrder: 20,
@@ -146,9 +149,8 @@ export const polls: Array<SelectablePoll> = [
       'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
     tutorialLength: 7,
     tutorialAlternatives: getAllCandidates,
-    tutorialDialogs: tutorialDialogs,
+    tutorialDialogs: getTutorialDialogs,
   },
-  */
   {
     name: YOUTUBE_POLL_NAME,
     displayOrder: 10,

--- a/frontend/src/utils/entity.ts
+++ b/frontend/src/utils/entity.ts
@@ -45,8 +45,8 @@ export const alreadyComparedWith = (
     const split = comparison.split('/');
     const index = split.indexOf(uid);
 
-    if (index != -1) {
-      if (index == 0) {
+    if (index !== -1) {
+      if (index === 0) {
         alreadyCompared.push(split[1]);
       } else {
         alreadyCompared.push(split[0]);

--- a/frontend/src/utils/polls/presidentielle2022.ts
+++ b/frontend/src/utils/polls/presidentielle2022.ts
@@ -34,13 +34,17 @@ export const getTutorialDialogs = (t: TFunction): OrderedDialogs => {
     },
     '2': {
       title: t('presidentielle2022.dialogs.tutorial.title3'),
-      messages: [t('presidentielle2022.dialogs.tutorial.message3.p10')],
+      messages: [
+        t('presidentielle2022.dialogs.tutorial.message3.p10'),
+        t('presidentielle2022.dialogs.tutorial.message3.p20'),
+      ],
     },
     '3': {
       title: t('presidentielle2022.dialogs.tutorial.title4'),
       messages: [
         t('presidentielle2022.dialogs.tutorial.message4.p10'),
         t('presidentielle2022.dialogs.tutorial.message4.p20'),
+        t('presidentielle2022.dialogs.tutorial.message4.p30'),
       ],
     },
     '4': {
@@ -48,7 +52,6 @@ export const getTutorialDialogs = (t: TFunction): OrderedDialogs => {
       messages: [
         t('presidentielle2022.dialogs.tutorial.message5.p10'),
         t('presidentielle2022.dialogs.tutorial.message5.p20'),
-        t('presidentielle2022.dialogs.tutorial.message5.p30'),
       ],
     },
     '5': {
@@ -67,70 +70,4 @@ export const getTutorialDialogs = (t: TFunction): OrderedDialogs => {
       ],
     },
   };
-};
-
-export const tutorialDialogs: OrderedDialogs = {
-  '0': {
-    title: 'Bienvenue dans Tournesol',
-    messages: [
-      'Pour vous familiariser avec ce système de comparaison, des petits' +
-        ' messages comme celui-ci apparaîtront pour vous guider pas à pas.',
-      'Commençons par une première comparaison 🌻',
-      'Faites coulisser la poignée bleu au dessous des candidat.es, puis' +
-        " enregistrez pour indiquer qui d'après vous devrait-être président.e.",
-      'Plus la poignée est au centre, plus les candidat.es sont considérés comme ' +
-        'similaires.',
-    ],
-  },
-  '1': {
-    title: 'Bravo !',
-    messages: [
-      "Continuons avec d'autres comparaisons.",
-      'Notez que vous pouvez choisir manuellement les candidat.es. en utilisant' +
-        ' le menu déroulant qui se trouve au dessus de leurs photos.',
-    ],
-  },
-  '2': {
-    title: 'Un conseil',
-    messages: [
-      "Ne vous en faites pas trop si vous n'etes pas sûr.e de vous. Il vous" +
-        ' sera possible de modifier toutes vos comparaisons par la suite.',
-    ],
-  },
-  '3': {
-    title: 'Avez-vous remarqué ?',
-    messages: [
-      'Il y a aussi des critères de comparaison optionnel sous les critères' +
-        ' principaux',
-      'Essayez de dérouler les critères optionnels pour donner un avis plus' +
-        ' complet sur les candidat.es',
-    ],
-  },
-  '4': {
-    title: 'Commment ça fonctionne ? (1/2)',
-    messages: [
-      'Contrairement au système de vote classique en France, ici vous donnez ' +
-        ' votre avis sur une multitudes de candidat.es.',
-      "Ainsi il est possible d'exprimer son choix préféré, puis son second," +
-        ' puis son troisième, etc.',
-    ],
-  },
-  '5': {
-    title: 'Commment ça fonctionne ? (2/2)',
-    messages: [
-      "C'est en aggrégeant les comparaisons de tous les utilisateurs que" +
-        ' Tournesol est capable de comprendre leurs préférences, et de' +
-        ' déterminer quel candidat.e devrait-être président.e.',
-      "Ce n'est donc pas la personne qui reçoit le plus de vote qui gagne " +
-        ' mais celle dont la somme des avis est la plus favorable.',
-    ],
-  },
-  '6': {
-    title: 'Merci beaucoup !',
-    messages: [
-      'Encore une dernière comparaison et vous pourrez voir vos résultats.',
-      'Nous espérons sincèrement que vous avez apprécié cette nouvelle manière' +
-        ' de voter.',
-    ],
-  },
 };

--- a/frontend/src/utils/polls/presidentielle2022.ts
+++ b/frontend/src/utils/polls/presidentielle2022.ts
@@ -1,3 +1,4 @@
+import { TFunction } from 'react-i18next';
 import { EntitiesService, Entity, TypeEnum } from 'src/services/openapi';
 import { OrderedDialogs } from 'src/utils/types';
 
@@ -12,6 +13,61 @@ export function getAllCandidates(): Promise<Entity[]> {
   }).then((data) => data.results ?? []);
   return CANDIDATES;
 }
+
+export const getTutorialDialogs = (t: TFunction): OrderedDialogs => {
+  return {
+    '0': {
+      title: t('presidentielle2022.dialogs.tutorial.title1'),
+      messages: [
+        t('presidentielle2022.dialogs.tutorial.message1.p10'),
+        t('presidentielle2022.dialogs.tutorial.message1.p20'),
+        t('presidentielle2022.dialogs.tutorial.message1.p30'),
+        t('presidentielle2022.dialogs.tutorial.message1.p40'),
+      ],
+    },
+    '1': {
+      title: t('presidentielle2022.dialogs.tutorial.title2'),
+      messages: [
+        t('presidentielle2022.dialogs.tutorial.message2.p10'),
+        t('presidentielle2022.dialogs.tutorial.message2.p20'),
+      ],
+    },
+    '2': {
+      title: t('presidentielle2022.dialogs.tutorial.title3'),
+      messages: [t('presidentielle2022.dialogs.tutorial.message3.p10')],
+    },
+    '3': {
+      title: t('presidentielle2022.dialogs.tutorial.title4'),
+      messages: [
+        t('presidentielle2022.dialogs.tutorial.message4.p10'),
+        t('presidentielle2022.dialogs.tutorial.message4.p20'),
+      ],
+    },
+    '4': {
+      title: t('presidentielle2022.dialogs.tutorial.title5'),
+      messages: [
+        t('presidentielle2022.dialogs.tutorial.message5.p10'),
+        t('presidentielle2022.dialogs.tutorial.message5.p20'),
+        t('presidentielle2022.dialogs.tutorial.message5.p30'),
+      ],
+    },
+    '5': {
+      title: t('presidentielle2022.dialogs.tutorial.title6'),
+      messages: [
+        t('presidentielle2022.dialogs.tutorial.message6.p10'),
+        t('presidentielle2022.dialogs.tutorial.message6.p20'),
+        t('presidentielle2022.dialogs.tutorial.message6.p30'),
+      ],
+    },
+    '6': {
+      title: t('presidentielle2022.dialogs.tutorial.title7'),
+      messages: [
+        t('presidentielle2022.dialogs.tutorial.message7.p10'),
+        t('presidentielle2022.dialogs.tutorial.message7.p20'),
+      ],
+    },
+  };
+};
 
 export const tutorialDialogs: OrderedDialogs = {
   '0': {

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TFunction } from 'react-i18next';
 import { SvgIconComponent } from '@mui/icons-material';
 import {
   Entity,
@@ -62,5 +63,5 @@ export type SelectablePoll = {
   // can be used by comparison series to limit the pool of entities
   // that are suggested after each comparison
   tutorialAlternatives?: () => Promise<Array<Entity>>;
-  tutorialDialogs?: OrderedDialogs;
+  tutorialDialogs?: (t: TFunction) => OrderedDialogs;
 };


### PR DESCRIPTION
**is subtask of** #681 

close #706 and #707

---

This PR add the possibility to translate the tutorial of each poll. It comes with a dialog proposition that could be updated at any moment. It also makes the `<ComparisonSeries>` component aware of the existing comparisons made by the user (see the commit c2b5e97, I accidentally pushed two features in the same branch, tell me if you prefer two PR @amatissart). 

I use several sub-keys in the translation so that we can add dialog for more than one series in a given poll.

The keys are " generic " and not talkative, but they help to add and remove paragraph rather than easily. Contrary to even more generic keys containing several paragraphs inside on string, which makes working on the translations uncomfortable.

**known limitations**

**(1)** updating an already made comparison by manually selecting a candidate results in a " soft lock "

I developed a fix on a local branch, I'll create a second pull request to make the reviews easier (see #721). 

**(2)** refreshing the page with make the comparison series to restart at 1

This is a missing feature, I'll update the component when **(1)** will be merged.