### PR TITLE
add jinja2 maximum version until flake8-html next release

### DIFF
--- a/backend/tests/requirements.txt
+++ b/backend/tests/requirements.txt
@@ -18,3 +18,6 @@ pytest-django==4.5.2
 
 # Factory tools
 factory-boy==3.2.1
+
+# Until flake8-html release a version > 0.4.1
+jinja2<=3.0.3


### PR DESCRIPTION
The issue of jinja2 new version is already fixed but not released: https://github.com/lordmauve/flake8-html/commit/edef580c6d5e0ccb3ab54aa31b42b4359f7b9235