### PR TITLE
[front] security: update `minimist` to 1.2.6 from 1.2.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "i18next": "^21.6.3",
     "i18next-browser-languagedetector": "^6.1.2",
     "i18next-http-backend": "1.3.2",
+    "minimist": "^1.2.6",
     "notistack": "^2.0.3",
     "precompress": "7.0.1",
     "react": "^17.0.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7048,6 +7048,11 @@ minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
 mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"


### PR DESCRIPTION
see: https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795