### PR TITLE
[front] refactor: snackbars are now displayed in the top right corner

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,3 +17,8 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.SnackbarItem-wrappedRoot.belowTopBar {
+  /* display alerts below the top bar, to avoid hiding buttons */
+  top: 66px;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,7 +18,12 @@ code {
     monospace;
 }
 
-.SnackbarItem-wrappedRoot.belowTopBar {
+/* -- start: third-party packages customization -- */
+
+/* pkg: notistack */
+.SnackbarContainer-root.belowTopBar {
   /* display alerts below the top bar, to avoid hiding buttons */
-  top: 66px;
+  top: 80px;
 }
+
+/* -- end: third-party packages customization -- */

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -35,6 +35,9 @@ ReactDOM.render(
           <ThemeProvider theme={theme}>
             <BrowserRouter>
               <SnackbarProvider
+                classes={{
+                  anchorOriginTopRight: 'belowTopBar',
+                }}
                 maxSnack={6}
                 anchorOrigin={{
                   vertical: 'top',

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -36,7 +36,7 @@ ReactDOM.render(
             <BrowserRouter>
               <SnackbarProvider
                 classes={{
-                  anchorOriginTopRight: 'belowTopBar',
+                  containerAnchorOriginTopRight: 'belowTopBar',
                 }}
                 maxSnack={6}
                 anchorOrigin={{

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -36,10 +36,9 @@ ReactDOM.render(
             <BrowserRouter>
               <SnackbarProvider
                 maxSnack={6}
-                autoHideDuration={6000}
                 anchorOrigin={{
-                  vertical: 'bottom',
-                  horizontal: 'center',
+                  vertical: 'top',
+                  horizontal: 'right',
                 }}
               >
                 <Suspense fallback={null}>


### PR DESCRIPTION
**Context** 

The snackbars were displayed at the bottom center of the screen, which could hide the submit button in the `<Comparison>` component and other UI components depending on the page.

As there is already the side bar on the left, I excluded the anchors bottom left, center left and top left.

As on mobile the bottom center is very similar to the bottom right I chose the top right position. I also excluded center top to avoid hiding potential important UI components as most of our pages display their content in a centered container