### PR TITLE
[front] feat: make `ComparisonSeries` "resumable"

### DIFF
--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -24,6 +24,7 @@ interface Props {
   generateInitial?: boolean;
   getAlternatives?: () => Promise<Array<Entity>>;
   length: number;
+  resumable?: boolean;
 }
 
 async function getUserComparisons(
@@ -57,6 +58,7 @@ const ComparisonSeries = ({
   generateInitial,
   getAlternatives,
   length,
+  resumable,
 }: Props) => {
   const { name: pollName } = useCurrentPoll();
 
@@ -123,8 +125,13 @@ const ComparisonSeries = ({
       const alternativesPromise = getAlternatives
         ? getAlternativesAsync(getAlternatives)
         : Promise.resolve();
+
       Promise.all([comparisonsPromise, alternativesPromise])
         .then(([comparisons, entities]) => {
+          if (resumable && comparisons.length > 0) {
+            setStep(comparisons.length);
+          }
+
           if (entities && initialize.current && (uidA === '' || uidB === '')) {
             setFirstComparisonParams(
               genInitialComparisonParams(entities, comparisons, uidA, uidB)

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -39,6 +39,7 @@ const ComparisonPage = () => {
             generateInitial={true}
             getAlternatives={tutorialAlternatives}
             length={tutorialLength}
+            resumable={true}
           />
         ) : (
           <Comparison />


### PR DESCRIPTION
must be rebased on main when #721 is merged

---

If a user that has already finished the tutorial manually add the `?series` in the presidentielle 2022 comparison page, he/she will arrive on the comparison series page, with the stepper showing everything is finished. From here, it will be possible to continue adding more comparisons, the UI automatically suggestion new a candidate after each submit.

I think it's a good feature to be able to follow an infinite chain of suggested comparisons. This allows users to not be forced to click on the drop down menus to select new candidates. But this feature might be removed when we will add the result page.