### PR TITLE
First implementation of "Mehestan" algorithm

### DIFF
--- a/backend/ml/inputs.py
+++ b/backend/ml/inputs.py
@@ -98,7 +98,6 @@ class MlInputFromDb(MlInput):
             entity_b=F("comparison__entity_2_id"),
             user_id=F("comparison__user_id"),
         )
-
         if len(values) > 0:
             df = pd.DataFrame(values)
             return df[

--- a/backend/ml/management/commands/ml_train.py
+++ b/backend/ml/management/commands/ml_train.py
@@ -5,6 +5,7 @@ from django.core.management.base import BaseCommand
 from core.models import User
 from ml.core import TOURNESOL_DEV, ml_run
 from ml.inputs import MlInputFromDb
+from ml.mehestan.run import run_mehestan
 from ml.outputs import (
     save_contributor_scores,
     save_entity_scores,
@@ -133,6 +134,6 @@ class Command(BaseCommand):
                         logging.debug("Process on all users")
                         process_licchavi(poll, ml_input, trusted_only=False)
                 elif poll.algorithm == ALGORITHM_MEHESTAN:
-                    raise NotImplementedError
+                    run_mehestan(ml_input=ml_input, poll=poll)
                 else:
-                    raise ValueError(f"unknown algorithm {repr(poll.algorithm)}'")
+                    raise ValueError(f"unknown algorithm {repr(algorithm)}'")

--- a/backend/ml/management/commands/ml_train.py
+++ b/backend/ml/management/commands/ml_train.py
@@ -136,4 +136,4 @@ class Command(BaseCommand):
                 elif poll.algorithm == ALGORITHM_MEHESTAN:
                     run_mehestan(ml_input=ml_input, poll=poll)
                 else:
-                    raise ValueError(f"unknown algorithm {repr(algorithm)}'")
+                    raise ValueError(f"unknown algorithm {repr(poll.algorithm)}'")

--- a/backend/ml/management/commands/ml_train_dev.py
+++ b/backend/ml/management/commands/ml_train_dev.py
@@ -2,10 +2,9 @@ import logging
 
 from django.core.management.base import BaseCommand
 
+from backend.ml.inputs import MlInputFromDb
 from ml.core import TOURNESOL_DEV
 from ml.dev.experiments import run_experiment
-
-from .ml_train import fetch_data
 
 """
 Machine Learning command file for developpement
@@ -26,10 +25,9 @@ class Command(BaseCommand):
     help = 'Runs the ml'
 
     def handle(self, *args, **options):
-        comparison_data_trusted = fetch_data()
-        comparison_data_not_trusted = fetch_data(trusted=False)
+        ml_input = MlInputFromDb(poll_name="videos")
+        comparison_data_trusted = ml_input.get_comparisons(trusted_only=True)
         if TOURNESOL_DEV:
             run_experiment(comparison_data_trusted)
-            run_experiment(comparison_data_not_trusted)
         else:
             logging.error('You must turn TOURNESOL_DEV to 1 to run this')

--- a/backend/ml/management/commands/ml_train_dev.py
+++ b/backend/ml/management/commands/ml_train_dev.py
@@ -2,9 +2,9 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from backend.ml.inputs import MlInputFromDb
 from ml.core import TOURNESOL_DEV
 from ml.dev.experiments import run_experiment
+from ml.inputs import MlInputFromDb
 
 """
 Machine Learning command file for developpement

--- a/backend/ml/mehestan/global_scores.py
+++ b/backend/ml/mehestan/global_scores.py
@@ -1,0 +1,330 @@
+import numpy as np
+import pandas as pd
+
+from ml.inputs import MlInput
+
+from .primitives import BrMean, QrDev, QrMed, QrUnc
+
+W = 20.0
+
+SCALING_WEIGHT_SUPERTRUSTED = W
+SCALING_WEIGHT_TRUSTED = 1.0
+SCALING_WEIGHT_NONTRUSTED = 0.0
+
+VOTE_WEIGHT_TRUSTED_PUBLIC = 1.0
+VOTE_WEIGHT_TRUSTED_PRIVATE = 0.5
+
+TOTAL_VOTE_WEIGHT_NONTRUSTED_DEFAULT = 2.0  # w_⨯,default
+TOTAL_VOTE_WEIGHT_NONTRUSTED_FRACTION = 0.1  # f_⨯
+
+
+# def get_user_scaling_weights():
+#     values = (
+#         User.objects.all()
+#         .annotate(
+#             scaling_weight=Case(
+#                 When(
+#                     pk__in=User.supertrusted_users(), then=SCALING_WEIGHT_SUPERTRUSTED
+#                 ),
+#                 When(pk__in=User.trusted_users(), then=SCALING_WEIGHT_TRUSTED),
+#                 default=SCALING_WEIGHT_NONTRUSTED,
+#             )
+#         )
+#         .values("scaling_weight", user_id=F("pk"))
+#     )
+#     return {u["user_id"]: u["scaling_weight"] for u in values}
+
+
+def get_user_scaling_weights(ml_input: MlInput):
+    ratings_properties = ml_input.get_ratings_properties()[
+        ["user_id", "is_trusted", "is_supertrusted"]
+    ]
+    df = ratings_properties.groupby("user_id").first()
+    df["scaling_weight"] = SCALING_WEIGHT_NONTRUSTED
+    df["scaling_weight"].mask(df.is_trusted, SCALING_WEIGHT_TRUSTED, inplace=True)
+    df["scaling_weight"].mask(
+        df.is_supertrusted, SCALING_WEIGHT_SUPERTRUSTED, inplace=True
+    )
+    return df["scaling_weight"].to_dict()
+
+
+def get_significantly_different_pairs(scores: pd.DataFrame):
+    scores = scores[["uid", "score", "uncertainty"]]
+    left, right = np.triu_indices(len(scores), k=1)
+    pairs = (
+        scores.iloc[left]
+        .reset_index(drop=True)
+        .join(
+            scores.iloc[right].reset_index(drop=True),
+            lsuffix="_a",
+            rsuffix="_b",
+        )
+    )
+    pairs.set_index(["uid_a", "uid_b"], inplace=True)
+    return pairs.loc[
+        np.abs(pairs.score_a - pairs.score_b)
+        >= 2 * (pairs.uncertainty_a + pairs.uncertainty_b)
+    ]
+
+
+def compute_scaling(
+    df: pd.DataFrame,
+    ml_input: MlInput,
+    users_to_compute=None,
+    reference_users=None,
+    compute_uncertainties=False,
+):
+    scaling_weights = get_user_scaling_weights(ml_input)
+    df = df.rename({"entity_id": "uid"}, axis=1)
+
+    if users_to_compute is None:
+        users_to_compute = set(df.user_id.unique())
+    else:
+        users_to_compute = set(users_to_compute)
+
+    if reference_users is None:
+        reference_users = set(df.user_id.unique())
+    else:
+        reference_users = set(reference_users)
+
+    s_dict = {}
+    delta_s_dict = {}
+
+    for (user_n, user_scores) in df[df.user_id.isin(users_to_compute)].groupby(
+        "user_id"
+    ):
+        s_nqm = []
+        delta_s_nqm = []
+        s_weights = []
+
+        ABn_all = get_significantly_different_pairs(user_scores)
+        user_scores_uids = set(ABn_all.index.get_level_values("uid_a")) | set(
+            ABn_all.index.get_level_values("uid_b")
+        )
+
+        for (user_m, m_scores) in df[
+            df.user_id.isin(reference_users - {user_n})
+        ].groupby("user_id"):
+            common_uids = user_scores_uids.intersection(m_scores.uid)
+
+            if len(common_uids) == 0:
+                continue
+
+            m_scores = m_scores[m_scores.uid.isin(common_uids)]
+            ABm = get_significantly_different_pairs(m_scores)
+            ABnm = ABn_all.join(ABm, how="inner", lsuffix="_n", rsuffix="_m")
+            if len(ABnm) == 0:
+                continue
+            s_nqmab = np.abs(ABnm.score_a_m - ABnm.score_b_m) / np.abs(
+                ABnm.score_a_n - ABnm.score_b_n
+            )
+
+            # To check: is it correct to subtract s_nqmab?
+            delta_s_nqmab = (
+                (
+                    np.abs(ABnm.score_a_m - ABnm.score_b_m)
+                    + ABnm.uncertainty_a_m
+                    + ABnm.uncertainty_b_m
+                )
+                / (
+                    np.abs(ABnm.score_a_n - ABnm.score_b_n)
+                    - ABnm.uncertainty_a_n
+                    - ABnm.uncertainty_b_n
+                )
+            ) - s_nqmab
+
+            s = QrMed(1, 1, s_nqmab, delta_s_nqmab)
+            s_nqm.append(s)
+            delta_s_nqm.append(QrUnc(1, 1, 1, s_nqmab, delta_s_nqmab, qr_med=s))
+            s_weights.append(scaling_weights[user_m])
+
+        s_weights = np.array(s_weights)
+        theta_inf = np.max(user_scores.score.abs())
+        s_nqm = np.array(s_nqm)
+        delta_s_nqm = np.array(delta_s_nqm)
+        if compute_uncertainties:
+            qr_med = QrMed(8 * W * theta_inf, s_weights, s_nqm - 1, delta_s_nqm)
+            s_dict[user_n] = 1 + qr_med
+            delta_s_dict[user_n] = QrUnc(
+                8 * W * theta_inf, 1, s_weights, s_nqm - 1, delta_s_nqm, qr_med=qr_med
+            )
+        else:
+            s_dict[user_n] = 1 + BrMean(
+                8 * W * theta_inf, s_weights, s_nqm - 1, delta_s_nqm
+            )
+
+    tau_dict = {}
+    delta_tau_dict = {}
+    for (user_n, user_scores) in df[df.user_id.isin(users_to_compute)].groupby(
+        "user_id"
+    ):
+        tau_nqm = []
+        delta_tau_nqm = []
+        s_weights = []
+        for (user_m, m_scores) in df[
+            df.user_id.isin(reference_users - {user_n})
+        ].groupby("user_id"):
+            common_uids = list(set(user_scores.uid).intersection(m_scores.uid))
+
+            if len(common_uids) == 0:
+                continue
+
+            m_scores = m_scores.set_index("uid").loc[common_uids]
+            n_scores = user_scores.set_index("uid").loc[common_uids]
+
+            tau_nqmab = (
+                s_dict.get(user_m, 1) * m_scores.score - s_dict[user_n] * n_scores.score
+            )
+            delta_tau_nqmab = (
+                s_dict[user_n] * n_scores.uncertainty
+                + s_dict.get(user_m, 1) * m_scores.uncertainty
+            )
+
+            tau = QrMed(1, 1, tau_nqmab, delta_tau_nqmab)
+            tau_nqm.append(tau)
+            delta_tau_nqm.append(QrUnc(1, 1, 1, tau_nqmab, delta_tau_nqmab, qr_med=tau))
+            s_weights.append(scaling_weights[user_m])
+
+        s_weights = np.array(s_weights)
+        tau_nqm = np.array(tau_nqm)
+        delta_tau_nqm = np.array(delta_tau_nqm)
+
+        if compute_uncertainties:
+            qr_med = QrMed(8 * W, s_weights, tau_nqm, delta_tau_nqm)
+            tau_dict[user_n] = qr_med
+            delta_tau_dict[user_n] = QrUnc(
+                8 * W, 1, s_weights, tau_nqm, delta_tau_nqm, qr_med=qr_med
+            )
+        else:
+            tau_dict[user_n] = BrMean(8 * W, s_weights, tau_nqm, delta_tau_nqm)
+
+    return pd.DataFrame(
+        {
+            "s": s_dict,
+            "tau": tau_dict,
+            **(
+                {"delta_s": delta_s_dict, "delta_tau": delta_tau_dict}
+                if compute_uncertainties
+                else {}
+            ),
+        }
+    )
+
+
+def get_scaling_for_supertrusted(ml_input: MlInput, individual_scores: pd.DataFrame):
+    rp = ml_input.get_ratings_properties()
+    rp.set_index(["user_id", "entity_id"], inplace=True)
+    rp = rp[rp.is_supertrusted]
+    df = individual_scores.join(rp, on=["user_id", "entity_id"], how="inner")
+    return compute_scaling(df, ml_input=ml_input)
+
+
+def get_global_scores(ml_input: MlInput, individual_scores: pd.DataFrame):
+    if len(individual_scores) == 0:
+        return pd.DataFrame(columns=["entity_id", "score", "uncertainty", "deviation"])
+
+    supertrusted_scaling = get_scaling_for_supertrusted(ml_input, individual_scores)
+    rp = ml_input.get_ratings_properties()
+
+    non_supertrusted = rp["user_id"][~rp.is_supertrusted].unique()
+    trusted_and_supertrusted = rp["user_id"][
+        (rp.is_supertrusted) | (rp.is_trusted)
+    ].unique()
+
+    rp.set_index(["user_id", "entity_id"], inplace=True)
+    df = individual_scores.join(rp, on=["user_id", "entity_id"], how="left")
+    df["is_public"].fillna(False, inplace=True)
+    df["is_trusted"].fillna(False, inplace=True)
+    df["is_supertrusted"].fillna(False, inplace=True)
+
+    df = df.join(supertrusted_scaling, on="user_id")
+    df["s"].fillna(1, inplace=True)
+    df["tau"].fillna(0, inplace=True)
+    df["score"] = df["s"] * df["score"] + df["tau"]
+    df["uncertainty"] *= df["s"]
+    df.drop(["s", "tau"], axis=1, inplace=True)
+
+    non_supertrusted_scaling = compute_scaling(
+        df,
+        ml_input=ml_input,
+        users_to_compute=non_supertrusted,
+        reference_users=trusted_and_supertrusted,
+        compute_uncertainties=True,
+    )
+
+    df = df.join(non_supertrusted_scaling, on="user_id")
+    df["s"].fillna(1, inplace=True)
+    df["tau"].fillna(0, inplace=True)
+    df["delta_s"].fillna(0, inplace=True)
+    df["delta_tau"].fillna(0, inplace=True)
+    df["uncertainty"] = (
+        df["s"] * df["uncertainty"]
+        + df["delta_s"] * df["score"].abs()
+        + df["delta_tau"]
+    )
+    df["score"] = df["score"] * df["s"] + df["tau"]
+    df.drop(["s", "tau", "delta_s", "delta_tau"], axis=1, inplace=True)
+
+    df[
+        "voting_weight"
+    ] = 0  # Voting weight for non trusted users will be computed per entity
+    df["voting_weight"].mask(
+        (df.is_trusted) & (df.is_public), VOTE_WEIGHT_TRUSTED_PUBLIC, inplace=True
+    )
+    df["voting_weight"].mask(
+        (df.is_trusted) & (~df.is_public), VOTE_WEIGHT_TRUSTED_PRIVATE, inplace=True
+    )
+
+    global_scores = {}
+    for (entity_id, scores) in df.groupby("entity_id"):
+        trusted_weight = scores["voting_weight"].sum()
+        non_trusted_weight = (
+            TOTAL_VOTE_WEIGHT_NONTRUSTED_DEFAULT
+            + TOTAL_VOTE_WEIGHT_NONTRUSTED_FRACTION * trusted_weight
+        )
+        nb_non_trusted_public = (
+            scores["is_public"] & (scores["voting_weight"] == 0)
+        ).sum()
+        nb_non_trusted_private = (
+            ~scores["is_public"] & (scores["voting_weight"] == 0)
+        ).sum()
+
+        if (nb_non_trusted_private > 0) or (nb_non_trusted_public > 0):
+            scores["voting_weight"].mask(
+                scores["is_public"] & (scores["voting_weight"] == 0),
+                min(
+                    VOTE_WEIGHT_TRUSTED_PUBLIC,
+                    2
+                    * non_trusted_weight
+                    / (2 * nb_non_trusted_public + nb_non_trusted_private),
+                ),
+                inplace=True,
+            )
+            scores["voting_weight"].mask(
+                ~scores["is_public"] & (scores["voting_weight"] == 0),
+                min(
+                    VOTE_WEIGHT_TRUSTED_PRIVATE,
+                    non_trusted_weight
+                    / (2 * nb_non_trusted_public + nb_non_trusted_private),
+                ),
+                inplace=True,
+            )
+
+        w = scores.voting_weight
+        theta = scores.score
+        delta = scores.uncertainty
+        rho = QrMed(2 * W, w, theta, delta)
+        rho_uncertainty = QrUnc(2 * W, 1, w, theta, delta, qr_med=rho)
+        rho_deviation = QrDev(2 * W, 1, w, theta, delta, qr_med=rho)
+        global_scores[entity_id] = {
+            "score": rho,
+            "uncertainty": rho_uncertainty,
+            "deviation": rho_deviation,
+        }
+
+    if len(global_scores) == 0:
+        return pd.DataFrame(columns=["entity_id", "score", "uncertainty", "deviation"])
+
+    result = pd.DataFrame.from_dict(global_scores, orient="index")
+    result.index.name = "entity_id"
+    return result.reset_index()

--- a/backend/ml/mehestan/individual.py
+++ b/backend/ml/mehestan/individual.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pandas as pd
+
+R_MAX = 10
+ALPHA = 0.01
+
+
+def compute_individual_score(scores):
+    scores = scores[["entity_a", "entity_b", "score"]]
+    scores_sym = pd.concat(
+        [
+            scores,
+            pd.DataFrame(
+                {
+                    "entity_a": scores.entity_b,
+                    "entity_b": scores.entity_a,
+                    "score": -1 * scores.score,
+                }
+            ),
+        ]
+    )
+
+    r = scores_sym.pivot(index="entity_a", columns="entity_b", values="score")
+
+    r_tilde = r / (1.0 + R_MAX)
+    r_tilde2 = r_tilde ** 2
+
+    # r.loc[a:b] is negative when a is prefered to b.
+    l = -1.0 * r_tilde / np.sqrt(1.0 - r_tilde2)  # noqa: E741
+    k = (1.0 - r_tilde2) ** 3
+
+    L = k.mul(l).sum(axis=1)
+    K_diag = pd.DataFrame(
+        data=np.diag(k.sum(axis=1) + ALPHA),
+        index=k.index,
+        columns=k.index,
+    )
+    K = K_diag.sub(k, fill_value=0)
+
+    # theta_star = K^-1 * L
+    theta_star = pd.Series(np.linalg.solve(K, L), index=L.index)
+
+    # Compute uncertainties
+    theta_star_numpy = theta_star.to_numpy()
+    theta_star_ab = pd.DataFrame(
+        np.subtract.outer(theta_star_numpy, theta_star_numpy),
+        index=theta_star.index,
+        columns=theta_star.index,
+    )
+    sigma2 = (1.0 + (np.nansum(k * (l - theta_star_ab) ** 2) / 2)) / len(scores)
+    delta_star = pd.Series(np.sqrt(sigma2) / np.sqrt(np.diag(K)), index=K.index)
+
+    result = pd.DataFrame(
+        {
+            "score": theta_star,
+            "uncertainty": delta_star,
+        }
+    )
+    result.index.name = "entity_id"
+    return result

--- a/backend/ml/mehestan/primitives.py
+++ b/backend/ml/mehestan/primitives.py
@@ -1,0 +1,90 @@
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import brentq
+
+EPSILON = 1e-6
+
+
+def QrMed(W: float, w: Union[pd.Series, float], x: pd.Series, delta: pd.Series):
+    if isinstance(w, pd.Series):
+        w = w.to_numpy()
+    if isinstance(x, pd.Series):
+        x = x.to_numpy()
+    if isinstance(delta, pd.Series):
+        delta = delta.to_numpy()
+    delta_2 = delta ** 2
+
+    def L_prime(m: float):
+        x_minus_m = x - m
+        return W * m - np.sum(w * x_minus_m / np.sqrt(delta_2 + x_minus_m ** 2))
+
+    m_low = -1.0
+    while L_prime(m_low) > 0:
+        m_low *= 2
+
+    m_up = 1.0
+    while L_prime(m_up) < 0:
+        m_up *= 2
+
+    return brentq(L_prime, m_low, m_up, xtol=EPSILON)
+
+
+def QrDev(
+    W: float,
+    default_dev: float,
+    w: Union[pd.Series, float],
+    x: pd.Series,
+    delta: pd.Series,
+    qr_med=None,
+):
+    if qr_med is None:
+        qr_med = QrMed(W, w, x, delta)
+    return default_dev + QrMed(W, w, np.abs(x - qr_med) - default_dev, delta)
+
+
+def QrUnc(
+    W: float,
+    default_dev: float,
+    w: pd.Series,
+    x: pd.Series,
+    delta: pd.Series,
+    qr_med=None,
+):
+    if isinstance(w, pd.Series):
+        w = w.to_numpy()
+    if isinstance(x, pd.Series):
+        x = x.to_numpy()
+    if isinstance(delta, pd.Series):
+        delta = delta.to_numpy()
+
+    if qr_med is None:
+        qr_med = QrMed(W, w, x, delta)
+    qr_dev = QrDev(W, default_dev, w, x, delta, qr_med=qr_med)
+    delta_2 = delta ** 2
+    h = W + np.sum(
+        w * np.minimum(1, delta_2 * (delta_2 + (x - qr_med) ** 2) ** (-3 / 2))
+    )
+
+    if h <= W:
+        return qr_dev
+
+    k = (h - W) ** (-1 / 2)
+    return (np.exp(-qr_dev) * qr_dev + np.exp(-k) * k) / (np.exp(-qr_dev) + np.exp(-k))
+
+
+def Clip(x: np.ndarray, center, radius):
+    return x.clip(center - radius, center + radius)
+
+
+def ClipMean(w, x: np.ndarray, center, radius):
+    return np.sum(w * Clip(x, center, radius)) / np.sum(w)
+
+
+def BrMean(W, w, x, delta):
+    if len(x) == 0:
+        return 0.0
+    if isinstance(w, float):
+        w = np.full(x.shape, w)
+    return ClipMean(w, x, center=QrMed(4 * W, w, x, delta), radius=np.sum(w) / (4 * W))

--- a/backend/ml/mehestan/primitives.py
+++ b/backend/ml/mehestan/primitives.py
@@ -92,15 +92,15 @@ def QrUnc(
     return (np.exp(-qr_dev) * qr_dev + np.exp(-k) * k) / (np.exp(-qr_dev) + np.exp(-k))
 
 
-def Clip(x: np.ndarray, center, radius):
+def Clip(x: np.ndarray, center: float, radius: float):
     return x.clip(center - radius, center + radius)
 
 
-def ClipMean(w, x: np.ndarray, center, radius):
+def ClipMean(w: np.ndarray, x: np.ndarray, center: float, radius: float):
     return np.sum(w * Clip(x, center, radius)) / np.sum(w)
 
 
-def BrMean(W, w, x, delta):
+def BrMean(W: float, w: Union[float, np.ndarray], x: np.ndarray, delta: np.ndarray):
     """
     Byzantine-robustified mean
     """

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+from ml.inputs import MlInput
+from ml.outputs import (
+    save_contributor_scores,
+    save_entity_scores,
+    save_tournesol_score_as_sum_of_criteria,
+)
+from tournesol.models import Poll
+
+from .global_scores import get_global_scores
+from .individual import compute_individual_score
+
+
+def get_individual_scores(ml_input: MlInput, criteria: str) -> pd.DataFrame:
+    comparisons_df = ml_input.get_comparisons(criteria=criteria)
+
+    individual_scores = []
+    for (user_id, user_comparisons) in comparisons_df.groupby("user_id"):
+        scores = compute_individual_score(user_comparisons)
+        if scores is None:
+            continue
+        scores["user_id"] = user_id
+        individual_scores.append(scores.reset_index())
+
+    if len(individual_scores) == 0:
+        return pd.DataFrame(columns=["user_id", "entity_id", "score", "uncertainty"])
+
+    result = pd.concat(individual_scores, ignore_index=True, copy=False)
+    return result[["user_id", "entity_id", "score", "uncertainty"]]
+
+
+def compute_mehestan_scores(ml_input, criteria):
+    indiv_scores = get_individual_scores(ml_input, criteria=criteria)
+    indiv_scores["criteria"] = criteria
+    global_scores = get_global_scores(ml_input, individual_scores=indiv_scores)
+    global_scores["criteria"] = criteria
+    return indiv_scores, global_scores
+
+
+def run_mehestan(ml_input: MlInput, poll: Poll):
+    for criteria in poll.criterias_list:
+        indiv_scores, global_scores = compute_mehestan_scores(ml_input, criteria=criteria)
+        save_contributor_scores(poll, indiv_scores, single_criteria=criteria)
+        save_entity_scores(poll, global_scores, single_criteria=criteria)
+    save_tournesol_score_as_sum_of_criteria(poll)

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -33,14 +33,14 @@ def get_individual_scores(ml_input: MlInput, criteria: str) -> pd.DataFrame:
 def compute_mehestan_scores(ml_input, criteria):
     indiv_scores = get_individual_scores(ml_input, criteria=criteria)
     indiv_scores["criteria"] = criteria
-    global_scores = get_global_scores(ml_input, individual_scores=indiv_scores)
+    global_scores, scalings = get_global_scores(ml_input, individual_scores=indiv_scores)
     global_scores["criteria"] = criteria
-    return indiv_scores, global_scores
+    return indiv_scores, global_scores, scalings
 
 
 def run_mehestan(ml_input: MlInput, poll: Poll):
     for criteria in poll.criterias_list:
-        indiv_scores, global_scores = compute_mehestan_scores(ml_input, criteria=criteria)
+        indiv_scores, global_scores, _ = compute_mehestan_scores(ml_input, criteria=criteria)
         save_contributor_scores(poll, indiv_scores, single_criteria=criteria)
         save_entity_scores(poll, global_scores, single_criteria=criteria)
     save_tournesol_score_as_sum_of_criteria(poll)

--- a/backend/ml/ml_requirements.txt
+++ b/backend/ml/ml_requirements.txt
@@ -2,7 +2,11 @@
 torch==1.9.1
 gin-config==0.4.0
 pandas==1.4.1
+numpy==1.22.3
+scipy==1.8.0
+numexpr==2.8.1
+Bottleneck==1.3.4
+
 
 # dev
 matplotlib==3.4.2 
-scipy==1.7.0

--- a/backend/tournesol/models/poll.py
+++ b/backend/tournesol/models/poll.py
@@ -29,10 +29,6 @@ class Poll(models.Model):
         max_length=32, choices=ALGORITHM_CHOICES, default=ALGORITHM_LICCHAVI
     )
 
-    # @property
-    # def algorithm(self):
-    #     return ALGORITHM_MEHESTAN
-
     @classmethod
     def default_poll(cls) -> "Poll":
         poll, _created = cls.objects.get_or_create(

--- a/backend/tournesol/models/poll.py
+++ b/backend/tournesol/models/poll.py
@@ -29,6 +29,10 @@ class Poll(models.Model):
         max_length=32, choices=ALGORITHM_CHOICES, default=ALGORITHM_LICCHAVI
     )
 
+    # @property
+    # def algorithm(self):
+    #     return ALGORITHM_MEHESTAN
+
     @classmethod
     def default_poll(cls) -> "Poll":
         poll, _created = cls.objects.get_or_create(


### PR DESCRIPTION
Based on the ongoing paper "Tournesol’s algorithms" by @lenhoanglnh 

Contrary to the previous algorithm that computes individual and global scores together, these scores are now computed in separate steps:

1. Compute **individual scores** for each (user, criteria),  based on raw comparisons scores submitted on Tournesol

2. Apply a **collaborative score scaling**. This is currently implemented in 2 substeps    
    * initialize the scalings for a set of "supertrusted" users
    * compute the scaling for the remaining users

3. Compute the **global scores** for each (entity, criteria) after the individual scores have been scaled + translated
 
4. Compute the **Tournesol score** as an aggregation of all criteria. Here we'll try to predict a global score for the main criterion, based on all criteria scores.  
     * This step is not implemented on this branch. For now, the Tournesol score is still  computed as a simple sum of all criteria.