### PR TITLE
[front] feat: polls must be configured to allow public comparisons

### DIFF
--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -54,11 +54,17 @@ const EntitySelector = ({
   otherUid,
   submitted = false,
 }: Props) => {
-  const { uid, rating } = value;
   const classes = useStyles();
+
+  const { name: pollName, options } = useCurrentPoll();
+
+  const { uid, rating } = value;
   const [loading, setLoading] = useState(false);
-  const { name: pollName } = useCurrentPoll();
   const [inputValue, setInputValue] = useState(value.uid);
+
+  const getDefaultStatus = () => {
+    return options?.comparisonsCanBePublic === true;
+  };
 
   const loadRating = useCallback(async () => {
     setLoading(true);
@@ -80,7 +86,7 @@ const EntitySelector = ({
               pollName,
               requestBody: {
                 uid,
-                is_public: true,
+                is_public: getDefaultStatus(),
               },
             });
           onChange({

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -63,10 +63,6 @@ const EntitySelector = ({
   const [inputValue, setInputValue] = useState(value.uid);
 
   const loadRating = useCallback(async () => {
-    const getDefaultStatus = () => {
-      return options?.comparisonsCanBePublic === true;
-    };
-
     setLoading(true);
     try {
       const contributorRating =
@@ -86,7 +82,7 @@ const EntitySelector = ({
               pollName,
               requestBody: {
                 uid,
-                is_public: getDefaultStatus(),
+                is_public: options?.comparisonsCanBePublic === true,
               },
             });
           onChange({

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -62,11 +62,11 @@ const EntitySelector = ({
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);
 
-  const getDefaultStatus = () => {
-    return options?.comparisonsCanBePublic === true;
-  };
-
   const loadRating = useCallback(async () => {
+    const getDefaultStatus = () => {
+      return options?.comparisonsCanBePublic === true;
+    };
+
     setLoading(true);
     try {
       const contributorRating =
@@ -101,7 +101,7 @@ const EntitySelector = ({
       }
     }
     setLoading(false);
-  }, [pollName, uid, onChange]);
+  }, [onChange, options?.comparisonsCanBePublic, pollName, uid]);
 
   useEffect(() => {
     if (isUidValid(uid) && rating == null) {

--- a/frontend/src/features/videos/PublicStatusAction.tsx
+++ b/frontend/src/features/videos/PublicStatusAction.tsx
@@ -31,7 +31,7 @@ export const UserRatingPublicToggle = ({
   onChange?: (rating: ContributorRating) => void;
 }) => {
   const { t } = useTranslation();
-  const { name: pollName, baseUrl } = useCurrentPoll();
+  const { name: pollName, baseUrl, options } = useCurrentPoll();
 
   const handleChange = React.useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -43,6 +43,10 @@ export const UserRatingPublicToggle = ({
     },
     [onChange, pollName, uid]
   );
+
+  const comparisonsCanBePublic = () => {
+    return options?.comparisonsCanBePublic === true;
+  };
 
   return (
     <Box display="flex" alignItems="center" flexWrap="wrap" width="100%" px={1}>
@@ -62,35 +66,37 @@ export const UserRatingPublicToggle = ({
         )}
       </Typography>
       <Box flexGrow={1} minWidth="12px" />
-      <Tooltip
-        title={
-          <Typography variant="caption">
-            {isPublic
-              ? t('video.contributionsArePublicMessage')
-              : t('video.contributionsArePrivateMessage')}
-          </Typography>
-        }
-        placement="bottom"
-      >
-        <Box component="label" display="inline-flex" alignItems="center">
-          <Switch
-            checked={isPublic}
-            onChange={handleChange}
-            size="small"
-            color="primary"
-            edge="start"
-          />
-          <Typography
-            variant="caption"
-            sx={{
-              color: isPublic ? '#222' : '#bbb',
-              textTransform: 'capitalize',
-            }}
-          >
-            {t('public')}
-          </Typography>
-        </Box>
-      </Tooltip>
+      {comparisonsCanBePublic() && (
+        <Tooltip
+          title={
+            <Typography variant="caption">
+              {isPublic
+                ? t('video.contributionsArePublicMessage')
+                : t('video.contributionsArePrivateMessage')}
+            </Typography>
+          }
+          placement="bottom"
+        >
+          <Box component="label" display="inline-flex" alignItems="center">
+            <Switch
+              checked={isPublic}
+              onChange={handleChange}
+              size="small"
+              color="primary"
+              edge="start"
+            />
+            <Typography
+              variant="caption"
+              sx={{
+                color: isPublic ? '#222' : '#bbb',
+                textTransform: 'capitalize',
+              }}
+            >
+              {t('public')}
+            </Typography>
+          </Box>
+        </Tooltip>
+      )}
     </Box>
   );
 };

--- a/frontend/src/features/videos/PublicStatusAction.tsx
+++ b/frontend/src/features/videos/PublicStatusAction.tsx
@@ -44,10 +44,6 @@ export const UserRatingPublicToggle = ({
     [onChange, pollName, uid]
   );
 
-  const comparisonsCanBePublic = () => {
-    return options?.comparisonsCanBePublic === true;
-  };
-
   return (
     <Box display="flex" alignItems="center" flexWrap="wrap" width="100%" px={1}>
       <Typography variant="caption" sx={{ fontSize: '11px' }}>
@@ -66,7 +62,7 @@ export const UserRatingPublicToggle = ({
         )}
       </Typography>
       <Box flexGrow={1} minWidth="12px" />
-      {comparisonsCanBePublic() && (
+      {options?.comparisonsCanBePublic === true && (
         <Tooltip
           title={
             <Typography variant="caption">

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -48,7 +48,7 @@ const NoRatingMessage = ({ hasFilter }: { hasFilter: boolean }) => {
 };
 
 const VideoRatingsPage = () => {
-  const { name: pollName } = useCurrentPoll();
+  const { name: pollName, options } = useCurrentPoll();
   const [ratings, setRatings] = useState<PaginatedContributorRatingList>({});
   const [isLoading, setIsLoading] = useState(true);
   const location = useLocation();
@@ -114,6 +114,10 @@ const VideoRatingsPage = () => {
     }
   };
 
+  const comparisonsCanBePublic = () => {
+    return options?.comparisonsCanBePublic === true;
+  };
+
   return (
     <RatingsContext.Provider
       value={{
@@ -123,9 +127,11 @@ const VideoRatingsPage = () => {
     >
       <ContentHeader title={t('myRatedVideosPage.title')} />
       <ContentBox noMinPaddingX maxWidth="md">
-        <Box px={{ xs: 2, sm: 0 }}>
-          <RatingsFilter />
-        </Box>
+        {comparisonsCanBePublic() && (
+          <Box px={{ xs: 2, sm: 0 }}>
+            <RatingsFilter />
+          </Box>
+        )}
         <LoaderWrapper isLoading={isLoading}>
           <VideoList
             videos={entities.map((ent) => videoFromRelatedEntity(ent))}

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -114,10 +114,6 @@ const VideoRatingsPage = () => {
     }
   };
 
-  const comparisonsCanBePublic = () => {
-    return options?.comparisonsCanBePublic === true;
-  };
-
   return (
     <RatingsContext.Provider
       value={{
@@ -127,7 +123,7 @@ const VideoRatingsPage = () => {
     >
       <ContentHeader title={t('myRatedVideosPage.title')} />
       <ContentBox noMinPaddingX maxWidth="md">
-        {comparisonsCanBePublic() && (
+        {options?.comparisonsCanBePublic === true && (
           <Box px={{ xs: 2, sm: 0 }}>
             <RatingsFilter />
           </Box>

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -156,5 +156,6 @@ export const polls: Array<SelectablePoll> = [
     iconComponent: YouTube,
     withSearchBar: true,
     topBarBackground: null,
+    comparisonsCanBePublic: true,
   },
 ];

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -59,6 +59,9 @@ export type SelectablePoll = {
   iconComponent: SvgIconComponent;
   withSearchBar: boolean;
   topBarBackground: string | null;
+  // if true the UI must not allow users to mark their comparisons as public
+  // contributor ratings must be created with is_public = false
+  comparisonsCanBePublic?: boolean;
   tutorialLength?: number;
   // can be used by comparison series to limit the pool of entities
   // that are suggested after each comparison

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -59,8 +59,9 @@ export type SelectablePoll = {
   iconComponent: SvgIconComponent;
   withSearchBar: boolean;
   topBarBackground: string | null;
-  // if true the UI must not allow users to mark their comparisons as public
-  // contributor ratings must be created with is_public = false
+  // if false or undefined, the UI must not allow users to mark their
+  // comparisons as public, and contributor ratings must be created with
+  // is_public = false
   comparisonsCanBePublic?: boolean;
   tutorialLength?: number;
   // can be used by comparison series to limit the pool of entities


### PR DESCRIPTION
**related to** #726 

---

Following our "private by default" policy, polls must be explicitly configured to allow users to set their comparisons public.

A poll with the `comparisonsCanBePublic` set to true, will have its entity card display the public / private checkbox. The front end page `/ratings/` will also display the filter by visibility option and update visibility buttons.

For now it's a front end only configuration, but it will be easy to make it a back configuration (a field in the Poll model for instance).

| a poll configured with `comparisonsCanBePublic` = true | a poll without `comparisonsCanBePublic`  |
|---|---|
| ![capture2](https://user-images.githubusercontent.com/39056254/160583544-437cfff7-3b06-4953-8f5f-896f2331d2b2.png) | ![capture](https://user-images.githubusercontent.com/39056254/160583710-bff3742b-b677-441c-a20f-1a490f82a68f.png) |
| ![cap](https://user-images.githubusercontent.com/39056254/160584766-3aad0f1d-ea88-45cc-8ba0-072a1e506ce6.png) | ![compa](https://user-images.githubusercontent.com/39056254/160584777-ec9c1b32-6ead-4560-9342-f5692e5e5db1.png) |