### PR TITLE
Define feature flag to enable poll presidentielle2022 per environment

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -10,3 +10,6 @@ REACT_APP_CSP_FRAME_SRC=https://www.youtube.com
 REACT_APP_CSP_IMAGE_SRC="https://i.ytimg.com https://www.paypal.com https://www.paypalobjects.com https://*.wikimedia.org"
 # 'unsafe-inline' is added here for development purposes only (used by hot reloading)
 REACT_APP_CSP_SCRIPT_SRC="'unsafe-inline' https://www.youtube.com/iframe_api https://www.youtube.com/s/player/"
+
+# Tournesol feature flags
+REACT_APP_POLL_PRESIDENTIELLE_2022_ENABLED=true

--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -7,3 +7,6 @@ REACT_APP_CSP_CONNECT_SRC=https://noembed.com
 REACT_APP_CSP_FRAME_SRC=https://www.youtube.com
 REACT_APP_CSP_IMAGE_SRC="https://i.ytimg.com https://www.paypal.com https://www.paypalobjects.com https://*.wikimedia.org"
 REACT_APP_CSP_SCRIPT_SRC="https://www.youtube.com/iframe_api https://www.youtube.com/s/player/"
+
+# Tournesol feature flags
+REACT_APP_POLL_PRESIDENTIELLE_2022_ENABLED=false

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,9 +1,15 @@
 import { TFunction } from 'react-i18next';
-import { YouTube } from '@mui/icons-material';
-import { SelectablePoll } from './types';
+import { YouTube, HowToVote } from '@mui/icons-material';
+import { SelectablePoll, RouteID } from './types';
+import {
+  getAllCandidates,
+  getTutorialDialogs,
+} from './polls/presidentielle2022';
 
 export const YOUTUBE_POLL_NAME = 'videos';
 export const PRESIDENTIELLE_2022_POLL_NAME = 'presidentielle2022';
+const PRESIDENTIELLE_2022_ENABLED =
+  process.env.REACT_APP_POLL_PRESIDENTIELLE_2022_ENABLED === 'true';
 
 const UID_DELIMITER = ':';
 export const UID_YT_NAMESPACE = 'yt' + UID_DELIMITER;
@@ -134,21 +140,23 @@ export const getEntityName = (t: TFunction, pollName: string) => {
   to be routed correctly.
 */
 export const polls: Array<SelectablePoll> = [
-  /*
-  {
-    name: PRESIDENTIELLE_2022_POLL_NAME,
-    displayOrder: 20,
-    path: '/presidentielle2022/',
-    disabledRouteIds: [RouteID.MyRateLaterList],
-    iconComponent: HowToVote,
-    withSearchBar: false,
-    topBarBackground:
-      'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
-    tutorialLength: 7,
-    tutorialAlternatives: getAllCandidates,
-    tutorialDialogs: getTutorialDialogs,
-  },
-  */
+  ...(PRESIDENTIELLE_2022_ENABLED
+    ? [
+        {
+          name: PRESIDENTIELLE_2022_POLL_NAME,
+          displayOrder: 20,
+          path: '/presidentielle2022/',
+          disabledRouteIds: [RouteID.MyRateLaterList, RouteID.Recommendations],
+          iconComponent: HowToVote,
+          withSearchBar: false,
+          topBarBackground:
+            'linear-gradient(60deg, #8b8be8 0%, white 33%, #e16767 100%)',
+          tutorialLength: 7,
+          tutorialAlternatives: getAllCandidates,
+          tutorialDialogs: getTutorialDialogs,
+        },
+      ]
+    : []),
   {
     name: YOUTUBE_POLL_NAME,
     displayOrder: 10,

--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -31,6 +31,7 @@ all:
           frontend_csp_frame_src: https://www.youtube.com
           frontend_csp_image_src: "https://i.ytimg.com https://www.paypal.com https://www.paypalobjects.com https://*.wikimedia.org"
           frontend_csp_script_src: "https://www.youtube.com/iframe_api https://www.youtube.com/s/player/"
+          frontend_presidentielle_2022_enabled: true
 
           mediawiki_domain_name: tournesol-wiki
           mediawiki_scheme: http
@@ -82,6 +83,7 @@ all:
           frontend_csp_frame_src: https://www.youtube.com
           frontend_csp_image_src: "https://i.ytimg.com https://www.paypal.com https://www.paypalobjects.com https://*.wikimedia.org"
           frontend_csp_script_src: "https://www.youtube.com/iframe_api https://www.youtube.com/s/player/"
+          frontend_presidentielle_2022_enabled: true
 
           # Setting this triggers TLS configuration
           letsencrypt_email: tournesol.application@gmail.com
@@ -140,6 +142,7 @@ all:
           frontend_csp_frame_src: https://www.youtube.com
           frontend_csp_image_src: "https://i.ytimg.com https://www.paypal.com https://www.paypalobjects.com https://*.wikimedia.org"
           frontend_csp_script_src: "https://www.youtube.com/iframe_api https://www.youtube.com/s/player/"
+          frontend_presidentielle_2022_enabled: false
 
           # Setting this triggers TLS configuration
           letsencrypt_email: tournesol.application@gmail.com

--- a/infra/ansible/roles/frontend/templates/.env.j2
+++ b/infra/ansible/roles/frontend/templates/.env.j2
@@ -28,3 +28,6 @@ REACT_APP_CSP_CONNECT_SRC="{{frontend_csp_connect_src}}"
 REACT_APP_CSP_FRAME_SRC="{{frontend_csp_frame_src}}"
 REACT_APP_CSP_IMAGE_SRC="{{frontend_csp_image_src}}"
 REACT_APP_CSP_SCRIPT_SRC="{{frontend_csp_script_src}}"
+
+# Tournesol feature flags
+REACT_APP_POLL_PRESIDENTIELLE_2022_ENABLED="{{ frontend_presidentielle_2022_enabled | lower }}"


### PR DESCRIPTION
A custom environment variable is used to add the poll `presidentielle2022` to the list of selectable polls in frontend.
This mechanism relies on variables that are embedded during the build time: 
see https://create-react-app.dev/docs/adding-custom-environment-variables/ for more details.

This new poll will be enabled in development environment, in tournesol-vm, and on staging. (Not on production for the moment).

This way, the "main" branch remains deployable on all environments at any time. And the feature can easily be disabled at deploy time if necessary.



