### PR TITLE
[front] feat: disable My rated items page on `presidentielle2022`

### DIFF
--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -157,7 +157,11 @@ export const polls: Array<SelectablePoll> = [
           name: PRESIDENTIELLE_2022_POLL_NAME,
           displayOrder: 20,
           path: '/presidentielle2022/',
-          disabledRouteIds: [RouteID.MyRateLaterList, RouteID.Recommendations],
+          disabledRouteIds: [
+            RouteID.Recommendations,
+            RouteID.MyRateLaterList,
+            RouteID.MyComparedItems,
+          ],
           iconComponent: HowToVote,
           withSearchBar: false,
           topBarBackground:


### PR DESCRIPTION
As this page is not optimized to display something else than a video list, we decided with Adrien to disable it for now.

The feature provided by the page (a link to a filtered list of comparisons) is still available in the comparison UI.