### PR TITLE
Recompute individual scores on comparison submit, for Mehestan only

### DIFF
--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -1,6 +1,9 @@
+from typing import Optional
+
 import pandas as pd
 
-from ml.inputs import MlInput
+from core.models import User
+from ml.inputs import MlInput, MlInputFromDb
 from ml.outputs import (
     save_contributor_scores,
     save_entity_scores,
@@ -12,8 +15,10 @@ from .global_scores import get_global_scores
 from .individual import compute_individual_score
 
 
-def get_individual_scores(ml_input: MlInput, criteria: str) -> pd.DataFrame:
-    comparisons_df = ml_input.get_comparisons(criteria=criteria)
+def get_individual_scores(
+    ml_input: MlInput, criteria: str, single_user_id: Optional[int] = None
+) -> pd.DataFrame:
+    comparisons_df = ml_input.get_comparisons(criteria=criteria, user_id=single_user_id)
 
     individual_scores = []
     for (user_id, user_comparisons) in comparisons_df.groupby("user_id"):
@@ -33,14 +38,26 @@ def get_individual_scores(ml_input: MlInput, criteria: str) -> pd.DataFrame:
 def compute_mehestan_scores(ml_input, criteria):
     indiv_scores = get_individual_scores(ml_input, criteria=criteria)
     indiv_scores["criteria"] = criteria
-    global_scores, scalings = get_global_scores(ml_input, individual_scores=indiv_scores)
+    global_scores, scalings = get_global_scores(
+        ml_input, individual_scores=indiv_scores
+    )
     global_scores["criteria"] = criteria
     return indiv_scores, global_scores, scalings
 
 
+def update_user_scores(poll: Poll, user: User):
+    ml_input = MlInputFromDb(poll_name=poll.name)
+    for criteria in poll.criterias_list:
+        scores = get_individual_scores(ml_input, criteria, single_user_id=user.pk)
+        scores["criteria"] = criteria
+        save_contributor_scores(poll, scores, single_criteria=criteria, single_user_id=user.pk)
+
+
 def run_mehestan(ml_input: MlInput, poll: Poll):
     for criteria in poll.criterias_list:
-        indiv_scores, global_scores, _ = compute_mehestan_scores(ml_input, criteria=criteria)
+        indiv_scores, global_scores, _ = compute_mehestan_scores(
+            ml_input, criteria=criteria
+        )
         save_contributor_scores(poll, indiv_scores, single_criteria=criteria)
         save_entity_scores(poll, global_scores, single_criteria=criteria)
     save_tournesol_score_as_sum_of_criteria(poll)

--- a/backend/tournesol/entities/candidate.py
+++ b/backend/tournesol/entities/candidate.py
@@ -2,7 +2,6 @@ from urllib.parse import quote
 
 import requests
 from django.db.models import Q
-from django.utils import timezone
 
 from tournesol.serializers.metadata import CandidateMetadata
 
@@ -36,11 +35,7 @@ class CandidateEntity(EntityType):
             raise AttributeError(f"{self.instance} is not a wikidata entity")
         return self.instance.uid[3:]
 
-    def refresh_metadata(self, force=False, save=True):
-        self.instance.last_metadata_request_at = timezone.now()
-        if save:
-            self.instance.save(update_fields=["last_metadata_request_at"])
-
+    def update_metadata_field(self):
         resp = requests.get(
             WIKIDATA_API_BASE_URL,
             params={
@@ -88,6 +83,3 @@ class CandidateEntity(EntityType):
             metadata["twitter_username"] = get_property_value("P2002")
 
         self.instance.metadata = metadata
-        self.instance.metadata_timestamp = timezone.now()
-        if save:
-            self.instance.save(update_fields=["metadata", "metadata_timestamp"])

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -62,7 +62,6 @@ class VideoEntity(EntityType):
         for (metadata_key, metadata_value) in metadata.items():
             if metadata_value is not None:
                 self.instance.metadata[metadata_key] = metadata_value
-        self.instance.metadata_timestamp = timezone.now()
 
     def metadata_needs_to_be_refreshed(self) -> bool:
         """

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -2,6 +2,7 @@ import datetime
 from copy import deepcopy
 from unittest.mock import patch
 
+from django.core.management import call_command
 from django.db.models import ObjectDoesNotExist, Q
 from django.test import TestCase
 from django.utils import timezone
@@ -10,9 +11,17 @@ from rest_framework.test import APIClient
 
 from core.tests.factories.user import UserFactory
 from core.utils.time import time_ago
-from tournesol.models import Comparison, Entity, Poll
-from tournesol.tests.factories.comparison import ComparisonFactory
+from tournesol.models import (
+    Comparison,
+    ContributorRatingCriteriaScore,
+    Entity,
+    EntityCriteriaScore,
+    Poll,
+)
+from tournesol.models.poll import ALGORITHM_MEHESTAN
+from tournesol.tests.factories.comparison import ComparisonCriteriaScoreFactory, ComparisonFactory
 from tournesol.tests.factories.entity import VideoFactory
+from tournesol.tests.factories.poll import CriteriaRankFactory, PollFactory
 
 
 class ComparisonApiTestCase(TestCase):
@@ -923,3 +932,76 @@ class ComparisonApiTestCase(TestCase):
         self.assertContains(
             response, "not a valid criteria", status_code=status.HTTP_400_BAD_REQUEST
         )
+
+
+class ComparisonWithMehestanTest(TestCase):
+    def setUp(self):
+        self.poll = PollFactory(algorithm=ALGORITHM_MEHESTAN)
+        CriteriaRankFactory(poll=self.poll, criteria__name="criteria1")
+        CriteriaRankFactory(poll=self.poll, criteria__name="criteria2", optional=True)
+
+        self.entities = VideoFactory.create_batch(3)
+        self.user1, self.user2 = UserFactory.create_batch(2)
+
+        comparison = ComparisonFactory(
+            poll=self.poll,
+            user=self.user1,
+            entity_1=self.entities[0],
+            entity_2=self.entities[1],
+        )
+
+        for (criteria, score) in [("criteria1", 1), ("criteria2", 2)]:
+            ComparisonCriteriaScoreFactory(
+                comparison=comparison,
+                criteria=criteria,
+                score=score,
+            )
+
+        self.client = APIClient()
+
+    def test_update_individual_scores_after_new_comparison(self):
+        call_command("ml_train")
+
+        self.assertEqual(ContributorRatingCriteriaScore.objects.count(), 4)
+        self.assertEqual(EntityCriteriaScore.objects.count(), 4)
+
+        self.client.force_authenticate(self.user2)
+        resp = self.client.post(
+            f"/users/me/comparisons/{self.poll.name}",
+            data={
+                "entity_a":{
+                    "uid": self.entities[0].uid
+                },
+                "entity_b": {
+                    "uid": self.entities[2].uid
+                },
+                "criteria_scores": [
+                    {
+                        "criteria": "criteria1",
+                        "score": 3
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, 201, resp.content)
+
+        # Individual scores related to the new comparison have been computed
+        self.assertEqual(
+            ContributorRatingCriteriaScore.objects
+                .filter(contributor_rating__user=self.user2)
+                .count(),
+            2
+        )
+        # The score related to the less prefered entity is negative
+        user_score = ContributorRatingCriteriaScore.objects.get(
+            contributor_rating__user=self.user2,
+            contributor_rating__entity=self.entities[0],
+            criteria="criteria1",
+        )
+        self.assertLess(user_score.score, 0)
+
+        # Global scores and individual scores related to other users are unchanged
+        self.assertEqual(ContributorRatingCriteriaScore.objects.count(), 6)
+        self.assertEqual(EntityCriteriaScore.objects.count(), 4)

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -965,6 +965,14 @@ class ComparisonWithMehestanTest(TestCase):
         self.assertEqual(ContributorRatingCriteriaScore.objects.count(), 4)
         self.assertEqual(EntityCriteriaScore.objects.count(), 4)
 
+        # user2 has no contributor scores before the comparison is submitted
+        self.assertEqual(
+            ContributorRatingCriteriaScore.objects
+                .filter(contributor_rating__user=self.user2)
+                .count(),
+            0
+        )
+
         self.client.force_authenticate(self.user2)
         resp = self.client.post(
             f"/users/me/comparisons/{self.poll.name}",

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -8,7 +8,9 @@ from django.http import Http404
 from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, generics, mixins
 
+from ml.mehestan.run import update_user_scores
 from tournesol.models import Comparison, ContributorRating
+from tournesol.models.poll import ALGORITHM_MEHESTAN
 from tournesol.serializers.comparison import ComparisonSerializer, ComparisonUpdateSerializer
 from tournesol.views.mixins.poll import PollScopedViewMixin
 
@@ -116,6 +118,8 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
         ContributorRating.objects.get_or_create(
             poll=poll, user=self.request.user, entity=comparison.entity_2
         )
+        if poll.algorithm == ALGORITHM_MEHESTAN:
+            update_user_scores(poll, user=self.request.user)
 
 
 class ComparisonListFilteredApi(ComparisonListBaseApi):
@@ -203,6 +207,12 @@ class ComparisonDetailApi(
         context["reverse"] = self.currently_reversed
         context["poll"] = self.poll_from_url
         return context
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        poll = self.poll_from_url
+        if poll.algorithm == ALGORITHM_MEHESTAN:
+            update_user_scores(poll, user=self.request.user)
 
     def get(self, request, *args, **kwargs):
         """Retrieve a comparison made by the logged user, in the given poll."""

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -214,6 +214,12 @@ class ComparisonDetailApi(
         if poll.algorithm == ALGORITHM_MEHESTAN:
             update_user_scores(poll, user=self.request.user)
 
+    def perform_destroy(self, instance):
+        super().perform_destroy(instance)
+        poll = self.poll_from_url
+        if poll.algorithm == ALGORITHM_MEHESTAN:
+            update_user_scores(poll, user=self.request.user)
+
     def get(self, request, *args, **kwargs):
         """Retrieve a comparison made by the logged user, in the given poll."""
         return self.retrieve(request, *args, **kwargs)

--- a/backend/tournesol/views/contributor_recommendations.py
+++ b/backend/tournesol/views/contributor_recommendations.py
@@ -42,7 +42,9 @@ class ContributorRecommendationsBaseView(PollRecommendationsBaseAPIView):
 
     def filter_unsafe(self, queryset, filters):
         show_unsafe = filters["unsafe"]
-        if not show_unsafe:
+        if show_unsafe:
+            queryset = queryset.filter(total_score__isnull=False)
+        else:
             # Ignore RECOMMENDATIONS_MIN_CONTRIBUTORS, only filter on the
             # total score
             queryset = queryset.filter(total_score__gt=0)


### PR DESCRIPTION
For polls using the new "Mehestan" algorithm, individual scores are quite cheap to compute and can be updated every time a comparison is created, updated or deleted.

Moreover, it's a prerequisite to implement the "results" page described in #740