### PR TITLE
[front] feat: `ComparisonSeries` may redirect the user at the end of a series

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -58,6 +58,7 @@
     "withNComparisons_one": "with {{nComp}} comparison",
     "withNComparisons_other": "with {{nComp}} comparisons",
     "score": "score:",
+    "ifYourRankingSeemsOff": "If your ranking seems off, you can either modify your existing comparisons or add new comparisons using the buttons below.",
     "seeMyComparisons": "see my comparisons",
     "addNewComparisons": "make new comparisons"
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -63,6 +63,7 @@
     "withNComparisons_many": "avec {{nComp}} comparaisons",
     "withNComparisons_other": "avec {{nComp}} comparaisons",
     "score": "score :",
+    "ifYourRankingSeemsOff": "Si votre classement vous semble inadéquat, vous pouvez soit modifier vos comparaisons existantes, soit en ajouter de nouvelles en utilisant les boutons ci-dessous.",
     "seeMyComparisons": "voir mes comparaisons",
     "addNewComparisons": "ajouter des comparaisons"
   },

--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -21,6 +21,8 @@ interface Props {
   generateInitial?: boolean;
   getAlternatives?: () => Promise<Array<Entity>>;
   length: number;
+  // redirect to this URL when the series is over
+  redirectTo?: string;
   resumable?: boolean;
 }
 
@@ -44,6 +46,7 @@ const ComparisonSeries = ({
   generateInitial,
   getAlternatives,
   length,
+  redirectTo,
   resumable,
 }: Props) => {
   const { name: pollName } = useCurrentPoll();
@@ -248,6 +251,10 @@ const ComparisonSeries = ({
         to={{ pathname: location.pathname, search: firstComparisonParams }}
       />
     );
+  }
+
+  if (redirectTo && step >= length) {
+    return <Redirect to={{ pathname: redirectTo }} />;
   }
 
   return (

--- a/frontend/src/features/feedback/StackedCandidatesPaper.tsx
+++ b/frontend/src/features/feedback/StackedCandidatesPaper.tsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 import {
   Avatar,
+  Box,
   Button,
   Divider,
   Grid,
@@ -106,9 +107,13 @@ const StackedCandidatesPaper = ({
           );
         })}
       </List>
+      <Box pt={2} pb={1} px={2}>
+        <Typography paragraph variant="body2" textAlign="justify">
+          {t('stackedCandidatesPaper.ifYourRankingSeemsOff')}
+        </Typography>
+      </Box>
       <Grid
         container
-        mt={1}
         spacing={2}
         justifyContent="center"
         sx={{ color: 'secondary.main' }}

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -8,6 +8,12 @@ import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import Comparison from 'src/features/comparisons/Comparison';
 import ComparisonSeries from 'src/features/comparisonSeries/ComparisonSeries';
 
+/**
+ * Display the standard comparison UI or the poll tutorial.
+ *
+ * The tutorial is displayed if the `series` URL parameter is present and the
+ * poll's tutorial options are configured.
+ */
 const ComparisonPage = () => {
   const { t } = useTranslation();
 
@@ -15,7 +21,7 @@ const ComparisonPage = () => {
   const searchParams = new URLSearchParams(location.search);
   const series: string = searchParams.get('series') || 'false';
 
-  const { options } = useCurrentPoll();
+  const { options, baseUrl } = useCurrentPoll();
   const tutorialLength = options?.tutorialLength ?? 0;
   const tutorialAlternatives = options?.tutorialAlternatives ?? undefined;
   const tutorialDialogs = options?.tutorialDialogs ?? undefined;
@@ -39,6 +45,7 @@ const ComparisonPage = () => {
             generateInitial={true}
             getAlternatives={tutorialAlternatives}
             length={tutorialLength}
+            redirectTo={`${baseUrl}/personal/feedback`}
             resumable={true}
           />
         ) : (


### PR DESCRIPTION
**related to** #740 

---

This pull request allows developers to add a redirection after a comparison series.

It also makes the `presidentielle2022` tutorial to redirect the user after the last comparison.

If a user tries to manually access the tutorial after having made 7 or more comparisons, the component `<ComparisonSeries>` automatically redirects the user to the feedback page. 

**bonus** it also adds a missing translation in `<StackedCandidatesPaper>`