### PR TITLE
Fix nb of comparisons not being updated during comparison series

### DIFF
--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -71,8 +71,6 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
   const location = useLocation();
   const { showSuccessAlert } = useNotifications();
   const { name: pollName } = useCurrentPoll();
-
-  const [submitted, setSubmitted] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [initialComparison, setInitialComparison] =
     useState<ComparisonRequest | null>(null);
@@ -123,7 +121,6 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
       } else if (uidKey === UID_PARAMS.vidB) {
         setSelectorB(newValue);
       }
-      setSubmitted(false);
     },
     [history]
   );
@@ -172,26 +169,22 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
         requestBody: c,
       });
       setInitialComparison(c);
-
-      // the presence of the `afterSubmitCallback` prop suggests we are in
-      // a comparison series, some state updates are not triggered here to avoid
-      // race conditions
-      if (!afterSubmitCallback) {
-        // Refresh ratings statistics after the comparisons have been submitted
-        setSubmitted(true);
-      }
     }
 
     if (afterSubmitCallback) {
       const suggestion = afterSubmitCallback(c.entity_a.uid, c.entity_b.uid);
-
       if (suggestion.uid) {
         if (suggestion.refreshLeft) {
           onChangeA({ uid: suggestion.uid, rating: null });
+          setSelectorB((value) => ({ ...value, ratingIsExpired: true }));
         } else {
           onChangeB({ uid: suggestion.uid, rating: null });
+          setSelectorA((value) => ({ ...value, ratingIsExpired: true }));
         }
       }
+    } else {
+      setSelectorA((value) => ({ ...value, ratingIsExpired: true }));
+      setSelectorB((value) => ({ ...value, ratingIsExpired: true }));
     }
 
     showSuccessAlert(t('comparison.successfullySubmitted'));
@@ -230,7 +223,6 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
           value={selectorA}
           onChange={onChangeA}
           otherUid={uidB}
-          submitted={submitted}
         />
       </Grid>
       <Grid
@@ -246,7 +238,6 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
           value={selectorB}
           onChange={onChangeB}
           otherUid={uidA}
-          submitted={submitted}
         />
       </Grid>
       <Grid

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -37,28 +37,22 @@ interface Props {
   value: SelectorValue;
   onChange: (newValue: SelectorValue) => void;
   otherUid: string | null;
-  submitted?: boolean;
 }
 
 export interface SelectorValue {
   uid: string;
   rating: ContributorRating | null;
+  ratingIsExpired?: boolean;
 }
 
 const isUidValid = (uid: string) => uid.match(/\w+:.+/);
 
-const EntitySelector = ({
-  title,
-  value,
-  onChange,
-  otherUid,
-  submitted = false,
-}: Props) => {
+const EntitySelector = ({ title, value, onChange, otherUid }: Props) => {
   const classes = useStyles();
 
   const { name: pollName, options } = useCurrentPoll();
 
-  const { uid, rating } = value;
+  const { uid, rating, ratingIsExpired } = value;
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);
 
@@ -73,6 +67,7 @@ const EntitySelector = ({
       onChange({
         uid,
         rating: contributorRating,
+        ratingIsExpired: false,
       });
     } catch (err) {
       if (err?.status === 404) {
@@ -88,6 +83,7 @@ const EntitySelector = ({
           onChange({
             uid,
             rating: contributorRating,
+            ratingIsExpired: false,
           });
         } catch (err) {
           console.error('Failed to initialize contributor rating.', err);
@@ -107,10 +103,10 @@ const EntitySelector = ({
 
   useEffect(() => {
     // Reload rating after the parent (comparison) form has been submitted.
-    if (submitted) {
+    if (ratingIsExpired) {
       loadRating();
     }
-  }, [loadRating, submitted]);
+  }, [loadRating, ratingIsExpired]);
 
   useEffect(() => {
     // Update input value when "uid" has been changed by the parent component


### PR DESCRIPTION
The `submitted` prop (used to notify the selector that a new comparison has been submitted) is replaced with a flag `ratingIsExpired` in the `SelectorValue`.

I am not sure that's much more elegant from a React point of view, but at least it's flexible enough to handle the case of a comparison series, where each selector needs to be updated separately.