### PR TITLE
correlations: catch ValueError when linear regression is undefined

### DIFF
--- a/backend/tournesol/tests/test_api_criteria_correlation.py
+++ b/backend/tournesol/tests/test_api_criteria_correlation.py
@@ -119,3 +119,32 @@ class CorrelationAPI(TestCase):
             [2, 1, None],
             [None, None, None]
         ])
+
+
+    def test_correlation_with_zeros_on_a_criteria(self):
+        self.client.force_authenticate(user=self.user)
+        for i, rating in enumerate(self.ratings):
+            ContributorRatingCriteriaScoreFactory(
+                contributor_rating=rating,
+                criteria="hello",
+                score=0.1 * i,
+            )
+            ContributorRatingCriteriaScoreFactory(
+                contributor_rating=rating,
+                criteria="world",
+                score=0,
+            )
+
+        response = self.client.get(f"/users/me/criteria_correlations/{self.poll.name}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = response.json()
+        self.assertEqual(response_json["correlations"], [
+            [1, None, None],
+            [0.0, None, None],
+            [None, None, None]
+        ])
+        self.assertEqual(response_json["slopes"], [
+            [1, None, None],
+            [0.0, None, None],
+            [None, None, None]
+        ])

--- a/backend/tournesol/views/criteria_correlations.py
+++ b/backend/tournesol/views/criteria_correlations.py
@@ -29,14 +29,12 @@ def get_linregress(scores_1: dict, scores_2: dict):
 
 
 class ContributorCriteriaCorrelationsSerializer(serializers.Serializer):
-    criterias = serializers.ListField(child=serializers.CharField(), default=list)
+    criterias = serializers.ListField(child=serializers.CharField())
     correlations = serializers.ListField(
-        child=serializers.ListField(child=serializers.FloatField(), default=list),
-        default=list
+        child=serializers.ListField(child=serializers.FloatField())
     )
     slopes = serializers.ListField(
-        child=serializers.ListField(child=serializers.FloatField(), default=list),
-        default=list
+        child=serializers.ListField(child=serializers.FloatField())
     )
 
 

--- a/backend/tournesol/views/criteria_correlations.py
+++ b/backend/tournesol/views/criteria_correlations.py
@@ -15,10 +15,15 @@ def get_linregress(scores_1: dict, scores_2: dict):
     """
     # At least two datapoints are necessary to compute the slope and correlation
     if sum(entity in scores_1 for entity in scores_2) > 1:
-        return linregress(
-            [scores_1[e] for e in scores_1 if e in scores_2],
-            [scores_2[e] for e in scores_1 if e in scores_2],
-        )
+        try:
+            return linregress(
+                [scores_1[e] for e in scores_1 if e in scores_2],
+                [scores_2[e] for e in scores_1 if e in scores_2],
+            )
+        except ValueError:
+            # regression is undefined if all x values are identical
+            # (e.g all scores are 0 for one of the criteria)
+            return None
     else:
         return None
 

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1794,6 +1794,10 @@ components:
             items:
               type: number
               format: float
+      required:
+      - correlations
+      - criterias
+      - slopes
     ContributorCriteriaScore:
       type: object
       properties:
@@ -1906,24 +1910,24 @@ components:
     ContributorRecommendations:
       type: object
       properties:
-        is_public:
-          type: boolean
-          readOnly: true
-        metadata:
-          type: object
-          additionalProperties: {}
         uid:
           type: string
           description: A unique identifier, build with a namespace and an external
             id.
           maxLength: 144
-        total_score:
-          type: number
-          format: float
+        metadata:
+          type: object
+          additionalProperties: {}
         criteria_scores:
           type: array
           items:
             $ref: '#/components/schemas/ContributorCriteriaScore'
+          readOnly: true
+        total_score:
+          type: number
+          format: float
+        is_public:
+          type: boolean
           readOnly: true
         tournesol_score:
           type: number


### PR DESCRIPTION
Fixes server error for some criteria scores distributions.

Also makes the fields in the response required, to help with the frontend integration.