### PR TITLE
fix: Remove NaNs from dictionary before JSON encoding in correlation API

### DIFF
--- a/backend/tournesol/tests/test_api_criteria_correlation.py
+++ b/backend/tournesol/tests/test_api_criteria_correlation.py
@@ -86,6 +86,34 @@ class CorrelationAPI(TestCase):
         response = self.client.get(f"/users/me/criteria_correlations/this_is_not_a_poll/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_correlation_all_zeros(self):
+        self.client.force_authenticate(user=self.user)
+        for i, rating in enumerate(self.ratings):
+            ContributorRatingCriteriaScoreFactory(
+                contributor_rating=rating,
+                criteria="hello",
+                score=0,
+            )
+            ContributorRatingCriteriaScoreFactory(
+                contributor_rating=rating,
+                criteria="world",
+                score=0,
+            )
+        response = self.client.get(f"/users/me/criteria_correlations/{self.poll.name}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_json = response.json()
+        self.assertEqual(response_json["correlations"], [
+            [None, None, None],
+            [None, None, None],
+            [None, None, None]
+        ])
+        self.assertEqual(response_json["slopes"], [
+            [None, None, None],
+            [None, None, None],
+            [None, None, None]
+        ])
+
+
     def test_correlation_perfect_slope(self):
         self.client.force_authenticate(user=self.user)
         for i, rating in enumerate(self.ratings):

--- a/backend/tournesol/views/criteria_correlations.py
+++ b/backend/tournesol/views/criteria_correlations.py
@@ -1,9 +1,8 @@
 import numpy as np
-
-from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.generics import GenericAPIView
+from rest_framework.response import Response
 from scipy.stats import linregress
 
 from tournesol.models.ratings import ContributorRating
@@ -76,11 +75,15 @@ class ContributorCriteriaCorrelationsView(PollScopedViewMixin, GenericAPIView):
         serializer = ContributorCriteriaCorrelationsSerializer({
             "criterias": criterias,
             "correlations": [
-                [self.clean(getattr(linear_regressions[c1][c2], 'rvalue', None)) for c1 in criterias]
+                [self.clean(getattr(
+                    linear_regressions[c1][c2], 'rvalue', None
+                )) for c1 in criterias]
                 for c2 in criterias
             ],
             "slopes": [
-                [self.clean(getattr(linear_regressions[c1][c2], 'slope', None)) for c1 in criterias]
+                [self.clean(getattr(
+                    linear_regressions[c1][c2], 'slope', None
+                )) for c1 in criterias]
                 for c2 in criterias
             ],
         })


### PR DESCRIPTION
This fixes a bug that occured for me because I had version 1.7 of scipy. Although the bug does not occur anymore with scipy 1.8. I still think the fix is valuable because NaN values may occur for yet unforseen reasons.