### PR TITLE
Fix Chip position when a criteria is skipped

### DIFF
--- a/frontend/src/features/comparisons/CriteriaSlider.tsx
+++ b/frontend/src/features/comparisons/CriteriaSlider.tsx
@@ -48,7 +48,9 @@ const CriteriaLabelWithTooltip = ({ children, criteria }: Props) => {
   const tooltip = getCriteriaTooltips(t, criteria) || '';
   return tooltip ? (
     <Tooltip title={tooltip} placement="top">
-      <Box sx={{ cursor: 'help' }}>{children}</Box>
+      <Box component="span" sx={{ cursor: 'help' }}>
+        {children}
+      </Box>
     </Tooltip>
   ) : (
     <>{children}</>
@@ -144,15 +146,13 @@ const CriteriaSlider = ({
           />
           <Typography fontSize={{ xs: '90%', sm: '100%' }}>
             <CriteriaLabel criteria={criteria} criteriaLabel={criteriaLabel} />
-            {criteriaValue === undefined ? (
+            {criteriaValue === undefined && (
               <Chip
                 component="span"
                 size="small"
                 label={t('comparison.criteriaSkipped')}
-                sx={{ height: '100%', ml: 2 }}
+                sx={{ height: '100%', ml: 1 }}
               />
-            ) : (
-              ''
             )}
           </Typography>
           <Box component="span" flexGrow={1} />


### PR DESCRIPTION
The `Chip` was displayed on a new line when a Tooltip was defined on the criteria

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/4726554/161507180-6c99b70c-9c9c-4f9f-b528-a3325df39028.png)|![image](https://user-images.githubusercontent.com/4726554/161507327-e3aa2136-1633-4b8d-b505-d236f0890ecb.png)

