### PR TITLE
[front] feat: add climate analysis tools in the comparison helper

### DIFF
--- a/frontend/src/features/comparisons/ComparisonHelperPresidentielle2022.tsx
+++ b/frontend/src/features/comparisons/ComparisonHelperPresidentielle2022.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-import { Typography, Link, Box } from '@mui/material';
+import { Typography, Link, Box, Grid } from '@mui/material';
 import { getAllCandidates } from 'src/utils/polls/presidentielle2022';
 import { Entity } from 'src/services/openapi';
 
@@ -19,91 +19,127 @@ const ComparisonHelperPresidentielle2022 = () => {
     });
   }, []);
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', p: 3 }}>
-      <Typography variant="h3">Aide pour effectuer les comparaisons</Typography>
-      <Typography paragraph>
-        Si vous ne connaissez pas suffisemment bien les candidats et leur
-        programmes, nous (l&apos;Association Tournesol) vous proposons les
-        differentes sources d&apos;information ci-dessous que nous avons
-        trouvées utiles.
-      </Typography>
-
-      <Typography variant="h4">
-        Les site web officiels des candidats:
-      </Typography>
-      <ul>
-        {' '}
-        {candidates.map(
-          ({ metadata }) =>
-            metadata && (
+    <>
+      <Box sx={{ backgroundColor: '#eee', p: 3 }}>
+        <Typography variant="h3">
+          Aide pour effectuer les comparaisons
+        </Typography>
+      </Box>
+      <Box sx={{ display: 'flex', flexDirection: 'column', p: 3 }}>
+        <Typography paragraph>
+          Si vous ne connaissez pas suffisemment bien les candidat.es et leurs
+          programmes, nous (l&apos;Association Tournesol) vous proposons
+          ci-dessous differentes sources d&apos;information que nous avons
+          trouvées utiles.
+        </Typography>
+        <Grid container justifyContent="space-between">
+          <Grid item>
+            <Typography variant="h4" color="secondary">
+              Sites web officiels des candidat.es
+            </Typography>
+            <ul>
+              {' '}
+              {candidates.map(
+                ({ metadata }) =>
+                  metadata && (
+                    <li>
+                      <Link
+                        color="text.secondary"
+                        href={metadata.website_url}
+                        rel="noopener"
+                        target="_blank"
+                      >
+                        {metadata.name}
+                      </Link>
+                    </li>
+                  )
+              )}
+            </ul>
+          </Grid>
+          <Grid item>
+            <Typography variant="h6">📰 Comparateurs de programmes</Typography>
+            <ul>
               <li>
                 <Link
                   color="text.secondary"
-                  href={metadata.website_url}
+                  href="https://www.lemonde.fr/les-decodeurs/article/2022/02/16/election-presidentielle-2022-comparez-les-programmes-des-principaux-candidats_6113964_4355770.html"
                   rel="noopener"
                   target="_blank"
                 >
-                  {metadata.name}
+                  Du journal Le Monde
                 </Link>
               </li>
-            )
-        )}
-      </ul>
-      <Typography variant="h4">Des comparateurs de programmes:</Typography>
-      <ul>
-        <li>
-          <Link
-            color="text.secondary"
-            href="https://www.lemonde.fr/les-decodeurs/article/2022/02/16/election-presidentielle-2022-comparez-les-programmes-des-principaux-candidats_6113964_4355770.html"
-            rel="noopener"
-            target="_blank"
-          >
-            Du journal Le Monde
-          </Link>
-        </li>
-        <li>
-          <Link
-            color="text.secondary"
-            href="https://www.humanite.fr/comparateur-des-programmes-presidentielle-2022"
-            rel="noopener"
-            target="_blank"
-          >
-            Du journal l&apos;Humanité
-          </Link>
-        </li>
-        <li>
-          <Link
-            color="text.secondary"
-            href="https://comparateur-programmes.lefigaro.fr/"
-            rel="noopener"
-            target="_blank"
-          >
-            Du journal Le Figaro
-          </Link>
-        </li>
-      </ul>
-      <Typography variant="h4">Les articles de Wikipedia:</Typography>
-      <ul>
-        {' '}
-        {candidates.map(
-          ({ metadata }) =>
-            metadata && (
               <li>
                 <Link
                   color="text.secondary"
-                  href={`https://fr.wikipedia.org/wiki/${encodeURIComponent(
-                    metadata.frwiki_title
-                  )}`}
+                  href="https://www.humanite.fr/comparateur-des-programmes-presidentielle-2022"
                   rel="noopener"
                   target="_blank"
                 >
-                  {metadata.name}
+                  Du journal l&apos;Humanité
                 </Link>
               </li>
-            )
-        )}
-      </ul>
-    </Box>
+              <li>
+                <Link
+                  color="text.secondary"
+                  href="https://comparateur-programmes.lefigaro.fr/"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  Du journal Le Figaro
+                </Link>
+              </li>
+            </ul>
+            <Typography variant="h6">🌳 Analyses des mesures climat</Typography>
+            <ul>
+              <li>
+                <Link
+                  color="text.secondary"
+                  href="https://reseauactionclimat.org/presidentielle-candidats-climat/"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  par le Réseau Action Climat France
+                </Link>
+              </li>
+              <li>
+                <Link
+                  color="text.secondary"
+                  href="https://presidentielle2022.theshifters.org/decryptage/"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  par The Shifters
+                </Link>
+              </li>
+            </ul>
+          </Grid>
+        </Grid>
+        <Typography variant="h4" color="secondary">
+          Pages Wikipedia des candidat.es
+        </Typography>
+        <ul>
+          {' '}
+          {candidates.map(
+            ({ metadata }) =>
+              metadata && (
+                <li>
+                  <Link
+                    color="text.secondary"
+                    href={`https://fr.wikipedia.org/wiki/${encodeURIComponent(
+                      metadata.frwiki_title
+                    )}`}
+                    rel="noopener"
+                    target="_blank"
+                  >
+                    {metadata.name}
+                  </Link>
+                </li>
+              )
+          )}
+        </ul>
+      </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
This pull request adds a `Analyses des mesures climat` section in the comparison helper component.

It also:
- makes the text more compact on desktop, using two columns Grid
- adds a bit of CSS to make the component more welcoming
- makes the titles gender-friendly

![screencapture-localhost-3000-presidentielle2022-comparison-2022-04-04-10_58_21](https://user-images.githubusercontent.com/39056254/161510110-9211f492-1dc6-44c4-8ec2-6989595127c7.png)