### PR TITLE
[front] fix: prevent comparison to be submitted several times in row

### DIFF
--- a/frontend/src/features/comparisons/ComparisonSliders.tsx
+++ b/frontend/src/features/comparisons/ComparisonSliders.tsx
@@ -47,6 +47,7 @@ const ComparisonSliders = ({
   const classes = useStyles();
   const { criteriaByName, criterias } = useCurrentPoll();
   const isMounted = useRef(true);
+  const [disableSubmit, setDisableSubmit] = useState(false);
 
   const castToComparison = (c: ComparisonRequest | null): ComparisonRequest => {
     return c
@@ -84,7 +85,10 @@ const ComparisonSliders = ({
   }, []);
 
   const submitComparison = async () => {
+    setDisableSubmit(true);
     await submit(comparison);
+    setDisableSubmit(false);
+
     // avoid a "memory leak" warning if the component is unmounted on submit.
     if (isMounted.current) {
       setSubmitted(true);
@@ -205,6 +209,7 @@ const ComparisonSliders = ({
           )}
         </Box>
         <Button
+          disabled={disableSubmit}
           variant="contained"
           color="primary"
           size="large"

--- a/frontend/src/features/comparisons/ComparisonSliders.tsx
+++ b/frontend/src/features/comparisons/ComparisonSliders.tsx
@@ -86,8 +86,12 @@ const ComparisonSliders = ({
 
   const submitComparison = async () => {
     setDisableSubmit(true);
-    await submit(comparison);
-    setDisableSubmit(false);
+
+    try {
+      await submit(comparison);
+    } finally {
+      setDisableSubmit(false);
+    }
 
     // avoid a "memory leak" warning if the component is unmounted on submit.
     if (isMounted.current) {


### PR DESCRIPTION
This pull request prevents a single comparison to be submitted a second time before the first request has been fully processed by the back end.

This will greatly reduce the nuisance power of the submit button, and will very very very slightly reduce the number of requests sent to the back end. 