### PR TITLE
emails: Use convert_html_to_text directly and encode link text

### DIFF
--- a/backend/core/templates/accounts/register/body.html
+++ b/backend/core/templates/accounts/register/body.html
@@ -3,6 +3,6 @@
 <html>
 <body>
 <p>{% translate "Please verify your Tournesol account by clicking on this link:" %}</p>
-<p><a href="{{ verification_url | safe }}">{{ verification_url | safe }}</a></p>
+<p><a href="{{ verification_url | safe }}">{{ verification_url }}</a></p>
 </body>
 </html>

--- a/backend/core/templates/accounts/register_email/body.html
+++ b/backend/core/templates/accounts/register_email/body.html
@@ -12,7 +12,7 @@ If this wasn't you, please just ignore this email.
 {% else %}
 <p>{% blocktranslate %}You can verify the email {{ email }} by clicking on this link:{% endblocktranslate %}<p>
 <br>
-<p><a href="{{ verification_url | safe }}">{{ verification_url | safe }}</a></p>
+<p><a href="{{ verification_url | safe }}">{{ verification_url }}</a></p>
 {% endif %}
 </body>
 </html>

--- a/backend/core/templates/accounts/reset_password/body.html
+++ b/backend/core/templates/accounts/reset_password/body.html
@@ -6,6 +6,6 @@
 {% translate "You can reset your password on Tournesol by clicking on this link:" %}
 </p>
 
-<p><a href="{{ verification_url | safe }}">{{ verification_url | safe }}</a></p>
+<p><a href="{{ verification_url | safe }}">{{ verification_url }}</a></p>
 </body>
 </html>

--- a/backend/core/utils/converters.py
+++ b/backend/core/utils/converters.py
@@ -1,7 +1,0 @@
-from rest_registration.utils.html import convert_html_to_text_preserving_urls
-
-
-def html_to_text(value: str):
-    text = convert_html_to_text_preserving_urls(value)
-    # Workaround buggy conversion from "&timestamp" to "×tamp"
-    return text.replace("×", "&times")

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -103,7 +103,7 @@ REST_REGISTRATION = {
         "html_body": "accounts/reset_password/body.html",
         "subject": "accounts/reset_password/subject.txt",
     },
-    "VERIFICATION_EMAIL_HTML_TO_TEXT_CONVERTER": "core.utils.converters.html_to_text",
+    "VERIFICATION_EMAIL_HTML_TO_TEXT_CONVERTER": "rest_registration.utils.html.convert_html_to_text",
 }
 
 EMAIL_BACKEND = server_settings.get(


### PR DESCRIPTION
Following #792 
It should help in some cases where the validation link is rendered as decoded html