### PR TITLE
[back] perf: prevent extra queries per row in the poll admin UI

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ django-filter==2.4.0
 django-oauth-toolkit==1.7.0
 django-prometheus==2.2.0
 django-rest-registration==0.7.0
+django-sql-utils==0.6.1
 djangorestframework==3.13.1
 drf-spectacular==0.21.2
 fuzzysearch==0.7.3

--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -5,6 +5,7 @@ Administration interface of the `tournesol` app
 from django.contrib import admin
 from django.contrib.admin.filters import SimpleListFilter
 from django.db.models import Count, Q, QuerySet
+from sql_util.utils import SubqueryCount
 
 from .models import (
     Comparison,
@@ -235,11 +236,11 @@ class PollAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         qst = super().get_queryset(request)
-        qst = qst.annotate(_n_criteria=Count("criterias", distinct=True))
-        qst = qst.annotate(_n_comparisons=Count("comparisons", distinct=True))
+        qst = qst.annotate(_n_criteria=SubqueryCount("criterias"))
+        qst = qst.annotate(_n_comparisons=SubqueryCount("comparisons"))
         qst = qst.annotate(
-            _n_comparisons_per_criteria=Count(
-                "comparisons__criteria_scores", distinct=True
+            _n_comparisons_per_criteria=SubqueryCount(
+                "comparisons__criteria_scores"
             )
         )
         return qst

--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -1,5 +1,5 @@
 """
-Defines Tournesol's backend admin interface
+Administration interface of the `tournesol` app
 """
 
 from django.contrib import admin
@@ -226,31 +226,40 @@ class PollAdmin(admin.ModelAdmin):
         'name',
         'algorithm',
         'entity_type',
-        'get_n_criterias',
+        'get_n_criteria',
         'get_n_comparisons',
         'get_n_comparisons_per_criteria',
     )
-    list_filter = (
-        'algorithm',
-        'entity_type'
-    )
+    list_filter = ("algorithm", "entity_type")
     inlines = (CriteriasInline,)
 
-    @admin.display(description="# criterias")
-    def get_n_criterias(self, obj):
-        return obj.criterias.count()
+    def get_queryset(self, request):
+        qst = super().get_queryset(request)
+        qst = qst.annotate(_n_criteria=Count("criterias", distinct=True))
+        qst = qst.annotate(_n_comparisons=Count("comparisons", distinct=True))
+        qst = qst.annotate(
+            _n_comparisons_per_criteria=Count(
+                "comparisons__criteria_scores", distinct=True
+            )
+        )
+        return qst
 
-    @admin.display(description="# comparisons")
+    @admin.display(description="# criterias", ordering="-_n_criteria")
+    def get_n_criteria(self, obj):
+        return obj._n_criteria
+
+    @admin.display(description="# comparisons", ordering="-_n_comparisons")
     def get_n_comparisons(self, obj):
-        return obj.comparisons.count()
+        return obj._n_comparisons
 
-    @admin.display(description="# comparisons (x criteria)")
+    @admin.display(
+        description="# comparisons (x criteria)",
+        ordering="-_n_comparisons_per_criteria",
+    )
     def get_n_comparisons_per_criteria(self, obj):
-        return obj.comparisons.aggregate(Count("criteria_scores"))['criteria_scores__count']
+        return obj._n_comparisons_per_criteria
 
 
 @admin.register(Criteria)
 class CriteriaAdmin(admin.ModelAdmin):
-    inlines = (
-        CriteriaLocalesInline,
-    )
+    inlines = (CriteriaLocalesInline,)

--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -4,7 +4,7 @@ Administration interface of the `tournesol` app
 
 from django.contrib import admin
 from django.contrib.admin.filters import SimpleListFilter
-from django.db.models import Count, Q, QuerySet
+from django.db.models import Q, QuerySet
 from sql_util.utils import SubqueryCount
 
 from .models import (


### PR DESCRIPTION
### option A

Using Django only with the strategy `Count(..., dinstinct=True)`

```python
    def get_queryset(self, request):
        qst = super().get_queryset(request)
        qst = qst.annotate(_n_criteria=Count("criterias", distinct=True))
        qst = qst.annotate(_n_comparisons=Count("comparisons", distinct=True))
        qst = qst.annotate(
            _n_comparisons_per_criteria=Count(
                "comparisons__criteria_scores", distinct=True
            )
        )
        return qst
```

Generates the following SQL query (with three expensive `LEFT OUTER JOIN`):

```sql
SELECT 
  "tournesol_poll"."id", 
  "tournesol_poll"."name", 
  "tournesol_poll"."entity_type", 
  "tournesol_poll"."algorithm", 
  COUNT(
    DISTINCT "tournesol_criteriarank"."criteria_id"
  ) AS "_n_criteria", 
  COUNT(
    DISTINCT "tournesol_comparison"."id"
  ) AS "_n_comparisons", 
  COUNT(
    DISTINCT "tournesol_comparisoncriteriascore"."id"
  ) AS "_n_comparisons_per_criteria" 
FROM 
  "tournesol_poll" 
  LEFT OUTER JOIN "tournesol_criteriarank" ON (
    "tournesol_poll"."id" = "tournesol_criteriarank"."poll_id"
  ) 
  LEFT OUTER JOIN "tournesol_comparison" ON (
    "tournesol_poll"."id" = "tournesol_comparison"."poll_id"
  ) 
  LEFT OUTER JOIN "tournesol_comparisoncriteriascore" ON (
    "tournesol_comparison"."id" = "tournesol_comparisoncriteriascore"."comparison_id"
  ) 
GROUP BY 
  "tournesol_poll"."id", 
  descending = True;
```

### Option B

Using an extra package `django-sql-utils` (see: https://github.com/martsberger/django-sql-utils)

```python
        qst = super().get_queryset(request)
        qst = qst.annotate(_n_criteria=SubqueryCount("criterias"))
        qst = qst.annotate(_n_comparisons=SubqueryCount("comparisons"))
        qst = qst.annotate(
            _n_comparisons_per_criteria=SubqueryCount(
                "comparisons__criteria_scores"
            )
        )
        return qst
```

Generated the following SQL query, without `JOIN`:

```sql
EXPLAIN ANALYZE SELECT 
  "tournesol_poll"."id", 
  "tournesol_poll"."name", 
  "tournesol_poll"."entity_type", 
  "tournesol_poll"."algorithm", 
  COALESCE(
    (
      SELECT 
        COUNT(U0."criteria_id") AS "aggregation" 
      FROM 
        "tournesol_criteriarank" U0 
      WHERE 
        U0."poll_id" = ("tournesol_poll"."id") 
      GROUP BY 
        U0."poll_id"
    ), 
    0
  ) AS "_n_criteria", 
  COALESCE(
    (
      SELECT 
        COUNT(U0."id") AS "aggregation" 
      FROM 
        "tournesol_comparison" U0 
      WHERE 
        U0."poll_id" = ("tournesol_poll"."id") 
      GROUP BY 
        U0."poll_id"
    ), 
    0
  ) AS "_n_comparisons", 
  COALESCE(
    (
      SELECT 
        COUNT(U0."id") AS "aggregation" 
      FROM 
        "tournesol_comparisoncriteriascore" U0 
        INNER JOIN "tournesol_comparison" U1 ON (U0."comparison_id" = U1."id") 
      WHERE 
        U1."poll_id" = ("tournesol_poll"."id") 
      GROUP BY 
        U1."poll_id"
    ), 
    0
  ) AS "_n_comparisons_per_criteria" 
FROM 
  "tournesol_poll";
```

### Comparison

A table with the execution time in ms of the option A and B, measured on my laptop directly in PostgreSQL with the `EXPLAIN ANALYZE`.


| run | option A (ms) | option B (ms) |
|-----|-------------|-----------|
| 1   | 708.543     | 38.699    | 
| 2   | 729.329     | 36.874    | 
| 3   | 926.469     | 41.210    | 
| 4   | 762.857     | 35.282    | 

Note that it seems to be possible to have the same performance as B without installing an extra package by doing few somersaults with `Subquery` + `OuterRef` + `order_by` + `values` + `annotate` + `values` again + `Coalesce`. This could be the **option C**.

The following example, without an extra package:

```python
subquery = Subquery(Child.objects.filter(parent_id=OuterRef('id')).order_by()
                    .values('parent').annotate(count=Count('pk'))
                    .values('count'), output_field=IntegerField())
Parent.objects.annotate(child_count=Coalesce(subquery, 0))
```

is equivalent to the `django-sql-utils` version (equivalent according to `django-sql-utils` )

```python
Parent.objects.annotate(child_count=SubqueryCount('child'))
```

That's it!

With this package:
- we have a ~ 15/20 times faster SQL query in the Poll admin (compared to my original proposition)
- according to the Chromium developer tools, the loading time of the Poll admin in this branch is equivalent to the loading time of the Poll admin on `main`
- this is not very relevant because we don't have performance issue in the Poll admin
- but might be relevant in the future as the loading time will increase faster on `main` the more we add polls
- also the `SubqueryCount` may be useful elsewhere in the admin, on in the API
- we don't need to think about potential performance issue the day we will have dozen of active polls
- and it allows to order the column `# comparisons`, `# criteria` and `# comparisons (x criteria)`

What do you think @amatissart ? do you think it's a reasonable trade off ?