### PR TITLE
[back] refactor: reset `user_burst` limit to 120/min instead of 1200

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -274,19 +274,8 @@ REST_FRAMEWORK = {
         "tournesol.throttling.SustainedUserRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": {
-        # TOFIX
-        #
-        # `user_burst` has been temporarily set to 1200 because the front end
-        # currently makes 1 request per video in its /comparisons/ page. The
-        # authenticated users are able to make up to 21 requests for each
-        # click on the pagintion buttons, exceeding quickly the 120 limit.
-        #
-        # one option is to refactor the GET /users/me/comparisons/ view to
-        # include the video metadata in the response, allowing the users to
-        # get all comparisons + videos information in only one request
-        # default rates applied to all requests
         "anon_burst": "120/min",
-        "user_burst": "1200/min",
+        "user_burst": "120/min",
         "anon_sustained": "3600/hour",
         "user_sustained": "3600/hour",
         # specific rates for specific parts of the API

--- a/backend/settings/urls.py
+++ b/backend/settings/urls.py
@@ -20,12 +20,12 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_registration.api.urls import urlpatterns as original_registration_urlpatterns
 from rest_registration.api.views import register, register_email, send_reset_password_link
 
-from tournesol.throttling import EmailThrottle
+from tournesol.throttling import GlobalEmailScopeThrottle
 
 # Override throttle_classes on views defined by rest_registration
-register.cls.throttle_classes = [EmailThrottle]
-send_reset_password_link.cls.throttle_classes = [EmailThrottle]
-register_email.cls.throttle_classes = [EmailThrottle]
+register.cls.throttle_classes = [GlobalEmailScopeThrottle]
+send_reset_password_link.cls.throttle_classes = [GlobalEmailScopeThrottle]
+register_email.cls.throttle_classes = [GlobalEmailScopeThrottle]
 
 exclude_patterns = ["login", "logout"]
 filtered_registration_urls = [pattern for pattern in original_registration_urlpatterns if pattern.name not in exclude_patterns]

--- a/backend/tournesol/tests/test_api_user.py
+++ b/backend/tournesol/tests/test_api_user.py
@@ -6,7 +6,7 @@ from rest_framework.test import APIClient
 
 from core.models import EmailDomain, User
 from core.tests.factories.user import UserFactory
-from tournesol.throttling import EmailThrottle
+from tournesol.throttling import GlobalEmailScopeThrottle
 
 
 class UserDeletionTestCase(TestCase):
@@ -88,7 +88,7 @@ class UserRegistrationTest(TestCase):
             status_code=400
         )
 
-    @patch.object(EmailThrottle, "get_rate", new=lambda *_: "2/min")
+    @patch.object(GlobalEmailScopeThrottle, "get_rate", new=lambda *_: "2/min")
     def test_register_throttle(self):
         """
         Throttle should be triggered on the 3rd request

--- a/backend/tournesol/throttling.py
+++ b/backend/tournesol/throttling.py
@@ -8,7 +8,7 @@ from rest_framework.throttling import (
 
 class BurstAnonRateThrottle(AnonRateThrottle):
     """
-    Limit the rate of API calls that may be made by an anonymous users.
+    Limit the rate of API calls that may be made by an anonymous user.
 
     Should be used to define a rate for a short period of time.
     """
@@ -18,7 +18,7 @@ class BurstAnonRateThrottle(AnonRateThrottle):
 
 class BurstUserRateThrottle(UserRateThrottle):
     """
-    Limit the rate of API calls that may be made by an authenticated users.
+    Limit the rate of API calls that may be made by an authenticated user.
 
     Should be used to define a rate for a short period of time.
     """
@@ -28,7 +28,7 @@ class BurstUserRateThrottle(UserRateThrottle):
 
 class SustainedAnonRateThrottle(AnonRateThrottle):
     """
-    Limit the rate of API calls that may be made by an anonymous users.
+    Limit the rate of API calls that may be made by an anonymous user.
 
     Should be used in addition to `BurstAnonRateThrottle` to define a rate
     that can be sustained for a longer period.
@@ -39,7 +39,7 @@ class SustainedAnonRateThrottle(AnonRateThrottle):
 
 class SustainedUserRateThrottle(UserRateThrottle):
     """
-    Limit the rate of API calls that may be made by an authenticated users.
+    Limit the rate of API calls that may be made by an authenticated user.
 
     Should be used in addition to `BurstUserRateThrottle` to define a rate
     that can be sustained for a longer period.
@@ -50,8 +50,8 @@ class SustainedUserRateThrottle(UserRateThrottle):
 
 class PostScopeRateThrottle(ScopedRateThrottle):
     """
-    Limit the rate of only HTTP POST by different amounts for various parts
-    of the API.
+    Limit the rate of only HTTP POST requests made by an authenticated or
+    an anonymous user.
 
     All other HTTP methods are authorized, and passed to the next throttle
     in the chain.
@@ -63,10 +63,12 @@ class PostScopeRateThrottle(ScopedRateThrottle):
         return super().allow_request(request, view)
 
 
-class EmailThrottle(SimpleRateThrottle):
+class GlobalEmailScopeThrottle(SimpleRateThrottle):
     """
-    A global rate limit for account register, password reset, etc,
-    shared by all clients.
+    A global rate limit for POST requests involving email sending like the
+    account creations, password reset, etc.
+
+    This limit is shared by all clients.
     """
 
     scope = "email"


### PR DESCRIPTION
Also rename `EmailThrottle` into `GlobalEmailScopeThrottle` to make it clear to all developers that the limit is shared globally by all clients (contrary to the other throttles that don't use the world `Global` in their name).

It also fixes few typo made by the me of the past.