### PR TITLE
[infra] fix: prevent anonymous users to edit the Wiki

### DIFF
--- a/infra/ansible/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/infra/ansible/roles/mediawiki/templates/LocalSettings.php.j2
@@ -148,6 +148,20 @@ wfLoadSkin( 'Vector' );
 # End of automatically generated settings.
 # Add more configuration options below.
 
+#
+# start: Authorizations --
+# documentation:
+#   https://www.mediawiki.org/wiki/Manual:User_rights
+#   https://www.mediawiki.org/wiki/Manual:Preventing_access
+
+# disable anonymous editing
+$wgGroupPermissions['*']['edit'] = false;
+# prevent new user registrations except by sysops
+$wgGroupPermissions['*']['createaccount'] = false;
+
+# end: Authorizations --
+#
+
 wfLoadExtension( 'Babel' );
 
 wfLoadExtension( 'cldr' );


### PR DESCRIPTION
**related to** #205 and #557

---

This pull request makes the Wiki non-editable for the anonymous users.

My motivation comes from the fact that the current Wiki describes the Tournesol project, by giving precise information about the association, how criteria for videos were designed, the problems we are trying to solve, etc. This is more a documentation made by the association rather than a tool for the community to organize its knowledge.

To prevent any misinformation, I disabled the anonymous editing, and the possibility for anonymous users to create account (even if it was not working before, now the button is properly hidden).

As anonymous users are not able to edit anything, does this PR close the issue #205? @lfaucon 