### PR TITLE
[back] perf: speed-up Mehestan criteria processing with multiprocesses

### DIFF
--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -67,13 +67,9 @@ def update_user_scores(poll: Poll, user: User):
 def _run_mehestan_for_criterion(criteria: str, ml_input: MlInput, poll_pk: int):
     """
     Run Mehestan for the given criterion, in the given poll.
-
-    This function must not use any model instance as parameter, but instead
-    must query the database to retrieve the desired instances. This allows to
-    use this function in a forked process, without sharing database
-    connections with the parent process, which may lead to exceptions or
-    undesirable effects.
     """
+    # Retrieving the poll instance here allows this function to be run in a
+    # forked process. See the function `run_mehestan`.
     poll = Poll.objects.get(pk=poll_pk)
     logger.info(
         "Mehestan for poll '%s': computing scores for crit '%s'",
@@ -98,21 +94,31 @@ def _run_mehestan_for_criterion(criteria: str, ml_input: MlInput, poll_pk: int):
 
 
 def run_mehestan(ml_input: MlInput, poll: Poll):
+    """
+    This function use multiprocessing.
+
+        1. Always close all database connections in the main process before
+           creating forks. Django will automatically re-create new database
+           connections when needed.
+
+        2. Do not pass Django model's instances as arguments to the function
+           run by child processes. Using such instances in child processes
+           will raise an exception: connection already closed.
+
+        3. Do not fork the main process within a code block managed by
+           a single database transaction.
+
+    See the indications to close the database connections:
+        - https://www.psycopg.org/docs/usage.html#thread-and-process-safety
+        - https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT
+
+    See how django handles database connections:
+        - https://docs.djangoproject.com/en/4.0/ref/databases/#connection-management
+    """
     logger.info("Mehestan for poll '%s': Start", poll.name)
 
-    # This function use multiprocessing.
-    #
-    # Thus, the model instances used by the child processes MUST NOT come from
-    # the parent process. Child processes must autonomously retrieve the
-    # objects using their own database connection.
-    #
-    # See the indications to close the database connections before forking
-    # a process:
-    #   https://www.psycopg.org/docs/usage.html#thread-and-process-safety
-    #   https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT
-    #
-    # See how django handles database connections:
-    #   https://docs.djangoproject.com/en/4.0/ref/databases/#connection-management
+    # Avoid passing model's instances as arguments to the function run by the
+    # child processes. See this method docstring.
     poll_pk = poll.pk
     criteria = poll.criterias_list
 

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -63,7 +63,7 @@ def update_user_scores(poll: Poll, user: User):
 def run_mehestan(ml_input: MlInput, poll: Poll):
     logger.info("Mehestan for poll '%s': Start", poll.name)
 
-    def _process(criteria):
+    def _process(criteria: str):
         logger.info(
             "Mehestan for poll '%s': computing scores for crit '%s'",
             poll.name,
@@ -85,6 +85,7 @@ def run_mehestan(ml_input: MlInput, poll: Poll):
             criteria,
         )
 
+    # compute each criterion in parallel
     with Pool(processes=os.cpu_count() - 1) as pool:
         pool.imap_unordered(_process, poll.criterias_list)
 

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -120,7 +120,7 @@ def run_mehestan(ml_input: MlInput, poll: Poll):
 
     # compute each criterion in parallel
     with Pool(processes=max(1, os.cpu_count() - 1)) as pool:
-        for i in pool.imap_unordered(
+        for _ in pool.imap_unordered(
             partial(_run_mehestan_for_criterion, ml_input=ml_input, poll_pk=poll_pk),
             criteria,
         ):

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -1,4 +1,6 @@
 import logging
+import os
+from multiprocessing import Pool
 from typing import Optional
 
 import pandas as pd
@@ -60,7 +62,8 @@ def update_user_scores(poll: Poll, user: User):
 
 def run_mehestan(ml_input: MlInput, poll: Poll):
     logger.info("Mehestan for poll '%s': Start", poll.name)
-    for criteria in poll.criterias_list:
+
+    def _process(criteria):
         logger.info(
             "Mehestan for poll '%s': computing scores for crit '%s'",
             poll.name,
@@ -81,5 +84,9 @@ def run_mehestan(ml_input: MlInput, poll: Poll):
             poll.name,
             criteria,
         )
+
+    with Pool(processes=os.cpu_count() - 1) as pool:
+        pool.imap_unordered(_process, poll.criterias_list)
+
     save_tournesol_score_as_sum_of_criteria(poll)
     logger.info("Mehestan for poll '%s': Done", poll.name)

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -119,7 +119,7 @@ def run_mehestan(ml_input: MlInput, poll: Poll):
     os.register_at_fork(before=db.connections.close_all)
 
     # compute each criterion in parallel
-    with Pool(processes=os.cpu_count() - 1) as pool:
+    with Pool(processes=max(1, os.cpu_count() - 1)) as pool:
         for i in pool.imap_unordered(
             partial(_run_mehestan_for_criterion, ml_input=ml_input, poll_pk=poll_pk),
             criteria,

--- a/backend/ml/outputs.py
+++ b/backend/ml/outputs.py
@@ -84,16 +84,27 @@ def save_contributor_scores(
         for contributor_id, video_id, _, _, _ in scores_list
         if (contributor_id, video_id) not in rating_ids
     )
-    created_ratings = ContributorRating.objects.bulk_create(
-        ContributorRating(
-            poll_id=poll.pk,
-            entity_id=video_id,
-            user_id=contributor_id,
-        )
-        for contributor_id, video_id in ratings_to_create
+    ContributorRating.objects.bulk_create(
+        (
+            ContributorRating(
+                poll_id=poll.pk,
+                entity_id=video_id,
+                user_id=contributor_id,
+            )
+            for contributor_id, video_id in ratings_to_create
+        ),
+        ignore_conflicts=True,
     )
+    # Refresh the `ratings_id` with the newly created `ContributorRating`s.
     rating_ids.update(
-        {(rating.user_id, rating.entity_id): rating.id for rating in created_ratings}
+        {
+            (contributor_id, entity_id): rating_id
+            for rating_id, contributor_id, entity_id in ContributorRating.objects.filter(
+                poll_id=poll.pk,
+            ).values_list(
+                "id", "user_id", "entity_id"
+            )
+        }
     )
 
     scores_to_delete = ContributorRatingCriteriaScore.objects.filter(

--- a/backend/ml/outputs.py
+++ b/backend/ml/outputs.py
@@ -88,10 +88,10 @@ def save_contributor_scores(
         (
             ContributorRating(
                 poll_id=poll.pk,
-                entity_id=video_id,
+                entity_id=entity_id,
                 user_id=contributor_id,
             )
-            for contributor_id, video_id in ratings_to_create
+            for contributor_id, entity_id in ratings_to_create
         ),
         ignore_conflicts=True,
     )
@@ -99,9 +99,7 @@ def save_contributor_scores(
     rating_ids.update(
         {
             (contributor_id, entity_id): rating_id
-            for rating_id, contributor_id, entity_id in ContributorRating.objects.filter(
-                poll_id=poll.pk,
-            ).values_list(
+            for rating_id, contributor_id, entity_id in ratings.values_list(
                 "id", "user_id", "entity_id"
             )
         }

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 from django.db.models import ObjectDoesNotExist, Q
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -934,7 +934,7 @@ class ComparisonApiTestCase(TestCase):
         )
 
 
-class ComparisonWithMehestanTest(TestCase):
+class ComparisonWithMehestanTest(TransactionTestCase):
     def setUp(self):
         self.poll = PollFactory(algorithm=ALGORITHM_MEHESTAN)
         CriteriaRankFactory(poll=self.poll, criteria__name="criteria1")


### PR DESCRIPTION
It's just an idea, I haven't tested it yet against a big database.

### unexpected behaviour

**(1)**

There is currently a bug when running `python manage.py test` or `pytest` locally on my laptop, the following exceptions are raised by the test `ComparisonWithMehestanTest.test_update_individual_scores_after_new_comparison`:

```
psycopg2.OperationalError: SSL error: decryption failed or bad record mac
django.db.utils.OperationalError: SSL error: decryption failed or bad record mac
```

They may be related to this: https://code.djangoproject.com/ticket/31637

**(2)**

The `Pyscopg` documentation says the connection to the database must be created after forks.

> **libpq** connections [shouldn’t be used by a forked processes](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNECT), so when using a module such as [multiprocessing](https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing) or a forking web deploy method such as FastCGI make sure to create the connections after the fork.

See: https://www.psycopg.org/docs/usage.html#thread-and-process-safety

The `PostgreSQL` also warns about this

> **Warning** On Unix, forking a process with open libpq connections can lead to unpredictable results because the parent and child processes share the same sockets and operating system resources. For this reason, such usage is not recommended, though doing an exec from the child process to load a new executable is safe.

See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT

Note that according to the Django 4.0 documentation, the framework should automatically create a new connections when needed. Closing the connections before forking might allow Django to automatically re-create connections in the child processes.

See: https://docs.djangoproject.com/en/4.0/ref/databases/#connection-management

**(3)**

I'm currently investigating how to properly create a new database connection in each child processes.

It seems the `ml_train` works well if all connections are closed before forking and processing individually each criterion.

Still, the `ml_train` fails when it is run by `python manage.py test` or `pytest`, with the following exceptions:

```
psycopg2.InterfaceError: connection already closed
django.db.utils.InterfaceError: connection already closed
```

As Django should automatically create new connections when needed, I think the problem might come from the way the tests are run, i.e. with a single transaction for each test, which makes the multiprocessing code to complain.

**important notes** without closing the database before forking, the tests involving Mehestan failed only on my desktop, now they are failing even on the CI ( which is coherent ).

**(4)**

...