### PR TITLE
[back] sec: upgrate django to 4.0.4 (from 4.0.3)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.0.3
+Django==4.0.4
 django-computed-property==0.3.0
 django-cors-headers==3.11.0
 django-countries==7.2.1


### PR DESCRIPTION
It fixes two vulnerabilities and few bugs:
- CVE-2022-28346
- CVE-2022-28347

See the full release note: https://docs.djangoproject.com/en/4.0/releases/4.0.4/