### PR TITLE
[back] fix: possible email duplication

### DIFF
--- a/backend/core/locale/fr/LC_MESSAGES/django.po
+++ b/backend/core/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-05 15:08+0000\n"
+"POT-Creation-Date: 2022-04-14 09:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,14 +22,18 @@ msgstr ""
 msgid "email address"
 msgstr "adresse e-mail"
 
-#: core/serializers/user.py:18
+#: core/serializers/user.py:19
 #, python-format
 msgid "'%(name)s' is a reserved username"
 msgstr "'%(name)s' est un nom d'utilisateur reservé"
 
-#: core/serializers/user.py:20
+#: core/serializers/user.py:21
 msgid "'@' is not allowed in username"
 msgstr "Un nom d'utilisateur ne peut pas contenir '@'"
+
+#: core/serializers/user.py:39 core/serializers/user.py:59
+msgid "A user with this email address already exists."
+msgstr "Un utilisateur avec cet e-mail existe déjà."
 
 #: core/templates/accounts/register/body.html:5
 msgid "Please verify your Tournesol account by clicking on this link:"

--- a/backend/core/models/user.py
+++ b/backend/core/models/user.py
@@ -5,6 +5,7 @@ Defines Tournesol's User model and user preferences
 import logging
 
 from django.contrib.auth.models import AbstractUser
+from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import CheckConstraint, F, Func, Q, Value
@@ -243,6 +244,17 @@ class User(AbstractUser):
         _, domain_part = self.email.rsplit('@', 1)
         domain = f"@{domain_part}".lower()
         EmailDomain.objects.get_or_create(domain=domain)
+
+    def clean(self):
+        value = self.email
+
+        similar = User.objects.filter(email__iexact=value)
+        n_similar = similar.count()
+
+        if n_similar > 1:
+            raise ValidationError(_("A user with this email address already exists."))
+        elif n_similar == 1 and similar[0].pk != self.pk:
+            raise ValidationError(_("A user with this email address already exists."))
 
     def save(self, *args, **kwargs):
         update_fields = kwargs.get('update_fields')

--- a/backend/core/models/user.py
+++ b/backend/core/models/user.py
@@ -248,13 +248,12 @@ class User(AbstractUser):
     def clean(self):
         value = self.email
 
-        similar = User.objects.filter(email__iexact=value)
-        n_similar = similar.count()
+        similar_email = User.objects.filter(email__iexact=value).exclude(pk=self.pk)
 
-        if n_similar > 1:
-            raise ValidationError(_("A user with this email address already exists."))
-        elif n_similar == 1 and similar[0].pk != self.pk:
-            raise ValidationError(_("A user with this email address already exists."))
+        if similar_email.exists():
+            raise ValidationError(
+                {"email": _("A user with this email address already exists.")}
+            )
 
     def save(self, *args, **kwargs):
         update_fields = kwargs.get('update_fields')

--- a/backend/core/serializers/user.py
+++ b/backend/core/serializers/user.py
@@ -36,7 +36,7 @@ def validate_email_uniqueness_iexact(value: str) -> str:
     except User.DoesNotExist:
         pass
     else:
-        raise ValidationError("A user with this email address already exists.")
+        raise ValidationError(_("A user with this email address already exists."))
 
     return value
 
@@ -56,7 +56,7 @@ class RegisterEmailSerializer(DefaultRegisterEmailSerializer):
         validators=[
             UniqueValidator(
                 queryset=User.objects.all(),
-                message="A user with this email address already exists.",
+                message=_("A user with this email address already exists."),
                 lookup="iexact",
             ),
         ]

--- a/backend/core/serializers/user.py
+++ b/backend/core/serializers/user.py
@@ -23,7 +23,7 @@ def _validate_username(value):
 
 
 @wrap_validation_error_with_field("email")
-def validate_email_lower_uniqueness(value: str) -> str:
+def validate_email_uniqueness_iexact(value: str) -> str:
     """Raise an error if an email is considered already in use.
 
     Even if emails are considered case-sensitive by the RFC 5321, several
@@ -46,7 +46,7 @@ class RegisterUserSerializer(DefaultRegisterUserSerializer):
         return _validate_username(value)
 
     def validate(self, data):
-        validate_email_lower_uniqueness(data["email"])
+        validate_email_uniqueness_iexact(data["email"])
         super(RegisterUserSerializer, self).validate(data)
         return data
 
@@ -57,6 +57,7 @@ class RegisterEmailSerializer(DefaultRegisterEmailSerializer):
             UniqueValidator(
                 queryset=User.objects.all(),
                 message="A user with this email address already exists.",
+                lookup="iexact",
             ),
         ]
     )

--- a/backend/core/tests/test_api_accounts.py
+++ b/backend/core/tests/test_api_accounts.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-
 from rest_framework import status
 from rest_framework.test import APIClient
 

--- a/backend/core/tests/test_api_accounts.py
+++ b/backend/core/tests/test_api_accounts.py
@@ -1,0 +1,81 @@
+from django.test import TestCase
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.models.user import User
+from core.tests.factories.user import UserFactory
+
+
+class AccountsRegisterTestCase(TestCase):
+    """
+    TestCase of the /accounts/register/ API.
+
+    Even if this API is provided by a third-party package, its default
+    behaviour has been customized, and thus needs to be tested.
+    """
+    _existing_username = "existing"
+    _existing_email = "existing@example.org"
+    _existing_email_alt = "Existing@example.org"
+
+    _non_existing_username = "non-existing"
+    _non_existing_email = "non-existing@example.org"
+
+    def setUp(self):
+        self.client = APIClient()
+        self.existing_user = UserFactory(
+            username=self._existing_username, email=self._existing_email
+        )
+
+    def test_anon_cant_register_with_existing_email(self):
+        """
+        An anonymous user can't register with a variant of an email address
+        already in use.
+        """
+        n_users = User.objects.all().count()
+
+        # a user cannot use an email address already in use
+        invalid_payload = {
+            "username": self._non_existing_username,
+            "email": self._existing_email,
+            "password": "password",
+            "password_confirm": "password",
+        }
+        response = self.client.post(
+            "/accounts/register/",
+            invalid_payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.all().count(), n_users)
+
+        # a user cannot use a lower/upper variant of an email address already
+        # in use
+        invalid_payload = {
+            "username": self._non_existing_username,
+            "email": self._existing_email_alt,
+            "password": "password",
+            "password_confirm": "password",
+        }
+        response = self.client.post(
+            "/accounts/register/",
+            invalid_payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.all().count(), n_users)
+
+        # using a new email address is obviously valid
+        valid_payload = {
+            "username": self._non_existing_username,
+            "email": self._non_existing_email,
+            "password": "password",
+            "password_confirm": "password",
+        }
+        response = self.client.post(
+            "/accounts/register/",
+            valid_payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(User.objects.all().count(), n_users + 1)

--- a/backend/core/tests/test_api_accounts.py
+++ b/backend/core/tests/test_api_accounts.py
@@ -37,8 +37,8 @@ class AccountsRegisterTestCase(TestCase):
         invalid_payload = {
             "username": self._non_existing_username,
             "email": self._existing_email,
-            "password": "password",
-            "password_confirm": "password",
+            "password": "uncommon_password",
+            "password_confirm": "uncommon_password",
         }
         response = self.client.post(
             "/accounts/register/",
@@ -54,8 +54,8 @@ class AccountsRegisterTestCase(TestCase):
         invalid_payload = {
             "username": self._non_existing_username,
             "email": self._existing_email_alt,
-            "password": "password",
-            "password_confirm": "password",
+            "password": "uncommon_password",
+            "password_confirm": "uncommon_password",
         }
         response = self.client.post(
             "/accounts/register/",

--- a/backend/core/tests/test_api_accounts.py
+++ b/backend/core/tests/test_api_accounts.py
@@ -23,11 +23,11 @@ class AccountsRegisterTestCase(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.existing_user = UserFactory(
+        self.existing_user: User = UserFactory(
             username=self._existing_username, email=self._existing_email
         )
 
-    def test_anon_cant_register_with_existing_email(self):
+    def test_register_with_already_used_email(self) -> None:
         """
         An anonymous user can't register with a variant of an email address
         already in use.
@@ -47,6 +47,7 @@ class AccountsRegisterTestCase(TestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("email", response.data)
         self.assertEqual(User.objects.all().count(), n_users)
 
         # a user cannot use a lower/upper variant of an email address already
@@ -63,19 +64,59 @@ class AccountsRegisterTestCase(TestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("email", response.data)
         self.assertEqual(User.objects.all().count(), n_users)
 
         # using a new email address is obviously valid
         valid_payload = {
             "username": self._non_existing_username,
             "email": self._non_existing_email,
-            "password": "password",
-            "password_confirm": "password",
+            "password": "uncommon_password",
+            "password_confirm": "uncommon_password",
         }
         response = self.client.post(
             "/accounts/register/",
             valid_payload,
             format="json",
         )
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(User.objects.all().count(), n_users + 1)
+
+    def test_register_email_with_already_used_email(self) -> None:
+        """
+        An authenticated user can't register with a variant of an email
+        address already in use.
+        """
+        used_email = "also_used@example.org"
+        used_email_alt = "also_USED@example.org"
+
+        UserFactory(email=used_email)
+        self.client.force_authenticate(user=self.existing_user)
+
+        # a user cannot use an email address already in use
+        response = self.client.post(
+            "/accounts/register-email/",
+            {"email": used_email},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("email", response.data)
+
+        # a user cannot use a lower/upper variant of an email address already
+        # in use
+        response = self.client.post(
+            "/accounts/register-email/",
+            {"email": used_email_alt},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("email", response.data)
+
+        # using a new email address is obviously valid
+        response = self.client.post(
+            "/accounts/register-email/",
+            {"email": self._non_existing_email},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/backend/core/tests/test_reset_password.py
+++ b/backend/core/tests/test_reset_password.py
@@ -8,14 +8,14 @@ from core.tests.factories.user import UserFactory
 
 class TestPasswordReset(TestCase):
 
-    @patch("rest_registration.utils.verification.verify_signer_or_bad_request", new= lambda x:True)
+    @patch("rest_registration.utils.signers.DataSigner.verify", new=lambda x: True)
     def test_reset_password_force_user_activation(self):
         client = APIClient()
         user = UserFactory(is_active=False)
 
         resp = client.post("/accounts/reset-password/", data={
             "user_id": user.id,
-            "password": "new_password",
+            "password": "very_uncommon_pwd",
             "timestamp": 123,
             "signature": "abc",
         }, format="json")


### PR DESCRIPTION
This pull request prevents users to create several account by using lower/upper variant of the same email address.

The front end doesn't enforce using only lower case email addresses as some providers might use case sensitive ones. 

I also added a `clean()` method on the `User` model so that we cannot create inconsistencies from the admin interface.

**to-do**
- [x] make it work for `/accounts/register/`
- [x] make it work for `/accounts/register-email/` 
- [x] translate the message 
- [x] add tests
- [x] make the admin UI aware of this