### PR TITLE
chore: Upgrade minimist to >=1.2.6 in frontend and tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,6 +77,7 @@
     "fetch-mock-jest": "^1.5.1",
     "husky": "^7.0.1",
     "i18next-parser": "^5.3.0",
+    "minimist": ">=1.2.6",
     "openapi-typescript-codegen": "^0.19.0",
     "prettier": "^2.3.2",
     "react-test-renderer": "^17.0.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7132,7 +7132,7 @@ minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@>=1.2.6, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "@cypress/skip-test": "^2.6.1",
     "cypress": "^8.6.0",
+    "minimist": ">=1.2.6",
     "typescript": "^4.4.4"
   }
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -749,7 +749,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.5:
+minimist@>=1.2.6, minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
This was recommended as a critical security upgrade by dependabot