### PR TITLE
part 1/2 : score inconsistencies (next: cyclic inconsistencies) (#671)

### DIFF
--- a/backend/core/utils/constants.py
+++ b/backend/core/utils/constants.py
@@ -20,3 +20,9 @@ YOUTUBE_VIDEO_ID_REGEX_SYMBOL = "[A-Za-z0-9-_]"
 
 # The whole video ID
 YOUTUBE_VIDEO_ID_REGEX = rf"{YOUTUBE_VIDEO_ID_REGEX_SYMBOL}{{11}}"
+
+# Maximal absolute value for a rating [-100, 100]
+RATING_MAX = 100.0
+
+# Maximal absolute value for a comparison [-10, 10]
+COMPARISON_MAX = 10.0

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -288,10 +288,6 @@ REST_FRAMEWORK = {
     },
 }
 
-# Maximal value for a rating (0-100)
-# 0 means left video is best, 100 means right video is best
-MAX_VALUE = 100.0
-
 LEGACY_CRITERIAS = [
     'largely_recommended',
     'reliability',

--- a/backend/tournesol/models/comparisons.py
+++ b/backend/tournesol/models/comparisons.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.db.models import F, ObjectDoesNotExist, Q
 
 from core.models import User
+from core.utils.constants import COMPARISON_MAX
 
 from .poll import Poll
 
@@ -128,7 +129,7 @@ class ComparisonCriteriaScore(models.Model):
     )
     score = models.FloatField(
         help_text="Score for the given comparison",
-        validators=[MinValueValidator(-10.0), MaxValueValidator(10.0)],
+        validators=[MinValueValidator(-COMPARISON_MAX), MaxValueValidator(COMPARISON_MAX)],
     )
     # TODO: ask Lê if weights should be in a certain range (maybe always > 0)
     # and add validation if required

--- a/backend/tournesol/serializers/inconsistencies.py
+++ b/backend/tournesol/serializers/inconsistencies.py
@@ -1,0 +1,42 @@
+from rest_framework import serializers
+from rest_framework.serializers import Serializer
+
+
+class ScoreInconsistencySerializer(Serializer):
+    """
+    Serializer for one element
+    """
+
+    inconsistency = serializers.FloatField()
+    entity_1_uid = serializers.CharField()
+    entity_2_uid = serializers.CharField()
+    criteria = serializers.CharField()
+    comparison_score = serializers.FloatField()
+    entity_1_rating = serializers.FloatField()
+    entity_2_rating = serializers.FloatField()
+
+
+class ScoreInconsistenciesSerializer(Serializer):
+    """
+    Returns the score inconsistencies and related data.
+    Used from a dictionary, not a queryset.
+    The count is exhaustive, but the results list is truncated at 100 elements.
+    """
+    mean_inconsistency = serializers.FloatField()
+    count = serializers.IntegerField()
+    results = ScoreInconsistencySerializer(many=True)
+
+
+class ScoreInconsistenciesFilterSerializer(serializers.Serializer):
+
+    inconsistency_threshold = serializers.FloatField(
+        default=5.0,
+        help_text="Comparisons with an inconsistency score above this threshold are "
+                  "considered inconsistent and listed in the response (max. 100 responses)",
+    )
+
+    date_gte = serializers.DateTimeField(
+        default=None,
+        help_text="Restrict the search to entities created or edited after this date"
+                  "Accepted formats: ISO 8601 datetime (e.g `2021-12-01T12:45:00`) ",
+    )

--- a/backend/tournesol/serializers/inconsistencies.py
+++ b/backend/tournesol/serializers/inconsistencies.py
@@ -6,37 +6,45 @@ class ScoreInconsistencySerializer(Serializer):
     """
     Serializer for one element
     """
-
     inconsistency = serializers.FloatField()
+    criterion = serializers.CharField()
     entity_1_uid = serializers.CharField()
     entity_2_uid = serializers.CharField()
-    criteria = serializers.CharField()
     comparison_score = serializers.FloatField()
     entity_1_rating = serializers.FloatField()
     entity_2_rating = serializers.FloatField()
 
 
-class ScoreInconsistenciesSerializer(Serializer):
+class ScoreInconsistenciesStatsSerializer(Serializer):
     """
-    Returns the score inconsistencies and related data.
-    Used from a dictionary, not a queryset.
-    The count is exhaustive, but the results list is truncated at 100 elements.
+    Return some statistics for each criterion,
+    to be able to compare the results for the different criteria
     """
     mean_inconsistency = serializers.FloatField()
+    inconsistent_comparisons_count = serializers.IntegerField()
+    comparisons_count = serializers.IntegerField()
+
+
+class ScoreInconsistenciesSerializer(Serializer):
+    """
+    Returns the score inconsistencies and some statistics.
+    Used from a dictionary, not a queryset.
+    """
     count = serializers.IntegerField()
     results = ScoreInconsistencySerializer(many=True)
+    stats = serializers.DictField(child=ScoreInconsistenciesStatsSerializer(), label="criterion")
 
 
-class ScoreInconsistenciesFilterSerializer(serializers.Serializer):
+class ScoreInconsistenciesFilterSerializer(Serializer):
 
     inconsistency_threshold = serializers.FloatField(
         default=5.0,
         help_text="Comparisons with an inconsistency score above this threshold are "
-                  "considered inconsistent and listed in the response (max. 100 responses)",
+                  "considered inconsistent and listed in the response (max. 100 responses).",
     )
 
     date_gte = serializers.DateTimeField(
         default=None,
-        help_text="Restrict the search to entities created or edited after this date"
-                  "Accepted formats: ISO 8601 datetime (e.g `2021-12-01T12:45:00`) ",
+        help_text="Restrict the search to entities created or edited after this date.\n"
+                  "Accepted formats: ISO 8601 datetime (e.g `2021-12-01T12:45:00`).",
     )

--- a/backend/tournesol/serializers/inconsistencies.py
+++ b/backend/tournesol/serializers/inconsistencies.py
@@ -10,9 +10,10 @@ class ScoreInconsistencySerializer(Serializer):
     criterion = serializers.CharField()
     entity_1_uid = serializers.CharField()
     entity_2_uid = serializers.CharField()
-    comparison_score = serializers.FloatField()
     entity_1_rating = serializers.FloatField()
     entity_2_rating = serializers.FloatField()
+    comparison_score = serializers.FloatField()
+    expected_comparison_score = serializers.FloatField()
 
 
 class ScoreInconsistenciesStatsSerializer(Serializer):

--- a/backend/tournesol/tests/test_api_inconsistencies.py
+++ b/backend/tournesol/tests/test_api_inconsistencies.py
@@ -1,0 +1,387 @@
+import datetime
+from math import sqrt
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.tests.factories.user import UserFactory
+from tournesol.models import (
+    Comparison,
+    ComparisonCriteriaScore,
+    ContributorRating,
+    ContributorRatingCriteriaScore,
+    Poll,
+)
+from tournesol.tests.factories.comparison import ComparisonCriteriaScoreFactory, ComparisonFactory
+from tournesol.tests.factories.entity import EntityFactory
+from tournesol.tests.factories.poll import PollWithCriteriasFactory
+from tournesol.tests.factories.ratings import (
+    ContributorRatingCriteriaScoreFactory,
+    ContributorRatingFactory,
+)
+
+default_inconsistency_threshold = 5.0
+
+class ScoreInconsistenciesApiTestCase(TestCase):
+    """
+    TestCase of the Score Inconsistencies API.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+
+        self.user = UserFactory()
+        self.poll = Poll.default_poll()
+        self.criterion = self.poll.criterias_list[0]
+
+        self.url = f"/users/me/inconsistencies/score/{self.poll.name}"
+
+    def _create_comparison_and_rating(self,
+                                      rating_score_1=0.0,
+                                      rating_score_2=0.0,
+                                      uncertainty=0.0,
+                                      comparison_score=default_inconsistency_threshold + 1,
+                                      criterion=None,
+                                      user=None):
+        """
+        Creates a comparison, and the rating of both entities.
+        By default, to simplify, the ratings and uncertainty are set to 0.
+
+        comparison_score is set to (default_threshold + 1) by default, so that, with the
+        comparison imprecision, this will by default return an inconsistency
+        of (default_threshold + 0.5), and the comparison will be marked inconsistent.
+        """
+        if not criterion:
+            criterion = self.criterion
+
+        if not user:
+            user = self.user
+
+        entity_1 = EntityFactory()
+        entity_2 = EntityFactory()
+
+        comparison = ComparisonFactory(
+            poll=self.poll,
+            user=user,
+            entity_1=entity_1,
+            entity_2=entity_2,
+        )
+
+        ComparisonCriteriaScoreFactory(
+            comparison=comparison,
+            criteria=criterion,
+            score=comparison_score,
+        )
+
+        rating_1 = ContributorRatingFactory(user=user, entity=entity_1, poll=self.poll)
+        rating_2 = ContributorRatingFactory(user=user, entity=entity_2, poll=self.poll)
+
+        ContributorRatingCriteriaScoreFactory(
+            contributor_rating=rating_1,
+            criteria=criterion,
+            score=rating_score_1,
+            uncertainty=uncertainty,
+        )
+        ContributorRatingCriteriaScoreFactory(
+            contributor_rating=rating_2,
+            criteria=criterion,
+            score=rating_score_2,
+            uncertainty=uncertainty,
+        )
+
+
+    def test_only_for_authorized_users(self):
+        """An anonymous user can't access the score inconsistencies API"""
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+    def test_with_multiple_criteria(self):
+        """
+        Test with multiple criteria of the same comparison,
+        and verify the API output format.
+        """
+
+        self.client.force_authenticate(self.user)
+
+        entity1 = EntityFactory()
+        entity2 = EntityFactory()
+
+        comparison = ComparisonFactory(
+            poll=self.poll,
+            user=self.user,
+            entity_1=entity1,
+            entity_2=entity2,
+        )
+
+        rating_1 = ContributorRatingFactory(user=self.user, entity=entity1, poll=self.poll)
+        rating_2 = ContributorRatingFactory(user=self.user, entity=entity2, poll=self.poll)
+
+        comparison_score = default_inconsistency_threshold + 1
+        rating_1_score = 0.01
+        rating_2_score = 0.02
+
+        nb_criteria = len(self.poll.criterias_list)
+        self.assertGreater(nb_criteria, 1)
+        for criterion in self.poll.criterias_list:
+
+            ComparisonCriteriaScoreFactory(
+                comparison=comparison,
+                criteria=criterion,
+                score=comparison_score,
+            )
+
+            ContributorRatingCriteriaScoreFactory(
+                contributor_rating=rating_1,
+                criteria=criterion,
+                score=rating_1_score,
+                uncertainty=0,
+            )
+
+            ContributorRatingCriteriaScoreFactory(
+                contributor_rating=rating_2,
+                criteria=criterion,
+                score=rating_2_score,
+                uncertainty=0,
+            )
+
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], nb_criteria)
+        self.assertEqual(response.data["count"], len(response.data["results"]))
+
+        for dictionary in response.data["results"]:
+            self.assertTrue("inconsistency" in dictionary)
+            self.assertTrue("criteria" in dictionary)
+
+            self.assertTrue(dictionary["criteria"] in self.poll.criterias_list)
+
+            self.assertEqual(dictionary["entity_1_uid"], entity1.uid)
+            self.assertEqual(dictionary["entity_2_uid"], entity2.uid)
+            self.assertEqual(dictionary["comparison_score"], comparison_score)
+            self.assertEqual(dictionary["entity_1_rating"], rating_1_score)
+            self.assertEqual(dictionary["entity_2_rating"], rating_2_score)
+
+
+    def test_date_filter(self):
+        """Can filter old comparisons"""
+        self.client.force_authenticate(self.user)
+
+        self._create_comparison_and_rating()
+
+        tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
+        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+
+        response = self.client.get(
+            self.url + f"?date_gte={yesterday.isoformat()}",
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+        response = self.client.get(
+            self.url + f"?date_gte={tomorrow.isoformat()}",
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+
+    def test_threshold_filter(self):
+        """Can adjust the inconsistency threshold"""
+        self.client.force_authenticate(self.user)
+
+        self._create_comparison_and_rating()
+
+        response = self.client.get(
+            self.url + f"?inconsistency_threshold={default_inconsistency_threshold}",
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+        response = self.client.get(
+            self.url + f"?inconsistency_threshold={default_inconsistency_threshold + 1}",
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+
+    def test_uncertainty(self):
+        """
+        The effect of the uncertainty on the resulting inconsistency is complex,
+        but an uncertainty of 0.1 should be enough here to get below the inconsistency threshold.
+        """
+        self.client.force_authenticate(self.user)
+
+        self._create_comparison_and_rating(uncertainty = 0.1)
+
+        response = self.client.get(
+            self.url + f"?inconsistency_threshold={default_inconsistency_threshold}",
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+        self._create_comparison_and_rating()
+
+        response = self.client.get(
+            self.url + f"?inconsistency_threshold={default_inconsistency_threshold}",
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+
+    def test_ignore_other_polls(self):
+        """ Test the inconsistency calculation"""
+        self.client.force_authenticate(self.user)
+
+        self._create_comparison_and_rating()
+
+        request_poll = PollWithCriteriasFactory()
+
+        response = self.client.get(
+            f"/users/me/inconsistencies/score/{request_poll.name}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+
+    def test_ignore_other_contributors(self):
+        """ Test the inconsistency calculation"""
+        self.client.force_authenticate(self.user)
+
+        user = UserFactory()
+        self._create_comparison_and_rating(user=user)
+
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+
+    def test_results_order(self):
+        """
+        Test that the results are sorted by decreasing inconsistency
+        """
+        self.client.force_authenticate(self.user)
+        comparison_scores_list = [1, 10, 3, 5, 7, 3]
+        for comparison_score in comparison_scores_list:
+            self._create_comparison_and_rating(comparison_score=comparison_score)
+
+        response = self.client.get(self.url + "?inconsistency_threshold=0", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], len(comparison_scores_list))
+
+        inconsistencies_sum = 0
+        for index, comparison_score in enumerate(sorted(comparison_scores_list, reverse=True)):
+            inconsistency = response.data["results"][index]["inconsistency"]
+            inconsistencies_sum += inconsistency
+            self.assertAlmostEqual(inconsistency, comparison_score - 0.5)
+
+        self.assertAlmostEqual(response.data["mean_inconsistency"],
+                               inconsistencies_sum / len(comparison_scores_list))
+
+
+    def test_inconsistency_good_rating(self):
+        """
+        Verify the inconsistency for extremely good ratings.
+        The rating_difference can, in theory, take any value.
+        The inconsistency though should always be in [0,19.5[ with a comparison
+        score of 10 or -10, and in [0,9.5[ for a comparison score of 0.
+
+        It is 19.5 and 9.5 instead of 20 and 10 because if the comparison_imprecision
+        (comparison are made on integers, so they are implicitly rounded
+        to the nearest integer.)
+        """
+        self.client.force_authenticate(self.user)
+        extremely_good_rating = 10000.0
+
+        self._create_comparison_and_rating(comparison_score=10.0,
+                                           rating_score_2=extremely_good_rating)
+
+        response = self.client.get(self.url + "?inconsistency_threshold=0", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["inconsistency"], 0)
+
+        self._create_comparison_and_rating(comparison_score=0.0,
+                                           rating_score_2=extremely_good_rating)
+
+        response = self.client.get(self.url + "?inconsistency_threshold=0", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+        inconsistency = response.data["results"][0]["inconsistency"]
+        self.assertAlmostEqual(inconsistency, 9.5, places=4)
+
+        self._create_comparison_and_rating(comparison_score=-10.0,
+                                           rating_score_2=extremely_good_rating)
+
+        response = self.client.get(self.url + "?inconsistency_threshold=0", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 3)
+        inconsistency = response.data["results"][0]["inconsistency"]
+        self.assertAlmostEqual(inconsistency, 19.5, places=4)
+
+
+    def test_inconsistency_bad_rating(self):
+        """
+        Verify the inconsistency for extremely bad ratings.
+        The rating_difference can, in theory, take any value.
+        The inconsistency though should always be in [0,19.5[ with a comparison
+        score of 10 or -10, and in [0,9.5[ for a comparison score of 0.
+
+        It is 19.5 and 9.5 instead of 20 and 10 because if the comparison_imprecision
+        (comparison are made on integers, so they are implicitly rounded
+        to the nearest integer.)
+        """
+        self.client.force_authenticate(self.user)
+        extremely_bad_rating = -10000.0
+
+        self._create_comparison_and_rating(comparison_score=-10.0,
+                                           rating_score_2=extremely_bad_rating)
+
+        response = self.client.get(self.url + "?inconsistency_threshold=0", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["inconsistency"], 0)
+
+        self._create_comparison_and_rating(comparison_score=0.0,
+                                           rating_score_2=extremely_bad_rating)
+
+        response = self.client.get(self.url + "?inconsistency_threshold=0", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+        inconsistency = response.data["results"][0]["inconsistency"]
+        self.assertAlmostEqual(inconsistency, 9.5, places=4)
+
+        self._create_comparison_and_rating(comparison_score=10.0,
+                                           rating_score_2=extremely_bad_rating)
+
+        response = self.client.get(self.url + "?inconsistency_threshold=0", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 3)
+        inconsistency = response.data["results"][0]["inconsistency"]
+        self.assertAlmostEqual(inconsistency, 19.5, places=4)
+
+
+    def test_inconsistency_zero(self):
+        """
+        The inconsistency 0 can is obtained notably when
+        rating_difference = comparison_score / sqrt(100 - comparison_score²)
+        (with rating_difference = rating_2 - rating_1)
+        """
+        self.client.force_authenticate(self.user)
+
+        comparison_score = -6
+        rating_difference = comparison_score / sqrt(100 - comparison_score**2)
+        self._create_comparison_and_rating(comparison_score=comparison_score,
+                                          rating_score_2=rating_difference)
+
+        response = self.client.get(self.url + "?inconsistency_threshold=0", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["inconsistency"], 0)
+

--- a/backend/tournesol/tests/test_api_inconsistencies.py
+++ b/backend/tournesol/tests/test_api_inconsistencies.py
@@ -61,6 +61,9 @@ class ScoreInconsistenciesApiTestCase(TestCase):
         entity_1 = EntityFactory()
         entity_2 = EntityFactory()
 
+        rating_1 = ContributorRatingFactory(user=user, entity=entity_1, poll=self.poll)
+        rating_2 = ContributorRatingFactory(user=user, entity=entity_2, poll=self.poll)
+
         ComparisonCriteriaScoreFactory(
             comparison__poll=self.poll,
             comparison__user=user,
@@ -69,9 +72,6 @@ class ScoreInconsistenciesApiTestCase(TestCase):
             criteria=criterion,
             score=comparison_score,
         )
-
-        rating_1 = ContributorRatingFactory(user=user, entity=entity_1, poll=self.poll)
-        rating_2 = ContributorRatingFactory(user=user, entity=entity_2, poll=self.poll)
 
         ContributorRatingCriteriaScoreFactory(
             contributor_rating=rating_1,
@@ -104,15 +104,15 @@ class ScoreInconsistenciesApiTestCase(TestCase):
         entity1 = EntityFactory()
         entity2 = EntityFactory()
 
+        rating_1 = ContributorRatingFactory(user=self.user, entity=entity1, poll=self.poll)
+        rating_2 = ContributorRatingFactory(user=self.user, entity=entity2, poll=self.poll)
+
         comparison = ComparisonFactory(
             poll=self.poll,
             user=self.user,
             entity_1=entity1,
             entity_2=entity2,
         )
-
-        rating_1 = ContributorRatingFactory(user=self.user, entity=entity1, poll=self.poll)
-        rating_2 = ContributorRatingFactory(user=self.user, entity=entity2, poll=self.poll)
 
         comparison_score = default_inconsistency_threshold + 1
         rating_1_score = 0.01

--- a/backend/tournesol/tests/test_api_inconsistencies.py
+++ b/backend/tournesol/tests/test_api_inconsistencies.py
@@ -152,9 +152,11 @@ class ScoreInconsistenciesApiTestCase(TestCase):
             self.assertGreater(results["inconsistency"], default_inconsistency_threshold)
             self.assertEqual(results["entity_1_uid"], entity1.uid)
             self.assertEqual(results["entity_2_uid"], entity2.uid)
-            self.assertEqual(results["comparison_score"], comparison_score)
             self.assertEqual(results["entity_1_rating"], rating_1_score)
             self.assertEqual(results["entity_2_rating"], rating_2_score)
+            self.assertEqual(results["comparison_score"], comparison_score)
+            self.assertGreater(results["expected_comparison_score"], 0)
+            self.assertLess(results["expected_comparison_score"], 1)
 
         for criterion in self.poll.criterias_list:
             self.assertIn(criterion, response.data["stats"])
@@ -349,8 +351,7 @@ class ScoreInconsistenciesApiTestCase(TestCase):
     def test_inconsistency_bad_rating(self):
         """
         Verify the inconsistency for extremely bad ratings.
-        The rating_difference can, in theory, take any value.
-        The inconsistency though should always be in [0,19.5[ with a comparison
+        The inconsistency should always be in [0,19.5[ with a comparison
         score of 10 or -10, and in [0,9.5[ for a comparison score of 0.
 
         It is 19.5 and 9.5 instead of 20 and 10 because if the comparison_imprecision

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -16,6 +16,7 @@ from .views.criteria_correlations import ContributorCriteriaCorrelationsView
 from .views.email_domains import EmailDomainsList
 from .views.entities import EntitiesViewSet
 from .views.exports import ExportAllView, ExportComparisonsView, ExportPublicComparisonsView
+from .views.inconsistencies import ScoreInconsistencies
 from .views.polls import PollsCriteriaScoreDistributionView, PollsRecommendationsView, PollsView
 from .views.ratings import (
     ContributorRatingDetail,
@@ -91,6 +92,12 @@ urlpatterns = [
         "users/me/contributor_ratings/<str:poll_name>/<str:uid>/",
         ContributorRatingDetail.as_view(),
         name="ratings_me_detail",
+    ),
+    # Inconsistencies API
+    path(
+        "users/me/inconsistencies/score/<str:poll_name>",
+        ScoreInconsistencies.as_view(),
+        name="score_inconsistencies",
     ),
     # User recommendations API
     path(

--- a/backend/tournesol/views/inconsistencies.py
+++ b/backend/tournesol/views/inconsistencies.py
@@ -1,0 +1,177 @@
+from math import sqrt
+
+from django.db.models import ObjectDoesNotExist
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework.generics import GenericAPIView
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from tournesol.models import ComparisonCriteriaScore, ContributorRatingCriteriaScore
+from tournesol.serializers.inconsistencies import (
+    ScoreInconsistenciesFilterSerializer,
+    ScoreInconsistenciesSerializer,
+)
+from tournesol.views.mixins.poll import PollScopedViewMixin
+
+
+@extend_schema_view(
+    get=extend_schema(
+        parameters=[
+            ScoreInconsistenciesFilterSerializer,
+        ]
+    )
+)
+class ScoreInconsistencies(PollScopedViewMixin, GenericAPIView):
+    """
+    List the comparisons criteria for which the given score is very
+    different from what would be expected from both entities' criteria scores.
+    """
+
+    serializer_class = ScoreInconsistenciesSerializer
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        poll = self.poll_from_url
+        user = request.user
+
+        filter_serializer = ScoreInconsistenciesFilterSerializer(data=request.query_params)
+        filter_serializer.is_valid(raise_exception=True)
+        filters = filter_serializer.validated_data
+
+        contributor_comparisons_criteria = ComparisonCriteriaScore.objects.filter(
+            comparison__user=user,
+            comparison__poll=poll,
+        ).select_related("comparison")
+
+        if filters["date_gte"]:
+            contributor_comparisons_criteria = contributor_comparisons_criteria.filter(
+                comparison__datetime_lastedit__gte=filters["date_gte"]
+            )
+
+        ratings = ContributorRatingCriteriaScore.objects.filter(
+            contributor_rating__user=user,
+            contributor_rating__poll=poll,
+        ).select_related("contributor_rating")
+
+        comparisons_count = 0
+        inconsistency_sum = 0.0
+        inconsistencies_count = 0
+        inconsistent_criterion_comparisons = []
+
+        for comparison_criterion in contributor_comparisons_criteria:
+            comparisons_count += 1
+
+            entity_1 = comparison_criterion.comparison.entity_1
+            entity_2 = comparison_criterion.comparison.entity_2
+
+            try:
+                entity_1_rating = ratings.get(
+                    contributor_rating__entity=entity_1,
+                    criteria=comparison_criterion.criteria,
+                )
+                entity_2_rating = ratings.get(
+                    contributor_rating__entity=entity_2,
+                    criteria=comparison_criterion.criteria,
+                )
+            except ObjectDoesNotExist:
+                continue
+
+            uncertainty = entity_1_rating.uncertainty + entity_2_rating.uncertainty
+
+            inconsistency = self._calculate_inconsistency(entity_1_rating.score,
+                                                          entity_2_rating.score,
+                                                          comparison_criterion.score,
+                                                          uncertainty)
+
+            if inconsistency >= filters["inconsistency_threshold"]:
+                inconsistencies_count += 1
+                inconsistency_sum += inconsistency
+                criterion_comparison = {
+                    "inconsistency": inconsistency,
+                    "entity_1_uid": entity_1,
+                    "entity_2_uid": entity_2,
+                    "criteria": comparison_criterion.criteria,
+                    "comparison_score": comparison_criterion.score,
+                    "entity_1_rating": entity_1_rating.score,
+                    "entity_2_rating": entity_2_rating.score,
+                }
+                inconsistent_criterion_comparisons.append(criterion_comparison)
+
+        inconsistent_criterion_comparisons.sort(key=lambda d: d['inconsistency'], reverse=True)
+
+        # No need to return everything, return at most 100 elements
+        inconsistent_criterion_comparisons = inconsistent_criterion_comparisons[:100]
+
+        mean_inconsistency = 0
+        if comparisons_count > 0:
+            mean_inconsistency = inconsistency_sum / comparisons_count
+
+        response = {
+            "mean_inconsistency": mean_inconsistency,
+            "count": len(inconsistent_criterion_comparisons),
+            "results": inconsistent_criterion_comparisons,
+        }
+
+        return Response(ScoreInconsistenciesSerializer(response).data)
+
+    @staticmethod
+    def _calculate_inconsistency(entity_1_calculated_rating,
+                                 entity_2_calculated_rating,
+                                 comparison_score,
+                                 uncertainty):
+        """
+        Calculate the inconsistency between the comparison
+        criterion score and the general rating of the entity.
+
+        Let's note R the rating difference (rating2 - rating1),
+        r its variable counterpart, U the uncertainty and C the
+        comparison (positive if the 2nd entity is preferred).
+        Consider this function i:
+        i(r) = |C - 10r / sqrt(r² + 1)| (cf issue #671 discussion)
+        The inconsistency is the minimum of i(r) for r in [R - U, R + U]
+
+        The function i(r), is either:
+        1 - always increasing, if c <= -10 (normally, c is in [-10, 10])
+        2 - decreasing to 0, then increasing (because it is an absolute value)
+        3 - always decreasing, if c >= 10
+        So, the inconsistency is either i(R - U) in case 1, inconsistency(R + U)
+        in case 3, or 0 in case 2.
+        The value of R for which i(r) = 0 is C / sqrt(100 - C²), which
+        helps in case 2 to know if the minimum is 0 by checking if this root
+        is in [R - U, R + U].
+
+        There is also an imprecision of 0.5 on the comparison,
+        since the comparisons are made on floats and not integers,
+        which is subtracted on the result of the previous calculation.
+        """
+
+        base_rating_difference = entity_2_calculated_rating - entity_1_calculated_rating
+
+        def inconsistency_calculation(rating_difference):
+            return abs(comparison_score - 10 * rating_difference /
+                       sqrt((rating_difference**2) + 1))
+
+        min_rating_difference = base_rating_difference - uncertainty
+        max_rating_difference = base_rating_difference + uncertainty
+
+        if comparison_score <= -10:
+            min_inconsistency = inconsistency_calculation(min_rating_difference)
+        elif comparison_score >= 10:
+            min_inconsistency = inconsistency_calculation(max_rating_difference)
+        else:
+            root = comparison_score / sqrt(100 - comparison_score**2)
+            if max_rating_difference < root:
+                # The inconsistency is decreasing with the rating_difference
+                min_inconsistency = inconsistency_calculation(max_rating_difference)
+            elif root < min_rating_difference:
+                # The inconsistency is increasing with the rating_difference
+                min_inconsistency = inconsistency_calculation(min_rating_difference)
+            else:
+                # The root is a possible value for the rating_difference
+                min_inconsistency = 0
+
+        # Comparison imprecision of 0.5, because comparisons scores are on integers, not floats
+        inconsistency = max(min_inconsistency - 0.5, 0)
+
+        return inconsistency

--- a/backend/tournesol/views/inconsistencies.py
+++ b/backend/tournesol/views/inconsistencies.py
@@ -146,7 +146,6 @@ class ScoreInconsistencies(PollScopedViewMixin, GenericAPIView):
 
         return response
 
-
     @staticmethod
     def _calculate_inconsistency(entity_1_calculated_rating,
                                  entity_2_calculated_rating,


### PR DESCRIPTION
The score inconsistencies measure the difference between the rating scores calculated by the machine learning and the comparisons.

I decided to allow low threshold values (even 0), but to limit the number of results in the response to 100 (even if the count can get higher) to limit the size of the response.

A potential issue us that the machine learning rating scores may not have been updated with the latest comparisons. This is quite problematic that the ContributorRatingCriteriaScores can't be updated directly after each modification, which would also allow for quick feedback, notably in the contributor recommendations.

The next part is on cyclic inconsistencies, which is trickier in terms of algorithms and computation time.

Feel free to suggest corrections or improvements.