### PR TITLE
e2e extension: dismiss Youtube ad before checking 'Rate Later' button visibility

### DIFF
--- a/tests/cypress/integration/browser-extension/extension.spec.ts
+++ b/tests/cypress/integration/browser-extension/extension.spec.ts
@@ -35,9 +35,9 @@ onlyOn('headed', () => {
         cy.visit('https://www.youtube.com/watch?v=6jK9bFWE--g');
         consent();
         cy.get('body').then($body => {
-          if ($body.text().includes('dismiss')) {
+          if ($body.find("button:contains('Dismiss')") {
             // Dismiss Youtube Ad if present
-            cy.contains('button', 'dismiss', {matchCase: false}).click();
+            cy.contains('button', 'Dismiss', {matchCase: false}).click();
           }
           cy.contains('button', 'Rate later', {matchCase: false}).should('be.visible');
         })

--- a/tests/cypress/integration/browser-extension/extension.spec.ts
+++ b/tests/cypress/integration/browser-extension/extension.spec.ts
@@ -34,7 +34,13 @@ onlyOn('headed', () => {
       it('shows "Rate later" button on video page', () => {
         cy.visit('https://www.youtube.com/watch?v=6jK9bFWE--g');
         consent();
-        cy.contains('button', 'Rate later', {matchCase: false}).should('be.visible');
+        cy.get('body').then($body => {
+          if ($body.text().includes('dismiss')) {
+            // Dismiss Youtube Ad if present
+            cy.contains('button', 'dismiss', {matchCase: false}).click();
+          }
+          cy.contains('button', 'Rate later', {matchCase: false}).should('be.visible');
+        })
       })
     })
 })

--- a/tests/cypress/integration/browser-extension/extension.spec.ts
+++ b/tests/cypress/integration/browser-extension/extension.spec.ts
@@ -35,7 +35,7 @@ onlyOn('headed', () => {
         cy.visit('https://www.youtube.com/watch?v=6jK9bFWE--g');
         consent();
         cy.get('body').then($body => {
-          if ($body.find("button:contains('Dismiss')") {
+          if ($body.find("button:contains('Dismiss')").length > 0) {
             // Dismiss Youtube Ad if present
             cy.contains('button', 'Dismiss', {matchCase: false}).click();
           }


### PR DESCRIPTION
This is an attempt to workaround the regular failures observed on GitHub CI, during the tests of the browser extension.  
Due to a banner visible on Youtube US in some cases, the "rate later" button could be hidden.

In this PR, we are trying to "dismiss" this banner if it's present
![image](https://user-images.githubusercontent.com/4726554/164054779-33aaa5f7-e370-4aa7-aa77-7012542f0edd.png)
