### PR TITLE
[back] feat: allow case insensitive login with email

### DIFF
--- a/backend/core/oauth_validator.py
+++ b/backend/core/oauth_validator.py
@@ -37,6 +37,8 @@ class CustomOAuth2Validator(OAuth2Validator):
             except ObjectDoesNotExist:
                 try:
                     user = user_model.objects.get(email__iexact=username)
+                except ObjectDoesNotExist:
+                    return False
                 except user_model.MultipleObjectsReturned:
                     return False
 

--- a/tests/cypress/integration/frontend/login.ts
+++ b/tests/cypress/integration/frontend/login.ts
@@ -28,4 +28,17 @@ describe('Login', () => {
     cy.contains('Logout').click();
     cy.contains('Log in').should('be.visible');
   })
+
+  it('can login with lower/upper email variant and logout', () => {
+    cy.visit('/');
+    cy.contains('Log in').click();
+    cy.location('pathname').should('equal', '/login');
+    cy.focused().type('USER1@tournesol.app');
+    cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+    cy.location('pathname').should('equal', '/');
+    cy.contains('.MuiToolbar-root', 'user1').should('be.visible');
+    cy.contains('Log in').should('not.exist');
+    cy.contains('Logout').click();
+    cy.contains('Log in').should('be.visible');
+  })
 })


### PR DESCRIPTION
**related to** https://github.com/tournesol-app/tournesol/issues/811

follows the work of #812

---

The new login strategy is the following:
- consider the input as a username, try to fetch the user by username
- if no user is found, and a `@` is present in the username, try to fetch the user by email
  - email are matched case insensitively **(new)**
  - if no user is found, or if several users are found (inconsistent database), return bad credentials

I wanted to add a test directly in the back end, to be sure the `/o/token` endpoint correctly returns a token when a user tries to login with a lower/upper variant of its email, and to cover our `CustomOAuth2Validator` code. But to save a bit of time to work on the new presidentielle features I finally added an end-to-end test.

The request I wanted to test was the following (and I currently don't know how to imitate the `-u` of `curl` with the DRF test client):

```shell
curl -X POST -d "grant_type=password&username=<username>&password=<password>" -u "<client_id>:<client_secret>" http://localhost:8000/o/token/
```

I think I'll add this test later: it will be faster than end-to-end tests and will allow us to easily test different use cases.

### further improvements

The reset password feature should also be case insensitive.

**to-do**
- [x] add tests
- [ ] something else?