### PR TITLE
Set cache headers to avoid stale version of the app or translations being loaded

### DIFF
--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -9,9 +9,12 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
-map $sent_http_content_type $expires {
-    default     off;
-    text/html   0;
+map $sent_http_content_type $frontend_expires {
+    default             off;
+    # index page (html), and translations (json) should be
+    # revalidated on every visit.
+    text/html           0;
+    application/json    0;
 }
 
 server {
@@ -29,7 +32,7 @@ server {
         {% else %}
             root /srv/tournesol-frontend;
             try_files $uri /index.html;
-            expires $expires;
+            expires $frontend_expires;
         {% endif %}
     }
 

--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -9,6 +9,11 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+map $sent_http_content_type $expires {
+    default     off;
+    text/html   0;
+}
+
 server {
     client_max_body_size 100M;
 
@@ -24,6 +29,7 @@ server {
         {% else %}
             root /srv/tournesol-frontend;
             try_files $uri /index.html;
+            expires $expires;
         {% endif %}
     }
 


### PR DESCRIPTION
When deploying a new version of the frontend, browsers may continue to use an expired cached version of the html content. Then, other resources that may have been updated (.css, .js, etc) are not reloaded even if their URL has changed. So we need to set an explicit cache policy for resources whose URL does not change.

This change will force browsers to revalidate the frontend responses with html or json content, including the translation files.

Fixes #566