### PR TITLE
[front] refactor: reco. page uses polls API instead of the legacy video

### DIFF
--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -7,7 +7,7 @@ import PageNotFound from 'src/pages/404/PageNotFound';
 import ComparisonListPage from 'src/pages/comparisons/ComparisonList';
 import FeedbackPage from 'src/pages/personal/feedback/FeedbackPage';
 import HomePage from 'src/pages/home/Home';
-import VideoRecommendationPage from 'src/pages/videos/VideoRecommendation';
+import RecommendationPage from 'src/pages/recommendations/RecommendationPage';
 import VideoRatingsPage from 'src/pages/videos/VideoRatings';
 import ComparisonPage from 'src/pages/comparisons/Comparison';
 import RateLaterPage from 'src/pages/rateLater/RateLater';
@@ -54,7 +54,7 @@ const PollRoutes = ({ pollName }: Props) => {
     {
       id: RouteID.Recommendations,
       url: 'recommendations',
-      page: VideoRecommendationPage,
+      page: RecommendationPage,
       type: PublicRoute,
     },
     {

--- a/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
@@ -49,6 +49,7 @@ describe('VideoRecommendationPage', () => {
     expect(loadRecommendationsLanguages()).toEqual('fr,en');
     expect(getRecommendedVideosSpy).toHaveBeenCalledTimes(1);
     expect(getRecommendedVideosSpy).toHaveBeenLastCalledWith(
+      20,
       '?language=fr%2Cen',
       expect.anything()
     );
@@ -65,6 +66,7 @@ describe('VideoRecommendationPage', () => {
     expect(loadRecommendationsLanguages()).toEqual('de');
     expect(getRecommendedVideosSpy).toHaveBeenCalledTimes(1);
     expect(getRecommendedVideosSpy).toHaveBeenLastCalledWith(
+      20,
       '?language=de',
       expect.anything()
     );
@@ -80,6 +82,7 @@ describe('VideoRecommendationPage', () => {
     expect(loadRecommendationsLanguages()).toEqual('de');
     expect(getRecommendedVideosSpy).toHaveBeenCalledTimes(1);
     expect(getRecommendedVideosSpy).toHaveBeenLastCalledWith(
+      20,
       '?language=fr',
       expect.anything()
     );

--- a/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
@@ -11,7 +11,7 @@ import {
 } from 'src/utils/recommendationsLanguages';
 import * as RecommendationApi from 'src/features/recommendation/RecommendationApi';
 
-import VideoRecommendationPage from './VideoRecommendation';
+import RecommendationPage from './RecommendationPage';
 
 const VideoList = () => null;
 jest.mock('src/features/videos/VideoList', () => VideoList);
@@ -33,7 +33,7 @@ describe('VideoRecommendationPage', () => {
     render(
       <Router history={history}>
         <ThemeProvider theme={theme}>
-          <VideoRecommendationPage />
+          <RecommendationPage />
         </ThemeProvider>
       </Router>
     );

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -34,7 +34,7 @@ function RecommendationsPage() {
     results: [],
   };
 
-  const [entities, setVideos] = useState(prov);
+  const [entities, setEntities] = useState(prov);
   const entitiesCount = entities.count || 0;
 
   const searchParams = useMemo(
@@ -74,7 +74,7 @@ function RecommendationsPage() {
 
     const fetchVideos = async () => {
       setIsLoading(true);
-      setVideos(
+      setEntities(
         (await getRecommendedVideos(limit, location.search, criterias)) || []
       );
       setIsLoading(false);

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -17,25 +17,30 @@ import {
 } from 'src/utils/recommendationsLanguages';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
-function VideoRecommendationPage() {
+function RecommendationsPage() {
   const { t } = useTranslation();
+
+  const history = useHistory();
+  const location = useLocation();
+  const { criterias } = useCurrentPoll();
+  const [isLoading, setIsLoading] = useState(true);
+
   const prov: PaginatedVideoSerializerWithCriteriaList = {
     count: 0,
     results: [],
   };
-  const [videos, setVideos] = useState(prov);
-  const [isLoading, setIsLoading] = useState(true);
-  const location = useLocation();
-  const history = useHistory();
+
+  const [entities, setVideos] = useState(prov);
+  const videoCount = entities.count || 0;
+
   const searchParams = useMemo(
     () => new URLSearchParams(location.search),
     [location.search]
   );
   const limit = 20;
   const offset = Number(searchParams.get('offset') || 0);
-  const videoCount = videos.count || 0;
+
   const locationSearchRef = useRef<string>();
-  const { criterias } = useCurrentPoll();
 
   function handleOffsetChange(newOffset: number) {
     searchParams.set('offset', newOffset.toString());
@@ -80,7 +85,7 @@ function VideoRecommendationPage() {
         </Box>
         <LoaderWrapper isLoading={isLoading}>
           <VideoList
-            videos={videos.results || []}
+            videos={entities.results || []}
             emptyMessage={
               isLoading ? '' : t('noVideoCorrespondsToSearchCriterias')
             }
@@ -99,4 +104,4 @@ function VideoRecommendationPage() {
   );
 }
 
-export default VideoRecommendationPage;
+export default RecommendationsPage;

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -184,7 +184,11 @@ export const polls: Array<SelectablePoll> = [
           name: PRESIDENTIELLE_2022_POLL_NAME,
           displayOrder: 20,
           path: '/presidentielle2022/',
-          disabledRouteIds: [RouteID.MyRateLaterList, RouteID.MyComparedItems],
+          disabledRouteIds: [
+            RouteID.Recommendations,
+            RouteID.MyRateLaterList,
+            RouteID.MyComparedItems,
+          ],
           iconComponent: HowToVote,
           withSearchBar: false,
           topBarBackground:

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -184,11 +184,7 @@ export const polls: Array<SelectablePoll> = [
           name: PRESIDENTIELLE_2022_POLL_NAME,
           displayOrder: 20,
           path: '/presidentielle2022/',
-          disabledRouteIds: [
-            RouteID.Recommendations,
-            RouteID.MyRateLaterList,
-            RouteID.MyComparedItems,
-          ],
+          disabledRouteIds: [RouteID.MyRateLaterList, RouteID.MyComparedItems],
           iconComponent: HowToVote,
           withSearchBar: false,
           topBarBackground:

--- a/frontend/src/utils/entity.ts
+++ b/frontend/src/utils/entity.ts
@@ -1,5 +1,10 @@
 import { RelatedEntityObject } from './types';
-import { Entity, Video } from 'src/services/openapi';
+import {
+  Entity,
+  Recommendation,
+  Video,
+  VideoSerializerWithCriteria,
+} from 'src/services/openapi';
 
 export const videoFromRelatedEntity = (entity: RelatedEntityObject): Video => {
   return {
@@ -14,6 +19,20 @@ export const videoFromRelatedEntity = (entity: RelatedEntityObject): Video => {
     rating_n_contributors: 0,
     duration: entity.metadata.duration,
     video_id: entity.metadata.video_id,
+  };
+};
+
+export const videoWithCriteriaFromRecommendation = (
+  entity: Recommendation
+): VideoSerializerWithCriteria => {
+  const video = videoFromRelatedEntity(entity);
+
+  return {
+    ...video,
+    criteria_scores: entity.criteria_scores,
+    tournesol_score: entity.tournesol_score || null,
+    rating_n_ratings: entity.n_comparisons,
+    rating_n_contributors: entity.n_contributors,
   };
 };
 

--- a/frontend/src/utils/entity.ts
+++ b/frontend/src/utils/entity.ts
@@ -30,7 +30,7 @@ export const videoWithCriteriaFromRecommendation = (
   return {
     ...video,
     criteria_scores: entity.criteria_scores,
-    tournesol_score: entity.tournesol_score || null,
+    tournesol_score: entity.tournesol_score ?? null,
     rating_n_ratings: entity.n_comparisons,
     rating_n_contributors: entity.n_contributors,
   };


### PR DESCRIPTION
**related to** #833 

---

First step of the issue #833.

The recommendation page now uses the new poll API instead of the legacy video API to retrieve the recommended entities.

It still only works with videos for now, but I'll make it even more generic in the next PR. I also want to update `getRecommendedVideos` to make it work with any type of entity.

**bonus**

There is now a `videoWithCriteriaFromRecommendation` function able to build a `VideoSerializerWithCriteria` object from a `Recommendation` object. Useful to rework the high level components, like the recommendation page, which are using child components that still use legacy video types.  

The limit parameter of the recommendation API is now a parameter of the `getRecommendedVideos` function.


