### PR TITLE
[back] feat: recommendations can be filtered by metadata

### DIFF
--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -34,15 +34,9 @@ class EntityType(ABC):
     @classmethod
     def filter_metadata(cls, qst, filters):
         for key, values in filters:
-
             # add several OR expressions if multiple values are provided
             if len(values) > 1:
-                expression = Q(**{"metadata__" + key: values[0]})
-
-                for val in values[1:]:
-                    expression = expression | Q(**{"metadata__" + key: val})
-
-                qst = qst.filter(expression)
+                qst = qst.filter(**{"metadata__" + key + "__in": values})
             else:
                 qst = qst.filter(**{"metadata__" + key: values[0]})
 

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -33,7 +33,6 @@ class EntityType(ABC):
     @classmethod
     def filter_metadata(cls, qst, filters):
         for key, values in filters:
-            # add several OR expressions if multiple values are provided
             if len(values) > 1:
                 qst = qst.filter(**{"metadata__" + key + "__in": values})
             else:

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -33,8 +33,7 @@ class EntityType(ABC):
 
     @classmethod
     def filter_metadata(cls, qst, filters):
-        for fil in filters:
-            key, values = fil
+        for key, values in filters:
 
             # add several OR expressions if multiple values are provided
             if len(values) > 1:

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -31,6 +31,13 @@ class EntityType(ABC):
         return qs.filter(add_time__gte=dt)
 
     @classmethod
+    def filter_metadata(cls, qs, filters):
+        for fil in filters:
+            qs = qs.filter(**{'metadata__' + fil[0]: fil[1]})
+
+        return qs
+
+    @classmethod
     @abstractmethod
     def filter_search(cls, qs, query: str):
         raise NotImplementedError

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -2,7 +2,6 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Type
 
-from django.db.models import Q
 from django.utils import timezone
 from django.utils.functional import cached_property
 from rest_framework.serializers import Serializer

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -52,18 +52,15 @@ logger = logging.getLogger(__name__)
                 examples=[
                     OpenApiExample(
                         name="Some filters available for videos.",
-                        value={
-                            "language": "fr,pt",
-                            "uploader": "kurzgesagtES"
-                        },
+                        value={"language": "fr,pt", "uploader": "kurzgesagtES"},
                     ),
                     OpenApiExample(
                         name="Some filters available for candidates.",
                         value={
                             "name": "A candidate full name",
-                            "youtube_channel_id": "channel ID"
+                            "youtube_channel_id": "channel ID",
                         },
-                    )
+                    ),
                 ],
             ),
         ],
@@ -81,7 +78,7 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
         """
         _metadata_from_filter("metadata[language]") -> "language"
         """
-        return filtr.split('[')[1][:-1]
+        return filtr.split("[")[1][:-1]
 
     def filter_by_parameters(self, request, queryset, poll: Poll):
         """
@@ -105,10 +102,11 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
         if date_gte:
             queryset = poll.entity_cls.filter_date_gte(queryset, date_gte)
 
-        metadata_filters = [(self._metadata_from_filter(key), value)
-                            for (key, value)
-                            in request.query_params.items()
-                            if key.startswith('metadata[')]
+        metadata_filters = [
+            (self._metadata_from_filter(key), value)
+            for (key, value) in request.query_params.lists()
+            if key.startswith("metadata[")
+        ]
 
         if metadata_filters:
             queryset = poll.entity_cls.filter_metadata(queryset, metadata_filters)

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -103,8 +103,8 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
             queryset = poll.entity_cls.filter_date_gte(queryset, date_gte)
 
         metadata_filters = [
-            (self._metadata_from_filter(key), value)
-            for (key, value) in request.query_params.lists()
+            (self._metadata_from_filter(key), values)
+            for (key, values) in request.query_params.lists()
             if key.startswith("metadata[")
         ]
 

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -51,10 +51,17 @@ logger = logging.getLogger(__name__)
                 description="Filter by one or more metadata.",
                 examples=[
                     OpenApiExample(
-                        name="metadata example",
+                        name="Some filters available for videos.",
                         value={
                             "language": "fr,pt",
                             "uploader": "kurzgesagtES"
+                        },
+                    ),
+                    OpenApiExample(
+                        name="Some filters available for candidates.",
+                        value={
+                            "name": "A candidate full name",
+                            "youtube_channel_id": "channel ID"
                         },
                     )
                 ],
@@ -71,6 +78,9 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
     """
 
     def _metadata_from_filter(self, filtr: str):
+        """
+        _metadata_from_filter("metadata[language]") -> "language"
+        """
         return filtr.split('[')[1][:-1]
 
     def filter_by_parameters(self, request, queryset, poll: Poll):


### PR DESCRIPTION
**related to** #833 

will unlock #838 

---

The objective is to upgrade the poll API recommendations endpoint so that it provides as much features as the video API recommendations.

This should ease the development of a recommendations page in the front end that works with different entity type.

**to-do**
- [x] make it possible to filter by single value metadata `metadata[name]=hello`
- [x] make it possible to filter by multiple values metadata `metadata[language]=fr,pt` 
- [x] add tests for the new metadata filter