### PR TITLE
Improve charts on smaller screens

### DIFF
--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -16,10 +16,6 @@ import { displayScore } from 'src/utils/criteria';
 const BAR_CHART_CRITERIA_SCORE_MIN = -1;
 const BAR_CHART_CRITERIA_SCORE_MAX = 1;
 
-interface Props {
-  video: VideoSerializerWithCriteria;
-}
-
 const between = (a: number, b: number, x: number | undefined): number => {
   // clips x between a and b
   return Math.min(b, Math.max(a, x || 0));
@@ -38,7 +34,15 @@ const criteriaColors: { [criteria: string]: string } = {
   default: '#000000',
 };
 
-const CriteriaBarChart = ({ video }: Props) => {
+const SizedBarChart = ({
+  video,
+  width,
+  height,
+}: {
+  video: VideoSerializerWithCriteria;
+  width?: number;
+  height?: number;
+}) => {
   const { getCriteriaLabel } = useCurrentPoll();
 
   const renderCustomAxisTick = ({
@@ -52,7 +56,7 @@ const CriteriaBarChart = ({ video }: Props) => {
   }) => {
     return (
       <svg
-        x={x - 30 + 250}
+        x={x - 30 + (width || 0) / 2}
         y={y - 30}
         width="60"
         height="60"
@@ -95,47 +99,57 @@ const CriteriaBarChart = ({ video }: Props) => {
     });
 
   return (
-    <ResponsiveContainer width="100%" height={500}>
-      <BarChart layout="vertical" data={data}>
-        <XAxis
-          type="number"
-          domain={[BAR_CHART_CRITERIA_SCORE_MIN, BAR_CHART_CRITERIA_SCORE_MAX]}
-          hide={true}
-        />
+    <BarChart layout="vertical" width={width} height={height} data={data}>
+      <XAxis
+        type="number"
+        domain={[BAR_CHART_CRITERIA_SCORE_MIN, BAR_CHART_CRITERIA_SCORE_MAX]}
+        hide={true}
+      />
 
-        <Bar dataKey="clipped_score" barSize={20}>
-          {data.map((entry) => (
-            <Cell
-              key={entry.criteria}
-              fill={criteriaColors[entry.criteria] || criteriaColors['default']}
-            />
-          ))}
-        </Bar>
-        <YAxis
-          type="category"
-          dataKey="criteria"
-          tick={renderCustomAxisTick}
-          interval={0}
-          axisLine={false}
-          tickLine={false}
-          width={6}
-        />
-        <Tooltip
-          cursor={{ stroke: 'black', strokeWidth: 2, fill: 'transparent' }}
-          content={(props: TooltipProps<number, string>) => {
-            const payload = props?.payload;
-            if (payload && payload[0]) {
-              const { criteria, score } = payload[0].payload;
-              return (
-                <pre>
-                  {getCriteriaLabel(criteria)}: {displayScore(score)}
-                </pre>
-              );
-            }
-            return null;
-          }}
-        />
-      </BarChart>
+      <Bar dataKey="clipped_score" barSize={20}>
+        {data.map((entry) => (
+          <Cell
+            key={entry.criteria}
+            fill={criteriaColors[entry.criteria] || criteriaColors['default']}
+          />
+        ))}
+      </Bar>
+      <YAxis
+        type="category"
+        dataKey="criteria"
+        tick={renderCustomAxisTick}
+        interval={0}
+        axisLine={false}
+        tickLine={false}
+        width={6}
+      />
+      <Tooltip
+        cursor={{ stroke: 'black', strokeWidth: 2, fill: 'transparent' }}
+        content={(props: TooltipProps<number, string>) => {
+          const payload = props?.payload;
+          if (payload && payload[0]) {
+            const { criteria, score } = payload[0].payload;
+            return (
+              <pre>
+                {getCriteriaLabel(criteria)}: {displayScore(score)}
+              </pre>
+            );
+          }
+          return null;
+        }}
+      />
+    </BarChart>
+  );
+};
+
+interface Props {
+  video: VideoSerializerWithCriteria;
+}
+
+const CriteriaBarChart = ({ video }: Props) => {
+  return (
+    <ResponsiveContainer width="100%" height={500}>
+      <SizedBarChart video={video} />
     </ResponsiveContainer>
   );
 };

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -147,6 +147,8 @@ interface Props {
 }
 
 const CriteriaBarChart = ({ video }: Props) => {
+  // ResponsiveContainer adds the width and height props to its child component.
+  // We need the width to position the icons.
   return (
     <ResponsiveContainer width="100%" height={500}>
       <SizedBarChart video={video} />

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -150,7 +150,7 @@ const CriteriaBarChart = ({ video }: Props) => {
   // ResponsiveContainer adds the width and height props to its child component.
   // We need the width to position the icons.
   return (
-    <ResponsiveContainer width="100%" height={500}>
+    <ResponsiveContainer width="100%" aspect={1}>
       <SizedBarChart video={video} />
     </ResponsiveContainer>
   );

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -7,6 +7,7 @@ import {
   Cell,
   Tooltip,
   TooltipProps,
+  ResponsiveContainer,
 } from 'recharts';
 import { VideoSerializerWithCriteria } from 'src/services/openapi';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
@@ -94,46 +95,48 @@ const CriteriaBarChart = ({ video }: Props) => {
     });
 
   return (
-    <BarChart width={500} height={500} layout="vertical" data={data}>
-      <XAxis
-        type="number"
-        domain={[BAR_CHART_CRITERIA_SCORE_MIN, BAR_CHART_CRITERIA_SCORE_MAX]}
-        hide={true}
-      />
+    <ResponsiveContainer width="100%" height={500}>
+      <BarChart layout="vertical" data={data}>
+        <XAxis
+          type="number"
+          domain={[BAR_CHART_CRITERIA_SCORE_MIN, BAR_CHART_CRITERIA_SCORE_MAX]}
+          hide={true}
+        />
 
-      <Bar dataKey="clipped_score" barSize={20}>
-        {data.map((entry) => (
-          <Cell
-            key={entry.criteria}
-            fill={criteriaColors[entry.criteria] || criteriaColors['default']}
-          />
-        ))}
-      </Bar>
-      <YAxis
-        type="category"
-        dataKey="criteria"
-        tick={renderCustomAxisTick}
-        interval={0}
-        axisLine={false}
-        tickLine={false}
-        width={6}
-      />
-      <Tooltip
-        cursor={{ stroke: 'black', strokeWidth: 2, fill: 'transparent' }}
-        content={(props: TooltipProps<number, string>) => {
-          const payload = props?.payload;
-          if (payload && payload[0]) {
-            const { criteria, score } = payload[0].payload;
-            return (
-              <pre>
-                {getCriteriaLabel(criteria)}: {displayScore(score)}
-              </pre>
-            );
-          }
-          return null;
-        }}
-      />
-    </BarChart>
+        <Bar dataKey="clipped_score" barSize={20}>
+          {data.map((entry) => (
+            <Cell
+              key={entry.criteria}
+              fill={criteriaColors[entry.criteria] || criteriaColors['default']}
+            />
+          ))}
+        </Bar>
+        <YAxis
+          type="category"
+          dataKey="criteria"
+          tick={renderCustomAxisTick}
+          interval={0}
+          axisLine={false}
+          tickLine={false}
+          width={6}
+        />
+        <Tooltip
+          cursor={{ stroke: 'black', strokeWidth: 2, fill: 'transparent' }}
+          content={(props: TooltipProps<number, string>) => {
+            const payload = props?.payload;
+            if (payload && payload[0]) {
+              const { criteria, score } = payload[0].payload;
+              return (
+                <pre>
+                  {getCriteriaLabel(criteria)}: {displayScore(score)}
+                </pre>
+              );
+            }
+            return null;
+          }}
+        />
+      </BarChart>
+    </ResponsiveContainer>
   );
 };
 

--- a/frontend/src/components/CriteriaRadarChart.tsx
+++ b/frontend/src/components/CriteriaRadarChart.tsx
@@ -5,6 +5,7 @@ import {
   PolarGrid,
   PolarAngleAxis,
   PolarRadiusAxis,
+  ResponsiveContainer,
 } from 'recharts';
 import { VideoSerializerWithCriteria } from 'src/services/openapi';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
@@ -74,25 +75,27 @@ const CriteriaRadarChart = ({ video }: Props) => {
     }));
 
   return (
-    <RadarChart width={300} height={300} outerRadius="80%" data={data}>
-      <PolarGrid />
-      <PolarAngleAxis dataKey="criteria" tick={renderCustomAxisTick} />
-      {/* An invisible PolarRadiusAxis used to enforce the axis between 0 and 1 */}
-      <PolarRadiusAxis
-        domain={[
-          RADAR_CHART_CRITERIA_SCORE_MIN,
-          RADAR_CHART_CRITERIA_SCORE_MAX,
-        ]}
-        axisLine={false}
-        tick={false}
-      />
-      <Radar
-        dataKey="score"
-        stroke="#8884d8"
-        fill="#8884d8"
-        fillOpacity={0.6}
-      />
-    </RadarChart>
+    <ResponsiveContainer width="100%" height={500}>
+      <RadarChart outerRadius="80%" data={data}>
+        <PolarGrid />
+        <PolarAngleAxis dataKey="criteria" tick={renderCustomAxisTick} />
+        {/* An invisible PolarRadiusAxis used to enforce the axis between 0 and 1 */}
+        <PolarRadiusAxis
+          domain={[
+            RADAR_CHART_CRITERIA_SCORE_MIN,
+            RADAR_CHART_CRITERIA_SCORE_MAX,
+          ]}
+          axisLine={false}
+          tick={false}
+        />
+        <Radar
+          dataKey="score"
+          stroke="#8884d8"
+          fill="#8884d8"
+          fillOpacity={0.6}
+        />
+      </RadarChart>
+    </ResponsiveContainer>
   );
 };
 

--- a/frontend/src/components/CriteriaRadarChart.tsx
+++ b/frontend/src/components/CriteriaRadarChart.tsx
@@ -75,7 +75,7 @@ const CriteriaRadarChart = ({ video }: Props) => {
     }));
 
   return (
-    <ResponsiveContainer width="100%" height={500}>
+    <ResponsiveContainer width="100%" aspect={1}>
       <RadarChart outerRadius="80%" data={data}>
         <PolarGrid />
         <PolarAngleAxis dataKey="criteria" tick={renderCustomAxisTick} />

--- a/frontend/src/pages/videos/VideoAnalysis.tsx
+++ b/frontend/src/pages/videos/VideoAnalysis.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import makeStyles from '@mui/styles/makeStyles';
 import Grid from '@mui/material/Grid';
+import Box from '@mui/material/Box';
 
 import Card from 'src/components/Card';
 import VideoCard from 'src/features/videos/VideoCard';
@@ -28,23 +29,27 @@ function VideoAnalysis() {
   return (
     <div className={classes.root}>
       <VideoCard video={video} />
-      <Grid
-        container
-        spacing={2}
-        justifyContent="center"
-        sx={{ marginTop: 3, marginBottom: 3 }}
+      <Box
+        sx={{
+          marginTop: 3,
+          marginBottom: 3,
+          width: '100%',
+          maxWidth: 1000,
+        }}
       >
-        <Grid item xs="auto">
-          <Card>
-            <CriteriaRadarChart video={video} />
-          </Card>
+        <Grid container spacing={2} justifyContent="center">
+          <Grid item xs={12} md={6}>
+            <Card>
+              <CriteriaRadarChart video={video} />
+            </Card>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Card>
+              <CriteriaBarChart video={video} />
+            </Card>
+          </Grid>
         </Grid>
-        <Grid item xs="auto">
-          <Card>
-            <CriteriaBarChart video={video} />
-          </Card>
-        </Grid>
-      </Grid>
+      </Box>
     </div>
   );
 }


### PR DESCRIPTION
Related comment: https://github.com/tournesol-app/tournesol/pull/828#issuecomment-1106376425

The charts are now responsive and the same size. They work well down to a window width of 420px.

![image](https://user-images.githubusercontent.com/28259/164710245-e650dc03-51a6-4cd0-82e8-b92467daff65.png)

![image](https://user-images.githubusercontent.com/28259/164710401-75653bfa-fd73-429a-884b-99cc9806d635.png)
