### PR TITLE
Implement `EntityTabsBox` to use in video selector and analysis page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -82,6 +82,9 @@
     "autoEntityButton": "Auto",
     "pasteUrlOrVideoId": "Paste URL or Video ID"
   },
+  "tabsBox": {
+    "emptyList": "This list is empty"
+  },
   "stackedCandidatesPaper": {
     "title_one": "Your ranking of the candidates",
     "title_other": "Your ranking of the candidates according to your {{comparisonsNbr}} comparisons",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -85,6 +85,9 @@
     "autoEntityButton": "Auto",
     "pasteUrlOrVideoId": "Coller une URL ou un ID de vidéo"
   },
+  "tabsBox": {
+    "emptyList": "Cette liste est vide"
+  },
   "stackedCandidatesPaper": {
     "title_one": "Votre classement des candidat.e.s",
     "title_many": "Votre classement des candidat.e.s d'après vos {{comparisonsNbr}} comparaisons",

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -180,6 +180,7 @@ export const RowEntityCard = ({ entity }: { entity: RelatedEntityObject }) => {
           uid={entity.uid}
           title={entity.metadata.name}
           titleMaxLines={1}
+          withLink={false}
           fontSize="1em"
         />
         {entity.type == TypeEnum.VIDEO && (

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -162,7 +162,7 @@ export const RowEntityCard = ({ entity }: { entity: RelatedEntityObject }) => {
       alignItems="center"
       gap={1}
       height="70px"
-      sx={entityCardMainSx}
+      sx={{ ...entityCardMainSx, bgcolor: 'transparent' }}
     >
       <Box sx={{ aspectRatio: '16 / 9', height: '100%' }}>
         <EntityImagery

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -7,6 +7,7 @@ import {
   IconButton,
   useTheme,
   useMediaQuery,
+  Stack,
 } from '@mui/material';
 import {
   ExpandMore as ExpandMoreIcon,
@@ -19,7 +20,7 @@ import { ActionList, JSONValue, RelatedEntityObject } from 'src/utils/types';
 import EntityCardTitle from './EntityCardTitle';
 import EntityCardScores from './EntityCardScores';
 import EntityImagery from './EntityImagery';
-import EntityMetadata from './EntityMetadata';
+import EntityMetadata, { VideoMetadata } from './EntityMetadata';
 import { entityCardMainSx } from './style';
 
 const EntityCard = ({
@@ -150,6 +151,47 @@ const EntityCard = ({
         </Grid>
       )}
     </Grid>
+  );
+};
+
+export const RowEntityCard = ({ entity }: { entity: RelatedEntityObject }) => {
+  return (
+    <Box
+      display="flex"
+      flexDirection="row"
+      alignItems="center"
+      gap={1}
+      height="70px"
+      sx={entityCardMainSx}
+    >
+      <Box sx={{ aspectRatio: '16 / 9', height: '100%' }}>
+        <EntityImagery
+          entity={entity}
+          config={{
+            [TypeEnum.VIDEO]: {
+              displayPlayer: false,
+              thumbnailLink: false,
+            },
+          }}
+        />
+      </Box>
+      <Stack gap="4px">
+        <EntityCardTitle
+          uid={entity.uid}
+          title={entity.metadata.name}
+          titleMaxLines={1}
+          fontSize="1em"
+        />
+        {entity.type == TypeEnum.VIDEO && (
+          <VideoMetadata
+            views={entity.metadata.views}
+            uploader={entity.metadata.uploader}
+            publicationDate={entity.metadata.publication_date}
+            withLinks={false}
+          />
+        )}
+      </Stack>
+    </Box>
   );
 };
 

--- a/frontend/src/components/entity/EntityCardScores.tsx
+++ b/frontend/src/components/entity/EntityCardScores.tsx
@@ -121,7 +121,7 @@ const EntityCardScores = ({
         flexWrap="wrap"
         alignItems="center"
         columnGap="12px"
-        paddingBottom={1}
+        py={1}
       >
         {showTournesolScore &&
           'tournesol_score' in entity &&

--- a/frontend/src/components/entity/EntityCardTitle.tsx
+++ b/frontend/src/components/entity/EntityCardTitle.tsx
@@ -10,38 +10,48 @@ const EntityCardTitle = ({
   title,
   compact = true,
   titleMaxLines = 3,
+  withLink = true,
   ...rest
 }: {
   uid: string;
   title: string;
   compact?: boolean;
   titleMaxLines?: number;
+  withLink?: boolean;
   [propName: string]: unknown;
 }) => {
   const { baseUrl } = useCurrentPoll();
 
+  const titleNode = (
+    <Typography
+      color="text.primary"
+      sx={{
+        fontSize: compact ? '1em !important' : '',
+        lineHeight: 1.3,
+        textAlign: 'left',
+        // Limit text to 3 lines and show ellipsis
+        display: '-webkit-box',
+        overflow: 'hidden',
+        WebkitLineClamp: titleMaxLines,
+        WebkitBoxOrient: 'vertical',
+      }}
+      variant={compact ? 'body1' : 'h6'}
+      title={title}
+      {...rest}
+    >
+      {title}
+    </Typography>
+  );
+
   return (
     <Box display="flex" flexWrap="wrap">
-      <RouterLink className="no-decoration" to={`${baseUrl}/entities/${uid}`}>
-        <Typography
-          color="text.primary"
-          sx={{
-            fontSize: compact ? '1em !important' : '',
-            lineHeight: 1.3,
-            textAlign: 'left',
-            // Limit text to 3 lines and show ellipsis
-            display: '-webkit-box',
-            overflow: 'hidden',
-            WebkitLineClamp: titleMaxLines,
-            WebkitBoxOrient: 'vertical',
-          }}
-          variant={compact ? 'body1' : 'h6'}
-          title={title}
-          {...rest}
-        >
-          {title}
-        </Typography>
-      </RouterLink>
+      {withLink ? (
+        <RouterLink className="no-decoration" to={`${baseUrl}/entities/${uid}`}>
+          {titleNode}
+        </RouterLink>
+      ) : (
+        titleNode
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -28,6 +28,7 @@ export const DurationWrapper = React.forwardRef(function DurationWrapper(
     <Box
       position="relative"
       height="100%"
+      width="100%"
       onClick={() => setIsDurationVisible(false)}
       ref={ref}
     >

--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -84,58 +84,62 @@ const EntityImagery = ({
 }: {
   entity: RelatedEntityObject;
   compact?: boolean;
-  config?: { [k: string]: { [k: string]: JSONValue } };
+  config?: { [k in TypeEnum]?: { [k: string]: JSONValue } };
 }) => {
   const { baseUrl } = useCurrentPoll();
   const videoConfig = config[TypeEnum.VIDEO] ?? {};
 
   if (entity.type === TypeEnum.VIDEO) {
+    if (videoConfig.displayPlayer ?? true) {
+      return (
+        <Box
+          sx={{
+            aspectRatio: '16 / 9',
+            width: '100%',
+          }}
+        >
+          <VideoPlayer
+            videoId={entity.metadata.video_id}
+            duration={entity.metadata.duration}
+          />
+        </Box>
+      );
+    }
+
+    const thumbnail = (
+      <DurationWrapper duration={entity.metadata.duration}>
+        <img
+          className="full-width"
+          src={`https://i.ytimg.com/vi/${idFromUid(entity.uid)}/mqdefault.jpg`}
+          alt={entity.metadata.name}
+        />
+      </DurationWrapper>
+    );
+
     return (
-      <>
-        {/* Display the video player by default, unless otherwise configured. */}
-        {videoConfig?.displayPlayer ?? true ? (
-          <Box
-            sx={{
-              aspectRatio: '16 / 9',
-              width: '100%',
-            }}
-          >
-            <VideoPlayer
-              videoId={entity.metadata.video_id}
-              duration={entity.metadata.duration}
-            />
-          </Box>
-        ) : (
-          <Box
-            display="flex"
-            alignItems="center"
-            bgcolor="black"
-            width="100%"
+      <Box
+        display="flex"
+        alignItems="center"
+        bgcolor="black"
+        width="100%"
+        sx={{
+          '& img': {
             // prevent the RouterLink to add few extra pixels
-            lineHeight={0}
-            sx={{
-              '& > img': {
-                flex: 1,
-              },
-            }}
+            display: 'block',
+          },
+        }}
+      >
+        {videoConfig.thumbnailLink ?? true ? (
+          <RouterLink
+            to={`${baseUrl}/entities/${entity.uid}`}
+            className="full-width"
           >
-            <RouterLink
-              to={`${baseUrl}/entities/${entity.uid}`}
-              className="full-width"
-            >
-              <DurationWrapper duration={entity.metadata.duration}>
-                <img
-                  className="full-width"
-                  src={`https://i.ytimg.com/vi/${idFromUid(
-                    entity.uid
-                  )}/mqdefault.jpg`}
-                  alt={entity.metadata.name}
-                />
-              </DurationWrapper>
-            </RouterLink>
-          </Box>
+            {thumbnail}
+          </RouterLink>
+        ) : (
+          thumbnail
         )}
-      </>
+      </Box>
     );
   }
   if (entity.type === TypeEnum.CANDIDATE_FR_2022) {

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -60,7 +60,7 @@ export const VideoMetadata = ({
             </Link>
           </Tooltip>
         ) : (
-          { uploader }
+          uploader
         ))}
     </Box>
   );

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -21,14 +21,14 @@ export const VideoMetadata = ({
   return (
     <Box
       sx={{
-        marginBottom: '8px',
         display: 'flex',
         flexWrap: 'wrap',
         alignContent: 'space-between',
         fontFamily: 'Poppins',
         fontSize: '0.8em',
         color: 'neutral.main',
-        gap: '12px',
+        columnGap: '12px',
+        lineHeight: '1.3',
       }}
     >
       {views && (

--- a/frontend/src/components/entity/style.ts
+++ b/frontend/src/components/entity/style.ts
@@ -3,7 +3,6 @@ import { SxProps } from '@mui/material';
 export const entityCardMainSx: SxProps = {
   margin: 0,
   width: '100%',
-  background: '#FFFFFF',
   border: '1px solid #DCD8CB',
   boxShadow: '0px 0px 8px rgba(0, 0, 0, 0.02), 0px 2px 4px rgba(0, 0, 0, 0.05)',
   borderRadius: '4px',

--- a/frontend/src/components/entity/style.ts
+++ b/frontend/src/components/entity/style.ts
@@ -3,6 +3,7 @@ import { SxProps } from '@mui/material';
 export const entityCardMainSx: SxProps = {
   margin: 0,
   width: '100%',
+  bgcolor: '#FFFFFF',
   border: '1px solid #DCD8CB',
   boxShadow: '0px 0px 8px rgba(0, 0, 0, 0.02), 0px 2px 4px rgba(0, 0, 0, 0.05)',
   borderRadius: '4px',

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react';
+import { Tabs, Tab, Paper, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { RelatedEntityObject } from 'src/utils/types';
+import { VideoCardFromId } from '../videos/VideoCard';
+
+interface Props {
+  tabs: EntitiesTab[];
+  onSelectEntity: (entityUid: string) => void;
+}
+
+export interface EntitiesTab {
+  name: string;
+  label: string;
+  fetch: () => Promise<RelatedEntityObject[]>;
+  disabled?: boolean;
+}
+
+enum SelectorTabs {
+  RateLater = 'rate-later',
+  Recommendations = 'recommendations',
+  RecentlyCompared = 'recently-compared',
+}
+
+const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
+  const { t } = useTranslation();
+  const [tabValue, setTabValue] = useState(SelectorTabs.RateLater);
+  const [options, setOptions] = useState<RelatedEntityObject[]>([]);
+
+  useEffect(() => {
+    const tab = tabs.find((t) => t.name === tabValue);
+    if (!tab) {
+      return;
+    }
+    tab.fetch().then(setOptions);
+  }, [tabs, tabValue]);
+
+  return (
+    <Paper
+      elevation={10}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        ul: {
+          flexGrow: 1,
+          listStyleType: 'none',
+          p: 0,
+          overflowY: 'scroll',
+          maxHeight: '40vh',
+          marginTop: 1,
+          marginBottom: 0,
+          '.MuiModal-root &': {
+            maxHeight: 'none',
+          },
+        },
+        li: {
+          cursor: 'pointer',
+          '&:hover': {
+            bgcolor: 'action.selected',
+          },
+        },
+        width: 'min(700px, 100vw)',
+        bgcolor: 'white',
+        overflow: 'hidden',
+      }}
+    >
+      <Tabs
+        textColor="secondary"
+        indicatorColor="secondary"
+        value={tabValue}
+        onChange={(e, value) => setTabValue(value)}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{
+          bgcolor: 'grey.100',
+          borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+          '& .MuiTabs-scrollButtons.Mui-disabled': {
+            opacity: 0.3,
+          },
+        }}
+      >
+        {tabs.map(({ label, name, disabled }) => (
+          <Tab key={name} value={name} label={label} disabled={disabled} />
+        ))}
+      </Tabs>
+      {options.length > 0 ? (
+        <ul>
+          {options.map((entity) => (
+            <li
+              key={entity.metadata.video_id}
+              onClick={() => onSelectEntity(entity.uid)}
+            >
+              <VideoCardFromId
+                videoId={entity.metadata.video_id}
+                variant="row"
+              />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <Typography variant="subtitle1" paragraph m={2} color="neutral.main">
+          {t('listbox.empty_list')}
+        </Typography>
+      )}
+    </Paper>
+  );
+};
+
+export default EntityTabsBox;

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -99,7 +99,7 @@ const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
         </ul>
       ) : (
         <Typography variant="subtitle1" paragraph m={2} color="neutral.main">
-          {t('listbox.empty_list')}
+          {t('tabsBox.emptyList')}
         </Typography>
       )}
     </Paper>

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -16,15 +16,9 @@ export interface EntitiesTab {
   disabled?: boolean;
 }
 
-enum SelectorTabs {
-  RateLater = 'rate-later',
-  Recommendations = 'recommendations',
-  RecentlyCompared = 'recently-compared',
-}
-
 const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
   const { t } = useTranslation();
-  const [tabValue, setTabValue] = useState(SelectorTabs.RateLater);
+  const [tabValue, setTabValue] = useState(tabs[0]?.name);
   const [options, setOptions] = useState<RelatedEntityObject[]>([]);
 
   useEffect(() => {
@@ -45,10 +39,9 @@ const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
           flexGrow: 1,
           listStyleType: 'none',
           p: 0,
+          m: 0,
           overflowY: 'scroll',
           maxHeight: '40vh',
-          marginTop: 1,
-          marginBottom: 0,
           '.MuiModal-root &': {
             maxHeight: 'none',
           },
@@ -56,12 +49,16 @@ const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
         li: {
           cursor: 'pointer',
           '&:hover': {
-            bgcolor: 'action.selected',
+            bgcolor: 'grey.50',
+          },
+          '&:first-of-type': {
+            marginTop: 1,
           },
         },
         width: 'min(700px, 100vw)',
         bgcolor: 'white',
         overflow: 'hidden',
+        flexGrow: 1,
       }}
     >
       <Tabs

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Tabs, Tab, Paper, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { RelatedEntityObject } from 'src/utils/types';
-import { VideoCardFromId } from '../videos/VideoCard';
+import { RowEntityCard } from 'src/components/entity/EntityCard';
 
 interface Props {
   tabs: EntitiesTab[];
@@ -83,14 +83,8 @@ const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
       {options.length > 0 ? (
         <ul>
           {options.map((entity) => (
-            <li
-              key={entity.metadata.video_id}
-              onClick={() => onSelectEntity(entity.uid)}
-            >
-              <VideoCardFromId
-                videoId={entity.metadata.video_id}
-                variant="row"
-              />
+            <li key={entity.uid} onClick={() => onSelectEntity(entity.uid)}>
+              <RowEntityCard entity={entity} />
             </li>
           ))}
         </ul>

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -49,7 +49,7 @@ const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
         li: {
           cursor: 'pointer',
           '&:hover': {
-            bgcolor: 'grey.50',
+            bgcolor: 'grey.100',
           },
           '&:first-of-type': {
             marginTop: 1,

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -10,11 +10,9 @@ import {
   useMediaQuery,
   useTheme,
   Theme,
-  Stack,
 } from '@mui/material';
 
 import { ActionList, VideoObject } from 'src/utils/types';
-import { useVideoMetadata } from './VideoApi';
 import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
@@ -23,7 +21,6 @@ import { videoIdFromEntity } from 'src/utils/video';
 import VideoCardScores from './VideoCardScores';
 import EntityCardTitle from 'src/components/entity/EntityCardTitle';
 import { entityCardMainSx } from 'src/components/entity/style';
-import EmptyEntityCard from 'src/components/entity/EmptyEntityCard';
 import { DurationWrapper } from 'src/components/entity/EntityImagery';
 import { VideoMetadata } from 'src/components/entity/EntityMetadata';
 import { useCurrentPoll } from 'src/hooks';
@@ -204,61 +201,5 @@ function VideoCard({
     </Grid>
   );
 }
-
-export const RowVideoCard = ({ video }: { video: VideoObject }) => {
-  return (
-    <Box
-      display="flex"
-      flexDirection="row"
-      alignItems="center"
-      gap={1}
-      height="70px"
-      sx={entityCardMainSx}
-    >
-      <Box sx={{ aspectRatio: '16 / 9', height: '100%' }}>
-        <img
-          height="100%"
-          src={`https://i.ytimg.com/vi/${video.video_id}/mqdefault.jpg`}
-        />
-      </Box>
-      <Stack gap="4px">
-        <EntityCardTitle
-          uid={video.uid}
-          title={video.name}
-          titleMaxLines={1}
-          fontSize="1em"
-        />
-        <VideoMetadata
-          views={video.views}
-          uploader={video.uploader}
-          publicationDate={video.publication_date}
-          withLinks={false}
-        />
-      </Stack>
-    </Box>
-  );
-};
-
-export const VideoCardFromId = ({
-  videoId,
-  variant = 'full',
-  ...rest
-}: {
-  videoId: string;
-  variant: 'full' | 'compact' | 'row';
-  [propname: string]: unknown;
-}) => {
-  const video = useVideoMetadata(videoId);
-  if (video == null || !video.video_id) {
-    return <EmptyEntityCard compact={variant === 'compact'} />;
-  }
-  if (variant === 'compact') {
-    return <VideoCard video={video} compact {...rest} />;
-  }
-  if (variant === 'row') {
-    return <RowVideoCard video={video} {...rest} />;
-  }
-  return <VideoCard video={video} {...rest} />;
-};
 
 export default VideoCard;

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -10,6 +10,7 @@ import {
   useMediaQuery,
   useTheme,
   Theme,
+  Stack,
 } from '@mui/material';
 
 import { ActionList, VideoObject } from 'src/utils/types';
@@ -220,7 +221,7 @@ export const RowVideoCard = ({ video }: { video: VideoObject }) => {
           src={`https://i.ytimg.com/vi/${video.video_id}/mqdefault.jpg`}
         />
       </Box>
-      <Box flex={1}>
+      <Stack gap="4px">
         <EntityCardTitle
           uid={video.uid}
           title={video.name}
@@ -233,7 +234,7 @@ export const RowVideoCard = ({ video }: { video: VideoObject }) => {
           publicationDate={video.publication_date}
           withLinks={false}
         />
-      </Box>
+      </Stack>
     </Box>
   );
 };

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -1,6 +1,6 @@
-import { VideoService, UsersService } from 'src/services/openapi';
+import { VideoService, UsersService, TypeEnum } from 'src/services/openapi';
 import { YOUTUBE_POLL_NAME } from './constants';
-import { VideoObject } from './types';
+import { RelatedEntityObject, VideoObject } from './types';
 
 export function extractVideoId(idOrUrl: string) {
   const matchUrl = idOrUrl.match(
@@ -173,3 +173,17 @@ export const convertDurationToClockDuration = (duration: number) => {
   const seconds = roundToTwoDigits(duration % 60);
   return hours > 0 ? `${hours}:${minutes}:${seconds}` : `${minutes}:${seconds}`;
 };
+
+export const videoToEntity = (video: VideoObject): RelatedEntityObject => ({
+  uid: video.uid,
+  type: TypeEnum.VIDEO,
+  metadata: {
+    name: video.name,
+    description: video.description,
+    publication_data: video.publication_date,
+    uploader: video.uploader,
+    language: video.language,
+    duration: video.duration,
+    video_id: video.video_id,
+  },
+});

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -1,6 +1,6 @@
-import { VideoService, UsersService, TypeEnum } from 'src/services/openapi';
+import { VideoService, UsersService } from 'src/services/openapi';
 import { YOUTUBE_POLL_NAME } from './constants';
-import { RelatedEntityObject, VideoObject } from './types';
+import { VideoObject } from './types';
 
 export function extractVideoId(idOrUrl: string) {
   const matchUrl = idOrUrl.match(
@@ -173,17 +173,3 @@ export const convertDurationToClockDuration = (duration: number) => {
   const seconds = roundToTwoDigits(duration % 60);
   return hours > 0 ? `${hours}:${minutes}:${seconds}` : `${minutes}:${seconds}`;
 };
-
-export const videoToEntity = (video: VideoObject): RelatedEntityObject => ({
-  uid: video.uid,
-  type: TypeEnum.VIDEO,
-  metadata: {
-    name: video.name,
-    description: video.description,
-    publication_data: video.publication_date,
-    uploader: video.uploader,
-    language: video.language,
-    duration: video.duration,
-    video_id: video.video_id,
-  },
-});


### PR DESCRIPTION
This adds a new component `EntityTabsBox`
Accepts a list of `EntityTab` in props, to define how to fetch the different lists of entities.

A few limitations:
 * uses `RowVideoCard` (to be made more generic in the future)
 * tabs style is based on MUI `Tabs` (could be customized?)

The first use-case will be to enrich the VideoInput, with the possibility to pick a video from multiple tabs (see #856)