### PR TITLE
[front] refactor: add an `EntityList` component (2/3)

### DIFF
--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import VideoList from 'src/features/videos/VideoList';
+import { useCurrentPoll } from 'src/hooks';
+import { VideoSerializerWithCriteria } from 'src/services/openapi';
+import { Recommendation } from 'src/services/openapi/models/Recommendation';
+import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { videoWithCriteriaFromRecommendation } from 'src/utils/entity';
+import { ActionList } from 'src/utils/types';
+
+interface Props {
+  // entities are only Recommendation[] for now but we should also allow
+  // "pure" entities, without data related to the current poll
+  entities: Recommendation[] | undefined;
+  actions?: ActionList;
+  settings?: ActionList;
+  personalScores?: { [uid: string]: number };
+  isLoading: boolean;
+}
+
+/**
+ * Display a list of entities.
+ *
+ * Entities can be pure entities, or entities expanded with data related to
+ * the current poll, like the number of comparisons, the tournesol score,
+ * etc.
+ *
+ * According to the current poll, this component renders a specific child
+ * component able to correctly display the entities.
+ *
+ * Component tree:
+ *
+ *   ParentPage
+ *   |
+ *   +-- EntityList (here)
+ *       |
+ *       +-- CandidateList
+ *       +-- VideoList
+ *       +-- etc.
+ */
+function EntityList({
+  entities,
+  actions,
+  settings = [],
+  personalScores,
+  isLoading,
+}: Props) {
+  const { t } = useTranslation();
+  const { name: pollName } = useCurrentPoll();
+
+  /**
+   * Return VideoSerializerWithCriteria[] from Recommendation[]
+   */
+  const getResultsAsVideoWithCriteria = (
+    results: Recommendation[] | undefined
+  ): VideoSerializerWithCriteria[] => {
+    if (!results) {
+      return [];
+    }
+    return results.map((entity) => videoWithCriteriaFromRecommendation(entity));
+  };
+
+  if (pollName === YOUTUBE_POLL_NAME) {
+    return (
+      <VideoList
+        videos={getResultsAsVideoWithCriteria(entities)}
+        actions={actions}
+        settings={settings}
+        personalScores={personalScores}
+        emptyMessage={isLoading ? '' : t('noVideoCorrespondsToSearchCriterias')}
+      />
+    );
+  }
+
+  return <></>;
+}
+
+export default EntityList;

--- a/frontend/src/features/recommendation/RecommendationApi.tsx
+++ b/frontend/src/features/recommendation/RecommendationApi.tsx
@@ -3,6 +3,130 @@ import {
   PollCriteria,
   PollsService,
 } from 'src/services/openapi';
+import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
+
+const getParamValueAsNumber = (
+  params: URLSearchParams,
+  key: string
+): number | undefined => {
+  const value = params.get(key);
+  return value ? Number(value) : undefined;
+};
+
+/**
+ * Replace the key `date` of `params` by a new one compatible with the API.
+ */
+const buildDateURLParameter = (
+  pollName: string,
+  params: URLSearchParams
+): void => {
+  function format(str: string) {
+    if (str.length == 1) {
+      return '0'.concat(str);
+    } else if (str.length == 4) {
+      return str.slice(2);
+    } else {
+      return str;
+    }
+  }
+
+  if (pollName === YOUTUBE_POLL_NAME) {
+    const conversionTime = new Map();
+    const dayInMillisecondes = 1000 * 60 * 60 * 24;
+
+    conversionTime.set('Any', 1);
+    // Set today to 36 hours instead of 24; to get most of the videos from the
+    // previous day
+    conversionTime.set('Today', dayInMillisecondes * 1.5);
+    conversionTime.set('Week', dayInMillisecondes * 7);
+    conversionTime.set('Month', dayInMillisecondes * 31);
+    conversionTime.set('Year', dayInMillisecondes * 365);
+    const dateNow = Date.now();
+
+    if (params.get('date')) {
+      const date = params.get('date');
+      params.delete('date');
+      if (date != 'Any') {
+        // TODO: figure out why adding 1 month is needed here
+        const limitPublicationDateMilliseconds =
+          dateNow - conversionTime.get(date);
+        const param_date = new Date(limitPublicationDateMilliseconds);
+        const [d, m, y, H, M, S] = [
+          param_date.getDate().toString(),
+          (param_date.getMonth() + 1).toString(),
+          param_date.getFullYear().toString(),
+          param_date.getHours().toString(),
+          param_date.getMinutes().toString(),
+          param_date.getSeconds().toString(),
+        ].map((t) => format(t));
+        params.append('date_gte', `${d}-${m}-${y}-${H}-${M}-${S}`);
+      }
+    }
+  }
+};
+
+/**
+ * Return a metadata `Record` based on the URL parameters, compliant with the
+ * given poll.
+ *
+ * This `Record` is meant to be used as parameter of the generated API
+ * services.
+ */
+const getMetadataFilter = (
+  pollName: string,
+  params: URLSearchParams
+): Record<string, string | string[]> => {
+  const metadata: Record<string, string | string[]> = {};
+
+  // build a filter for the YouTube poll
+  if (pollName === YOUTUBE_POLL_NAME) {
+    const languageFilter = params.get('language');
+    const uploaderFilter = params.get('uploader');
+
+    if (languageFilter) {
+      metadata['language'] = languageFilter.split(',');
+    }
+
+    if (uploaderFilter) {
+      metadata['uploader'] = uploaderFilter;
+    }
+  }
+
+  return metadata;
+};
+
+// make it work with video
+export const getRecommendations = async (
+  pollName: string,
+  limit: number,
+  searchString: string,
+  criterias: PollCriteria[]
+): Promise<PaginatedRecommendationList> => {
+  const params = new URLSearchParams(searchString);
+
+  buildDateURLParameter(pollName, params);
+
+  try {
+    return await PollsService.pollsRecommendationsList({
+      name: pollName,
+      limit: limit,
+      offset: getParamValueAsNumber(params, 'offset'),
+      search: params.get('search') ?? undefined,
+      dateGte: params.get('date_gte') ?? undefined,
+      unsafe: params.get('unsafe') === 'true' ?? undefined,
+      metadata: getMetadataFilter(pollName, params),
+      weights: Object.fromEntries(
+        criterias.map((c) => [c.name, getParamValueAsNumber(params, c.name)])
+      ),
+    });
+  } catch (err) {
+    console.error(err);
+    return {
+      results: [],
+      count: 0,
+    };
+  }
+};
 
 export const getRecommendedVideos = async (
   limit: number,

--- a/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
@@ -26,7 +26,7 @@ describe('VideoRecommendationPage', () => {
     historySpy = jest.spyOn(history, 'replace');
     navigatorLanguagesGetter = jest.spyOn(window.navigator, 'languages', 'get');
     getRecommendedVideosSpy = jest
-      .spyOn(RecommendationApi, 'getRecommendedVideos')
+      .spyOn(RecommendationApi, 'getRecommendations')
       .mockImplementation(async () => ({ count: 0, results: [] }));
   });
   const component = () => {
@@ -49,6 +49,7 @@ describe('VideoRecommendationPage', () => {
     expect(loadRecommendationsLanguages()).toEqual('fr,en');
     expect(getRecommendedVideosSpy).toHaveBeenCalledTimes(1);
     expect(getRecommendedVideosSpy).toHaveBeenLastCalledWith(
+      'videos',
       20,
       '?language=fr%2Cen',
       expect.anything()
@@ -66,6 +67,7 @@ describe('VideoRecommendationPage', () => {
     expect(loadRecommendationsLanguages()).toEqual('de');
     expect(getRecommendedVideosSpy).toHaveBeenCalledTimes(1);
     expect(getRecommendedVideosSpy).toHaveBeenLastCalledWith(
+      'videos',
       20,
       '?language=de',
       expect.anything()
@@ -82,6 +84,7 @@ describe('VideoRecommendationPage', () => {
     expect(loadRecommendationsLanguages()).toEqual('de');
     expect(getRecommendedVideosSpy).toHaveBeenCalledTimes(1);
     expect(getRecommendedVideosSpy).toHaveBeenLastCalledWith(
+      'videos',
       20,
       '?language=fr',
       expect.anything()

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -87,7 +87,13 @@ function RecommendationsPage() {
           <SearchFilter />
         </Box>
         <LoaderWrapper isLoading={isLoading}>
-          <EntityList entities={entities.results} isLoading={isLoading} />
+          <EntityList
+            entities={entities.results}
+            isRecommendation={true}
+            emptyMessage={
+              isLoading ? '' : t('noVideoCorrespondsToSearchCriterias')
+            }
+          />
         </LoaderWrapper>
         {!isLoading && entitiesCount > 0 && (
           <Pagination

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -8,7 +8,7 @@ import LoaderWrapper from 'src/components/LoaderWrapper';
 import Pagination from 'src/components/Pagination';
 import EntityList from 'src/features/entities/EntityList';
 import SearchFilter from 'src/features/recommendation/SearchFilter';
-import { getRecommendedVideos } from 'src/features/recommendation/RecommendationApi';
+import { getRecommendations } from 'src/features/recommendation/RecommendationApi';
 import { ContentBox, ContentHeader } from 'src/components';
 
 import {
@@ -23,7 +23,7 @@ function RecommendationsPage() {
 
   const history = useHistory();
   const location = useLocation();
-  const { criterias } = useCurrentPoll();
+  const { name: pollName, criterias } = useCurrentPoll();
   const [isLoading, setIsLoading] = useState(true);
 
   const prov: PaginatedRecommendationList = {
@@ -72,12 +72,17 @@ function RecommendationsPage() {
     const fetchVideos = async () => {
       setIsLoading(true);
       setEntities(
-        (await getRecommendedVideos(limit, location.search, criterias)) || []
+        (await getRecommendations(
+          pollName,
+          limit,
+          location.search,
+          criterias
+        )) || []
       );
       setIsLoading(false);
     };
     fetchVideos();
-  }, [location.search, history, searchParams, criterias]);
+  }, [criterias, history, location.search, pollName, searchParams]);
 
   return (
     <>

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -3,23 +3,20 @@ import { useLocation, useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
 
-import type {
-  PaginatedRecommendationList,
-  Recommendation,
-} from 'src/services/openapi';
+import type { PaginatedRecommendationList } from 'src/services/openapi';
+import LoaderWrapper from 'src/components/LoaderWrapper';
 import Pagination from 'src/components/Pagination';
-import VideoList from 'src/features/videos/VideoList';
+import EntityList from 'src/features/entities/EntityList';
 import SearchFilter from 'src/features/recommendation/SearchFilter';
 import { getRecommendedVideos } from 'src/features/recommendation/RecommendationApi';
 import { ContentBox, ContentHeader } from 'src/components';
-import LoaderWrapper from 'src/components/LoaderWrapper';
+
 import {
   saveRecommendationsLanguages,
   loadRecommendationsLanguages,
   recommendationsLanguagesFromNavigator,
 } from 'src/utils/recommendationsLanguages';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { videoWithCriteriaFromRecommendation } from 'src/utils/entity';
 
 function RecommendationsPage() {
   const { t } = useTranslation();
@@ -82,13 +79,6 @@ function RecommendationsPage() {
     fetchVideos();
   }, [location.search, history, searchParams, criterias]);
 
-  const getResultsAsVideos = (results: Recommendation[] | undefined) => {
-    if (!results) {
-      return [];
-    }
-    return results.map((entity) => videoWithCriteriaFromRecommendation(entity));
-  };
-
   return (
     <>
       <ContentHeader title={t('recommendationsPage.title')} />
@@ -97,12 +87,7 @@ function RecommendationsPage() {
           <SearchFilter />
         </Box>
         <LoaderWrapper isLoading={isLoading}>
-          <VideoList
-            videos={getResultsAsVideos(entities.results)}
-            emptyMessage={
-              isLoading ? '' : t('noVideoCorrespondsToSearchCriterias')
-            }
-          />
+          <EntityList entities={entities.results} isLoading={isLoading} />
         </LoaderWrapper>
         {!isLoading && entitiesCount > 0 && (
           <Pagination

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -94,7 +94,6 @@ function RecommendationsPage() {
         <LoaderWrapper isLoading={isLoading}>
           <EntityList
             entities={entities.results}
-            isRecommendation={true}
             emptyMessage={
               isLoading ? '' : t('noVideoCorrespondsToSearchCriterias')
             }

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -10,7 +10,6 @@ import type {
 } from 'src/services/openapi';
 import type { RelatedEntityObject } from 'src/utils/types';
 import Pagination from 'src/components/Pagination';
-import VideoList from 'src/features/videos/VideoList';
 import { UsersService } from 'src/services/openapi';
 import { ContentBox, ContentHeader, LoaderWrapper } from 'src/components';
 import {
@@ -18,8 +17,8 @@ import {
   RatingsContext,
 } from 'src/features/videos/PublicStatusAction';
 import RatingsFilter from 'src/features/ratings/RatingsFilter';
-import { videoFromRelatedEntity } from 'src/utils/entity';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import EntityList from 'src/features/entities/EntityList';
 
 const NoRatingMessage = ({ hasFilter }: { hasFilter: boolean }) => {
   const { t } = useTranslation();
@@ -164,8 +163,9 @@ const VideoRatingsPage = () => {
           </Box>
         )}
         <LoaderWrapper isLoading={isLoading}>
-          <VideoList
-            videos={entities.map((ent) => videoFromRelatedEntity(ent))}
+          <EntityList
+            entities={entities}
+            isRecommendation={false}
             settings={[PublicStatusAction]}
             emptyMessage={<NoRatingMessage hasFilter={hasFilter} />}
             personalScores={personalScores}

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -165,7 +165,6 @@ const VideoRatingsPage = () => {
         <LoaderWrapper isLoading={isLoading}>
           <EntityList
             entities={entities}
-            isRecommendation={false}
             settings={[PublicStatusAction]}
             emptyMessage={<NoRatingMessage hasFilter={hasFilter} />}
             personalScores={personalScores}

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -184,7 +184,11 @@ export const polls: Array<SelectablePoll> = [
           name: PRESIDENTIELLE_2022_POLL_NAME,
           displayOrder: 20,
           path: '/presidentielle2022/',
-          disabledRouteIds: [RouteID.MyRateLaterList, RouteID.MyComparedItems],
+          disabledRouteIds: [
+            RouteID.Recommendations,
+            RouteID.MyRateLaterList,
+            RouteID.MyComparedItems,
+          ],
           iconComponent: HowToVote,
           withSearchBar: false,
           topBarBackground:

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -184,11 +184,7 @@ export const polls: Array<SelectablePoll> = [
           name: PRESIDENTIELLE_2022_POLL_NAME,
           displayOrder: 20,
           path: '/presidentielle2022/',
-          disabledRouteIds: [
-            RouteID.Recommendations,
-            RouteID.MyRateLaterList,
-            RouteID.MyComparedItems,
-          ],
+          disabledRouteIds: [RouteID.MyRateLaterList, RouteID.MyComparedItems],
           iconComponent: HowToVote,
           withSearchBar: false,
           topBarBackground:

--- a/frontend/src/utils/entity.ts
+++ b/frontend/src/utils/entity.ts
@@ -22,7 +22,7 @@ export const videoFromRelatedEntity = (entity: RelatedEntityObject): Video => {
   };
 };
 
-export const videoWithCriteriaFromRecommendation = (
+export const videoWithScoresFromRecommendation = (
   entity: Recommendation
 ): VideoSerializerWithCriteria => {
   const video = videoFromRelatedEntity(entity);


### PR DESCRIPTION
**related to** #833

---

**(1)**

The pages recommendation and ratings now uses the new `EntityList` component. This component is simply a wrapper around a `VideoList` but step by step will become generic.

The very specific component `RateLater` uses directly the `VideoList` instead, as the rate later API only works with video (and not entity) JSON object.

**(2)**

The feature `RecommendationApi` is now generic and can retrieve recommendations from any poll.

### further improvements

The `VideoRatings` could be refactored into an `EntityRatings`, because it currently works with entities but is still called `VideoRatings`. 