### PR TITLE
[e2e] tests: add missing tests related tot he upload filter

### DIFF
--- a/tests/cypress/integration/frontend/recommendationsPage.ts
+++ b/tests/cypress/integration/frontend/recommendationsPage.ts
@@ -1,11 +1,84 @@
-describe('Recommendations', () => {
-    it('sets default languages properly and backward navigation works', () => {
-      cy.visit('/');
-      cy.location('pathname').should('equal', '/');
-      cy.contains('Recommendations').click();
-      cy.contains('Filters', {matchCase: false}).should('be.visible');
-      cy.location('search').should('contain', 'language=en');
-      cy.go('back');
-      cy.location('pathname').should('equal', '/');
-    })
-  })
+describe('Recommendations page', () => {
+  describe('Poll - video', () => {
+    describe('Search filters', () => {
+      it('sets default languages properly and backward navigation works', () => {
+        cy.visit('/');
+        cy.location('pathname').should('equal', '/');
+        cy.contains('Recommendations').click();
+        cy.contains('Filters', {matchCase: false}).should('be.visible');
+        cy.location('search').should('contain', 'language=en');
+        cy.go('back');
+        cy.location('pathname').should('equal', '/');
+      })
+  
+      describe('Filter - upload date', () => {
+        it('must propose 5 timedelta', () => {
+          cy.visit('/');
+          cy.contains('Recommendations').click();
+
+          cy.contains('Filters', {matchCase: false}).click();
+          cy.contains('Uploaded', {matchCase: false}).should('be.visible');
+          cy.contains('A day ago', {matchCase: false}).should('be.visible');
+          cy.contains('A week ago', {matchCase: false}).should('be.visible');
+          cy.contains('A month ago', {matchCase: false}).should('be.visible');
+          cy.contains('A year ago', {matchCase: false}).should('be.visible');
+          cy.contains('All time', {matchCase: false}).should('be.visible');
+        })
+
+        it('must filter by month by default ', () => {
+          cy.visit('/');
+          cy.contains('Recommendations').click();
+
+          // The month filter must appear in the URL.
+          cy.location('search').should('contain', 'date=Month');
+
+          cy.contains('Filters', {matchCase: false}).click();
+          // The month input must be checked.
+          cy.contains('A month ago', {matchCase: false}).should('be.visible');
+          cy.get('input[type=checkbox][name=Month]').should('be.checked');
+
+          // Currently there is no recent video in the development data.
+          cy.contains('No video corresponds to your search criterias.', {matchCase: false}).should('be.visible');
+        })
+
+        it('allows to filter: a year ago', () => {
+          cy.visit('/');
+          cy.contains('Recommendations').click();
+
+          cy.contains('Filters', {matchCase: false}).click();
+          // Video are filtered by month by default.
+          cy.get('input[type=checkbox][name=Month]').should('be.checked');
+          cy.contains('No video corresponds to your search criterias.', {matchCase: false}).should('be.visible');
+
+          cy.contains('A year ago', {matchCase: false}).should('be.visible');
+          cy.get('input[type=checkbox][name="Year"]').check();
+          cy.get('input[type=checkbox][name="Year"]').should('be.checked');
+          cy.get('input[type=checkbox][name=Month]').should('not.be.checked');
+
+          cy.location('search').should('contain', 'date=Year');
+          cy.contains('Showing videos 1 to 20 of', {matchCase: false}).should('be.visible');
+          cy.contains('No video corresponds to your search criterias.', {matchCase: false}).should('not.exist');
+        })
+
+        it('allows to filter: all time', () => {
+          cy.visit('/');
+          cy.contains('Recommendations').click();
+
+          cy.contains('Filters', {matchCase: false}).click();
+          // Video are filtered by month by default.
+          cy.get('input[type=checkbox][name=Month]').should('be.checked');
+          cy.contains('No video corresponds to your search criterias.', {matchCase: false}).should('be.visible');
+
+          cy.contains('A year ago', {matchCase: false}).should('be.visible');
+          cy.get('input[type=checkbox][name=""]').check();
+          cy.get('input[type=checkbox][name=""]').should('be.checked');
+          cy.get('input[type=checkbox][name=Month]').should('not.be.checked');
+
+          cy.location('search').should('contain', 'date=');
+          cy.contains('Showing videos 1 to 20 of', {matchCase: false}).should('be.visible');
+          cy.contains('No video corresponds to your search criterias.', {matchCase: false}).should('not.exist');
+        })
+      });
+    });
+  });
+})


### PR DESCRIPTION
These tests are not very robust yet. As they check the presence of videos using the upload date filter, they will start to fail in ~ 7 months if no new videos are added to the development data.

Few solutions: **(1)** automatically set the upload date of videos to various recent date in the dev-env, so that at any point in time we are sure we have X videos considered uploaded during the last month, Y during the last year, etc. **(2)** regularly add new videos to the development data (which can make some tests slightly harder to maintain if they are counting videos objects). 