### PR TITLE
Fix video metadata not being serialized correctly on refresh

### DIFF
--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -57,6 +57,12 @@ class EntityType(ABC):
         serializer.is_valid(raise_exception=True)
         return serializer.validated_data
 
+    @property
+    def cleaned_metadata(self):
+        serializer = self.metadata_serializer_class(data=self.instance.metadata)
+        serializer.is_valid(raise_exception=True)
+        return serializer.data
+
     def metadata_needs_to_be_refreshed(self) -> bool:
         return False
 
@@ -77,6 +83,8 @@ class EntityType(ABC):
             self.instance.save(update_fields=["last_metadata_request_at"])
 
         self.update_metadata_field()
+        # Ensure that the metadata format is valid after refresh
+        self.instance.metadata = self.cleaned_metadata
         self.instance.metadata_timestamp = timezone.now()
         if save:
             self.instance.save(update_fields=["metadata", "metadata_timestamp"])

--- a/backend/tournesol/migrations/0038_fix_metadata_views.py
+++ b/backend/tournesol/migrations/0038_fix_metadata_views.py
@@ -15,7 +15,7 @@ def migrate_forward(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('tournesol', '0037_contributorscaling'),
+        ('tournesol', '0038_alter_entitycriteriascore_unique_together_and_more'),
     ]
 
     operations = [migrations.RunPython(migrate_forward, migrations.RunPython.noop)]

--- a/backend/tournesol/migrations/0038_fix_metadata_views.py
+++ b/backend/tournesol/migrations/0038_fix_metadata_views.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+def migrate_forward(apps, schema_editor):
+    """
+    Convert number of views from str to int in metadata
+    """
+    Entity = apps.get_model("tournesol", "Entity")
+    for entity in Entity.objects.filter(type="video").iterator():
+        views = entity.metadata.get("views")
+        if isinstance(views, str):
+            entity.metadata["views"] = int(views)
+            entity.save(update_fields=["metadata"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tournesol', '0037_contributorscaling'),
+    ]
+
+    operations = [migrations.RunPython(migrate_forward, migrations.RunPython.noop)]
+

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -886,7 +886,9 @@ class ComparisonApiTestCase(TestCase):
 
     @patch("tournesol.utils.api_youtube.get_video_metadata")
     def test_metadata_refresh_on_comparison_creation(self, mock_get_video_metadata):
-        mock_get_video_metadata.return_value = {}
+        mock_get_video_metadata.return_value = {
+            "views": "42000"
+        }
 
         user = UserFactory(username="non_existing_user")
         self.client.force_authenticate(user=user)
@@ -909,6 +911,8 @@ class ComparisonApiTestCase(TestCase):
         response = self.client.post(self.comparisons_base_url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
         self.assertEqual(len(mock_get_video_metadata.mock_calls), 2)
+        video01.refresh_from_db()
+        self.assertEqual(video01.metadata["views"], 42000)
 
         data = {
             "entity_a": {"uid": self._uid_01},


### PR DESCRIPTION
When the video metadata are refreshed on comparison submit, the metadata serializer was not called. 
And the number of views was stored as a string instead of an integer in the "metadata" JSON field.
