### PR TITLE
[front] style: set background to light grey instead of white

### DIFF
--- a/frontend/src/features/frame/Frame.tsx
+++ b/frontend/src/features/frame/Frame.tsx
@@ -19,7 +19,6 @@ const useStyles = makeStyles({
     flexGrow: 1,
     overflow: 'auto',
     height: '100%',
-    backgroundColor: '#ffffff',
   },
 });
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,7 +2,7 @@ html, body, #root {
   margin: 0;
   width: 100%;
   height: 100%;
-  background-color: #ffffff;
+  background-color: #fafafa;
 }
 
 body {


### PR DESCRIPTION
**related to** #857 

---

The majority of our components used a white background, and the main background of the application was white too. This absence of contrast made hard to distinguish foreground components from background ones.

It also removed the benefits of using MUI `<Paper>` and similar components, which have a drop shadow that makes them look like a paper displayed on top on something else. Cast on a white background this shadow is less clear-cut, and acts more as a simple delimiter rather than a proper invitation to consider the component more important than underlying surface.

Having different contrast between foreground and background component helps to understand what's going on on the screen (modals are usually display on top of a greyed background), and should help the user navigate in the application. 

| before | after |
|-------------|-----------|
| ![capture](https://user-images.githubusercontent.com/39056254/166927809-4e7f38c3-9abd-499e-ac69-31b0a4ba0ecd.png) | ![cap2](https://user-images.githubusercontent.com/39056254/166927826-a821cac8-b88e-4a6f-af59-65a2c74b6380.png)  |

I used the color `#fafafa` instead of `#ffffff`.

The color of the title container and the side bar container might feel too close the new back ground color. 

**important** I saw on Figma that all backgrounds were white, and there were no `<Paper>` with borders or shadows. A possible second step in a following PR could be to keep the background white and to remove the borders of our papers [1]. If we want to keep the borders this PR should be enough and should make the application more accessible. 

See https://www.figma.com/file/3uI7FiBhXp0hhgdTdHBSkj/Tournesol?node-id=46%3A0

[1]: this could be a "good first issue".