### PR TITLE
Add script to update openapi with dev-env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ end representation the back end OpenAPI schema.
 **step 3** Don't forget to re-generate the service files by running
 `scripts/generate-services-from-openapi.sh`
 
+If you're using `dev-env` you can update the schema and the service files by running the script `dev-env/update-openapi.sh`.
+
 ### Front end
 
 To correct the lint of frontend files, it is possible to activate plugin

--- a/dev-env/update-openapi.sh
+++ b/dev-env/update-openapi.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+DIR="$(realpath -e "$(dirname "$0")")"
+cd "$DIR"
+
+set -x
+
+curl -o ../frontend/scripts/openapi.yaml http://localhost:8000/schema/
+docker exec tournesol-dev-front scripts/generate-services-from-openapi.sh


### PR DESCRIPTION
Updating openapi when using dev-env is not easy. The `yarn update-schema` command doesn't work within the container (`wget` is not installed and the API is not accessible through the default `localhost:8000`). So I made a small script to do it.

It may be better to make `update-schema` work in the container, but this solution is simple (and `curl` is already a requirement). I'm not sure where it should be documented though.