### PR TITLE
Candidates ranking page with total_score in card and multiple score modes 

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -171,7 +171,7 @@
         "label": "All equal"
       },
       "trustedOnly": {
-        "description": "Only accounts associated with <2>a trusted email address</2>are considered",
+        "description": "Only accounts associated with <2>a trusted email address</2> are considered",
         "label": "Trusted only"
       }
     },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -317,7 +317,9 @@
       "whyCompareCandidates": "Initially developped to identify top videos of public utility, Tournesol now enables you to compare the French presidential election candidates. And so you will receive feedback and insights from Tournesol's algorithms about your explicited preferences.",
       "dataUsage": "Submitted data will never be revealed to other users, and will only be used to help research on the ethics of algorithms and artificial intelligence.",
       "createAccount": "Create account",
-      "start": "Start"
+      "start": "Start",
+      "pollIsClosed": "The poll is now closed.",
+      "seeResults": "See results"
     },
     "contributeTitle": "Contribute!",
     "contributeDetail": "Tournesol identifies high quality content from comparisons provided by the community. To contribute, you must compare videos that you have watched. First copy paste two links to videos, then tell us which video you think should be largely recommended. If you want to you can also compare the videos in more details based on the multiple comparison criterias.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -24,6 +24,9 @@
     "contributionsArePrivateMessage": "Your contributions about this item are currently private. The details of your personal ratings are not published, but they may still be used to compute public aggregated scores.",
     "personalScore": "Personal score: {{score}}"
   },
+  "score": {
+    "totalScoreBasedOnRankingChoice": "Score based on selected ranking parameters"
+  },
   "pagination": {
     "videos": "videos",
     "previousButton": "Previous {{limit}}",
@@ -159,9 +162,18 @@
     "allLanguages": "All languages",
     "language": "Language",
     "scoreMode": {
-      "default": "Default",
-      "allEqual": "All users are equal",
-      "trustedOnly": "Trusted emails only"
+      "default": {
+        "description": "More importance is given to accounts associated with a trusted email address",
+        "label": "Default"
+      },
+      "allEqual": {
+        "description": "Equal importance is given to all accounts",
+        "label": "All equal"
+      },
+      "trustedOnly": {
+        "description": "Only accounts associated with <2>a trusted email address</2>are considered",
+        "label": "Trusted only"
+      }
     },
     "scoreModeSection": "Voting rights",
     "uploader": "Uploader"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -158,6 +158,12 @@
     "uploadDate": "Uploaded",
     "allLanguages": "All languages",
     "language": "Language",
+    "scoreMode": {
+      "default": "Default",
+      "allEqual": "All users are equal",
+      "trustedOnly": "Trusted emails only"
+    },
+    "scoreModeSection": "Voting rights",
     "uploader": "Uploader"
   },
   "ratings": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -323,7 +323,9 @@
       "whyCompareCandidates": "Initialement conçue pour la recommendation de vidéos d'utilité publique, Tournesol vous propose aujourd'hui de comparer les candidats à l'élection présidentielle française 2022. Ainsi, vous obtiendrez un aperçu de la façon dont les algorithmes de Tournesol analysent les préférences que vous exprimez.",
       "dataUsage": "Les données enregistrées ne seront jamais dévoilées aux autres utilisateurs, et ne serviront  qu'à la recherche dans l'éthique des algorithmes et en intelligence artificielle.",
       "createAccount": "Créer un compte",
-      "start": "Commencer"
+      "start": "Commencer",
+      "pollIsClosed": "Le scrutin est maintenant fermé.",
+      "seeResults": "Voir les résultats"
     },
     "contributeTitle": "Participez !",
     "contributeDetail": "Vous aussi, participez en donnant votre avis sur les vidéos YouTube que vous avez regardées. D'après vous, lesquelles devraient être les plus largement recommandées selon les différents critères identifiés par Tournesol ?",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -27,6 +27,9 @@
     "contributionsArePrivateMessage": "Vos contributions impliquant cet élément sont actuellement privées. Les détails de vos jugements ne sont pas publiés, mais ils sont tout de même pris en compte pour calculer des scores agrégés publics.",
     "personalScore": "Score personnel\u00a0: {{score}}"
   },
+  "score": {
+    "totalScoreBasedOnRankingChoice": "Score basé sur les critères de classement selectionnés"
+  },
   "pagination": {
     "videos": "vidéos",
     "previousButton": "{{limit}} prec.",
@@ -165,9 +168,18 @@
     "allLanguages": "Toutes",
     "language": "Langues",
     "scoreMode": {
-      "default": "Par défaut",
-      "allEqual": "Tous à égalité",
-      "trustedOnly": "Emails fiables seulement"
+      "default": {
+        "description": "Davantage d'importance est donnée aux comptes associés à une adresse e-mail fiable",
+        "label": "Par défaut"
+      },
+      "allEqual": {
+        "description": "Importance égale pour tous les comptes",
+        "label": "À égalité"
+      },
+      "trustedOnly": {
+        "description": "Seuls les comptes associés à <2>une adresse e-mail fiable</2> sont inclus",
+        "label": "E-mails fiables seulement"
+      }
     },
     "scoreModeSection": "Droits de vote",
     "uploader": "Chaîne"

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -164,6 +164,12 @@
     "uploadDate": "Mises en ligne depuis",
     "allLanguages": "Toutes",
     "language": "Langues",
+    "scoreMode": {
+      "default": "Par défaut",
+      "allEqual": "Tous à égalité",
+      "trustedOnly": "Emails fiables seulement"
+    },
+    "scoreModeSection": "Droits de vote",
     "uploader": "Chaîne"
   },
   "ratings": {

--- a/frontend/src/components/ChoicesFilterSection.tsx
+++ b/frontend/src/components/ChoicesFilterSection.tsx
@@ -20,7 +20,7 @@ import {
 interface Props {
   title: string;
   value: string;
-  choices: Record<string, string>;
+  choices: Record<string, React.ReactNode>;
   multipleChoice?: boolean;
   radio?: boolean;
   tooltip?: string;

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -19,6 +19,7 @@ import EntityMetadata from './EntityMetadata';
 import { entityCardMainSx } from './style';
 import { RelatedEntityObject, ActionList } from 'src/utils/types';
 import EntityCardScores from './EntityCardScores';
+import { TypeEnum } from 'src/services/openapi';
 
 const EntityCard = ({
   entity,
@@ -41,27 +42,26 @@ const EntityCard = ({
 
   const displayEntityCardScores = () => {
     if ('tournesol_score' in entity && !compact) {
-      return <EntityCardScores entity={entity} />;
+      return (
+        <EntityCardScores
+          entity={entity}
+          showTournesolScore={entity.type !== TypeEnum.CANDIDATE_FR_2022}
+          showTotalScore={entity.type === TypeEnum.CANDIDATE_FR_2022}
+        />
+      );
     }
     return null;
   };
 
   return (
     <Grid container sx={entityCardMainSx}>
-      <Grid
-        item
-        xs={12}
-        sm={compact ? 12 : 4}
-        md={compact ? 12 : 3}
-        sx={{ aspectRatio: '16 / 9' }}
-      >
-        <EntityImagery entity={entity} />
+      <Grid item xs={12} sm={compact ? 12 : 'auto'}>
+        <EntityImagery entity={entity} compact={compact} />
       </Grid>
       <Grid
         item
         xs={12}
-        sm={compact ? 12 : 7}
-        md={compact ? 12 : 8}
+        sm={compact ? 12 : true}
         sx={{
           padding: 1,
         }}

--- a/frontend/src/components/entity/EntityCardScores.tsx
+++ b/frontend/src/components/entity/EntityCardScores.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { Box, Theme, Stack, Tooltip, Typography } from '@mui/material';
-import { Warning as WarningIcon } from '@mui/icons-material';
+import {
+  Warning as WarningIcon,
+  HelpOutline as HelpIcon,
+} from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import { displayScore } from 'src/utils/criteria';
@@ -100,10 +103,18 @@ const EntityCardScores = ({
   return (
     <>
       {showTotalScore && (
-        <Typography color="text.secondary">
-          Score : <strong>{entity.total_score.toFixed(2)}</strong>
-          {''}
-        </Typography>
+        <Box display="flex" alignItems="center" columnGap={1}>
+          <Typography color="text.secondary">
+            Score : <strong>{entity.total_score.toFixed(2)}</strong>
+            {''}
+          </Typography>
+          <Tooltip
+            title={t('score.totalScoreBasedOnRankingChoice')}
+            placement="right"
+          >
+            <HelpIcon fontSize="inherit" color="action" />
+          </Tooltip>
+        </Box>
       )}
       <Box
         display="flex"

--- a/frontend/src/components/entity/EntityCardScores.tsx
+++ b/frontend/src/components/entity/EntityCardScores.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-import { Box, Theme, Stack, Tooltip } from '@mui/material';
+import { Box, Theme, Stack, Tooltip, Typography } from '@mui/material';
 import { Warning as WarningIcon } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
@@ -10,6 +10,8 @@ import CriteriaIcon from '../CriteriaIcon';
 
 interface Props {
   entity: Recommendation;
+  showTournesolScore?: boolean;
+  showTotalScore?: boolean;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -37,7 +39,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const EntityCardScores = ({ entity }: Props) => {
+const EntityCardScores = ({
+  entity,
+  showTournesolScore = true,
+  showTotalScore = false,
+}: Props) => {
   const { t } = useTranslation();
   const classes = useStyles();
   const { getCriteriaLabel, options } = useCurrentPoll();
@@ -92,97 +98,111 @@ const EntityCardScores = ({ entity }: Props) => {
   );
 
   return (
-    <Box
-      display="flex"
-      flexWrap="wrap"
-      alignItems="center"
-      columnGap="12px"
-      paddingBottom={1}
-    >
-      {'tournesol_score' in entity && entity.tournesol_score != null && (
-        <Tooltip title={tournesolScoreTitle} placement="right">
-          <Box
-            display="flex"
-            alignItems="center"
-            data-testid="video-card-overall-score"
-            {...(isUnsafe && {
-              sx: {
-                filter: 'grayscale(100%)',
-                opacity: 0.6,
-              },
-            })}
-          >
-            <img
-              className="tournesol"
-              src={'/svg/tournesol.svg'}
-              alt="logo"
-              title="Overall score"
-              width={32}
-            />
-            <span className={classes.nb_tournesol}>
-              {entity.tournesol_score.toFixed(0)}
+    <>
+      {showTotalScore && (
+        <Typography color="text.secondary">
+          Score : <strong>{entity.total_score.toFixed(2)}</strong>
+          {''}
+        </Typography>
+      )}
+      <Box
+        display="flex"
+        flexWrap="wrap"
+        alignItems="center"
+        columnGap="12px"
+        paddingBottom={1}
+      >
+        {showTournesolScore &&
+          'tournesol_score' in entity &&
+          entity.tournesol_score != null && (
+            <Tooltip title={tournesolScoreTitle} placement="right">
+              <Box
+                display="flex"
+                alignItems="center"
+                data-testid="video-card-overall-score"
+                {...(isUnsafe && {
+                  sx: {
+                    filter: 'grayscale(100%)',
+                    opacity: 0.6,
+                  },
+                })}
+              >
+                <img
+                  className="tournesol"
+                  src={'/svg/tournesol.svg'}
+                  alt="logo"
+                  title="Overall score"
+                  width={32}
+                />
+                <span className={classes.nb_tournesol}>
+                  {entity.tournesol_score.toFixed(0)}
+                </span>
+              </Box>
+            </Tooltip>
+          )}
+
+        {nbRatings != null && nbRatings > 0 && (
+          <Box data-testid="video-card-ratings">
+            <span className={classes.ratings}>
+              <Trans t={t} i18nKey="video.nbComparisonsBy" count={nbRatings}>
+                {{ count: nbRatings }} comparisons by
+              </Trans>
+            </span>{' '}
+            <span className={classes.contributors}>
+              <Trans
+                t={t}
+                i18nKey="video.nbContributors"
+                count={nbContributors}
+              >
+                {{ count: nbContributors }} contributors
+              </Trans>
             </span>
           </Box>
-        </Tooltip>
-      )}
+        )}
 
-      {nbRatings != null && nbRatings > 0 && (
-        <Box data-testid="video-card-ratings">
-          <span className={classes.ratings}>
-            <Trans t={t} i18nKey="video.nbComparisonsBy" count={nbRatings}>
-              {{ count: nbRatings }} comparisons by
-            </Trans>
-          </span>{' '}
-          <span className={classes.contributors}>
-            <Trans t={t} i18nKey="video.nbContributors" count={nbContributors}>
-              {{ count: nbContributors }} contributors
-            </Trans>
-          </span>
-        </Box>
-      )}
-
-      {max_criteria !== '' && (
-        <Box
-          data-testid="video-card-minmax-criterias"
-          display="flex"
-          alignItems="center"
-          sx={{
-            fontFamily: 'Poppins',
-            fontSize: '0.9em',
-            color: 'text.secondary',
-            gap: '6px',
-          }}
-        >
-          {max_score > 0 && (
-            <>
-              <span>{t('video.criteriaRatedHigh')}</span>
-              <CriteriaIcon
-                criteriaName={max_criteria}
-                emojiSize="26px"
-                imgWidth="32px"
-                tooltip={`${getCriteriaLabel(max_criteria)}: ${displayScore(
-                  max_score
-                )}`}
-              />
-            </>
-          )}
-          <span />
-          {min_score < 0 && (
-            <>
-              <span>{t('video.criteriaRatedLow')}</span>
-              <CriteriaIcon
-                criteriaName={min_criteria}
-                emojiSize="26px"
-                imgWidth="32px"
-                tooltip={`${getCriteriaLabel(min_criteria)}: ${displayScore(
-                  min_score
-                )}`}
-              />
-            </>
-          )}
-        </Box>
-      )}
-    </Box>
+        {max_criteria !== '' && (
+          <Box
+            data-testid="video-card-minmax-criterias"
+            display="flex"
+            alignItems="center"
+            sx={{
+              fontFamily: 'Poppins',
+              fontSize: '0.9em',
+              color: 'text.secondary',
+              gap: '6px',
+            }}
+          >
+            {max_score > 0 && (
+              <>
+                <span>{t('video.criteriaRatedHigh')}</span>
+                <CriteriaIcon
+                  criteriaName={max_criteria}
+                  emojiSize="26px"
+                  imgWidth="32px"
+                  tooltip={`${getCriteriaLabel(max_criteria)}: ${displayScore(
+                    max_score
+                  )}`}
+                />
+              </>
+            )}
+            <span />
+            {min_score < 0 && (
+              <>
+                <span>{t('video.criteriaRatedLow')}</span>
+                <CriteriaIcon
+                  criteriaName={min_criteria}
+                  emojiSize="26px"
+                  imgWidth="32px"
+                  tooltip={`${getCriteriaLabel(min_criteria)}: ${displayScore(
+                    min_score
+                  )}`}
+                />
+              </>
+            )}
+          </Box>
+        )}
+      </Box>
+    </>
   );
 };
 

--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import ReactPlayer from 'react-player/youtube';
-import { Box } from '@mui/material';
+import { Avatar, Box } from '@mui/material';
 import { TypeEnum } from 'src/services/openapi';
 import { convertDurationToClockDuration } from 'src/utils/video';
 import { RelatedEntityObject } from 'src/utils/types';
@@ -26,6 +26,10 @@ const PlayerWrapper = React.forwardRef(function PlayerWrapper(
       height="100%"
       onClick={() => setIsDurationVisible(false)}
       ref={ref}
+      sx={{
+        minWidth: '240px',
+        minHeight: '135px',
+      }}
     >
       {isDurationVisible && formattedDuration && (
         <Box
@@ -71,14 +75,33 @@ export const VideoPlayer = ({
   );
 };
 
-const EntityImagery = ({ entity }: { entity: RelatedEntityObject }) => {
+const EntityImagery = ({
+  entity,
+  compact = false,
+}: {
+  entity: RelatedEntityObject;
+  compact?: boolean;
+}) => {
   if (entity.type === TypeEnum.VIDEO) {
-    return (
+    const player = (
       <VideoPlayer
         videoId={entity.metadata.video_id}
         duration={entity.metadata.duration}
       />
     );
+
+    if (compact) {
+      return (
+        <Box
+          sx={{
+            aspectRatio: '16 / 9',
+          }}
+        >
+          {player}
+        </Box>
+      );
+    }
+    return player;
   }
   if (entity.type === TypeEnum.CANDIDATE_FR_2022) {
     return (
@@ -87,13 +110,25 @@ const EntityImagery = ({ entity }: { entity: RelatedEntityObject }) => {
         maxHeight="280px"
         justifyContent="center"
         sx={{
-          '& img': {
+          '& > img': {
             flex: 1,
             objectFit: 'contain',
           },
         }}
       >
-        <img src={entity.metadata.image_url} alt={entity.metadata.name} />
+        {compact ? (
+          <img src={entity.metadata.image_url} alt={entity.metadata.name} />
+        ) : (
+          <Avatar
+            alt={entity?.metadata?.name || ''}
+            src={entity?.metadata?.image_url || ''}
+            sx={{
+              width: '60px',
+              height: '60px',
+              m: 2,
+            }}
+          />
+        )}
       </Box>
     );
   }

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -25,6 +25,7 @@ import {
   Info as InfoIcon,
   ListAlt as ListIcon,
   Stars as StarsIcon,
+  TableRows as TableRowsIcon,
   VideoLibrary,
   WatchLater as WatchLaterIcon,
 } from '@mui/icons-material';
@@ -35,7 +36,7 @@ import { LanguageSelector } from 'src/components';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import {
   getRecommendationPageName,
-  PRESIDENTIELLE_2022_POLL_NAME,
+  YOUTUBE_POLL_NAME,
 } from 'src/utils/constants';
 import { RouteID } from 'src/utils/types';
 import Footer from './Footer';
@@ -132,7 +133,8 @@ const SideBar = () => {
     {
       id: RouteID.Recommendations,
       targetUrl: `${path}recommendations${defaultRecoSearchParams}`,
-      IconComponent: VideoLibrary,
+      IconComponent:
+        pollName === YOUTUBE_POLL_NAME ? VideoLibrary : TableRowsIcon,
       displayText: getRecommendationPageName(t, pollName),
     },
     { displayText: 'divider_1' },
@@ -201,14 +203,6 @@ const SideBar = () => {
           if (!IconComponent || !targetUrl)
             return <Divider key={displayText} />;
           if (id && disabledItems.includes(id)) {
-            return;
-          }
-
-          // Temporary: hide results page for "presidentielle2022" in menu
-          if (
-            id === RouteID.Recommendations &&
-            pollName === PRESIDENTIELLE_2022_POLL_NAME
-          ) {
             return;
           }
 

--- a/frontend/src/features/recommendation/CriteriaFilter.tsx
+++ b/frontend/src/features/recommendation/CriteriaFilter.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Grid, Typography, Slider, Tooltip } from '@mui/material';
-//import Autocomplete from '@mui/material/Autocomplete';
 
 import makeStyles from '@mui/styles/makeStyles';
 import withStyles from '@mui/styles/withStyles';
@@ -13,6 +12,7 @@ import CriteriaSelector from 'src/features/criteria/CriteriaSelector';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
+import { PRESIDENTIELLE_2022_POLL_NAME } from 'src/utils/constants';
 
 const useStyles = makeStyles(() => ({
   featuresContainer: {
@@ -80,7 +80,12 @@ function SingleCriteriaFilter({ setFilter }: FilterProps) {
   // end.
   const extraOption = '_total_score';
   const { criterias } = useCurrentPoll();
-  const [selectedCriteria, setSelectedCriteria] = useState(extraOption);
+  const { name: pollName, options } = useCurrentPoll();
+  const [selectedCriteria, setSelectedCriteria] = useState(() =>
+    pollName === PRESIDENTIELLE_2022_POLL_NAME
+      ? options?.mainCriterionName ?? ''
+      : extraOption
+  );
 
   function handleCriteriaChange(criteria: string) {
     setSelectedCriteria(criteria);
@@ -97,7 +102,9 @@ function SingleCriteriaFilter({ setFilter }: FilterProps) {
     <CriteriaSelector
       criteria={selectedCriteria}
       setCriteria={handleCriteriaChange}
-      extraEmptyOption={extraOption}
+      extraEmptyOption={
+        pollName === PRESIDENTIELLE_2022_POLL_NAME ? undefined : extraOption
+      }
     />
   );
 }
@@ -241,7 +248,7 @@ function CriteriaFilter({ setFilter }: FilterProps) {
                     onChange={() => setIsMultipleFilter(!isMultipleFilter)}
                   />
                 }
-                label={t('filter.multipleCriteria') as string}
+                label={t('filter.multipleCriteria')}
                 aria-label="multiple criteria"
               />
             </FormGroup>

--- a/frontend/src/features/recommendation/RecommendationApi.tsx
+++ b/frontend/src/features/recommendation/RecommendationApi.tsx
@@ -128,7 +128,9 @@ export const getRecommendations = async (
       offset: getParamValueAsNumber(params, 'offset'),
       search: params.get('search') ?? undefined,
       dateGte: params.get('date_gte') ?? undefined,
-      unsafe: params.get('unsafe') === 'true' || pollOptions?.unsafeDefault,
+      unsafe: params.has('unsafe')
+        ? params.get('unsafe') === 'true'
+        : pollOptions?.unsafeDefault,
       metadata: getMetadataFilter(pollName, params),
       scoreMode: (params.get('score_mode') as ScoreModeEnum) ?? undefined,
       weights: criteriaWeights,

--- a/frontend/src/features/recommendation/ScoreModeFilter.tsx
+++ b/frontend/src/features/recommendation/ScoreModeFilter.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Link as RouterLink } from 'react-router-dom';
+import { useTranslation, Trans } from 'react-i18next';
+import { Link, Tooltip } from '@mui/material';
+import { HelpOutline } from '@mui/icons-material';
 import { ChoicesFilterSection } from 'src/components';
 
 import { ScoreModeEnum } from 'src/features/recommendation/RecommendationApi';
@@ -9,13 +12,47 @@ interface Props {
   onChange: (value: string) => void;
 }
 
+const helpIcon = <HelpOutline fontSize="inherit" sx={{}} />;
+
 function ScoreModeFilter(props: Props) {
   const { t } = useTranslation();
 
   const scoreModeChoices = {
-    [ScoreModeEnum.DEFAULT]: t('filter.scoreMode.default'),
-    [ScoreModeEnum.ALL_EQUAL]: t('filter.scoreMode.allEqual'),
-    [ScoreModeEnum.TRUSTED_ONLY]: t('filter.scoreMode.trustedOnly'),
+    [ScoreModeEnum.DEFAULT]: (
+      <Tooltip title={t('filter.scoreMode.default.description')}>
+        <span>
+          {t('filter.scoreMode.default.label')} {helpIcon}
+        </span>
+      </Tooltip>
+    ),
+    [ScoreModeEnum.ALL_EQUAL]: (
+      <Tooltip title={t('filter.scoreMode.allEqual.description')}>
+        <span>
+          {t('filter.scoreMode.allEqual.label')} {helpIcon}
+        </span>
+      </Tooltip>
+    ),
+    [ScoreModeEnum.TRUSTED_ONLY]: (
+      <Tooltip
+        title={
+          <Trans t={t} i18nKey="filter.scoreMode.trustedOnly.description">
+            Only accounts associated with{' '}
+            <Link
+              component={RouterLink}
+              target="_blank"
+              to="/about/trusted_domains"
+            >
+              a trusted email address
+            </Link>
+            are considered
+          </Trans>
+        }
+      >
+        <span>
+          {t('filter.scoreMode.trustedOnly.label')} {helpIcon}
+        </span>
+      </Tooltip>
+    ),
   };
 
   return (

--- a/frontend/src/features/recommendation/ScoreModeFilter.tsx
+++ b/frontend/src/features/recommendation/ScoreModeFilter.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChoicesFilterSection } from 'src/components';
+
+import { ScoreModeEnum } from 'src/features/recommendation/RecommendationApi';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function ScoreModeFilter(props: Props) {
+  const { t } = useTranslation();
+
+  const scoreModeChoices = {
+    [ScoreModeEnum.DEFAULT]: t('filter.scoreMode.default'),
+    [ScoreModeEnum.ALL_EQUAL]: t('filter.scoreMode.allEqual'),
+    [ScoreModeEnum.TRUSTED_ONLY]: t('filter.scoreMode.trustedOnly'),
+  };
+
+  return (
+    <ChoicesFilterSection
+      title={t('filter.scoreModeSection')}
+      choices={scoreModeChoices}
+      radio
+      {...props}
+    />
+  );
+}
+
+export default ScoreModeFilter;

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -105,7 +105,7 @@ function SearchFilter() {
             <CriteriaFilter setFilter={setFilter} />
           </Grid>
           {pollName == PRESIDENTIELLE_2022_POLL_NAME && (
-            <Grid item xs={6} sm={4}>
+            <Grid item xs={12} sm={4}>
               <ScoreModeFilter
                 value={filterParams.get('score_mode') ?? ScoreModeEnum.DEFAULT}
                 onChange={(value) => setFilter('score_mode', value)}

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -8,13 +8,15 @@ import DateFilter from './DateFilter';
 import CriteriaFilter from './CriteriaFilter';
 import UploaderFilter from './UploaderFilter';
 import AdvancedFilter from './AdvancedFilter';
+import ScoreModeFilter from './ScoreModeFilter';
 import {
   recommendationFilters,
   defaultRecommendationFilters,
   YOUTUBE_POLL_NAME,
+  PRESIDENTIELLE_2022_POLL_NAME,
 } from 'src/utils/constants';
 import { saveRecommendationsLanguages } from 'src/utils/recommendationsLanguages';
-
+import { ScoreModeEnum } from 'src/features/recommendation/RecommendationApi';
 /**
  * Filter options for Videos recommendations
  *
@@ -102,6 +104,14 @@ function SearchFilter() {
           <Grid item xs={12} sm={12} md={6}>
             <CriteriaFilter setFilter={setFilter} />
           </Grid>
+          {pollName == PRESIDENTIELLE_2022_POLL_NAME && (
+            <Grid item xs={6} sm={4}>
+              <ScoreModeFilter
+                value={filterParams.get('score_mode') ?? ScoreModeEnum.DEFAULT}
+                onChange={(value) => setFilter('score_mode', value)}
+              />
+            </Grid>
+          )}
         </Grid>
       </Collapse>
     </Box>

--- a/frontend/src/pages/home/presidentielle2022/HomePresidentielle2022.tsx
+++ b/frontend/src/pages/home/presidentielle2022/HomePresidentielle2022.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Stack, Button, Typography } from '@mui/material';
+import { Box, Divider, Stack, Button, Typography } from '@mui/material';
 
 import TitleSection from 'src/pages/home/TitleSection';
 import PollListSection from 'src/pages/home/PollListSection';
@@ -11,7 +11,7 @@ import { useCurrentPoll, useLoginState } from 'src/hooks';
 const HomePresidentielle2022Page = () => {
   const { t } = useTranslation();
   const { isLoggedIn } = useLoginState();
-  const { baseUrl } = useCurrentPoll();
+  const { baseUrl, active } = useCurrentPoll();
 
   return (
     <AlternatingBackgroundColorSectionList
@@ -29,37 +29,59 @@ const HomePresidentielle2022Page = () => {
           {t('home.presidentielle2022.dataUsage')}
         </Typography>
 
-        <Stack spacing={2} direction="row">
-          {!isLoggedIn && (
+        {active ? (
+          <Stack spacing={2} direction="row">
+            {!isLoggedIn && (
+              <Button
+                size="large"
+                color="inherit"
+                variant="outlined"
+                component={Link}
+                to={`/signup`}
+                sx={{
+                  px: 4,
+                  textAlign: 'center',
+                  fontSize: '120%',
+                }}
+              >
+                {t('home.presidentielle2022.createAccount')}
+              </Button>
+            )}
             <Button
               size="large"
-              color="inherit"
-              variant="outlined"
+              color="primary"
+              variant="contained"
               component={Link}
-              to={`/signup`}
+              to={`${baseUrl}/comparison?series=true`}
               sx={{
                 px: 4,
-                textAlign: 'center',
                 fontSize: '120%',
               }}
             >
-              {t('home.presidentielle2022.createAccount')}
+              {t('home.presidentielle2022.start')}
             </Button>
-          )}
-          <Button
-            size="large"
-            color="primary"
-            variant="contained"
-            component={Link}
-            to={`${baseUrl}/comparison?series=true`}
-            sx={{
-              px: 4,
-              fontSize: '120%',
-            }}
-          >
-            {t('home.presidentielle2022.start')}
-          </Button>
-        </Stack>
+          </Stack>
+        ) : (
+          <Box width="100%">
+            <Divider sx={{ my: 1 }} />
+            <Typography paragraph color="#666">
+              {t('home.presidentielle2022.pollIsClosed')}
+            </Typography>
+            <Button
+              size="large"
+              color="primary"
+              variant="contained"
+              component={Link}
+              to={`${baseUrl}/recommendations`}
+              sx={{
+                px: 4,
+                fontSize: '120%',
+              }}
+            >
+              {t('home.presidentielle2022.seeResults')}
+            </Button>
+          </Box>
+        )}
       </TitleSection>
       <PollListSection />
       {/* 

--- a/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
@@ -81,6 +81,7 @@ describe('RecommendationPage', () => {
       'videos',
       20,
       '?language=fr%2Cen',
+      expect.anything(),
       expect.anything()
     );
   });
@@ -99,6 +100,7 @@ describe('RecommendationPage', () => {
       'videos',
       20,
       '?language=de',
+      expect.anything(),
       expect.anything()
     );
   });
@@ -116,6 +118,7 @@ describe('RecommendationPage', () => {
       'videos',
       20,
       '?language=fr',
+      expect.anything(),
       expect.anything()
     );
   });

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -78,7 +78,8 @@ function RecommendationsPage() {
           pollName,
           limit,
           location.search,
-          criterias
+          criterias,
+          options
         )) || []
       );
       setIsLoading(false);
@@ -91,6 +92,7 @@ function RecommendationsPage() {
     location.search,
     pollName,
     searchParams,
+    options,
   ]);
 
   return (
@@ -108,7 +110,7 @@ function RecommendationsPage() {
             }
           />
         </LoaderWrapper>
-        {!isLoading && entitiesCount > 0 && (
+        {!isLoading && entitiesCount > limit && (
           <Pagination
             offset={offset}
             count={entitiesCount}

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -12,7 +12,11 @@ import { idFromUid } from './video';
 
 export const CompareNowAction = ({ uid }: { uid: string }) => {
   const { t } = useTranslation();
-  const { baseUrl } = useCurrentPoll();
+  const { baseUrl, active } = useCurrentPoll();
+
+  if (!active) {
+    return null;
+  }
 
   return (
     <Tooltip title={`${t('actions.compareNow')}`} placement="left">

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -220,6 +220,7 @@ export const polls: Array<SelectablePoll> = [
           tutorialLength: 7,
           tutorialAlternatives: getAllCandidates,
           tutorialDialogs: getTutorialDialogs,
+          unsafeDefault: true,
         },
       ]
     : []),

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -4,6 +4,7 @@ import { SvgIconComponent } from '@mui/icons-material';
 import {
   Entity,
   EntityNoExtraField,
+  Recommendation,
   RelatedEntity,
   Video,
   VideoSerializerWithCriteria,
@@ -25,7 +26,10 @@ export type ActionList = Array<
   (({ uid }: { uid: string }) => JSX.Element) | React.ReactNode
 >;
 
-export type RelatedEntityObject = EntityNoExtraField | RelatedEntity;
+export type RelatedEntityObject =
+  | EntityNoExtraField
+  | RelatedEntity
+  | Recommendation;
 export type VideoObject = Video | VideoSerializerWithCriteria;
 
 /**
@@ -85,4 +89,6 @@ export type SelectablePoll = {
   // that are suggested after each comparison
   tutorialAlternatives?: () => Promise<Array<Entity>>;
   tutorialDialogs?: (t: TFunction) => OrderedDialogs;
+  // whether the 'unsafe' recommendations should be included by default
+  unsafeDefault?: boolean;
 };


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4726554/167139373-8847a21b-5cb8-4c82-a02f-9a61ba381ed2.png)


There are a few ugly workarounds in this PR to handle some differences between the videos recommendations and the candidate results:
 * "total_score" are displayed in the entity card instead of tournesol score, to adapt dynamically with the selected criteria
 * the default value for the `CriteriaFilter` is the main criterion, and the request parameters to the recommendations API have to be tweaked as the filter is currently only applied after the filter section is visible and its value changes.
 * a new filter "Voting rights" is present (only for this poll for now)

It should close #833