### PR TITLE
API for "proof of vote", add the signature on the personal feedback page

### DIFF
--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -5,6 +5,8 @@ Administration interface of the `tournesol` app
 from django.contrib import admin
 from django.contrib.admin.filters import SimpleListFilter
 from django.db.models import Q, QuerySet
+from django.urls import reverse
+from django.utils.html import format_html
 from sql_util.utils import SubqueryCount
 
 from .models import (
@@ -262,6 +264,7 @@ class PollAdmin(admin.ModelAdmin):
         'get_n_criteria',
         'get_n_comparisons',
         'get_n_comparisons_per_criteria',
+        'get_proof_of_vote_file',
     )
     list_filter = ("active", "algorithm", "entity_type")
     inlines = (CriteriasInline,)
@@ -291,6 +294,13 @@ class PollAdmin(admin.ModelAdmin):
     )
     def get_n_comparisons_per_criteria(self, obj):
         return obj._n_comparisons_per_criteria
+
+    @admin.display(description="Proof of vote")
+    def get_proof_of_vote_file(self, obj):
+        return format_html(
+            "<a href={url}>CSV</a>",
+            url=reverse("tournesol:export_poll_proof_of_vote", kwargs={"poll_name": obj.name})
+        )
 
 
 @admin.register(Criteria)

--- a/backend/tournesol/models/poll.py
+++ b/backend/tournesol/models/poll.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from django.core.signing import Signer
 from django.db import models
 from django.utils.functional import cached_property
 
@@ -64,3 +65,14 @@ class Poll(models.Model):
 
     def __str__(self) -> str:
         return f'Poll "{self.name}"'
+
+    def get_proof_of_vote(self, user_id: int):
+        """
+        Returns the user_id signed with a signature,
+        derived from the Django SECRET_KEY and the current poll name.
+
+        Should only be provided for the user after they submitted
+        at least 1 comparison in the current poll.
+        """
+        signer = Signer(salt=f"proof_of_vote:{self.name}")
+        return signer.sign(f"{user_id:05d}")

--- a/backend/tournesol/serializers/proof_of_vote.py
+++ b/backend/tournesol/serializers/proof_of_vote.py
@@ -1,0 +1,7 @@
+from rest_framework.fields import CharField
+from rest_framework.serializers import Serializer
+
+
+class ProofOfVoteSerializer(Serializer):
+    poll_name = CharField()
+    signature = CharField()

--- a/backend/tournesol/tests/test_proof_of_vote.py
+++ b/backend/tournesol/tests/test_proof_of_vote.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.tests.factories.user import UserFactory
+
+from .factories.comparison import ComparisonFactory
+from .factories.poll import PollFactory
+
+
+class PollsApi(TestCase):
+    def setUp(self):
+        self.poll = PollFactory()
+        self.user1 = UserFactory(pk=42)
+        self.user2 = UserFactory()
+        ComparisonFactory(
+            poll=self.poll,
+            user=self.user1
+        )
+
+    def test_proof_of_vote_denied(self):
+        """A user without comparison cannot retrieve a proof of vote"""
+        client = APIClient()
+        client.force_authenticate(self.user2)
+        response = client.get(f"/users/me/proof_of_votes/{self.poll.name}/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_retrieve_proof_of_vote(self):
+        """Retrieve a proof of vote """
+        client = APIClient()
+        client.force_authenticate(self.user1)
+        response = client.get(f"/users/me/proof_of_votes/{self.poll.name}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["poll_name"], self.poll.name)
+        self.assertTrue(response.data["signature"].startswith("00042:"))

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -7,6 +7,8 @@ Defines Tournesol's backend API routes
 from django.urls import include, path
 from rest_framework import routers
 
+from tournesol.views.proof_of_vote import ProofOfVoteView
+
 from .views import ComparisonDetailApi, ComparisonListApi, ComparisonListFilteredApi
 from .views.contributor_recommendations import (
     PrivateContributorRecommendationsView,
@@ -15,7 +17,12 @@ from .views.contributor_recommendations import (
 from .views.criteria_correlations import ContributorCriteriaCorrelationsView
 from .views.email_domains import EmailDomainsList
 from .views.entities import EntitiesViewSet
-from .views.exports import ExportAllView, ExportComparisonsView, ExportPublicComparisonsView
+from .views.exports import (
+    ExportAllView,
+    ExportComparisonsView,
+    ExportProofOfVoteView,
+    ExportPublicComparisonsView,
+)
 from .views.inconsistencies import ScoreInconsistencies
 from .views.polls import PollsCriteriaScoreDistributionView, PollsRecommendationsView, PollsView
 from .views.ratings import (
@@ -49,6 +56,11 @@ urlpatterns = [
         "exports/comparisons/",
         ExportPublicComparisonsView.as_view(),
         name="export_public",
+    ),
+    path(
+        "exports/polls/<str:poll_name>/proof_of_vote/",
+        ExportProofOfVoteView.as_view(),
+        name="export_poll_proof_of_vote",
     ),
     # Comparison API
     path(
@@ -121,6 +133,12 @@ urlpatterns = [
         "users/me/criteria_correlations/<str:poll_name>/",
         ContributorCriteriaCorrelationsView.as_view(),
         name="contributor_criteria_correlations",
+    ),
+    # Proof of votes
+    path(
+        "users/me/proof_of_votes/<str:poll_name>/",
+        ProofOfVoteView.as_view(),
+        name="proof_of_vote",
     ),
     # Email domain API
     path("domains/", EmailDomainsList.as_view(), name="email_domains_list"),

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -163,7 +163,7 @@ class ExportProofOfVoteView(PollScopedViewMixin, APIView):
     permission_classes = [IsAdminUser]
 
     @extend_schema(
-        description="Download current user data in .zip file",
+        description="Download .csv file with proof of vote signatures",
         responses={200: OpenApiTypes.BINARY},
     )
     def get(self, request, *args, **kwargs):

--- a/backend/tournesol/views/proof_of_vote.py
+++ b/backend/tournesol/views/proof_of_vote.py
@@ -1,5 +1,5 @@
 """
-API endpoints to show public statistics
+API endpoints to interact with the contributor's proof of work.
 """
 
 from rest_framework import generics
@@ -13,7 +13,7 @@ from .mixins.poll import PollScopedViewMixin
 
 class ProofOfVoteView(PollScopedViewMixin, generics.RetrieveAPIView):
     """
-    API for retrieving proof_of_vote in a given poll
+    API for retrieving the logged user's proof_of_vote in a given poll.
     """
     serializer_class = ProofOfVoteSerializer
 

--- a/backend/tournesol/views/proof_of_vote.py
+++ b/backend/tournesol/views/proof_of_vote.py
@@ -13,7 +13,7 @@ from .mixins.poll import PollScopedViewMixin
 
 class ProofOfVoteView(PollScopedViewMixin, generics.RetrieveAPIView):
     """
-    API for retrievring proof_of_vote in a given poll
+    API for retrieving proof_of_vote in a given poll
     """
     serializer_class = ProofOfVoteSerializer
 

--- a/backend/tournesol/views/proof_of_vote.py
+++ b/backend/tournesol/views/proof_of_vote.py
@@ -1,0 +1,33 @@
+"""
+API endpoints to show public statistics
+"""
+
+from rest_framework import generics
+from rest_framework.exceptions import PermissionDenied
+
+from tournesol.serializers.proof_of_vote import ProofOfVoteSerializer
+
+from ..models import Comparison
+from .mixins.poll import PollScopedViewMixin
+
+
+class ProofOfVoteView(PollScopedViewMixin, generics.RetrieveAPIView):
+    """
+    API for retrievring proof_of_vote in a given poll
+    """
+    serializer_class = ProofOfVoteSerializer
+
+    def get_object(self):
+        poll = self.poll_from_url
+        comparisons = Comparison.objects.filter(
+            user=self.request.user,
+            poll=poll,
+        )
+
+        if not comparisons.exists():
+            raise PermissionDenied
+
+        return {
+            "signature": poll.get_proof_of_vote(self.request.user.id),
+            "poll_name": poll.name,
+        }

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -363,14 +363,16 @@
       "notEnoughComparisons_other": "We need at least {{minComparisons}} different comparisons before being able to display your results. {{remainingComparisons}} comparisons are still required. Click on the button below, and follow the instructions to continue.",
       "continueComparisons": "Continue your comparisons",
       "thanksForComparingCandidates": "Thank you for comparing candidates on our platform",
-      "description": "Your opinions will now be included in a global evaluation and ranking of the candidates. After the election we will make the global results public. To protect the privacy and the opinions of all contributors, the individual contributions will remain private.",
+      "goToGlobalRanking": "Go to global ranking",
       "opinionsOnOnlineSharedContent": "We think your opinions on online shared contents are at least as equally important as your opinions on candidates.",
       "discoverTournesolVideos": "Discover Tournesol videos. A place where you can give your opinion on the YouTube videos you watch, to improve everyone's recommendations."
     },
     "generic": {
       "whatsNext": "What's next?",
       "discoverTournesol": "Discover Tournesol"
-    }
+    },
+    "proofOfVoteHelperText": "This code will be helpful to complete our survey.",
+    "proofOfVote": "Proof of vote"
   },
   "myRateLaterListPage": {
     "title": "My rate-later list"

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -370,14 +370,16 @@
       "notEnoughComparisons_other": "Nous avons besoin d'au moins {{minComparisons}} comparaisons différentes avant de pouvoir vous présenter des résultats. Il vous en restre encore {{remainingComparisons}} à faire. Cliquez sur le bouton ci-dessous pour continuer, et laissez-vous guider par les instructions.",
       "continueComparisons": "Continuer vos comparaisons",
       "thanksForComparingCandidates": "Merci d'avoir comparé des candidat.es sur notre plateforme",
-      "description": "Vos avis seront pris en compte dans l'évaluation et le classement global des candidat.es. Après les élections nous rendrons public les résultats globaux. Pour protéger la vie privée des contributeurs et contributrices, les résultats individuels resteront privés.",
+      "goToGlobalRanking": "Voir le classement global",
       "opinionsOnOnlineSharedContent": "Nous pensons que votre avis sur les contenus partagés en ligne est au moins aussi important que votre avis sur les candidat.es.",
       "discoverTournesolVideos": "Découvrez maintenant Tournesol vidéos. Un endroit qui vous permet de donner votre avis sur les vidéos YouTube que vous avez regardées, afin d'améliorer les recommandations de tous."
     },
     "generic": {
       "whatsNext": "Et maintenant ?",
       "discoverTournesol": "Découvrez Tournesol"
-    }
+    },
+    "proofOfVoteHelperText": "Ce code sera utile afin de répondre à notre sondage.",
+    "proofOfVote": "Preuve de participation"
   },
   "myRateLaterListPage": {
     "title": "À comparer plus tard"

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -426,6 +426,30 @@ paths:
                 type: string
                 format: binary
           description: ''
+  /exports/polls/{poll_name}/proof_of_vote/:
+    get:
+      operationId: exports_polls_proof_of_vote_retrieve
+      description: Download .csv file with proof of vote signatures
+      parameters:
+      - in: path
+        name: poll_name
+        schema:
+          type: string
+        required: true
+      tags:
+      - exports
+      security:
+      - cookieAuth: []
+      - oauth2:
+        - read write groups
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+                format: binary
+          description: ''
   /polls/{name}/:
     get:
       operationId: polls_retrieve
@@ -1371,6 +1395,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/ScoreInconsistencies'
           description: ''
+  /users/me/proof_of_votes/{poll_name}/:
+    get:
+      operationId: users_me_proof_of_votes_retrieve
+      description: API for retrieving proof_of_vote in a given poll
+      parameters:
+      - in: path
+        name: poll_name
+        schema:
+          type: string
+        required: true
+      tags:
+      - users
+      security:
+      - oauth2:
+        - read write groups
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProofOfVote'
+          description: ''
   /users/me/recommendations/{poll_name}:
     get:
       operationId: users_me_recommendations_list
@@ -2080,10 +2126,6 @@ components:
     ContributorRecommendations:
       type: object
       properties:
-        metadata:
-          type: object
-          additionalProperties: {}
-          readOnly: true
         tournesol_score:
           type: number
           format: float
@@ -2097,14 +2139,18 @@ components:
           readOnly: true
         type:
           $ref: '#/components/schemas/TypeEnum'
-        is_public:
-          type: boolean
+        metadata:
+          type: object
+          additionalProperties: {}
           readOnly: true
         uid:
           type: string
           description: A unique identifier, build with a namespace and an external
             id.
           maxLength: 144
+        is_public:
+          type: boolean
+          readOnly: true
         total_score:
           type: number
           format: float
@@ -2951,6 +2997,16 @@ components:
       required:
       - label
       - name
+    ProofOfVote:
+      type: object
+      properties:
+        poll_name:
+          type: string
+        signature:
+          type: string
+      required:
+      - poll_name
+      - signature
     RaceEnum:
       enum:
       - Not Specified
@@ -4374,6 +4430,10 @@ components:
       - video_id
       - views
   securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: sessionid
     oauth2:
       type: oauth2
       flows:

--- a/frontend/src/pages/personal/feedback/FeedbackPagePresidentielle2022.tsx
+++ b/frontend/src/pages/personal/feedback/FeedbackPagePresidentielle2022.tsx
@@ -23,6 +23,7 @@ import {
 } from 'src/services/openapi';
 import { getPollName, polls, YOUTUBE_POLL_NAME } from 'src/utils/constants';
 import { SelectablePoll } from 'src/utils/types';
+import ProofOfVote from './ProofOfVote';
 
 const COMPARISONS_NBR_MAX = 100;
 
@@ -157,13 +158,21 @@ const FeedbackPagePresidentielle2022 = () => {
           </>
         ) : (
           <>
-            <Typography variant="h2" textAlign="center">
+            <Typography variant="h3" textAlign="center">
               {t(
                 'myFeedbackPage.presidentielle2022.thanksForComparingCandidates'
               )}
             </Typography>
-            <Typography paragraph mt={2} textAlign="justify">
-              {t('myFeedbackPage.presidentielle2022.description')}
+            <ProofOfVote />
+            <Typography paragraph textAlign="right">
+              <Button
+                color="secondary"
+                variant="contained"
+                component={RouterLink}
+                to={`${baseUrl}/recommendations`}
+              >
+                {t('myFeedbackPage.presidentielle2022.goToGlobalRanking')}
+              </Button>
             </Typography>
             <Grid
               container

--- a/frontend/src/pages/personal/feedback/ProofOfVote.tsx
+++ b/frontend/src/pages/personal/feedback/ProofOfVote.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, TextField } from '@mui/material';
+import { UsersService } from 'src/services/openapi';
+import { useCurrentPoll } from 'src/hooks';
+
+const ProofOfVote = () => {
+  const { t } = useTranslation();
+  const { name: pollName } = useCurrentPoll();
+  const [code, setCode] = useState('');
+
+  useEffect(() => {
+    UsersService.usersMeProofOfVotesRetrieve({ pollName })
+      .then(({ signature }) => setCode(signature))
+      .catch(console.error);
+  }, [pollName]);
+
+  const codeHelperText = (
+    <span>
+      {t('myFeedbackPage.proofOfVoteHelperText')}{' '}
+      {/* TODO add link to survey:
+       <a target="_blank" href={'https://tournesol.app'} rel="noreferrer">
+        https://tournesol.app
+      </a> */}
+    </span>
+  );
+
+  return (
+    <Box my={2}>
+      {code && (
+        <>
+          <TextField
+            label={t('myFeedbackPage.proofOfVote')}
+            helperText={codeHelperText}
+            color="secondary"
+            fullWidth
+            value={code}
+            InputProps={{
+              readOnly: true,
+              sx: {
+                bgcolor: 'white',
+                fontFamily: 'monospace',
+              },
+            }}
+            onFocus={(e) => e.target.select()}
+          />
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default ProofOfVote;

--- a/frontend/src/pages/personal/feedback/ProofOfVote.tsx
+++ b/frontend/src/pages/personal/feedback/ProofOfVote.tsx
@@ -28,23 +28,21 @@ const ProofOfVote = () => {
   return (
     <Box my={2}>
       {code && (
-        <>
-          <TextField
-            label={t('myFeedbackPage.proofOfVote')}
-            helperText={codeHelperText}
-            color="secondary"
-            fullWidth
-            value={code}
-            InputProps={{
-              readOnly: true,
-              sx: {
-                bgcolor: 'white',
-                fontFamily: 'monospace',
-              },
-            }}
-            onFocus={(e) => e.target.select()}
-          />
-        </>
+        <TextField
+          label={t('myFeedbackPage.proofOfVote')}
+          helperText={codeHelperText}
+          color="secondary"
+          fullWidth
+          value={code}
+          InputProps={{
+            readOnly: true,
+            sx: {
+              bgcolor: 'white',
+              fontFamily: 'monospace',
+            },
+          }}
+          onFocus={(e) => e.target.select()}
+        />
       )}
     </Box>
   );


### PR DESCRIPTION
* New API route `GET /users/me/proof_of_votes/{poll_name}/`
  The signature is computed by a Django [`Signer`](https://docs.djangoproject.com/en/4.0/topics/signing/#module-django.core.signing), derived from the server `SECRET_KEY`, the poll name and the user id.
* Link on polls list for admins to download a .csv file with all signatures
* The code is visible at the top of the personal feedback page

![image](https://user-images.githubusercontent.com/4726554/167258159-98565d03-19ef-4719-b433-04161bf166e9.png)

