### PR TITLE
inconsistencies part 2/2 : cyclic inconsistencies (#671)

### DIFF
--- a/backend/tournesol/serializers/inconsistencies.py
+++ b/backend/tournesol/serializers/inconsistencies.py
@@ -2,6 +2,49 @@ from rest_framework import serializers
 from rest_framework.serializers import Serializer
 
 
+class CycleSerializer(Serializer):
+    """
+    Serializer for one cycle of length 3
+    """
+    criterion = serializers.CharField()
+    entity_1_uid = serializers.CharField()
+    entity_2_uid = serializers.CharField()
+    entity_3_uid = serializers.CharField()
+
+
+class CyclesStatsSerializer(Serializer):
+    """
+    Stats for each criterion
+
+    Includes the number of cycles, and the number of "comparison trios". This refers
+    to any 3 entities that all have a comparison to each other.
+
+    A useful metric could be the ratio of cycles (= cycles_count / comparison_trios_count).
+    We could consider that the better this ratio is, the more consistent the comparisons are.
+    """
+    cycles_count = serializers.IntegerField()
+    comparison_trios_count = serializers.IntegerField()
+
+
+class Length3CyclesSerializer(Serializer):
+    """
+    Return statistics about length-3 cycles in
+    the contributor's comparisons.
+    """
+    count = serializers.IntegerField()
+    results = CycleSerializer(many=True)
+    stats = serializers.DictField(child=CyclesStatsSerializer(), label="criterion")
+
+
+class Length3CyclesFilterSerializer(serializers.Serializer):
+
+    date_gte = serializers.DateTimeField(
+        default=None,
+        help_text="Restrict the search to entities created or edited after this date.\n"
+                  "Accepted formats: ISO 8601 datetime (e.g `2021-12-01T12:45:00`).",
+    )
+
+
 class ScoreInconsistencySerializer(Serializer):
     """
     Serializer for one element

--- a/backend/tournesol/serializers/inconsistencies.py
+++ b/backend/tournesol/serializers/inconsistencies.py
@@ -6,7 +6,7 @@ class CycleSerializer(Serializer):
     """
     Serializer for one cycle of length 3
     """
-    criterion = serializers.CharField()
+    criteria = serializers.CharField()
     entity_1_uid = serializers.CharField()
     entity_2_uid = serializers.CharField()
     entity_3_uid = serializers.CharField()
@@ -14,7 +14,7 @@ class CycleSerializer(Serializer):
 
 class CyclesStatsSerializer(Serializer):
     """
-    Stats for each criterion
+    Stats for each criteria
 
     Includes the number of cycles, and the number of "comparison trios". This refers
     to any 3 entities that all have a comparison to each other.
@@ -33,14 +33,14 @@ class Length3CyclesSerializer(Serializer):
     """
     count = serializers.IntegerField()
     results = CycleSerializer(many=True)
-    stats = serializers.DictField(child=CyclesStatsSerializer(), label="criterion")
+    stats = serializers.DictField(child=CyclesStatsSerializer(), label="criteria")
 
 
 class Length3CyclesFilterSerializer(serializers.Serializer):
 
     date_gte = serializers.DateTimeField(
         default=None,
-        help_text="Restrict the search to entities created or edited after this date.\n"
+        help_text="Restrict the search to comparisons done or edited after this date.\n"
                   "Accepted formats: ISO 8601 datetime (e.g `2021-12-01T12:45:00`).",
     )
 
@@ -50,7 +50,7 @@ class ScoreInconsistencySerializer(Serializer):
     Serializer for one element
     """
     inconsistency = serializers.FloatField()
-    criterion = serializers.CharField()
+    criteria = serializers.CharField()
     entity_1_uid = serializers.CharField()
     entity_2_uid = serializers.CharField()
     entity_1_rating = serializers.FloatField()
@@ -61,7 +61,7 @@ class ScoreInconsistencySerializer(Serializer):
 
 class ScoreInconsistenciesStatsSerializer(Serializer):
     """
-    Return some statistics for each criterion,
+    Return some statistics for each criteria,
     to be able to compare the results for the different criteria
     """
     mean_inconsistency = serializers.FloatField()
@@ -76,7 +76,7 @@ class ScoreInconsistenciesSerializer(Serializer):
     """
     count = serializers.IntegerField()
     results = ScoreInconsistencySerializer(many=True)
-    stats = serializers.DictField(child=ScoreInconsistenciesStatsSerializer(), label="criterion")
+    stats = serializers.DictField(child=ScoreInconsistenciesStatsSerializer(), label="criteria")
 
 
 class ScoreInconsistenciesFilterSerializer(Serializer):
@@ -89,6 +89,6 @@ class ScoreInconsistenciesFilterSerializer(Serializer):
 
     date_gte = serializers.DateTimeField(
         default=None,
-        help_text="Restrict the search to entities created or edited after this date.\n"
+        help_text="Restrict the search to comparisons done or edited after this date.\n"
                   "Accepted formats: ISO 8601 datetime (e.g `2021-12-01T12:45:00`).",
     )

--- a/backend/tournesol/tests/test_api_contributor_recommendations.py
+++ b/backend/tournesol/tests/test_api_contributor_recommendations.py
@@ -21,7 +21,7 @@ class ContributorRecommendationsApiTestCase(TestCase):
         self.client = APIClient()
 
         self.poll = Poll.default_poll()
-        self.criterion = self.poll.criterias_list[0]
+        self.criteria = self.poll.criterias_list[0]
 
         self.user1 = UserFactory()
         self.user2 = UserFactory()
@@ -50,7 +50,7 @@ class ContributorRecommendationsApiTestCase(TestCase):
             [
                 ContributorRatingCriteriaScore(
                     contributor_rating=contributor_rating,
-                    criteria=self.criterion,
+                    criteria=self.criteria,
                     score=1,
                     uncertainty=0,
                 )
@@ -209,7 +209,7 @@ class ContributorRecommendationsApiTestCase(TestCase):
         rating = ContributorRatingFactory(user=user, entity=entity, is_public=True)
         ContributorRatingCriteriaScoreFactory(
             contributor_rating=rating,
-            criteria=self.criterion,
+            criteria=self.criteria,
             score=-1,
         )
 
@@ -246,19 +246,19 @@ class ContributorRecommendationsApiTestCase(TestCase):
         user = UserFactory()
         self.client.force_authenticate(user)
 
-        criterion_score = 1.8
+        criteria_score = 1.8
         weight = 2
 
         entity = EntityFactory(tournesol_score=1)
         rating = ContributorRatingFactory(user=user, entity=entity, is_public=True)
         ContributorRatingCriteriaScoreFactory(
             contributor_rating=rating,
-            criteria=self.criterion,
-            score=criterion_score,
+            criteria=self.criteria,
+            score=criteria_score,
         )
 
         response = self.client.get(
-            f"/users/me/recommendations/{self.poll.name}?weights%5B{self.criterion}%5D={weight}",
+            f"/users/me/recommendations/{self.poll.name}?weights%5B{self.criteria}%5D={weight}",
             format="json",
         )
         self.assertEqual(response.status_code, 200)
@@ -269,10 +269,10 @@ class ContributorRecommendationsApiTestCase(TestCase):
         )
         self.assertEqual(
             response.data["results"][0]["criteria_scores"][0]["score"],
-            criterion_score,
+            criteria_score,
         )
         self.assertEqual(
-            response.data["results"][0]["total_score"], criterion_score * weight
+            response.data["results"][0]["total_score"], criteria_score * weight
         )
 
         # user2's score on this entity must not affect user1's recommendations
@@ -281,12 +281,12 @@ class ContributorRecommendationsApiTestCase(TestCase):
         )
         ContributorRatingCriteriaScoreFactory(
             contributor_rating=rating2,
-            criteria=self.criterion,
+            criteria=self.criteria,
             score=-5,
         )
 
         response = self.client.get(
-            f"/users/me/recommendations/{self.poll.name}?weights%5B{self.criterion}%5D={weight}",
+            f"/users/me/recommendations/{self.poll.name}?weights%5B{self.criteria}%5D={weight}",
             format="json",
         )
 
@@ -299,10 +299,10 @@ class ContributorRecommendationsApiTestCase(TestCase):
         # It shouldn't have changed, other users' ratings are ignored
         self.assertEqual(
             response.data["results"][0]["criteria_scores"][0]["score"],
-            criterion_score,
+            criteria_score,
         )
         self.assertEqual(
-            response.data["results"][0]["total_score"], criterion_score * weight
+            response.data["results"][0]["total_score"], criteria_score * weight
         )
 
     def test_recommendations_are_sorted_by_descending_total_score(self):
@@ -314,7 +314,7 @@ class ContributorRecommendationsApiTestCase(TestCase):
             rating = ContributorRatingFactory(user=user, entity=entity, is_public=True)
             ContributorRatingCriteriaScoreFactory(
                 contributor_rating=rating,
-                criteria=self.criterion,
+                criteria=self.criteria,
                 score=score,
             )
 

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -24,7 +24,7 @@ from .views.exports import (
     ExportProofOfVoteView,
     ExportPublicComparisonsView,
 )
-from .views.inconsistencies import ScoreInconsistencies
+from .views.inconsistencies import Length3Cycles, ScoreInconsistencies
 from .views.polls import (
     PollsCriteriaScoreDistributionView,
     PollsEntityView,
@@ -117,6 +117,11 @@ urlpatterns = [
         name="ratings_me_detail",
     ),
     # Inconsistencies API
+    path(
+        "users/me/inconsistencies/length_3_cycles/<str:poll_name>",
+        Length3Cycles.as_view(),
+        name="length_3_cycles",
+    ),
     path(
         "users/me/inconsistencies/score/<str:poll_name>",
         ScoreInconsistencies.as_view(),

--- a/backend/tournesol/views/inconsistencies.py
+++ b/backend/tournesol/views/inconsistencies.py
@@ -167,8 +167,8 @@ class Length3Cycles(PollScopedViewMixin, GenericAPIView):
                 comparison_trios_count += len(self.all_connections[entity_1] &
                                               self.all_connections[entity_2])
 
-        # Every comparison trio should have been counted 6 times, like this:
-        # ((1, 2, 3), (2, 3, 1), (3, 1, 2), and the reverses (3, 2, 1), (1, 3, 2), (2, 1, 3))
+        # Every comparison trio should have been counted 6 times
+        # (any node can be counted in any order, so 1*2*3 = 6 possible permutations)
         comparison_trios_count //= 6
 
         return cycles_count, comparison_trios_count

--- a/backend/tournesol/views/inconsistencies.py
+++ b/backend/tournesol/views/inconsistencies.py
@@ -169,7 +169,6 @@ class Length3Cycles(PollScopedViewMixin, GenericAPIView):
 
         # Every comparison trio should have been counted 6 times, like this:
         # ((1, 2, 3), (2, 3, 1), (3, 1, 2), and the reverses (3, 2, 1), (1, 3, 2), (2, 1, 3))
-        assert (comparison_trios_count % 6) == 0
         comparison_trios_count //= 6
 
         return cycles_count, comparison_trios_count

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1428,6 +1428,47 @@ paths:
                 type: string
                 format: binary
           description: ''
+  /users/me/inconsistencies/length_3_cycles/{poll_name}:
+    get:
+      operationId: users_me_inconsistencies_length_3_cycles_retrieve
+      description: |-
+        List the cycles of length 3 in the comparisons graphs.
+
+        These "graphs" (one graph per criteria) are modeled by considering
+        entities as nodes, and comparisons as directed edges.
+
+        A cycle between 3 entities A, B, C is when A is preferred to
+        B, which is preferred to C, which is preferred to A (A > B > C > A).
+        Longer cycles are ignored, because it would be too long to count.
+
+        A "comparison trio" is any set of 3 entities that are all compared to each other.
+        The ratio cycles_count / comparison_trios_count can be used as an indicator of consistency.
+      parameters:
+      - in: path
+        name: poll_name
+        schema:
+          type: string
+        required: true
+      - in: query
+        name: date_gte
+        schema:
+          type: string
+          format: date-time
+        description: |-
+          Restrict the search to comparisons done or edited after this date.
+          Accepted formats: ISO 8601 datetime (e.g `2021-12-01T12:45:00`).
+      tags:
+      - users
+      security:
+      - oauth2:
+        - read write groups
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Length3Cycles'
+          description: ''
   /users/me/inconsistencies/score/{poll_name}:
     get:
       operationId: users_me_inconsistencies_score_retrieve
@@ -1454,7 +1495,7 @@ paths:
           type: string
           format: date-time
         description: |-
-          Restrict the search to entities created or edited after this date.
+          Restrict the search to comparisons done or edited after this date.
           Accepted formats: ISO 8601 datetime (e.g `2021-12-01T12:45:00`).
       tags:
       - users
@@ -2233,15 +2274,9 @@ components:
     ContributorRecommendations:
       type: object
       properties:
-        criteria_scores:
-          type: array
-          items:
-            $ref: '#/components/schemas/ContributorCriteriaScore'
-          readOnly: true
-        type:
-          $ref: '#/components/schemas/TypeEnum'
-        is_public:
-          type: boolean
+        metadata:
+          type: object
+          additionalProperties: {}
           readOnly: true
         tournesol_score:
           type: number
@@ -2254,13 +2289,19 @@ components:
           description: A unique identifier, build with a namespace and an external
             id.
           maxLength: 144
-        metadata:
-          type: object
-          additionalProperties: {}
-          readOnly: true
+        type:
+          $ref: '#/components/schemas/TypeEnum'
         total_score:
           type: number
           format: float
+        criteria_scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContributorCriteriaScore'
+          readOnly: true
+        is_public:
+          type: boolean
+          readOnly: true
       required:
       - criteria_scores
       - is_public
@@ -2287,6 +2328,41 @@ components:
       - bins
       - criteria
       - distribution
+    Cycle:
+      type: object
+      description: Serializer for one cycle of length 3
+      properties:
+        criteria:
+          type: string
+        entity_1_uid:
+          type: string
+        entity_2_uid:
+          type: string
+        entity_3_uid:
+          type: string
+      required:
+      - criteria
+      - entity_1_uid
+      - entity_2_uid
+      - entity_3_uid
+    CyclesStats:
+      type: object
+      description: |-
+        Stats for each criteria
+
+        Includes the number of cycles, and the number of "comparison trios". This refers
+        to any 3 entities that all have a comparison to each other.
+
+        A useful metric could be the ratio of cycles (= cycles_count / comparison_trios_count).
+        We could consider that the better this ratio is, the more consistent the comparisons are.
+      properties:
+        cycles_count:
+          type: integer
+        comparison_trios_count:
+          type: integer
+      required:
+      - comparison_trios_count
+      - cycles_count
     DefaultSendResetPasswordLink:
       type: object
       description: |-
@@ -2469,6 +2545,27 @@ components:
       - Female
       - Male
       type: string
+    Length3Cycles:
+      type: object
+      description: |-
+        Return statistics about length-3 cycles in
+        the contributor's comparisons.
+      properties:
+        count:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cycle'
+        stats:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/CyclesStats'
+          title: criteria
+      required:
+      - count
+      - results
+      - stats
     MoralPhilosophyEnum:
       enum:
       - Not Specified
@@ -3960,7 +4057,7 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ScoreInconsistenciesStats'
-          title: criterion
+          title: criteria
       required:
       - count
       - results
@@ -3968,7 +4065,7 @@ components:
     ScoreInconsistenciesStats:
       type: object
       description: |-
-        Return some statistics for each criterion,
+        Return some statistics for each criteria,
         to be able to compare the results for the different criteria
       properties:
         mean_inconsistency:
@@ -3989,7 +4086,7 @@ components:
         inconsistency:
           type: number
           format: float
-        criterion:
+        criteria:
           type: string
         entity_1_uid:
           type: string
@@ -4009,7 +4106,7 @@ components:
           format: float
       required:
       - comparison_score
-      - criterion
+      - criteria
       - entity_1_rating
       - entity_1_uid
       - entity_2_rating


### PR DESCRIPTION
Please double-check that there is no mistake in the function _count_cycles_and_comparison_trios.

I actually prefer to avoid also implementing an API endpoint that returns a single cycle, but of possibly longer length, because:
- it requires time and effort, and complicates things
- It would be complicated to display on the frontend
- It doesn't provide overview on how many cycles are left (we can't computationally count the cycles of any length, this would be NP-complex)