### PR TITLE
[front] fix: missing traduction on about/trusted_domains page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -263,6 +263,7 @@
     "trustedEmailDomains": "Trusted email domains",
     "trustedDomainsToProtectTournesol": "In order to protect Tournesol from fake accounts, by default, Tournesol assigns a limited voting right to newly created accounts.",
     "trustedDomainsGainMoreVotingRights": "You can gain significantly more voting rights by validating <2>an email address from a trusted domain</2>. We are currently working on designing additional means for contributors to gain voting rights.",
+    "trustedDomainsValuable": "In any case, your contributions are valuable to us, as they will motivate further research in safe and ethical algorithms.",
     "trustedDomainsCurrentList": "Current list of trusted domains"
   },
   "privacyPolicy": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -269,6 +269,7 @@
     "trustedEmailDomains": "Noms de domaine fiables",
     "trustedDomainsToProtectTournesol": "Dans le but de protéger Tournesol des faux comptes, la plateforme assigne par défaut un droit de vote limité aux nouveaux comptes créés.",
     "trustedDomainsGainMoreVotingRights": "Vous pouvez obtenir un droit de vote significativement plus important en validant <2>une adresse e-mail provenant d'un domaine fiable</2>. Nous réfléchissons actuellement à des moyens alternatifs pour que les utilisateurs puissent bénéficier d'un droit de vote plus important.",
+    "trustedDomainsValuable": "Dans tous les cas, vos contributions sont utiles car elles motiveront et aideront la recherche en éthique des algorithmes et de l'intelligence artificielle",
     "trustedDomainsCurrentList": "Liste actuelle des domaines considérés fiables"
   },
   "privacyPolicy": {

--- a/frontend/src/pages/about/TrustedDomains.tsx
+++ b/frontend/src/pages/about/TrustedDomains.tsx
@@ -54,10 +54,7 @@ const TrustedDomains = () => {
                 to gain voting rights.
               </Trans>
             </p>
-            <p>
-              In any case, your contributions are valuable to us, as they will
-              motivate further research in safe and ethical algorithms.
-            </p>
+            <p>{t('about.trustedDomainsValuable')}</p>
           </Typography>
         </Box>
         <Box>


### PR DESCRIPTION
Found a page that was clearly written by @lfaucon : https://tournesol.app/about/trusted_domains ;) 