### PR TITLE
[front] feat: add the candidate analysis page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -325,6 +325,16 @@
       "goToGlobalRanking": "Go to global ranking"
     }
   },
+  "entityNotFound": {
+    "404": {
+      "title": "Not found",
+      "message": "The requested entity is either invalid, or not available anymore."
+    },
+    "unexpected": {
+      "title": "Unknown error",
+      "message": "An unexpected error has occured."
+    }
+  },
   "home": {
     "exploreTournesolPossibilities": "Explore Tournesol's Possibilities",
     "tournesolToComparedMultipleTypesOfAlternatives": "Tournesol is used to compare multiple types of alternatives. See the list below and choose the Tournesol that is best for you:",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -320,6 +320,11 @@
     "title": "My comparisons",
     "listHasNbComparisons_many": "You already did <1>{{comparisonCount}}</1> comparisons."
   },
+  "entityAnalysisPage": {
+    "candidate": {
+      "goToGlobalRanking": "Go to global ranking"
+    }
+  },
   "home": {
     "exploreTournesolPossibilities": "Explore Tournesol's Possibilities",
     "tournesolToComparedMultipleTypesOfAlternatives": "Tournesol is used to compare multiple types of alternatives. See the list below and choose the Tournesol that is best for you:",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -331,6 +331,16 @@
       "goToGlobalRanking": "Voir le classement global"
     }
   },
+  "entityNotFound": {
+    "404": {
+      "title": "Non trouvée",
+      "message": "L'entité demandée est invalide, ou n'est simplement plus disponible."
+    },
+    "unexpected": {
+      "title": "Erreur inconnue",
+      "message": "Une erreur innatendu est survenue."
+    }
+  },
   "home": {
     "exploreTournesolPossibilities": "Découvrez toutes les possibilités de Tournesol",
     "tournesolToComparedMultipleTypesOfAlternatives": "Tournesol permet de comparer toutes sortes de choses. Avec les boutons ci-dessous vous pouvez basculer d'un univers à un autre:",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -326,6 +326,11 @@
     "listHasNbComparisons_other": "Vous avez déjà fait <1>{{comparisonCount}}</1> comparaisons.",
     "title": "Mes comparaisons"
   },
+  "entityAnalysisPage": {
+    "candidate": {
+      "goToGlobalRanking": "Voir le classement global"
+    }
+  },
   "home": {
     "exploreTournesolPossibilities": "Découvrez toutes les possibilités de Tournesol",
     "tournesolToComparedMultipleTypesOfAlternatives": "Tournesol permet de comparer toutes sortes de choses. Avec les boutons ci-dessous vous pouvez basculer d'un univers à un autre:",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,7 +74,7 @@ function App() {
           <PublicRoute path="/about">
             <About />
           </PublicRoute>
-          {/* Specific to Videos */}
+          {/* LEGAGY route used for retro-compatibility */}
           <PublicRoute path="/video/:video_id">
             <VideoAnalysisPage />
           </PublicRoute>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,7 +32,7 @@ import { PollProvider } from './hooks/useCurrentPoll';
 // See https://reactjs.org/docs/code-splitting.html#route-based-code-splitting
 // for more details.
 const VideoAnalysisPage = React.lazy(
-  () => import('./pages/videos/VideoAnalysis')
+  () => import('./pages/videos/VideoAnalysisPage')
 );
 
 const API_URL = process.env.REACT_APP_API_URL;

--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -6,6 +6,7 @@ import PrivateRoute from 'src/features/login/PrivateRoute';
 import PageNotFound from 'src/pages/404/PageNotFound';
 import ComparisonListPage from 'src/pages/comparisons/ComparisonList';
 import FeedbackPage from 'src/pages/personal/feedback/FeedbackPage';
+import EntityAnalysisPage from 'src/pages/entities/EntityAnalysisPage';
 import HomePage from 'src/pages/home/Home';
 import RecommendationPage from 'src/pages/recommendations/RecommendationPage';
 import VideoRatingsPage from 'src/pages/videos/VideoRatings';
@@ -55,6 +56,12 @@ const PollRoutes = ({ pollName }: Props) => {
       id: RouteID.Recommendations,
       url: 'recommendations',
       page: RecommendationPage,
+      type: PublicRoute,
+    },
+    {
+      id: RouteID.EntityAnalysis,
+      url: 'entities/:uid',
+      page: EntityAnalysisPage,
       type: PublicRoute,
     },
     {

--- a/frontend/src/pages/entities/CandidateAnalysisPage.tsx
+++ b/frontend/src/pages/entities/CandidateAnalysisPage.tsx
@@ -1,7 +1,19 @@
 import React from 'react';
+import { Box, Container, Typography } from '@mui/material';
+import { Recommendation } from 'src/services/openapi';
 
-const CandidateAnalysisPage = () => {
-  return <p>Candidate analysis page</p>;
+interface Props {
+  entity: Recommendation;
+}
+
+const CandidateAnalysisPage = ({ entity }: Props) => {
+  return (
+    <Container>
+      <Box py={2}>
+        <Typography variant="h3">{entity.metadata.name}</Typography>
+      </Box>
+    </Container>
+  );
 };
 
 export default CandidateAnalysisPage;

--- a/frontend/src/pages/entities/CandidateAnalysisPage.tsx
+++ b/frontend/src/pages/entities/CandidateAnalysisPage.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Box, Container, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { Link as RouterLink } from 'react-router-dom';
+
+import { Box, Button, Container, Grid, Paper } from '@mui/material';
+
+import EntityImagery from 'src/components/entity/EntityImagery';
+import EntityCardTitle from 'src/components/entity/EntityCardTitle';
+import EntityCardScores from 'src/components/entity/EntityCardScores';
+import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import { Recommendation } from 'src/services/openapi';
 
 interface Props {
@@ -7,10 +15,39 @@ interface Props {
 }
 
 const CandidateAnalysisPage = ({ entity }: Props) => {
+  const { t } = useTranslation();
+  const { baseUrl } = useCurrentPoll();
+
   return (
     <Container>
       <Box py={2}>
-        <Typography variant="h3">{entity.metadata.name}</Typography>
+        <Box display="flex" justifyContent="flex-end">
+          <Button
+            color="secondary"
+            variant="outlined"
+            component={RouterLink}
+            to={`${baseUrl}/recommendations`}
+          >
+            {t('entityAnalysisPage.candidate.goToGlobalRanking')}
+          </Button>
+        </Box>
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <EntityImagery entity={entity} compact={true} />
+          </Grid>
+          <Grid item xs={12}>
+            <Paper>
+              <Box p={1}>
+                <EntityCardTitle title={entity.metadata.name} compact={false} />
+                <EntityCardScores
+                  entity={entity}
+                  showTournesolScore={false}
+                  showTotalScore={true}
+                />
+              </Box>
+            </Paper>
+          </Grid>
+        </Grid>
       </Box>
     </Container>
   );

--- a/frontend/src/pages/entities/CandidateAnalysisPage.tsx
+++ b/frontend/src/pages/entities/CandidateAnalysisPage.tsx
@@ -8,7 +8,7 @@ import EntityImagery from 'src/components/entity/EntityImagery';
 import EntityCardTitle from 'src/components/entity/EntityCardTitle';
 import EntityCardScores from 'src/components/entity/EntityCardScores';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { Recommendation } from 'src/services/openapi';
+import { Recommendation, TypeEnum } from 'src/services/openapi';
 
 interface Props {
   entity: Recommendation;
@@ -21,6 +21,7 @@ const CandidateAnalysisPage = ({ entity }: Props) => {
   return (
     <Container>
       <Box py={2}>
+        {/* Top level section, containing links and maybe more in the future. */}
         <Box display="flex" justifyContent="flex-end">
           <Button
             color="secondary"
@@ -31,6 +32,8 @@ const CandidateAnalysisPage = ({ entity }: Props) => {
             {t('entityAnalysisPage.candidate.goToGlobalRanking')}
           </Button>
         </Box>
+
+        {/* Entity section, with its title and scores. */}
         <Grid container spacing={2}>
           <Grid item xs={12}>
             <EntityImagery entity={entity} compact={true} />
@@ -41,8 +44,10 @@ const CandidateAnalysisPage = ({ entity }: Props) => {
                 <EntityCardTitle title={entity.metadata.name} compact={false} />
                 <EntityCardScores
                   entity={entity}
-                  showTournesolScore={false}
-                  showTotalScore={true}
+                  showTournesolScore={
+                    entity.type !== TypeEnum.CANDIDATE_FR_2022
+                  }
+                  showTotalScore={entity.type === TypeEnum.CANDIDATE_FR_2022}
                 />
               </Box>
             </Paper>

--- a/frontend/src/pages/entities/CandidateAnalysisPage.tsx
+++ b/frontend/src/pages/entities/CandidateAnalysisPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CandidateAnalysisPage = () => {
+  return <p>Candidate analysis page</p>;
+};
+
+export default CandidateAnalysisPage;

--- a/frontend/src/pages/entities/EntityAnalysisPage.tsx
+++ b/frontend/src/pages/entities/EntityAnalysisPage.tsx
@@ -6,7 +6,6 @@ import { Box, Button, Container, Grid, Typography } from '@mui/material';
 
 import { LoaderWrapper } from 'src/components';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { VideoAnalysis } from 'src/pages/videos/VideoAnalysisPage';
 import { ApiError, PollsService, Recommendation } from 'src/services/openapi';
 import {
   PRESIDENTIELLE_2022_POLL_NAME,
@@ -17,6 +16,12 @@ import { videoWithScoresFromRecommendation } from 'src/utils/entity';
 
 const CandidateAnalysisPage = React.lazy(
   () => import('src/pages/entities/CandidateAnalysisPage')
+);
+
+const VideoAnalysis = React.lazy(() =>
+  import('src/pages/videos/VideoAnalysisPage').then(({ VideoAnalysis }) => ({
+    default: VideoAnalysis,
+  }))
 );
 
 const EntityNotFound = ({ apiError }: { apiError: ApiError | undefined }) => {

--- a/frontend/src/pages/entities/EntityAnalysisPage.tsx
+++ b/frontend/src/pages/entities/EntityAnalysisPage.tsx
@@ -1,31 +1,96 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { Box, Container, Typography } from '@mui/material';
 
+import { LoaderWrapper } from 'src/components';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import { VideoAnalysis } from 'src/pages/videos/VideoAnalysisPage';
+import { ApiError, PollsService, Recommendation } from 'src/services/openapi';
 import {
   PRESIDENTIELLE_2022_POLL_NAME,
   YOUTUBE_POLL_NAME,
 } from 'src/utils/constants';
-import { useVideoMetadata } from 'src/features/videos/VideoApi';
-import { VideoAnalysis } from 'src/pages/videos/VideoAnalysisPage';
+
+import { videoWithScoresFromRecommendation } from 'src/utils/entity';
 
 const CandidateAnalysisPage = React.lazy(
   () => import('src/pages/entities/CandidateAnalysisPage')
 );
 
+/**
+ * TODO:
+ *
+ * - display a concise title
+ * - display a paragraph containing a comprehensive description
+ * - translate the title and the paragraph
+ */
+const EntityNotFound = ({ apiError }: { apiError: ApiError | undefined }) => {
+  if (apiError == undefined) {
+    return null;
+  }
+
+  let title: string;
+
+  switch (apiError.status) {
+    case 404:
+      title = 'Not Found';
+      break;
+    default:
+      title = 'Error';
+  }
+
+  return <Typography variant="h3">{title}</Typography>;
+  title;
+};
+
 const EntityAnalysisPage = () => {
   const { uid } = useParams<{ uid: string }>();
   const { name: pollName } = useCurrentPoll();
-  // TODO refator this to use the new endpoint for all entities
-  const video = useVideoMetadata(uid.split(':')[1]);
 
-  if (pollName === YOUTUBE_POLL_NAME) {
-    return <VideoAnalysis video={video} />;
-  }
-  if (pollName === PRESIDENTIELLE_2022_POLL_NAME) {
-    return <CandidateAnalysisPage />;
-  }
-  return null;
+  const [entity, setEntity] = useState<Recommendation>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [apiError, setApiError] = useState<ApiError>();
+
+  useEffect(() => {
+    async function getEntityWithPollStats(): Promise<Recommendation> {
+      const entity = await PollsService.pollsEntitiesRetrieve({
+        name: pollName,
+        uid,
+      });
+      return entity;
+    }
+
+    getEntityWithPollStats()
+      .then((entity) => {
+        setEntity(entity);
+        setIsLoading(false);
+      })
+      .catch((reason: ApiError) => {
+        setApiError(reason);
+        setIsLoading(false);
+      });
+  }, [pollName, uid]);
+
+  return (
+    <LoaderWrapper isLoading={isLoading}>
+      {entity ? (
+        <>
+          {pollName === PRESIDENTIELLE_2022_POLL_NAME && (
+            <CandidateAnalysisPage entity={entity} />
+          )}
+          {pollName === YOUTUBE_POLL_NAME && (
+            <VideoAnalysis video={videoWithScoresFromRecommendation(entity)} />
+          )}
+        </>
+      ) : (
+        <Container>
+          <Box py={2}>
+            <EntityNotFound apiError={apiError} />
+          </Box>
+        </Container>
+      )}
+    </LoaderWrapper>
+  );
 };
 
 export default EntityAnalysisPage;

--- a/frontend/src/pages/entities/EntityAnalysisPage.tsx
+++ b/frontend/src/pages/entities/EntityAnalysisPage.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { Box, Container, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router-dom';
+
+import { Box, Button, Container, Grid, Typography } from '@mui/material';
 
 import { LoaderWrapper } from 'src/components';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
@@ -17,30 +19,46 @@ const CandidateAnalysisPage = React.lazy(
   () => import('src/pages/entities/CandidateAnalysisPage')
 );
 
-/**
- * TODO:
- *
- * - display a concise title
- * - display a paragraph containing a comprehensive description
- * - translate the title and the paragraph
- */
 const EntityNotFound = ({ apiError }: { apiError: ApiError | undefined }) => {
+  const { t } = useTranslation();
+
+  const { options } = useCurrentPoll();
+  const path = options?.path ?? '/';
+
   if (apiError == undefined) {
     return null;
   }
 
   let title: string;
+  let message: string;
 
   switch (apiError.status) {
     case 404:
-      title = 'Not Found';
+      title = t('entityNotFound.404.title');
+      message = t('entityNotFound.404.message');
       break;
     default:
-      title = 'Error';
+      title = t('entityNotFound.unexpected.title');
+      message = t('entityNotFound.unexpected.message');
   }
 
-  return <Typography variant="h3">{title}</Typography>;
-  title;
+  return (
+    <Grid container justifyContent="center" textAlign="center">
+      <Grid item xs={12}>
+        <Typography variant="h2">{title}</Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <Typography variant="subtitle1">{message}</Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <Box mt={2}>
+          <Button variant="contained" component={Link} to={path}>
+            {t('pageNotFound.backToHomePage')}
+          </Button>
+        </Box>
+      </Grid>
+    </Grid>
+  );
 };
 
 const EntityAnalysisPage = () => {

--- a/frontend/src/pages/entities/EntityAnalysisPage.tsx
+++ b/frontend/src/pages/entities/EntityAnalysisPage.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import {
+  PRESIDENTIELLE_2022_POLL_NAME,
+  YOUTUBE_POLL_NAME,
+} from 'src/utils/constants';
+import { useVideoMetadata } from 'src/features/videos/VideoApi';
+import { VideoAnalysis } from 'src/pages/videos/VideoAnalysisPage';
+
+const CandidateAnalysisPage = React.lazy(
+  () => import('src/pages/entities/CandidateAnalysisPage')
+);
+
+const EntityAnalysisPage = () => {
+  const { uid } = useParams<{ uid: string }>();
+  const { name: pollName } = useCurrentPoll();
+  // TODO refator this to use the new endpoint for all entities
+  const video = useVideoMetadata(uid.split(':')[1]);
+
+  if (pollName === YOUTUBE_POLL_NAME) {
+    return <VideoAnalysis video={video} />;
+  }
+  if (pollName === PRESIDENTIELLE_2022_POLL_NAME) {
+    return <CandidateAnalysisPage />;
+  }
+  return null;
+};
+
+export default EntityAnalysisPage;

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -8,11 +8,13 @@ import VideoCard from 'src/features/videos/VideoCard';
 import { useVideoMetadata } from 'src/features/videos/VideoApi';
 import CriteriaBarChart from 'src/components/CriteriaBarChart';
 import { VideoPlayer } from 'src/components/entity/EntityImagery';
+import { VideoSerializerWithCriteria } from 'src/services/openapi';
 
-function VideoAnalysis() {
-  const { video_id } = useParams<{ video_id: string }>();
-  const video = useVideoMetadata(video_id);
-
+export const VideoAnalysis = ({
+  video,
+}: {
+  video: VideoSerializerWithCriteria;
+}) => {
   return (
     <Box display="flex" justifyContent="center">
       <Grid
@@ -23,7 +25,11 @@ function VideoAnalysis() {
         sx={{ marginTop: 3, marginBottom: 3 }}
       >
         <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
-          <VideoPlayer videoId={video_id} duration={video.duration} controls />
+          <VideoPlayer
+            videoId={video.video_id}
+            duration={video.duration}
+            controls
+          />
         </Grid>
         <Grid item xs={12}>
           <VideoCard video={video} showPlayer={false} />
@@ -36,6 +42,13 @@ function VideoAnalysis() {
       </Grid>
     </Box>
   );
-}
+};
 
-export default VideoAnalysis;
+const VideoAnalysisPage = () => {
+  const { video_id } = useParams<{ video_id: string }>();
+  const video = useVideoMetadata(video_id);
+
+  return <VideoAnalysis video={video} />;
+};
+
+export default VideoAnalysisPage;

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -87,11 +87,13 @@ export const RemoveFromRateLater = (asyncCallback?: () => void) => {
 
 export const AnalysisPageLink = ({ uid }: { uid: string }) => {
   const { t } = useTranslation();
+  const { baseUrl } = useCurrentPoll();
+
   return (
     <Tooltip title={`${t('actions.analysis')}`} placement="left">
       <IconButton
         size="medium"
-        href={`/video/${uid.slice(3)}`}
+        href={`${baseUrl}/entities/${uid}`}
         sx={{ color: '#CDCABC' }}
       >
         <QueryStatsIcon />

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import { IconButton, Tooltip } from '@mui/material';
 import CompareIcon from '@mui/icons-material/Compare';
 import AddIcon from '@mui/icons-material/Add';
@@ -92,9 +93,10 @@ export const AnalysisPageLink = ({ uid }: { uid: string }) => {
   return (
     <Tooltip title={`${t('actions.analysis')}`} placement="left">
       <IconButton
-        size="medium"
-        href={`${baseUrl}/entities/${uid}`}
         sx={{ color: '#CDCABC' }}
+        size="medium"
+        component={Link}
+        to={`${baseUrl}/entities/${uid}`}
       >
         <QueryStatsIcon />
       </IconButton>

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -207,8 +207,8 @@ export const polls: Array<SelectablePoll> = [
     ? [
         {
           name: PRESIDENTIELLE_2022_POLL_NAME,
-          defaultAuthEntityActions: [CompareNowAction],
-          defaultAnonEntityActions: [],
+          defaultAuthEntityActions: [CompareNowAction, AnalysisPageLink],
+          defaultAnonEntityActions: [AnalysisPageLink],
           displayOrder: 20,
           mainCriterionName: 'be_president',
           path: '/presidentielle2022/',

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -45,6 +45,7 @@ export enum RouteID {
   MyRateLaterList = 'myRateLaterList',
   MyFeedback = 'myFeedback',
   About = 'about',
+  EntityAnalysis = 'entities',
 }
 
 export type OrderedDialogs = {

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -39,13 +39,13 @@ export type VideoObject = Video | VideoSerializerWithCriteria;
 export enum RouteID {
   Home = 'home',
   Recommendations = 'recommendations',
+  EntityAnalysis = 'entityAnalysis',
   Comparison = 'comparison',
   MyComparisons = 'myComparisons',
   MyComparedItems = 'myComparedItems',
   MyRateLaterList = 'myRateLaterList',
   MyFeedback = 'myFeedback',
   About = 'about',
-  EntityAnalysis = 'entities',
 }
 
 export type OrderedDialogs = {


### PR DESCRIPTION
**related to** #830

---

Done:
- wiring the router for the entity analysis page

Todo:
- [x] Review, improve and merge PR #888 about `/polls/:poll_name/entities/uid` endpoint (⚠️ this can be optional if instead we build the page for one candidate out of pulling the scores for all 12 candidates from the recommendation endpoint)
- [ ] Implement minimalistic layout for the candidate analysis that includes:
    - [ ] Large picture of the candidate **// will rework the global layout at the end, see my comments below**
    - [x] The candidates' card without the avatar
    - [ ] The criteria score bar chart **// will do in a second PR, see my comments below**
    - [ ] (nice to have) #881 The ratings distribution per criteria
- [ ] (nice to have) Option to change the scores based on the multiple score modes
- [ ] (nice to have) Candidates rank (1st to 12th) per rating criteria