### PR TITLE
[front] feat: do not invite people to compare in inactive poll

### DIFF
--- a/frontend/src/features/feedback/StackedCandidatesPaper.tsx
+++ b/frontend/src/features/feedback/StackedCandidatesPaper.tsx
@@ -38,7 +38,7 @@ const StackedCandidatesPaper = ({
 }: Props) => {
   const [sortingCriteria, setSortingCriteria] = useState('be_president');
   const { t } = useTranslation();
-  const { baseUrl } = useCurrentPoll();
+  const { active, baseUrl } = useCurrentPoll();
 
   const nComparisons = Object.fromEntries(
     ratings.map((rating) => {
@@ -133,7 +133,7 @@ const StackedCandidatesPaper = ({
               {t('stackedCandidatesPaper.ifYourRankingSeemsOff')}
             </Typography>
           </Box>
-          <Grid container>
+          <Grid container justifyContent="flex-end">
             <Grid item xs={6} sx={{ px: 1 }}>
               <Button
                 color="secondary"
@@ -146,18 +146,20 @@ const StackedCandidatesPaper = ({
                 {t('stackedCandidatesPaper.seeMyComparisons')}
               </Button>
             </Grid>
-            <Grid item xs={6} sx={{ px: 1 }}>
-              <Button
-                color="secondary"
-                component={RouterLink}
-                variant="contained"
-                to={`${baseUrl}/comparison`}
-                sx={{ height: '100%' }}
-                fullWidth
-              >
-                {t('stackedCandidatesPaper.addNewComparisons')}
-              </Button>
-            </Grid>
+            {active && (
+              <Grid item xs={6} sx={{ px: 1 }}>
+                <Button
+                  color="secondary"
+                  component={RouterLink}
+                  variant="contained"
+                  to={`${baseUrl}/comparison`}
+                  sx={{ height: '100%' }}
+                  fullWidth
+                >
+                  {t('stackedCandidatesPaper.addNewComparisons')}
+                </Button>
+              </Grid>
+            )}
           </Grid>
         </>
       }

--- a/frontend/src/features/feedback/StackedCriteriaPaper.tsx
+++ b/frontend/src/features/feedback/StackedCriteriaPaper.tsx
@@ -59,7 +59,7 @@ const CriteriaCorrelationListItem = (correlation: {
  */
 const StackedCriteriaPaper = ({ criteriaCorrelations }: Props) => {
   const { t } = useTranslation();
-  const { baseUrl } = useCurrentPoll();
+  const { active, baseUrl } = useCurrentPoll();
 
   const orderedCriteriaCorrelations = criteriaCorrelations.criteria
     .map((criterion, idx) => {
@@ -107,19 +107,21 @@ const StackedCriteriaPaper = ({ criteriaCorrelations }: Props) => {
               {t('stackedCriteriaPaper.ifYourRankingSeemsOff')}
             </Typography>
           </Box>
-          <Grid container spacing={1}>
-            <Grid item xs={6} sx={{ px: 1 }}>
-              <Button
-                color="secondary"
-                component={RouterLink}
-                variant="outlined"
-                to={`${baseUrl}/comparison`}
-                sx={{ height: '100%' }}
-                fullWidth
-              >
-                {t('stackedCriteriaPaper.addNewComparisons')}
-              </Button>
-            </Grid>
+          <Grid container spacing={1} justifyContent="flex-end">
+            {active && (
+              <Grid item xs={6} sx={{ px: 1 }}>
+                <Button
+                  color="secondary"
+                  component={RouterLink}
+                  variant="outlined"
+                  to={`${baseUrl}/comparison`}
+                  sx={{ height: '100%' }}
+                  fullWidth
+                >
+                  {t('stackedCriteriaPaper.addNewComparisons')}
+                </Button>
+              </Grid>
+            )}
             <Grid item xs={6} sx={{ px: 1 }}>
               <Button
                 color="secondary"


### PR DESCRIPTION
This PR disables the `Make new comparisons` buttons on the personal feedback page when the poll is inactive.

#### before

![screencapture-localhost-3000-presidentielle2022-personal-feedback-2022-05-10-17_48_11](https://user-images.githubusercontent.com/39056254/167669953-7701b903-34ae-40b8-8374-894b612ca0db.png)

#### after

![screencapture-localhost-3000-presidentielle2022-personal-feedback-2022-05-10-17_47_44](https://user-images.githubusercontent.com/39056254/167669987-462c156b-36f2-45d0-90e9-d8a8895e595c.png)

