### PR TITLE
[front] refactor: sync' the style of candidate & video analysis page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -345,6 +345,9 @@
       "criteriaScores": {
         "title": "Scores per criterion"
       }
+    },
+    "generic": {
+      "compare": "Compare"
     }
   },
   "entityNotFound": {
@@ -379,10 +382,7 @@
     "getTheExtensionButton": "Get the extension",
     "extensionNotAvailableOnYourBrowser": "The extension is not available on your web browser. You may use it on <2>Firefox</2>, <4>Google Chrome</4> or <6>Chromium</6>.",
     "collaborativeContentRecommendations": "Collaborative Content Recommendations",
-    "tournesolPlatformDescription": "Tournesol is an <1>open source</1> platform which proposes a tool for collaborative decision. The main aim of this tool is to <3>collaboratively</3> identify top videos of public utility by eliciting contributors' judgements on content quality. Currently we are also exploring the possibility of using Tournesol's algorithms to evaluates candidates in an election.<br><br>Thanks to the data collected on Tournesol, we hope to contribute to making today's and tomorrow's large-scale algorithms <6>robustly beneficial</6> for all of humanity.",
-    "videos": {
-      "start": "Start" 
-    }
+    "tournesolPlatformDescription": "Tournesol is an <1>open source</1> platform which proposes a tool for collaborative decision. The main aim of this tool is to <3>collaboratively</3> identify top videos of public utility by eliciting contributors' judgements on content quality. Currently we are also exploring the possibility of using Tournesol's algorithms to evaluates candidates in an election.<br><br>Thanks to the data collected on Tournesol, we hope to contribute to making today's and tomorrow's large-scale algorithms <6>robustly beneficial</6> for all of humanity."
   },
   "reset": {
     "ifUserExistsResetLinkWillBeSent": "Done!<1></1>If this user exists, an email will be sent with a reset link.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -351,6 +351,9 @@
       "criteriaScores": {
         "title": "Scores par critère"
       }
+    },
+    "generic": {
+      "compare": "Comparer"
     }
   },
   "entityNotFound": {
@@ -385,10 +388,7 @@
     "getTheExtensionButton": "Installer l'extension",
     "extensionNotAvailableOnYourBrowser": "L'extension n'est malheureusement pas disponible pour votre navigateur web. Elle est compatible avec <2>Mozilla Firefox</2>, et <4>Google Chrome</4> ou <6>Chromium</6>.",
     "collaborativeContentRecommendations": "Recommandations collaboratives de contenus",
-    "tournesolPlatformDescription": "Tournesol est une plateforme <1>libre et open source</1> qui propose un outil de décision collaboratif transparent. Le but principal de cet outil est d'identifier les contenus informationel d'utilité publique de grande qualité en s'appuyant sur le jugement de contributeurs. Une autre application de l'algorithme de Tournesol que nous explorons en ce moment est l'évaluation des candidats à une élection.<br><br>Grâce aux données collectées sur cette plateforme, nous espérons rendre les algorithmes d'aujourd'hui et de demain <6>robustement bénéfique</6> à grande échelle, pour toute l'humanité.",
-    "videos": {
-      "start": "Commencer"
-    }
+    "tournesolPlatformDescription": "Tournesol est une plateforme <1>libre et open source</1> qui propose un outil de décision collaboratif transparent. Le but principal de cet outil est d'identifier les contenus informationel d'utilité publique de grande qualité en s'appuyant sur le jugement de contributeurs. Une autre application de l'algorithme de Tournesol que nous explorons en ce moment est l'évaluation des candidats à une élection.<br><br>Grâce aux données collectées sur cette plateforme, nous espérons rendre les algorithmes d'aujourd'hui et de demain <6>robustement bénéfique</6> à grande échelle, pour toute l'humanité."
   },
   "reset": {
     "ifUserExistsResetLinkWillBeSent": "C'est fait !<1></1>Si l'identifiant existe, un courriel avec un lien de réinitialisation sera envoyé.",

--- a/frontend/src/components/entity/style.ts
+++ b/frontend/src/components/entity/style.ts
@@ -3,7 +3,6 @@ import { SxProps } from '@mui/material';
 export const entityCardMainSx: SxProps = {
   margin: 0,
   width: '100%',
-  maxWidth: 1000,
   background: '#FFFFFF',
   border: '1px solid #DCD8CB',
   boxShadow: '0px 0px 8px rgba(0, 0, 0, 0.02), 0px 2px 4px rgba(0, 0, 0, 0.05)',

--- a/frontend/src/pages/entities/CandidateAnalysisPage.tsx
+++ b/frontend/src/pages/entities/CandidateAnalysisPage.tsx
@@ -20,7 +20,7 @@ const CandidateAnalysisPage = ({ entity }: Props) => {
   const { baseUrl } = useCurrentPoll();
 
   return (
-    <Container>
+    <Container sx={{ maxWidth: '1000px !important' }}>
       <Box py={2}>
         {/* Top level section, containing links and maybe more in the future. */}
         <Box mb={2} display="flex" justifyContent="flex-end">
@@ -34,7 +34,7 @@ const CandidateAnalysisPage = ({ entity }: Props) => {
           </Button>
         </Box>
 
-        {/* Entity section, with its title and scores. */}
+        {/* Entity section, with its picture, title and scores. */}
         <Grid container spacing={2}>
           <Grid item xs={12}>
             <EntityImagery entity={entity} compact={true} />
@@ -54,7 +54,7 @@ const CandidateAnalysisPage = ({ entity }: Props) => {
             </Paper>
           </Grid>
 
-          {/* data visualization */}
+          {/* Data visualization. */}
           <Grid item xs={12} sm={12} md={6}>
             <Paper>
               <Box

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams, Link as RouterLink } from 'react-router-dom';
 
-import { Box, Grid, Paper, Typography } from '@mui/material';
+import { Box, Button, Container, Grid, Paper, Typography } from '@mui/material';
+import CompareIcon from '@mui/icons-material/Compare';
 
 import CriteriaBarChart from 'src/components/CriteriaBarChart';
 import { VideoPlayer } from 'src/components/entity/EntityImagery';
 import CriteriaScoresDistribution from 'src/features/charts/CriteriaScoresDistribution';
 import { useVideoMetadata } from 'src/features/videos/VideoApi';
 import VideoCard from 'src/features/videos/VideoCard';
-import { useLoginState } from 'src/hooks';
+import { useCurrentPoll, useLoginState } from 'src/hooks';
 import { VideoSerializerWithCriteria } from 'src/services/openapi';
 import { PersonalCriteriaScoresContextProvider } from 'src/hooks/usePersonalCriteriaScores';
 import PersonalScoreCheckbox from 'src/components/PersonalScoreCheckbox';
@@ -21,31 +22,40 @@ export const VideoAnalysis = ({
   video: VideoSerializerWithCriteria;
 }) => {
   const { t } = useTranslation();
-  const { uid } = video;
+  const { baseUrl } = useCurrentPoll();
+
+  const entityId = `yt:${video.video_id}`;
   const actions = useLoginState() ? [CompareNowAction, AddToRateLaterList] : [];
 
   const { criteria_scores: criteriaScores } = video;
   const shouldDisplayCharts = criteriaScores && criteriaScores.length > 0;
 
   return (
-    <Box display="flex" justifyContent="center">
-      <Grid
-        container
-        spacing={2}
-        justifyContent="center"
-        maxWidth="md"
-        sx={{ marginTop: 3, marginBottom: 3 }}
-      >
-        <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
-          <VideoPlayer
-            videoId={video.video_id}
-            duration={video.duration}
-            controls
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <VideoCard video={video} actions={actions} showPlayer={false} />
-        </Grid>
+    <Container>
+      <Box py={2}>
+        {/* Top level section, containing links and maybe more in the future. */}
+        <Box mb={2} display="flex" justifyContent="flex-end">
+          <Button
+            color="secondary"
+            variant="contained"
+            endIcon={<CompareIcon />}
+            component={RouterLink}
+            to={`${baseUrl}/comparison?uidA=${entityId}`}
+          >
+            {t('entityAnalysisPage.generic.compare')}
+          </Button>
+        </Box>
+        <Grid container spacing={2} justifyContent="center">
+          <Grid item xs={12} sm={12} md={10} sx={{ aspectRatio: '16 / 9' }}>
+            <VideoPlayer
+              videoId={video.video_id}
+              duration={video.duration}
+              controls
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <VideoCard video={video} actions={actions} showPlayer={false} />
+          </Grid>
 
         {/* data visualization */}
         {shouldDisplayCharts && (

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -24,14 +24,14 @@ export const VideoAnalysis = ({
   const { t } = useTranslation();
   const { baseUrl } = useCurrentPoll();
 
-  const entityId = `yt:${video.video_id}`;
+  const uid = `yt:${video.video_id}`;
   const actions = useLoginState() ? [CompareNowAction, AddToRateLaterList] : [];
 
   const { criteria_scores: criteriaScores } = video;
   const shouldDisplayCharts = criteriaScores && criteriaScores.length > 0;
 
   return (
-    <Container>
+    <Container sx={{ maxWidth: '1000px !important' }}>
       <Box py={2}>
         {/* Top level section, containing links and maybe more in the future. */}
         <Box mb={2} display="flex" justifyContent="flex-end">
@@ -40,13 +40,15 @@ export const VideoAnalysis = ({
             variant="contained"
             endIcon={<CompareIcon />}
             component={RouterLink}
-            to={`${baseUrl}/comparison?uidA=${entityId}`}
+            to={`${baseUrl}/comparison?uidA=${uid}`}
           >
             {t('entityAnalysisPage.generic.compare')}
           </Button>
         </Box>
+
+        {/* Entity section, with its player, title, scores and actions. */}
         <Grid container spacing={2} justifyContent="center">
-          <Grid item xs={12} sm={12} md={10} sx={{ aspectRatio: '16 / 9' }}>
+          <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
             <VideoPlayer
               videoId={video.video_id}
               duration={video.duration}
@@ -57,52 +59,53 @@ export const VideoAnalysis = ({
             <VideoCard video={video} actions={actions} showPlayer={false} />
           </Grid>
 
-        {/* data visualization */}
-        {shouldDisplayCharts && (
-          <>
-            <Grid item xs={12} sm={12} md={6}>
-              <Paper>
-                <Box
-                  p={1}
-                  bgcolor="rgb(238, 238, 238)"
-                  display="flex"
-                  justifyContent="center"
-                >
-                  <Typography variant="h5">
-                    {t('entityAnalysisPage.chart.criteriaScores.title')}
-                  </Typography>
-                </Box>
-                <PersonalCriteriaScoresContextProvider uid={uid}>
-                  <Box px={2} pt={1}>
-                    <PersonalScoreCheckbox />
+          {/* data visualization */}
+          {shouldDisplayCharts && (
+            <>
+              <Grid item xs={12} sm={12} md={6}>
+                <Paper>
+                  <Box
+                    p={1}
+                    bgcolor="rgb(238, 238, 238)"
+                    display="flex"
+                    justifyContent="center"
+                  >
+                    <Typography variant="h5">
+                      {t('entityAnalysisPage.chart.criteriaScores.title')}
+                    </Typography>
+                  </Box>
+                  <PersonalCriteriaScoresContextProvider uid={uid}>
+                    <Box px={2} pt={1}>
+                      <PersonalScoreCheckbox />
+                    </Box>
+                    <Box p={1}>
+                      <CriteriaBarChart video={video} />
+                    </Box>
+                  </PersonalCriteriaScoresContextProvider>
+                </Paper>
+              </Grid>
+              <Grid item xs={12} sm={12} md={6}>
+                <Paper>
+                  <Box
+                    p={1}
+                    bgcolor="rgb(238, 238, 238)"
+                    display="flex"
+                    justifyContent="center"
+                  >
+                    <Typography variant="h5">
+                      {t('criteriaScoresDistribution.title')}
+                    </Typography>
                   </Box>
                   <Box p={1}>
-                    <CriteriaBarChart video={video} />
+                    <CriteriaScoresDistribution uid={uid} />
                   </Box>
-                </PersonalCriteriaScoresContextProvider>
-              </Paper>
-            </Grid>
-            <Grid item xs={12} sm={12} md={6}>
-              <Paper>
-                <Box
-                  p={1}
-                  bgcolor="rgb(238, 238, 238)"
-                  display="flex"
-                  justifyContent="center"
-                >
-                  <Typography variant="h5">
-                    {t('criteriaScoresDistribution.title')}
-                  </Typography>
-                </Box>
-                <Box p={1}>
-                  <CriteriaScoresDistribution uid={uid} />
-                </Box>
-              </Paper>
-            </Grid>
-          </>
-        )}
-      </Grid>
-    </Box>
+                </Paper>
+              </Grid>
+            </>
+          )}
+        </Grid>
+      </Box>
+    </Container>
   );
 };
 


### PR DESCRIPTION
This small PR aims to harmonize the look and feel of the analysis page of all polls.

**(1)**

The pages have now a dedicated section for the main actions they provide. The candidate page slightly invite the users to check the global ranking (using an outlined button), while the video page invite more frankly the users to compare the video (using a contained button).

**idea**: what about adding a share button next the compare button in the top right corner of the video analysis page? This will allow users to quickly copy / paste link (maybe share the page on social network), and may create a virtuous circle where people share & compare videos more easily.

**(2)**
 
The candidate and video analysis pages now use the same `<Container>`, the same width, and the same global padding. Both page are now more "relaxed" as they have an horizontal size of 1000 pixels, instead of the previous 900.

On the video analysis page, the size 1000 pixels allows the users to see the video in a wide player, while keeping visible all action buttons (compare, and add to the rate later list), and the titles of the charts.

**note**: I also removed the hard-coded maximum width of 1000 pixels in the entity card style, as it prevents it to fit the parent container, making it harder to include it in large layout. I personally think it's a good rule of thumb make this kind of component always take 100 % of the available space, as it make them very re-usable and fully delegate the layout design to the parent page / container.

As a consequence, if this PR is merged, the entity cards will take more horizontal space on the recommendations page. If this is not desirable, I think we should add a bit of CSS in the recommendations page container, instead of tweaking the entity card which will impact several other pages in the application.

### preview
![screencapture-localhost-3000-entities-yt-VKsekCHBuHI-2022-05-12-14_30_50](https://user-images.githubusercontent.com/39056254/168078482-2b076238-f170-4fd0-9abd-1c292f4ef9f9.png)

![screencapture-localhost-3000-presidentielle2022-entities-wd-Q5829-2022-05-12-14_32_25](https://user-images.githubusercontent.com/39056254/168078497-a1289fd0-ad7a-4c5f-8f65-5af6711a36e2.png)

