### PR TITLE
Add `jq` into infra base packages

### DIFF
--- a/infra/ansible/roles/base/tasks/main.yml
+++ b/infra/ansible/roles/base/tasks/main.yml
@@ -30,5 +30,6 @@
       - gpg
       - gpg-agent
       - rsync
+      - jq  # used at deploy time by get-vm-secrets
     install_recommends: no
     update_cache: yes


### PR DESCRIPTION
Required by #702, to read the server configuration in a more robust way, instead of parsing the .yml file manually.