### PR TITLE
[front] fix: video card aspect ratio on most mobile layout

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -55,7 +55,12 @@ const EntityCard = ({
 
   return (
     <Grid container sx={entityCardMainSx}>
-      <Grid item xs={12} sm={compact ? 12 : 'auto'}>
+      <Grid
+        item
+        xs={12}
+        sm={compact ? 12 : 'auto'}
+        sx={{ display: 'flex', justifyContent: 'center' }}
+      >
         <EntityImagery entity={entity} compact={compact} />
       </Grid>
       <Grid

--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -26,10 +26,6 @@ const PlayerWrapper = React.forwardRef(function PlayerWrapper(
       height="100%"
       onClick={() => setIsDurationVisible(false)}
       ref={ref}
-      sx={{
-        minWidth: '240px',
-        minHeight: '135px',
-      }}
     >
       {isDurationVisible && formattedDuration && (
         <Box
@@ -83,25 +79,20 @@ const EntityImagery = ({
   compact?: boolean;
 }) => {
   if (entity.type === TypeEnum.VIDEO) {
-    const player = (
-      <VideoPlayer
-        videoId={entity.metadata.video_id}
-        duration={entity.metadata.duration}
-      />
+    return (
+      <Box
+        sx={{
+          aspectRatio: '16 / 9',
+          width: '100%',
+          ...(compact ? {} : { minWidth: '240px' }),
+        }}
+      >
+        <VideoPlayer
+          videoId={entity.metadata.video_id}
+          duration={entity.metadata.duration}
+        />
+      </Box>
     );
-
-    if (compact) {
-      return (
-        <Box
-          sx={{
-            aspectRatio: '16 / 9',
-          }}
-        >
-          {player}
-        </Box>
-      );
-    }
-    return player;
   }
   if (entity.type === TypeEnum.CANDIDATE_FR_2022) {
     return (

--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -84,7 +84,7 @@ const EntityImagery = ({
         sx={{
           aspectRatio: '16 / 9',
           width: '100%',
-          ...(compact ? {} : { minWidth: '240px' }),
+          ...(compact ? {} : { minWidth: '240px', maxWidth: { sm: '240px' } }),
         }}
       >
         <VideoPlayer


### PR DESCRIPTION
The commit 3d2e33e seems to have broken the display of the video player for mobile.


I verified this new code both for presidentielle2022 and videos polls on both laptop and mobile. Only the presidentielle2022 page my comparisons page on mobile is still not working well, but it is less pressing to fix.