### PR TITLE
[front] style: `EntityCard` actions are now more accessible on mobile

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -80,6 +80,7 @@ const EntityCard = ({
         sx={{
           display: 'flex',
           alignItems: 'end',
+          justifyContent: 'space-between',
           flexDirection: 'column',
           [theme.breakpoints.down('sm')]: {
             flexDirection: 'row',

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -122,6 +122,7 @@ function VideoCard({
         sx={{
           display: 'flex',
           alignItems: 'end',
+          justifyContent: 'space-between',
           flexDirection: 'column',
           [theme.breakpoints.down('sm')]: {
             flexDirection: 'row',


### PR DESCRIPTION
I've been able to use Tournesol on mobile, and I found it difficult to click on the correct entity card actions. These action buttons are rather small, and it causes problem when their are close to each other.

I followed the design of the common action bar available on Android at the bottom of the screen (action previous / menu / all window).

### desktop preview

| before | after |
|-------------|-----------|
| ![screencapture-localhost-3000-recommendations-2022-05-16-10_24_33](https://user-images.githubusercontent.com/39056254/168551422-ab825f9c-30e8-4cae-8353-0f73f44f675a.png) | ![screencapture-localhost-3000-recommendations-2022-05-16-10_24_49](https://user-images.githubusercontent.com/39056254/168551455-7029786d-60d3-46e2-940a-a6f3f55d3c2e.png) |

### mobile preview

| before | after |
|-------------|-----------|
| ![cap2](https://user-images.githubusercontent.com/39056254/168552076-594ffa1a-ad47-421f-a049-fa7f0f330f37.png) | ![capture](https://user-images.githubusercontent.com/39056254/168552228-848b04e4-7bc7-4044-885b-d0d488f2269f.png) |