### PR TITLE
[front] feat: entities' titles are now clickable

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -74,7 +74,11 @@ const EntityCard = ({
         container
         direction="column"
       >
-        <EntityCardTitle title={entity.metadata.name} compact={compact} />
+        <EntityCardTitle
+          uid={entity.uid}
+          title={entity.metadata.name}
+          compact={compact}
+        />
         <EntityMetadata entity={entity} />
         {displayEntityCardScores()}
       </Grid>

--- a/frontend/src/components/entity/EntityCardTitle.tsx
+++ b/frontend/src/components/entity/EntityCardTitle.tsx
@@ -1,36 +1,47 @@
 import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+
 import { Box, Typography } from '@mui/material';
 
+import { useCurrentPoll } from 'src/hooks';
+
 const EntityCardTitle = ({
+  uid,
   title,
   compact = true,
   titleMaxLines = 3,
   ...rest
 }: {
+  uid: string;
   title: string;
   compact?: boolean;
   titleMaxLines?: number;
   [propName: string]: unknown;
 }) => {
+  const { baseUrl } = useCurrentPoll();
+
   return (
     <Box display="flex" flexWrap="wrap">
-      <Typography
-        sx={{
-          fontSize: compact ? '1em !important' : '',
-          lineHeight: 1.3,
-          textAlign: 'left',
-          // Limit text to 3 lines and show ellipsis
-          display: '-webkit-box',
-          overflow: 'hidden',
-          WebkitLineClamp: titleMaxLines,
-          WebkitBoxOrient: 'vertical',
-        }}
-        variant={compact ? 'body1' : 'h6'}
-        title={title}
-        {...rest}
-      >
-        {title}
-      </Typography>
+      <RouterLink className="no-decoration" to={`${baseUrl}/entities/${uid}`}>
+        <Typography
+          color="text.primary"
+          sx={{
+            fontSize: compact ? '1em !important' : '',
+            lineHeight: 1.3,
+            textAlign: 'left',
+            // Limit text to 3 lines and show ellipsis
+            display: '-webkit-box',
+            overflow: 'hidden',
+            WebkitLineClamp: titleMaxLines,
+            WebkitBoxOrient: 'vertical',
+          }}
+          variant={compact ? 'body1' : 'h6'}
+          title={title}
+          {...rest}
+        >
+          {title}
+        </Typography>
+      </RouterLink>
     </Box>
   );
 };

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -105,7 +105,7 @@ function VideoCard({
         container
         direction="column"
       >
-        <EntityCardTitle title={video.name} compact={compact} />
+        <EntityCardTitle uid={video.uid} title={video.name} compact={compact} />
         <VideoMetadata
           views={video.views}
           publicationDate={video.publication_date}
@@ -191,7 +191,12 @@ export const RowVideoCard = ({ video }: { video: VideoObject }) => {
         />
       </Box>
       <Box flex={1}>
-        <EntityCardTitle title={video.name} titleMaxLines={1} fontSize="1em" />
+        <EntityCardTitle
+          uid={video.uid}
+          title={video.name}
+          titleMaxLines={1}
+          fontSize="1em"
+        />
         <VideoMetadata
           views={video.views}
           uploader={video.uploader}

--- a/frontend/src/pages/entities/CandidateAnalysisPage.tsx
+++ b/frontend/src/pages/entities/CandidateAnalysisPage.tsx
@@ -42,7 +42,11 @@ const CandidateAnalysisPage = ({ entity }: Props) => {
           <Grid item xs={12}>
             <Paper>
               <Box p={1}>
-                <EntityCardTitle title={entity.metadata.name} compact={false} />
+                <EntityCardTitle
+                  uid={entity.uid}
+                  title={entity.metadata.name}
+                  compact={false}
+                />
                 <EntityCardScores
                   entity={entity}
                   showTournesolScore={


### PR DESCRIPTION
**related to** #931

---

This PR is the first step of the issue #931 , making the entities' titles clickable.

The following steps will be to make the thumbnail clickable, remove the analysis action and add a e2e tests.