### PR TITLE
[back] docs: make the YT API key setup more explicit

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -98,13 +98,26 @@ closer to the production one.
 
 #### Procedure
 
-Go to https://console.cloud.google.com/apis/ and create a new project. You
+##### Create and configure the key
+
+**(1)** Go to https://console.cloud.google.com/apis/ and create a new project. You
 can choose the name you prefer, we suggest `tournesol`. You should now
 be automatically redirected to the project dashboard.
 
-Go to the credentials page, accessible from the menu, and create new
-`API key `credentials. Do not apply any application nor API restriction. You
-should now be able to see the API key value by clicking on it.
+**(2)** Go to the credentials page, accessible from the menu, and create new
+`API key `credentials. You should now be able to see the API key value by
+clicking on it.
+
+**(3)** Unfold the action menu of your API key and click on modify. To secure
+the key usage you need to add few restrictions.
+
+Add an application restriction to define the only URLs or IP addresses allowed
+to use the key (not relevant for local development environments).
+
+Also add an API restriction to make the key able to query only the
+`YouTube Data API v3`. This setting can take few minutes to apply.
+
+##### Configure the back end
 
 Now configure the `YOUTUBE_API_KEY` setting with the API key value in your
 `SETTINGS_FILE`.  If you are using the dev-env, the settings file is

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,4 @@
-# Tournesol Backend
+# Tournesol back end
 
 The API of the Tournesol platform, made with Python and Django.
 
@@ -90,20 +90,44 @@ features will be missing. It's recommended to get and configure this API key if
 you plan to contribute regularly to the project, to make your environment
 closer to the production one.
 
+#### Requirements
+
+1. a Google account
+2. to be connected while following the procedure
+3. to have at least one YouTube video in the database
+
 #### Procedure
 
-* Go to https://console.cloud.google.com/apis/ and create a new project
-  named `tournesol`
+Go to https://console.cloud.google.com/apis/ and create a new project. You
+can choose the name you prefer, we suggest `tournesol-local`. You should now
+be automatically redirected to the project dashboard.
 
-* Setup you credentials by getting a API key. Do not restrict its use for
-  development purpose.
+Go to the credentials page, accessible from the menu, and create new
+`API key `credentials. Do not apply any application nor API restriction. You
+should now be able to see the API key value by clicking on it.
 
-* Set `YOUTUBE_API_KEY` value in your `SETTINGS_FILE`.  
-  If you are using the "dev-env", this is
-  in [backend/dev-env/settings-tournesol.yaml](./dev-env/settings-tournesol.yaml)
+Now configure the `YOUTUBE_API_KEY` setting with the API key value in your
+`SETTINGS_FILE`.  If you are using the dev-env, the settings file is
+[backend/dev-env/settings-tournesol.yaml](./dev-env/settings-tournesol.yaml)
 
-* Then go to https://console.cloud.google.com/apis/credentials/consent, and add
-  a user test (typicaly your gmail account)
+Finally, you need to enable your API key. The first time the back end will try
+to get metadata from YouTube, you will see an HTTP 403 error in the back end's
+logs, with an activation link.
+
+- Start the back end
+- Log in the administration interface with your superuser
+- Go the entities list
+- Select a YouTube video entity and run the action force refresh metadata 
+
+Check the back end's logs, and copy and paste the activation link in you
+browser. The link should look like this:
+
+```
+https://console.developers.google.com/apis/api/youtube.googleapis.com/overview?project=[YOUR_PROJECT_ID]
+```
+
+The back end is now ready to automatically update the videos' metadata when
+new videos are added using the API, and when using the force refresh action.
 
 ## Tests
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -99,7 +99,7 @@ closer to the production one.
 #### Procedure
 
 Go to https://console.cloud.google.com/apis/ and create a new project. You
-can choose the name you prefer, we suggest `tournesol-local`. You should now
+can choose the name you prefer, we suggest `tournesol`. You should now
 be automatically redirected to the project dashboard.
 
 Go to the credentials page, accessible from the menu, and create new

--- a/backend/README.md
+++ b/backend/README.md
@@ -94,15 +94,14 @@ closer to the production one.
 
 1. a Google account
 2. to be connected while following the procedure
-3. to have at least one YouTube video in the database
 
 #### Procedure
 
 ##### Create and configure the key
 
-**(1)** Go to https://console.cloud.google.com/apis/ and create a new project. You
-can choose the name you prefer, we suggest `tournesol`. You should now
-be automatically redirected to the project dashboard.
+**(1)** First go to https://console.cloud.google.com/apis/ and create a new
+project. You can choose the name you prefer, we suggest `tournesol`. You
+should now be automatically redirected to the project dashboard.
 
 **(2)** Go to the credentials page, accessible from the menu, and create new
 `API key `credentials. You should now be able to see the API key value by
@@ -117,27 +116,29 @@ to use the key (not relevant for local development environments).
 Also add an API restriction to make the key able to query only the
 `YouTube Data API v3`. This setting can take few minutes to apply.
 
-##### Configure the back end
+##### Configure the back end with the key
 
-Now configure the `YOUTUBE_API_KEY` setting with the API key value in your
-`SETTINGS_FILE`.  If you are using the dev-env, the settings file is
-[backend/dev-env/settings-tournesol.yaml](./dev-env/settings-tournesol.yaml)
+**(1)** Now configure the `YOUTUBE_API_KEY` setting with the API key value in your
+`SETTINGS_FILE`. If you are using the `dev-env`, the settings file is
+[backend/dev-env/settings-tournesol.yaml](./dev-env/settings-tournesol.yaml).
 
-Finally, you need to enable your API key. The first time the back end will try
-to get metadata from YouTube, you will see an HTTP 403 error in the back end's
-logs, with an activation link.
+**(2)** Finally, you need to enable your API keys. As long as the keys are not
+activated, the YouTube API will return an HTTP 403 error each time the back
+end  will try to get videos' metadata.
 
-- Start the back end
-- Log in the administration interface with your superuser
-- Go the entities list
-- Select a YouTube video entity and run the action force refresh metadata 
+To activate your keys, you need to know your project id. You can copy it from
+the page https://console.cloud.google.com/welcome.
 
-Check the back end's logs, and copy and paste the activation link in you
-browser. The link should look like this:
+Then simply visit the following URL. Don't forget to replace the string
+`{YOUR_PROJECT_ID}` by your own project ID.
 
 ```
-https://console.developers.google.com/apis/api/youtube.googleapis.com/overview?project=[YOUR_PROJECT_ID]
+https://console.developers.google.com/apis/api/youtube.googleapis.com/overview?project={YOUR_PROJECT_ID}
 ```
+
+If the URLs of the Google Cloud console in this document are outdated, you can
+always get the correct activation link from the back end's logs, by triggering
+a video metadata refresh from the administration interface.
 
 The back end is now ready to automatically update the videos' metadata when
 new videos are added using the API, and when using the force refresh action.


### PR DESCRIPTION
I followed the YouTube API key installation procedure from the back end's `README.md` to work on #931, and I took the time to update it to make it more explicit.

a ~ the requirements are now clear and more exhaustive

b ~ it is described when an action needs to be performed from a specific page of the Google Cloud dashboard

c ~ I didn't need to create a "test" user by visiting https://console.cloud.google.com/apis/credentials/consent as described before, so I didn't seem required I deleted this step (also it wasn't clear what kind of user it was... was it a Google Account? is it required if we already have a Google Account?)

d ~ nevertheless I needed to enable the API key by visiting a specific URL, so I added this step

You can see the rendered `README.md` here:
https://github.com/tournesol-app/tournesol/blob/back-update_ytapi_install/backend/README.md