### PR TITLE
[back] feat: automatically remove videos from rate later list

### DIFF
--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -121,6 +121,19 @@ class Entity(models.Model):
         )
         self.save(update_fields=["rating_n_ratings", "rating_n_contributors"])
 
+    def auto_remove_from_rate_later(self, user):
+        """
+        When called, the entity will be removed from the VideoRateLater
+        list if it has 4 or more comparisons
+        """
+        from .comparisons import Comparison
+
+        n_comparisons = Comparison.objects.filter(user=user).filter(
+            Q(entity_1=self) | Q(entity_2=self)
+        ).count()
+        if n_comparisons >= 4:
+            VideoRateLater.objects.filter(user=user, video=self).delete()
+
     @property
     def entity_cls(self):
         return ENTITY_TYPE_NAME_TO_CLASS[self.type]

--- a/backend/tournesol/tests/test_api_video_rate_later.py
+++ b/backend/tournesol/tests/test_api_video_rate_later.py
@@ -246,7 +246,7 @@ class VideoRateLaterApi(TestCase):
 
     def test_automatically_removed_after_4_comparisons(self):
         """
-        
+        Test the automated removal from the rate later list.
         """
         user = User.objects.get(username=self._user)
         other_user = User.objects.get(username=self._other)

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -117,8 +117,10 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
         comparison: Comparison = serializer.save()
         comparison.entity_1.update_n_ratings()
         comparison.entity_1.inner.refresh_metadata()
+        comparison.entity_1.auto_remove_from_rate_later(self.request.user)
         comparison.entity_2.update_n_ratings()
         comparison.entity_2.inner.refresh_metadata()
+        comparison.entity_2.auto_remove_from_rate_later(self.request.user)
         if poll.algorithm == ALGORITHM_MEHESTAN:
             update_user_scores(poll, user=self.request.user)
 

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -152,7 +152,7 @@
     "videoAlreadyInList": "The video is already in your Rate Later list.",
     "videoAdded": "Video added to your Rate Later list!",
     "addVideosToRateLaterList": "Add videos to your rate-later list",
-    "rateLaterFormIntroduction": "Copy-paste the id or the URL of a favorite video of yours.<1></1>You can search them in your <4>YouTube history page</4>, or your <7>liked video playlist</7>.<9></9>Our <12>browser extension</12> can also help you import videos effortlessly.<15></15>You will then be able to rate the videos you imported.",
+    "rateLaterFormIntroduction": "Copy-paste the id or the URL of a favorite video of yours.<1></1>You can search them in your <4>YouTube history page</4>, or your <7>liked video playlist</7>.<9></9>Our <12>browser extension</12> can also help you import videos effortlessly.<15></15>You will then be able to compare the videos you imported. They will be automatically removed from your list once you have enough comparisons.",
     "listHasNbVideos_one": "Your rate-later list now has <1>{{videoCount}}</1> video.",
     "listHasNbVideos_other": "Your rate-later list now has <1>{{videoCount}}</1> videos."
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -157,7 +157,7 @@
     "videoAlreadyInList": "La video est déjà dans votre liste.",
     "videoAdded": "Vidéo bien ajoutée à votre liste de vidéos à comparer plus tard.",
     "addVideosToRateLaterList": "Ajouter des videos à votre liste",
-    "rateLaterFormIntroduction": "Copiez-collez l'ID ou l'URL de l'une de vos vidéos favorites.<1></1>Vous pouvez les trouver dans votre <4>historique YouTube</4> ou votre <7>playlist</7> de vidéos aimées.<9></9>Notre <12>extension de navigateur</12> peut également vous aider à ajouter des vidéos facilement.<15></15>Les vidéos ainsi ajoutées peuvent ensuite être comparées.",
+    "rateLaterFormIntroduction": "Copiez-collez l'ID ou l'URL de l'une de vos vidéos favorites.<1></1>Vous pouvez les trouver dans votre <4>historique YouTube</4> ou votre <7>playlist</7> de vidéos aimées.<9></9>Notre <12>extension de navigateur</12> peut également vous aider à ajouter des vidéos facilement.<15></15>Les vidéos ainsi ajoutées peuvent être comparées, puis sont enlevées de la liste après un nombre suffisant de comparaisons.",
     "listHasNbVideos_one": "Votre liste contient actuellement <1>{{videoCount}}</1> vidéo.",
     "listHasNbVideos_many": "Votre liste contient actuellement <1>{{videoCount}}</1> vidéos.",
     "listHasNbVideos_other": "Votre liste contient actuellement <1>{{videoCount}}</1> vidéos."


### PR DESCRIPTION
My rate later list is growing unsustainably which makes it lose its purpose. I propose to automatically remove the videos after 4 or more comparisons.