### PR TITLE
Improve bar chart on video analysis page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.6",
     "@mui/styles": "^5.2.3",
+    "@react-hook/resize-observer": "^1.2.5",
     "@reduxjs/toolkit": "^1.7.1",
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.38",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3,12 +3,15 @@
     "filtersButton": "filters"
   },
   "personalCriteriaScores": {
-    "chartTooltip": "Personal score: {{score}}",
     "reasonWhyItCannotBeActivated": {
       "notLoggedIn": "You must be logged in to display personal scores.",
       "noPersonalScore": "You have not compared this video yet."
     },
     "activatePersonalScores": "Display personal scores"
+  },
+  "criteriaBarChart": {
+    "scoreTooltip": "Score calculated by Tournesol",
+    "personalScoreTooltip": "Your personal score"
   },
   "dialogBox": {
     "continue": "continue"

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -3,12 +3,15 @@
     "filtersButton": "filtres"
   },
   "personalCriteriaScores": {
-    "chartTooltip": "Score personnel: {{score}}",
     "reasonWhyItCannotBeActivated": {
       "notLoggedIn": "Vous devez être connecté.e pour afficher les scores personnels.",
       "noPersonalScore": "Vous n'avez pas encore comparé cette vidéo."
     },
     "activatePersonalScores": "Afficher les scores personnels"
+  },
+  "criteriaBarChart": {
+    "scoreTooltip": "Le score calculé par Tournesol",
+    "personalScoreTooltip": "Votre score personnel"
   },
   "dialogBox": {
     "continue": "continuer"

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -18,6 +18,7 @@ import useCriteriaChartData, {
 import { useTranslation } from 'react-i18next';
 import { lighten } from 'src/utils/color';
 import { Tooltip } from '@mui/material';
+import useResizeObserver from '@react-hook/resize-observer';
 
 const barMargin = 40; // The horizontal margin around the bar (must be enough for the icon and the score value)
 const criterionChartHeight = 40; // The height of a single criterion chart (circle + icon + bars)
@@ -411,7 +412,7 @@ const CriteriaBarChart = ({ video, entity }: Props) => {
     setWidth(width);
   }, []);
 
-  // TODO: handle div resize with @react-hook/resize-observer or custom code
+  useResizeObserver(containerRef, (entry) => setWidth(entry.contentRect.width));
 
   if (!shouldDisplayChart) return null;
 

--- a/frontend/src/hooks/useCriteriaChartData.ts
+++ b/frontend/src/hooks/useCriteriaChartData.ts
@@ -17,8 +17,8 @@ const SCORE_MIN = -1;
 const SCORE_MAX = 1;
 const DOMAIN = [SCORE_MIN, SCORE_MAX];
 
-export interface CriteriaChartDatum {
-  criteria: string;
+export interface CriterionChartScores {
+  criterion: string;
   score: number | undefined;
   clippedScore: number | undefined;
   personalScore: number | undefined;
@@ -27,7 +27,7 @@ export interface CriteriaChartDatum {
 
 export interface UseCriteriaChartDataValue {
   shouldDisplayChart: boolean; // Whether the chart should be displayed
-  data: CriteriaChartDatum[]; // The scores per criteria
+  data: CriterionChartScores[]; // The scores per criterion
   personalScoresActivated: boolean; // True if the data also contains personal scores
   domain: number[]; // Minimum and maximum score values that should be displayed (scores in data may be outside this domain)
 }
@@ -63,19 +63,19 @@ const useCriteriaChartData = ({
     [pollName]
   );
 
-  const personalScoreByCriteria = useMemo(() => {
+  const personalScoreByCriterion = useMemo(() => {
     if (!personalScoresActivated || personalCriteriaScores === undefined)
       return {};
 
     const result: {
-      [criteria: string]: {
+      [criterion: string]: {
         score: number | undefined;
         clippedScore: number | undefined;
       };
     } = {};
     personalCriteriaScores.forEach(
-      ({ criteria, score }) =>
-        (result[criteria] = {
+      ({ criteria: criterion, score }) =>
+        (result[criterion] = {
           score,
           clippedScore: clipScore(score),
         })
@@ -83,22 +83,22 @@ const useCriteriaChartData = ({
     return result;
   }, [personalScoresActivated, personalCriteriaScores, clipScore]);
 
-  const data = useMemo<CriteriaChartDatum[]>(() => {
+  const data = useMemo<CriterionChartScores[]>(() => {
     if (!shouldDisplayChart) return [];
 
-    return criteriaScores.map(({ score, criteria }) => {
+    return criteriaScores.map(({ score, criteria: criterion }) => {
       const clippedScore = clipScore(score);
       const { score: personalScore, clippedScore: clippedPersonalScore } =
-        personalScoreByCriteria[criteria] || {};
+        personalScoreByCriterion[criterion] || {};
       return {
-        criteria,
+        criterion,
         score,
         clippedScore,
         personalScore,
         clippedPersonalScore,
       };
     });
-  }, [shouldDisplayChart, criteriaScores, personalScoreByCriteria, clipScore]);
+  }, [shouldDisplayChart, criteriaScores, personalScoreByCriterion, clipScore]);
 
   return {
     shouldDisplayChart,

--- a/frontend/src/hooks/useCriteriaChartData.ts
+++ b/frontend/src/hooks/useCriteriaChartData.ts
@@ -45,8 +45,7 @@ const useCriteriaChartData = ({
   );
   const shouldDisplayChart = criteriaScores && criteriaScores.length > 0;
 
-  const { options, name: pollName } = useCurrentPoll();
-  const mainCriterionName = options?.mainCriterionName ?? '';
+  const { name: pollName } = useCurrentPoll();
 
   const { personalScoresActivated, personalCriteriaScores } =
     usePersonalCriteriaScores();
@@ -87,27 +86,19 @@ const useCriteriaChartData = ({
   const data = useMemo<CriteriaChartDatum[]>(() => {
     if (!shouldDisplayChart) return [];
 
-    return criteriaScores
-      .filter((s) => s.criteria != mainCriterionName)
-      .map(({ score, criteria }) => {
-        const clippedScore = clipScore(score);
-        const { score: personalScore, clippedScore: clippedPersonalScore } =
-          personalScoreByCriteria[criteria] || {};
-        return {
-          criteria,
-          score,
-          clippedScore,
-          personalScore,
-          clippedPersonalScore,
-        };
-      });
-  }, [
-    shouldDisplayChart,
-    criteriaScores,
-    personalScoreByCriteria,
-    mainCriterionName,
-    clipScore,
-  ]);
+    return criteriaScores.map(({ score, criteria }) => {
+      const clippedScore = clipScore(score);
+      const { score: personalScore, clippedScore: clippedPersonalScore } =
+        personalScoreByCriteria[criteria] || {};
+      return {
+        criteria,
+        score,
+        clippedScore,
+        personalScore,
+        clippedPersonalScore,
+      };
+    });
+  }, [shouldDisplayChart, criteriaScores, personalScoreByCriteria, clipScore]);
 
   return {
     shouldDisplayChart,

--- a/frontend/src/utils/color.ts
+++ b/frontend/src/utils/color.ts
@@ -1,0 +1,16 @@
+// Copied from https://stackoverflow.com/a/59387478
+export const lighten = (color: string, lighten: number) => {
+  const c = color.replace('#', '');
+  const rgb = [
+    parseInt(c.substr(0, 2), 16),
+    parseInt(c.substr(2, 2), 16),
+    parseInt(c.substr(4, 2), 16),
+  ];
+  let returnstatement = '#';
+  rgb.forEach((color) => {
+    returnstatement += Math.round(
+      (255 - color) * (1 - Math.pow(Math.E, -lighten)) + color
+    ).toString(16);
+  });
+  return returnstatement;
+};

--- a/frontend/src/utils/criteria.ts
+++ b/frontend/src/utils/criteria.ts
@@ -11,3 +11,18 @@ export const criteriaIcon = (criteriaName: string) => {
       : `/svg/${criteriaName}.svg`;
   return { emoji, imagePath };
 };
+
+const criterionColors: { [criteria: string]: string } = {
+  reliability: '#4F77DD',
+  importance: '#DC8A5D',
+  engaging: '#DFC642',
+  pedagogy: '#C28BED',
+  layman_friendly: '#4BB061',
+  diversity_inclusion: '#76C6CB',
+  backfire_risk: '#D37A80',
+  better_habits: '#9DD654',
+  entertaining_relaxing: '#D8B36D',
+};
+
+export const criterionColor = (criterion: string) =>
+  criterionColors[criterion] || '#506ad4';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1571,6 +1571,11 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@juggle/resize-observer@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
+  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz#0300943770e04231041a51bd39f0439b5c7ab4f0"
@@ -1726,6 +1731,27 @@
   version "2.11.5"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
+
+"@react-hook/latest@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@react-hook/latest/-/latest-1.0.3.tgz#c2d1d0b0af8b69ec6e2b3a2412ba0768ac82db80"
+  integrity sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==
+
+"@react-hook/passive-layout-effect@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz#c06dac2d011f36d61259aa1c6df4f0d5e28bc55e"
+  integrity sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==
+
+"@react-hook/resize-observer@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@react-hook/resize-observer/-/resize-observer-1.2.5.tgz#b59e2300de98bc6ddc6946942f21243cde10f984"
+  integrity sha512-qa0pPvRxq5VbdI8mMK2apPFsZOckhQ6D3Jc9yLuyHMNhui8yEih4qyFCZBDzzK3ymZS6LAltVSVg3l1Dg9vA0w==
+  dependencies:
+    "@juggle/resize-observer" "^3.3.1"
+    "@react-hook/latest" "^1.0.2"
+    "@react-hook/passive-layout-effect" "^1.2.0"
+    "@types/raf-schd" "^4.0.0"
+    raf-schd "^4.0.2"
 
 "@react-mock/fetch@^0.3.0":
   version "0.3.0"
@@ -2253,6 +2279,11 @@
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/raf-schd@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/raf-schd/-/raf-schd-4.0.1.tgz#1f9e03736f277fe9c7b82102bf18570a6ee19f82"
+  integrity sha512-Ha+EnKHFIh9EKW0/XZJPUd3EGDFisEvauaBd4VVCRPKeOqUxNEc9TodiY2Zhk33XCgzJucoFEcaoNcBAPHTQ2A==
 
 "@types/range-parser@*":
   version "1.2.4"
@@ -8460,6 +8491,11 @@ quick-temp@^0.1.8:
     mktemp "~0.4.0"
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
+
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
 
 raf@^3.4.0, raf@^3.4.1:
   version "3.4.1"


### PR DESCRIPTION
Related issue: https://github.com/tournesol-app/tournesol/issues/933

For now it only includes the main criteria and changes the design.

I added a dependency to [@react-hook/resize-observer](https://github.com/jaredLunde/react-hook/tree/master/packages/resize-observer#readme) because it was easier, it looks light, and it could be useful elsewhere. But we can also make something similar with custom code.

The new design:
![image](https://user-images.githubusercontent.com/28259/170966156-e5161fec-56f3-4ddf-b4ed-e324f9ee334c.png)
![image](https://user-images.githubusercontent.com/28259/170966261-74693d1e-b19f-47c2-9713-e988d2654ec3.png)
![image](https://user-images.githubusercontent.com/28259/170966342-22c5781d-236e-4c9f-b9bb-55e60359074f.png)
