### PR TITLE
[front] fix: duration not displayed on videos' thumbnails

### DIFF
--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -9,7 +9,7 @@ import { TypeEnum } from 'src/services/openapi';
 import { JSONValue, RelatedEntityObject } from 'src/utils/types';
 import { convertDurationToClockDuration, idFromUid } from 'src/utils/video';
 
-const DurationWrapper = React.forwardRef(function DurationWrapper(
+export const DurationWrapper = React.forwardRef(function DurationWrapper(
   {
     duration,
     children,

--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -13,11 +13,9 @@ const DurationWrapper = React.forwardRef(function DurationWrapper(
   {
     duration,
     children,
-    bottom = 0,
   }: {
     duration?: number;
     children: React.ReactNode;
-    bottom?: number;
   },
   ref
 ) {
@@ -36,14 +34,15 @@ const DurationWrapper = React.forwardRef(function DurationWrapper(
       {isDurationVisible && formattedDuration && (
         <Box
           position="absolute"
-          bottom={bottom}
+          bottom={0}
           right={0}
-          bgcolor="rgba(0,0,0,0.5)"
           color="#fff"
+          bgcolor="rgba(0,0,0,0.5)"
           px={1}
           fontFamily="system-ui, arial, sans-serif"
           fontSize="0.8em"
           fontWeight="bold"
+          lineHeight={1.5}
           sx={{ pointerEvents: 'none' }}
         >
           {formattedDuration}
@@ -123,7 +122,7 @@ const EntityImagery = ({
               to={`${baseUrl}/entities/${entity.uid}`}
               className="full-width"
             >
-              <DurationWrapper bottom={12} duration={entity.metadata.duration}>
+              <DurationWrapper duration={entity.metadata.duration}>
                 <img
                   className="full-width"
                   src={`https://i.ytimg.com/vi/${idFromUid(

--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -9,13 +9,15 @@ import { TypeEnum } from 'src/services/openapi';
 import { JSONValue, RelatedEntityObject } from 'src/utils/types';
 import { convertDurationToClockDuration, idFromUid } from 'src/utils/video';
 
-const PlayerWrapper = React.forwardRef(function PlayerWrapper(
+const DurationWrapper = React.forwardRef(function DurationWrapper(
   {
     duration,
     children,
+    bottom = 0,
   }: {
     duration?: number;
     children: React.ReactNode;
+    bottom?: number;
   },
   ref
 ) {
@@ -34,7 +36,7 @@ const PlayerWrapper = React.forwardRef(function PlayerWrapper(
       {isDurationVisible && formattedDuration && (
         <Box
           position="absolute"
-          bottom={0}
+          bottom={bottom}
           right={0}
           bgcolor="rgba(0,0,0,0.5)"
           color="#fff"
@@ -68,7 +70,7 @@ export const VideoPlayer = ({
       light
       width="100%"
       height="100%"
-      wrapper={PlayerWrapper}
+      wrapper={DurationWrapper}
       duration={duration}
       controls={controls}
     />
@@ -121,13 +123,15 @@ const EntityImagery = ({
               to={`${baseUrl}/entities/${entity.uid}`}
               className="full-width"
             >
-              <img
-                className="full-width"
-                src={`https://i.ytimg.com/vi/${idFromUid(
-                  entity.uid
-                )}/mqdefault.jpg`}
-                alt={entity.metadata.name}
-              />
+              <DurationWrapper bottom={12} duration={entity.metadata.duration}>
+                <img
+                  className="full-width"
+                  src={`https://i.ytimg.com/vi/${idFromUid(
+                    entity.uid
+                  )}/mqdefault.jpg`}
+                  alt={entity.metadata.name}
+                />
+              </DurationWrapper>
             </RouterLink>
           </Box>
         )}

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -23,6 +23,7 @@ import VideoCardScores from './VideoCardScores';
 import EntityCardTitle from 'src/components/entity/EntityCardTitle';
 import { entityCardMainSx } from 'src/components/entity/style';
 import EmptyEntityCard from 'src/components/entity/EmptyEntityCard';
+import { DurationWrapper } from 'src/components/entity/EntityImagery';
 import { VideoMetadata } from 'src/components/entity/EntityMetadata';
 import { useCurrentPoll } from 'src/hooks';
 import { UID_YT_NAMESPACE } from 'src/utils/constants';
@@ -112,11 +113,13 @@ function VideoCard({
               to={`${baseUrl}/entities/${UID_YT_NAMESPACE}${videoId}`}
               className="full-width"
             >
-              <img
-                className="full-width"
-                src={`https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`}
-                alt={video.name}
-              />
+              <DurationWrapper duration={video.duration || undefined}>
+                <img
+                  className="full-width"
+                  src={`https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`}
+                  alt={video.name}
+                />
+              </DurationWrapper>
             </RouterLink>
           </Box>
         </Grid>


### PR DESCRIPTION
**related to** #931 

---

The `<PlayerWrapper>` is now a `<DurationWrapper>` able to display the video duration on top of both players and thumbnails.