### PR TITLE
[front] refactor: hide the non-required `AnalysisPageLink`

### DIFF
--- a/frontend/src/features/videos/VideoList.tsx
+++ b/frontend/src/features/videos/VideoList.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 
 import { Typography, Box } from '@mui/material';
 import VideoCard from '../videos/VideoCard';
-import {
-  CompareNowAction,
-  AddToRateLaterList,
-  AnalysisPageLink,
-} from 'src/utils/action';
+import { CompareNowAction, AddToRateLaterList } from 'src/utils/action';
 import { useLoginState } from 'src/hooks';
 import { ActionList, VideoObject } from 'src/utils/types';
 
@@ -41,8 +37,8 @@ function VideoList({
   const { isLoggedIn } = useLoginState();
 
   const defaultActions = isLoggedIn
-    ? [CompareNowAction, AddToRateLaterList, AnalysisPageLink]
-    : [AnalysisPageLink];
+    ? [CompareNowAction, AddToRateLaterList]
+    : [];
 
   return (
     <>

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -1,11 +1,7 @@
 import { TFunction } from 'react-i18next';
 import { YouTube, HowToVote } from '@mui/icons-material';
 
-import {
-  AddToRateLaterList,
-  AnalysisPageLink,
-  CompareNowAction,
-} from './action';
+import { AddToRateLaterList, CompareNowAction } from './action';
 import {
   getAllCandidates,
   getTutorialDialogs as getPresidentielleTutorialDialogs,
@@ -212,8 +208,8 @@ export const polls: Array<SelectablePoll> = [
     ? [
         {
           name: PRESIDENTIELLE_2022_POLL_NAME,
-          defaultAuthEntityActions: [CompareNowAction, AnalysisPageLink],
-          defaultAnonEntityActions: [AnalysisPageLink],
+          defaultAuthEntityActions: [CompareNowAction],
+          defaultAnonEntityActions: [],
           displayOrder: 20,
           mainCriterionName: 'be_president',
           path: '/presidentielle2022/',
@@ -232,12 +228,8 @@ export const polls: Array<SelectablePoll> = [
     : []),
   {
     name: YOUTUBE_POLL_NAME,
-    defaultAuthEntityActions: [
-      CompareNowAction,
-      AddToRateLaterList,
-      AnalysisPageLink,
-    ],
-    defaultAnonEntityActions: [AnalysisPageLink],
+    defaultAuthEntityActions: [CompareNowAction, AddToRateLaterList],
+    defaultAnonEntityActions: [],
     defaultRecoLanguageDiscovery: true,
     defaultRecoSearchParams: 'date=Month',
     mainCriterionName: 'largely_recommended',


### PR DESCRIPTION
**related to** #931

---

The analysis page is now accessible by clicking on the videos' thumbnails and titles, so the analysis button in the entity lists is not required anymore.