### PR TITLE
[front] fix: do not interpret HTML tags from YT videos description

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "i18next-browser-languagedetector": "^6.1.2",
     "i18next-http-backend": "1.3.2",
     "linkify-html": "^3.0.5",
+    "linkify-string": "^3.0.4",
     "linkifyjs": "^3.0.5",
     "notistack": "^2.0.3",
     "precompress": "7.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,6 @@
     "i18next": "^21.6.3",
     "i18next-browser-languagedetector": "^6.1.2",
     "i18next-http-backend": "1.3.2",
-    "linkify-html": "^3.0.5",
     "linkify-string": "^3.0.4",
     "linkifyjs": "^3.0.5",
     "notistack": "^2.0.3",

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -24,7 +24,7 @@ import { VideoSerializerWithCriteria } from 'src/services/openapi';
 import { PersonalCriteriaScoresContextProvider } from 'src/hooks/usePersonalCriteriaScores';
 import PersonalScoreCheckbox from 'src/components/PersonalScoreCheckbox';
 import { CompareNowAction, AddToRateLaterList } from 'src/utils/action';
-import linkifyHtml from 'linkify-html';
+import linkifyStr from 'linkify-string';
 
 export const VideoAnalysis = ({
   video,
@@ -42,10 +42,7 @@ export const VideoAnalysis = ({
   const shouldDisplayCharts = criteriaScores && criteriaScores.length > 0;
 
   const linkifyOpts = { defaultProtocol: 'https', target: '_blank' };
-  const linkifiedDescription = linkifyHtml(
-    video.description || '',
-    linkifyOpts
-  );
+  const linkifiedDescription = linkifyStr(video.description || '', linkifyOpts);
 
   return (
     <Container sx={{ maxWidth: '1000px !important' }}>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6939,10 +6939,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-html@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/linkify-html/-/linkify-html-3.0.5.tgz#317181f7603e17b7d38492b0f6fdf9cce14f1e6b"
-  integrity sha512-3O7HEYjkugX+C/G2C2wyBmIt8Mt0pmeaHNIxRHodCFeQQeSxSoZHR+5hC1pi0WrmoEvfnSemyZyYTM8w3lo9cA==
+linkify-string@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/linkify-string/-/linkify-string-3.0.4.tgz#6abf1a5e436e800c729274ae08f5703484647f84"
+  integrity sha512-OnNqqRjlYXaXipIAbBC8sDXsSumI1ftatzFg141Pw9HEXWjTVLFcMZoKbFupshqWRavtNJ6QHLa+u6AlxxgeRw==
 
 linkifyjs@^3.0.5:
   version "3.0.5"


### PR DESCRIPTION
Related to #948 

After a discussion with @amatissart linkify-string is a library which produce harmless links and convert HTML entities in encoded characters compared to linkify-html library (https://linkify.js.org/docs/xss.html)