### PR TITLE
Selectable criterion on bar chart

### DIFF
--- a/frontend/src/features/charts/CriteriaScoresDistribution.tsx
+++ b/frontend/src/features/charts/CriteriaScoresDistribution.tsx
@@ -16,6 +16,7 @@ import CriteriaSelector from 'src/features/criteria/CriteriaSelector';
 import { useCurrentPoll } from 'src/hooks';
 import { PollsService, CriteriaDistributionScore } from 'src/services/openapi';
 import useSelectedCriterion from 'src/hooks/useSelectedCriterion';
+import { criterionColor } from 'src/utils/criteria';
 
 const displayScore = (score: number) => (10 * score).toFixed(0);
 
@@ -36,8 +37,10 @@ const binLabel = (index: number, bins: number[], t: TFunction) => {
 };
 
 const CriteriaScoresDistributionChart = ({
+  criterion,
   criteriaDistributionScore,
 }: {
+  criterion: string;
   criteriaDistributionScore: CriteriaDistributionScore;
 }) => {
   const { t } = useTranslation();
@@ -56,6 +59,8 @@ const CriteriaScoresDistributionChart = ({
     (value: number) => [value, t('criteriaScoresDistribution.label')],
     [t]
   );
+
+  const barColor = criterionColor(criterion);
 
   return (
     <ResponsiveContainer width="100%" height={360}>
@@ -79,7 +84,7 @@ const CriteriaScoresDistributionChart = ({
           }}
         />
         <Tooltip formatter={tooltipFormatter} />
-        <Bar dataKey="value" fill="#1282b2" />
+        <Bar dataKey="value" fill={barColor} />
       </BarChart>
     </ResponsiveContainer>
   );
@@ -130,6 +135,7 @@ const CriteriaScoresDistribution = ({
       {criteriaDistributionScore && (
         <Box py={1}>
           <CriteriaScoresDistributionChart
+            criterion={selectedCriterion}
             criteriaDistributionScore={criteriaDistributionScore}
           />
         </Box>

--- a/frontend/src/features/charts/CriteriaScoresDistribution.tsx
+++ b/frontend/src/features/charts/CriteriaScoresDistribution.tsx
@@ -15,6 +15,7 @@ import { Box } from '@mui/material';
 import CriteriaSelector from 'src/features/criteria/CriteriaSelector';
 import { useCurrentPoll } from 'src/hooks';
 import { PollsService, CriteriaDistributionScore } from 'src/services/openapi';
+import useSelectedCriterion from 'src/hooks/useSelectedCriterion';
 
 const displayScore = (score: number) => (10 * score).toFixed(0);
 
@@ -91,11 +92,8 @@ interface CriteriaScoresDistributionProps {
 const CriteriaScoresDistribution = ({
   uid,
 }: CriteriaScoresDistributionProps) => {
-  const { name: pollName, options } = useCurrentPoll();
-
-  const mainCriterionName = options?.mainCriterionName || '';
-  const [selectedCriteria, setSelectedCriteria] =
-    useState<string>(mainCriterionName);
+  const { name: pollName } = useCurrentPoll();
+  const { selectedCriterion, setSelectedCriterion } = useSelectedCriterion();
 
   const [criteriaScoresDistribution, setCriteriaScoresDistribution] = useState<
     CriteriaDistributionScore[]
@@ -116,17 +114,17 @@ const CriteriaScoresDistribution = ({
   const criteriaDistributionScore = useMemo(
     () =>
       criteriaScoresDistribution.find(
-        ({ criteria }) => criteria === selectedCriteria
+        ({ criteria: criterion }) => criterion === selectedCriterion
       ),
-    [selectedCriteria, criteriaScoresDistribution]
+    [selectedCriterion, criteriaScoresDistribution]
   );
 
   return (
     <>
       <Box px={2} pt={1} pb={1}>
         <CriteriaSelector
-          criteria={selectedCriteria}
-          setCriteria={setSelectedCriteria}
+          criteria={selectedCriterion}
+          setCriteria={setSelectedCriterion}
         />
       </Box>
       {criteriaDistributionScore && (

--- a/frontend/src/hooks/useSelectedCriterion.tsx
+++ b/frontend/src/hooks/useSelectedCriterion.tsx
@@ -1,0 +1,53 @@
+import React, {
+  createContext,
+  useState,
+  useEffect,
+  useMemo,
+  useContext,
+} from 'react';
+import { useCurrentPoll } from 'src/hooks';
+
+interface SelectedCriterionContextValue {
+  selectedCriterion: string;
+  setSelectedCriterion: (criterion: string) => void;
+}
+
+const SelectedCriterionContext = createContext<SelectedCriterionContextValue>({
+  selectedCriterion: '',
+  setSelectedCriterion: () => undefined,
+});
+
+export const SelectedCriterionProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { name: pollName, options } = useCurrentPoll();
+
+  const mainCriterionName = options?.mainCriterionName || '';
+  const [selectedCriterion, setSelectedCriterion] =
+    useState<string>(mainCriterionName);
+
+  // Reset the selected criterion when the poll changes
+  useEffect(() => {
+    setSelectedCriterion(mainCriterionName);
+  }, [pollName, mainCriterionName]);
+
+  const contextValue = useMemo(
+    () => ({
+      selectedCriterion,
+      setSelectedCriterion,
+    }),
+    [selectedCriterion]
+  );
+
+  return (
+    <SelectedCriterionContext.Provider value={contextValue}>
+      {children}
+    </SelectedCriterionContext.Provider>
+  );
+};
+
+const useSelectedCriterion = () => useContext(SelectedCriterionContext);
+
+export default useSelectedCriterion;

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -25,6 +25,7 @@ import { PersonalCriteriaScoresContextProvider } from 'src/hooks/usePersonalCrit
 import PersonalScoreCheckbox from 'src/components/PersonalScoreCheckbox';
 import { CompareNowAction, AddToRateLaterList } from 'src/utils/action';
 import linkifyStr from 'linkify-string';
+import { SelectedCriterionProvider } from 'src/hooks/useSelectedCriterion';
 
 export const VideoAnalysis = ({
   video,
@@ -99,7 +100,7 @@ export const VideoAnalysis = ({
 
           {/* Data visualization. */}
           {shouldDisplayCharts && (
-            <>
+            <SelectedCriterionProvider>
               <Grid item xs={12} sm={12} md={6}>
                 <Paper>
                   <Box
@@ -139,7 +140,7 @@ export const VideoAnalysis = ({
                   </Box>
                 </Paper>
               </Grid>
-            </>
+            </SelectedCriterionProvider>
           )}
         </Grid>
       </Box>

--- a/frontend/src/utils/criteria.ts
+++ b/frontend/src/utils/criteria.ts
@@ -13,6 +13,7 @@ export const criteriaIcon = (criteriaName: string) => {
 };
 
 const criterionColors: { [criteria: string]: string } = {
+  largely_recommended: '#ffc800',
   reliability: '#4F77DD',
   importance: '#DC8A5D',
   engaging: '#DFC642',
@@ -25,4 +26,4 @@ const criterionColors: { [criteria: string]: string } = {
 };
 
 export const criterionColor = (criterion: string) =>
-  criterionColors[criterion] || '#ffc800';
+  criterionColors[criterion] || '#506ad4';

--- a/frontend/src/utils/criteria.ts
+++ b/frontend/src/utils/criteria.ts
@@ -25,4 +25,4 @@ const criterionColors: { [criteria: string]: string } = {
 };
 
 export const criterionColor = (criterion: string) =>
-  criterionColors[criterion] || '#506ad4';
+  criterionColors[criterion] || '#ffc800';


### PR DESCRIPTION
Related issue: #933 

This branch and PR are made on top of https://github.com/tournesol-app/tournesol/pull/958. I didn't add the commits directly to the previous PR because it has already been reviewed.

It makes the criterion selectable in the bar chart. When selected the criterion chart has a light grey background (the same grey as in the paper title).

I also made a few extra changes:
- the "largely recommended" criteria is now yellow (the same yellow as in the main title bar)
- the bar color on the criteria scores distribution chart is now the criterion color
- fixed the criteria order in the bar chart to match the order in the comparison form. It also makes all the criteria listed even if some of them do not have a score

![image](https://user-images.githubusercontent.com/28259/172139479-479d7347-fa18-450d-bbda-0608c9cf7a80.png)
![image](https://user-images.githubusercontent.com/28259/172141967-0ec4d7f0-cab3-43c9-b49b-2a1a8a847d00.png)
![image](https://user-images.githubusercontent.com/28259/172140619-bb389b37-f8fd-469d-a669-f8d71b338eb3.png)

