### PR TITLE
suggestions: Fix score for suggested videos with video reference

### DIFF
--- a/backend/tournesol/suggestions/suggested_video.py
+++ b/backend/tournesol/suggestions/suggested_video.py
@@ -42,9 +42,11 @@ class SuggestedVideo:
         return self.uid.__hash__()
 
     def score_computation(self, reference: SuggestedVideo):
-        return (self.score_uncertainty + reference.score_uncertainty / (
-                    self.score + reference.score + 1)
-                ) / self.suggestibility_normalization
+        return (
+            (self.score_uncertainty + reference.score_uncertainty)
+            / (abs(self.score - reference.score) + 1)
+            / self.suggestibility_normalization
+        )
 
     @property
     def score(self):


### PR DESCRIPTION
As discussed with @Foebus, in the previous implementation the denominator could equal 0.

And I think there is another typo in the numerator : 
```python
self.score_uncertainty + reference.score_uncertainty / ( ... )
```
should be
```python
(self.score_uncertainty + reference.score_uncertainty) / ( ... )
```