### PR TITLE
extension: Look for new buttons container on Youtube redesign

### DIFF
--- a/browser-extension/src/addRateLaterButton.css
+++ b/browser-extension/src/addRateLaterButton.css
@@ -10,6 +10,7 @@ button#tournesol-rate-button {
   vertical-align: middle;
   text-transform: uppercase;
   font-weight: 500;
+  height: 36px;
 }
 
 button#tournesol-rate-button:disabled {

--- a/browser-extension/src/addRateLaterButton.js
+++ b/browser-extension/src/addRateLaterButton.js
@@ -18,6 +18,18 @@ if (document.body) {
   document.addEventListener('DOMContentLoaded', addRateLaterButton);
 }
 
+function getYtButtonsContainer() {
+  return (
+    // 2022-06-06: container used by Youtube redesign will be searched first.
+    document.querySelector(
+      '#menu.ytd-watch-metadata #top-level-buttons-computed'
+    ) ||
+    document.querySelector(
+      '#menu.ytd-video-primary-info-renderer #top-level-buttons-computed'
+    )
+  );
+}
+
 function addRateLaterButton() {
   const videoId = new URL(location.href).searchParams.get('v');
 
@@ -38,14 +50,10 @@ function addRateLaterButton() {
      ** Some ids on video pages are duplicated, so I take the first non-duplicated id and search in its childs the correct div to add the button
      ** Note: using .children[index] when child has no id
      */
-    if (
-      !document.getElementById('menu-container') ||
-      !document.getElementById('menu-container').children['menu'] ||
-      !document.getElementById('menu-container').children['menu'].children[0] ||
-      !document.getElementById('menu-container').children['menu'].children[0]
-        .children['top-level-buttons-computed']
-    )
+    const buttonsContainer = getYtButtonsContainer();
+    if (!buttonsContainer) {
       return;
+    }
 
     // If the button already exists, don't create a new one
     if (document.getElementById('tournesol-rate-button')) {
@@ -102,9 +110,9 @@ function addRateLaterButton() {
     };
 
     // Insert after like and dislike buttons
-    const div =
-      document.getElementById('menu-container').children['menu'].children[0]
-        .children['top-level-buttons-computed'];
-    div.insertBefore(rateLaterButton, div.children[2]);
+    buttonsContainer.insertBefore(
+      rateLaterButton,
+      buttonsContainer.children[2]
+    );
   }
 }


### PR DESCRIPTION
The rate-later button integration was broken on Youtube new design. And I finally managed to access this new version (on Chromium private browsing only).

The rate-later button will be inserted into the container used by the new design if it's found. The previous design (still accessed by most users) should not be impacted.

And this should also fix the sporadic failures of e2e tests.