### PR TITLE
[dev-env] feat: support docker-compose-plugin in addition to docker-compose

### DIFF
--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -3,7 +3,7 @@
 ## Quick start
 
 ### Requirements:
-* docker-compose (or docker compose plugin)
+* `docker-compose-plugin` (or `docker-compose`)
 * curl
 * expect
 

--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -3,7 +3,7 @@
 ## Quick start
 
 ### Requirements:
-* docker-compose
+* docker-compose (or docker compose plugin)
 * curl
 * expect
 

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -32,7 +32,7 @@ function compose_up_with_compose_plugin() {
 }
 
 function compose_up(){
-  if docker compose version ; then
+  if docker compose version 2>/dev/null; then
       echo "compose_up : docker-compose-plugin found"
       compose_up_with_compose_plugin "$@"
   else
@@ -60,7 +60,7 @@ function compose_stop_with_compose_plugin() {
 }
 
 function compose_stop(){
-  if docker compose version ; then
+  if docker compose version 2>/dev/null; then
       echo "compose_stop: docker-compose-plugin found"
       compose_stop_with_compose_plugin
   else

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -19,10 +19,27 @@ function is_front_ready() {
   curl -s localhost:3000 --max-time 1 -o /dev/null
 }
 
-function compose_up() {
+function compose_up_with_docker_compose() {
   DB_UID=$(id -u) \
   DB_GID=$(id -g) \
   docker-compose up --build --force-recreate -d "$@"
+}
+
+function compose_up_with_compose_plugin() {
+  DB_UID=$(id -u) \
+  DB_GID=$(id -g) \
+  docker compose up --build --force-recreate -d "$@"
+}
+
+function compose_up(){
+  if command -v docker-compose
+  then
+    echo "docker-compose found"
+    compose_up_with_docker_compose "$@"
+  else
+    echo "docker-compose not found, trying with docker"
+    compose_up_with_compose_plugin "$@"
+  fi
 }
 
 function wait_for() {

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -32,13 +32,14 @@ function compose_up_with_compose_plugin() {
 }
 
 function compose_up(){
-  if command -v docker-compose ; then
-    echo "compose_up : docker-compose found"
-    compose_up_with_docker_compose "$@"
-  else
-    echo "compose_up : docker-compose not found, trying with docker"
-    if docker compose version ; then
+  if docker compose version ; then
+      echo "compose_up : docker-compose-plugin found"
       compose_up_with_compose_plugin "$@"
+  else
+    echo "compose_up : docker-compose-plugin not found, trying to find docker-compose command"
+    if command -v docker-compose ; then
+      echo "compose_up : docker-compose found"
+      compose_up_with_docker_compose "$@"
     else
       echo "please install either docker-compose or docker-compose-plugin "
       exit 1
@@ -46,26 +47,27 @@ function compose_up(){
   fi
 }
 
-function compose_down_with_docker_compose() {
+function compose_stop_with_docker_compose() {
   DB_UID=$(id -u) \
   DB_GID=$(id -g) \
-  docker-compose down
+  docker-compose stop
 }
 
-function compose_down_with_compose_plugin() {
+function compose_stop_with_compose_plugin() {
   DB_UID=$(id -u) \
   DB_GID=$(id -g) \
-  docker compose down
+  docker compose stop
 }
 
-function compose_down(){
-  if command -v docker-compose ; then
-    echo "compose_down : docker-compose found"
-    compose_down_with_docker_compose
+function compose_stop(){
+  if docker compose version ; then
+      echo "compose_stop: docker-compose-plugin found"
+      compose_stop_with_compose_plugin
   else
-    echo "compose_down : docker-compose not found, trying with docker"
-    if docker compose version ; then
-      compose_down_with_compose_plugin
+    echo "compose_stop : docker-compose-plugin not found, trying to find docker-compose command"
+    if command -v docker-compose ; then
+      echo "compose_stop : docker-compose found"
+      compose_stop_with_docker_compose
     else
       echo "please install either docker-compose or docker-compose-plugin "
       exit 1
@@ -99,7 +101,7 @@ fi
 
 if [[ "${1:-""}" == 'stop' ]]; then
   echo "Stopping dev containers..."
-  compose_down
+  compose_stop
   echo "Docker containers are stopped."
   exit
 fi

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -34,11 +34,34 @@ function compose_up_with_compose_plugin() {
 function compose_up(){
   if command -v docker-compose
   then
-    echo "docker-compose found"
+    echo "compose_up : docker-compose found"
     compose_up_with_docker_compose "$@"
   else
-    echo "docker-compose not found, trying with docker"
+    echo "compose_up : docker-compose not found, trying with docker"
     compose_up_with_compose_plugin "$@"
+  fi
+}
+
+function compose_down_with_docker_compose() {
+  DB_UID=$(id -u) \
+  DB_GID=$(id -g) \
+  docker-compose down
+}
+
+function compose_down_with_compose_plugin() {
+  DB_UID=$(id -u) \
+  DB_GID=$(id -g) \
+  docker compose down
+}
+
+function compose_down(){
+  if command -v docker-compose
+  then
+    echo "compose_down : docker-compose found"
+    compose_down_with_docker_compose
+  else
+    echo "compose_down : docker-compose not found, trying with docker"
+    compose_down_with_compose_plugin
   fi
 }
 
@@ -63,6 +86,13 @@ if [[ "${1:-""}" == 'restart' ]]; then
   compose_up
   wait_for is_front_ready "front"
   echo "You can now access Tournesol on http://localhost:3000"
+  exit
+fi
+
+if [[ "${1:-""}" == 'stop' ]]; then
+  echo "Stopping dev containers..."
+  compose_down
+  echo "Docker containers are stopped."
   exit
 fi
 

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -37,7 +37,12 @@ function compose_up(){
     compose_up_with_docker_compose "$@"
   else
     echo "compose_up : docker-compose not found, trying with docker"
-    compose_up_with_compose_plugin "$@"
+    if docker compose version ; then
+      compose_up_with_compose_plugin "$@"
+    else
+      echo "please install either docker-compose or docker-compose-plugin "
+      exit 1
+    fi
   fi
 }
 
@@ -59,7 +64,12 @@ function compose_down(){
     compose_down_with_docker_compose
   else
     echo "compose_down : docker-compose not found, trying with docker"
-    compose_down_with_compose_plugin
+    if docker compose version ; then
+      compose_down_with_compose_plugin
+    else
+      echo "please install either docker-compose or docker-compose-plugin "
+      exit 1
+    fi
   fi
 }
 

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -32,8 +32,7 @@ function compose_up_with_compose_plugin() {
 }
 
 function compose_up(){
-  if command -v docker-compose
-  then
+  if command -v docker-compose ; then
     echo "compose_up : docker-compose found"
     compose_up_with_docker_compose "$@"
   else
@@ -55,8 +54,7 @@ function compose_down_with_compose_plugin() {
 }
 
 function compose_down(){
-  if command -v docker-compose
-  then
+  if command -v docker-compose ; then
     echo "compose_down : docker-compose found"
     compose_down_with_docker_compose
   else


### PR DESCRIPTION
Docker has released a V2 for Docker compose, integrated in Docker CLI, instead of the previous docker-compose binary.

https://docs.docker.com/compose/

By default, Docker suggest to install the docker compose plugin, like in this tutorial : 

https://docs.docker.com/engine/install/ubuntu/


Tournesol's dev_env sh script use the docker-compose binary to set up the dev env. The script can be adapted to automatically detect if that binary is either present or either docker compose plugin is.

enhancements :

* auto detection user's config :
    * A docker-compose is present
    * docker compose plugin is installed
    * None, script should advise to install one
* tear down command