### PR TITLE
[back] fix: server error on `entities_to_compare` 

### DIFF
--- a/backend/tournesol/suggestions/suggested_user_video.py
+++ b/backend/tournesol/suggestions/suggested_user_video.py
@@ -18,11 +18,11 @@ class SuggestedUserVideo(SuggestedVideo):
 
     @property
     def score(self):
-        return self.local_user.scores[self]
+        return self.local_user.scores.get(self, 0)
 
     @property
     def score_uncertainty(self):
-        return self.local_user.score_uncertainties[self]
+        return self.local_user.score_uncertainties.get(self, 0)
 
     @property
     def graph_sparsity(self):

--- a/backend/tournesol/suggestions/suggestionprovider.py
+++ b/backend/tournesol/suggestions/suggestionprovider.py
@@ -123,8 +123,11 @@ class SuggestionProvider:
             )
         )
         for c in query:
-            va = self._entity_to_video[c["uid1"]]
-            vb = self._entity_to_video[c["uid2"]]
+            uid1, uid2 = c["uid1"], c["uid2"]
+            if uid1 not in self._entity_to_video or uid2 not in self._entity_to_video:
+                continue
+            va = self._entity_to_video[uid1]
+            vb = self._entity_to_video[uid2]
             self._user_specific_graphs[new_user.id].add_edge(va, vb)
 
     def register_user_comparison(self, user: User, va: SuggestedVideo, vb: SuggestedVideo):

--- a/backend/tournesol/tests/test_suggestions.py
+++ b/backend/tournesol/tests/test_suggestions.py
@@ -391,7 +391,7 @@ class SuggestionAPITestCase(TestCase):
         suggestions = suggester.get_second_video_recommendation(new_user, self.videos[9].uid, 6)
         assert len(suggestions) == 6
 
-    def test_suggestions_with_new_video_without_score(self):
+    def test_suggestions_with_new_videos(self):
         new_video = VideoFactory()
         ComparisonCriteriaScoreFactory(
             comparison__user=self.central_scaled_user,
@@ -400,5 +400,10 @@ class SuggestionAPITestCase(TestCase):
             criteria=self._criteria,
         )
         suggester = SuggestionProvider(self.poll)
+        new_comparison = ComparisonCriteriaScoreFactory(
+            comparison__user=self.central_scaled_user,
+            comparison__entity_2=self.videos[0],
+            criteria=self._criteria,
+        )
         suggestions = suggester.get_second_video_recommendation(self.central_scaled_user, self.videos[0].uid, 6)
         assert len(suggestions) == 6

--- a/backend/tournesol/tests/test_suggestions.py
+++ b/backend/tournesol/tests/test_suggestions.py
@@ -390,3 +390,15 @@ class SuggestionAPITestCase(TestCase):
 
         suggestions = suggester.get_second_video_recommendation(new_user, self.videos[9].uid, 6)
         assert len(suggestions) == 6
+
+    def test_suggestions_with_new_video_without_score(self):
+        new_video = VideoFactory()
+        ComparisonCriteriaScoreFactory(
+            comparison__user=self.central_scaled_user,
+            comparison__entity_1=new_video,
+            comparison__entity_2=self.videos[0],
+            criteria=self._criteria,
+        )
+        suggester = SuggestionProvider(self.poll)
+        suggestions = suggester.get_second_video_recommendation(self.central_scaled_user, self.videos[0].uid, 6)
+        assert len(suggestions) == 6


### PR DESCRIPTION
A server error could be raised when a new video is present in the database with comparisons, but without contributor score.
This should fix the error reported by @GresilleSiffle in #856.

@Foebus Is `0.0` an appropriate default value for the `score_uncertainty` in `SuggestedUserVideo` ?