### PR TITLE
[ext] refactor: use the new `/entities/` URL instead of `/video/`

### DIFF
--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -87,7 +87,7 @@ function process() {
 
           // On click
           statisticsButton.onclick = () => {
-            open(`https://tournesol.app/video/${videoId}`);
+            open(`https://tournesol.app/entities/yt:${videoId}`);
           };
 
           var div =

--- a/browser-extension/src/browserAction/menu.js
+++ b/browser-extension/src/browserAction/menu.js
@@ -17,8 +17,11 @@ function get_current_tab_video_id() {
   }).then(get_tab_video_id);
 }
 
-function rate_now(e) {
-  const button = e.target;
+/**
+ * Open the Tournesol comparison page in a new tab.
+ */
+function rateNowAction(event) {
+  const button = event.target;
   get_current_tab_video_id().then(
     (videoId) => {
       chrome.tabs.create({
@@ -27,13 +30,18 @@ function rate_now(e) {
     },
     () => {
       button.disabled = true;
-      button.setAttribute('data-error', 'Not a Youtube video page.');
+      button.setAttribute('data-error', 'Not a YouTube video page.');
     }
   );
 }
 
-function rate_later(e) {
-  const button = e.target;
+/**
+ * Add the video to the user's rate-later list.
+ *
+ * If the user is not logged, display the login iframe.
+ */
+function addToRateLaterAction(event) {
+  const button = event.target;
   get_current_tab_video_id().then(
     async (videoId) => {
       button.disabled = true;
@@ -61,26 +69,32 @@ function rate_later(e) {
     },
     () => {
       button.disabled = true;
-      button.setAttribute('data-error', 'Not a Youtube video page.');
+      button.setAttribute('data-error', 'Not a YouTube video page.');
     }
   );
 }
 
-function details(e) {
-  const button = e.target;
+/**
+ * Open the Tournesol entity analysis page in a new tab.
+ */
+function openAnalysisPageAction(event) {
+  const button = event.target;
   get_current_tab_video_id().then(
     (videoId) => {
-      chrome.tabs.create({ url: `https://tournesol.app/video/${videoId}` });
+      chrome.tabs.create({ url: `https://tournesol.app/entities/yt:${videoId}` });
     },
     () => {
       button.disabled = true;
-      button.setAttribute('data-error', 'Not a Youtube video page.');
+      button.setAttribute('data-error', 'Not a YouTube video page.');
     }
   );
 }
 
+/**
+ * Create the action menu.
+ */
 document.addEventListener('DOMContentLoaded', function () {
-  document.getElementById('rate_now').addEventListener('click', rate_now);
-  document.getElementById('rate_later').addEventListener('click', rate_later);
-  document.getElementById('details').addEventListener('click', details);
+  document.getElementById('rate_now').addEventListener('click', rateNowAction);
+  document.getElementById('rate_later').addEventListener('click', addToRateLaterAction);
+  document.getElementById('details').addEventListener('click', openAnalysisPageAction);
 });

--- a/browser-extension/src/browserAction/menu.js
+++ b/browser-extension/src/browserAction/menu.js
@@ -81,7 +81,9 @@ function openAnalysisPageAction(event) {
   const button = event.target;
   get_current_tab_video_id().then(
     (videoId) => {
-      chrome.tabs.create({ url: `https://tournesol.app/entities/yt:${videoId}` });
+      chrome.tabs.create({
+        url: `https://tournesol.app/entities/yt:${videoId}`,
+      });
     },
     () => {
       button.disabled = true;
@@ -95,6 +97,10 @@ function openAnalysisPageAction(event) {
  */
 document.addEventListener('DOMContentLoaded', function () {
   document.getElementById('rate_now').addEventListener('click', rateNowAction);
-  document.getElementById('rate_later').addEventListener('click', addToRateLaterAction);
-  document.getElementById('details').addEventListener('click', openAnalysisPageAction);
+  document
+    .getElementById('rate_later')
+    .addEventListener('click', addToRateLaterAction);
+  document
+    .getElementById('details')
+    .addEventListener('click', openAnalysisPageAction);
 });

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
The browser extension now uses the new `/entities/` front end's URL instead of the legacy `/video/`.