### PR TITLE
[twitterbot] fix unwanted link in video title

### DIFF
--- a/backend/twitterbot/tests/test_tournesolbot.py
+++ b/backend/twitterbot/tests/test_tournesolbot.py
@@ -185,7 +185,7 @@ class TestTournesolBot(TestCase):
         )
 
         tweet_special_characters = (
-            "Aujourd'hui, je recommande 'Tournesol｡app is great! But automatic mention ﹫twitter "
+            "Aujourd'hui, je recommande 'Tournesol․app is great! But automatic mention ﹫twitter "
             "are not... 🌻' de @TournesolApp, comparée 77 fois sur #Tournesol🌻 par 28 "
             "contributeurs, critères favoris:"
             "\n- Important & actionnable"

--- a/backend/twitterbot/tests/test_tournesolbot.py
+++ b/backend/twitterbot/tests/test_tournesolbot.py
@@ -168,8 +168,6 @@ class TestTournesolBot(TestCase):
             "Tournesol is great! But this title is way to long to fit in one tweet🌻 #tournesol"
         )
 
-        print(prepare_tweet(self.videos[8]))
-
         tweet_text_too_long = (
             "Aujourd'hui, je recommande 'Tournesol is great! But this title is way to long to fit "
             "in one tweet...' de @TournesolApp, comparée 77 fois sur #Tournesol🌻 par 28 "
@@ -180,6 +178,22 @@ class TestTournesolBot(TestCase):
         )
 
         assert prepare_tweet(self.videos[8]) == tweet_text_too_long
+        
+        # Test replacement of special characters in the video title
+        self.videos[8].metadata["name"] = (
+            "Tournesol.app is great! But automatic mention @twitter are not... 🌻"
+        )
+
+        tweet_special_characters = (
+            "Aujourd'hui, je recommande 'Tournesol｡app is great! But automatic mention ﹫twitter "
+            "are not... 🌻' de @TournesolApp, comparée 77 fois sur #Tournesol🌻 par 28 "
+            "contributeurs, critères favoris:"
+            "\n- Important & actionnable"
+            "\n- Stimulant & suscite la réflexion"
+            "\nyoutu.be/AAAAAAAAAAA"
+        )
+
+        assert prepare_tweet(self.videos[8]) == tweet_special_characters
 
     def test_get_video_recommendations(self):
         """

--- a/backend/twitterbot/tournesolbot.py
+++ b/backend/twitterbot/tournesolbot.py
@@ -51,10 +51,9 @@ def prepare_tweet(video):
 
     # Replace "@" by a smaller "@" to avoid false mentions in the tweet
     video_title = video.metadata["name"].replace("@", "﹫")
-    
+
     # Replace "." in between words to avoid in the tweet false detection of links
     video_title = re.sub(r"\b(?:\.)\b", "｡", video_title)
-
 
     # Generate the text of the tweet
     tweet_text = settings.tweet_text_template[language].format(

--- a/backend/twitterbot/tournesolbot.py
+++ b/backend/twitterbot/tournesolbot.py
@@ -1,4 +1,5 @@
 import random
+import re
 
 from core.utils.time import time_ago
 from tournesol.models import Entity
@@ -48,8 +49,12 @@ def prepare_tweet(video):
         CriteriaLocale.objects.filter(language=language).values_list("criteria__name", "label")
     )
 
-    # Replace "@" by "at" to avoid false mentions in the tweet
-    video_title = video.metadata["name"].replace("@", "at")
+    # Replace "@" by a smaller "@" to avoid false mentions in the tweet
+    video_title = video.metadata["name"].replace("@", "﹫")
+    
+    # Replace "." in between words to avoid in the tweet false detection of links
+    video_title = re.sub(r"\b(?:\.)\b", "｡", video_title)
+
 
     # Generate the text of the tweet
     tweet_text = settings.tweet_text_template[language].format(

--- a/backend/twitterbot/tournesolbot.py
+++ b/backend/twitterbot/tournesolbot.py
@@ -53,7 +53,7 @@ def prepare_tweet(video):
     video_title = video.metadata["name"].replace("@", "﹫")
 
     # Replace "." in between words to avoid in the tweet false detection of links
-    video_title = re.sub(r"\b(?:\.)\b", "｡", video_title)
+    video_title = re.sub(r"\b(?:\.)\b", "․", video_title)
 
     # Generate the text of the tweet
     tweet_text = settings.tweet_text_template[language].format(


### PR DESCRIPTION
When there was a "." in between words in a video title, it was detected as a link by Twitter (and use 23 characters) which leads to too long tweet. Now, this kind dot in between words is replace by a character which look link a dot --> "｡"