### PR TITLE
[back] fix: Unexpected side-effect in unconnected_entities view

### DIFF
--- a/backend/tournesol/tests/test_api_unconnected_entities.py
+++ b/backend/tournesol/tests/test_api_unconnected_entities.py
@@ -85,7 +85,14 @@ class SimpleAllConnectedTest(TestCase):
             f"{self.user_base_url}/{self.video_source.uid}/",
             format="json",
         )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
 
+        # Make sure that no side-effect affects subsequent requests
+        response = self.client.get(
+            f"{self.user_base_url}/{self.video_source.uid}/",
+            format="json",
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 

--- a/backend/tournesol/views/unconnected_entities.py
+++ b/backend/tournesol/views/unconnected_entities.py
@@ -30,35 +30,36 @@ class UnconnectedEntitiesView(
     def get_queryset(self):
         # Get related entities from source entity
         source_node = get_object_or_404(Entity, uid=self.kwargs.get("uid"))
-        comparison_pairs = list(
+        comparisons = list(
             Comparison.objects.filter(
                 poll=self.poll_from_url, user=self.request.user
             ).values_list("entity_1_id", "entity_2_id")
         )
 
         all_connections = defaultdict(set)
-        already_visited_nodes = set()
 
-        for (entity_1_id, entity_2_id) in comparison_pairs:
+        for (entity_1_id, entity_2_id) in comparisons:
             all_connections[entity_1_id].add(entity_2_id)
             all_connections[entity_2_id].add(entity_1_id)
 
         def get_related_entities(entity_id):
-            already_visited_nodes.add(entity_id)
-            related_entities = set()
-            if entity_id not in all_connections:
-                return set()
+            already_visited_nodes = set()
+            related_entities = {entity_id}
+            to_visit = {entity_id}
 
-            for other_node in all_connections[entity_id]:
-                if other_node not in already_visited_nodes:
-                    related_entities.update(get_related_entities(other_node))
+            while to_visit:
+                node = to_visit.pop()
+                already_visited_nodes.add(node)
+                connections = all_connections.get(node, set())
+                to_visit.update(connections - already_visited_nodes)
+                related_entities.update(connections)
 
-            return all_connections[entity_id].union(related_entities)
+            return related_entities
 
         user_related_entities = get_related_entities(source_node.id)
         user_all_entities = set()
 
-        for (entity_1_id, entity_2_id) in comparison_pairs:
+        for (entity_1_id, entity_2_id) in comparisons:
             user_all_entities.add(entity_1_id)
             user_all_entities.add(entity_2_id)
 

--- a/backend/tournesol/views/unconnected_entities.py
+++ b/backend/tournesol/views/unconnected_entities.py
@@ -27,42 +27,39 @@ class UnconnectedEntitiesView(
     serializer_class = EntityNoExtraFieldSerializer
     permission_classes = [IsAuthenticated]
 
-    _already_visited_node_ = set()
-    _all_connections_ = defaultdict(set)
-
-    def get_related_entities(self, entity_id):
-
-        self._already_visited_node_.add(entity_id)
-
-        related_entities = set()
-        if self._all_connections_.get(entity_id) is None:
-            return set()
-
-        for other_node in self._all_connections_.get(entity_id):
-            if other_node not in self._already_visited_node_:
-                related_entities.update(self.get_related_entities(other_node))
-
-        return self._all_connections_.get(entity_id).union(related_entities)
-
     def get_queryset(self):
-        # Get related entities from source
-        source_node = Entity.objects.none()
-
+        # Get related entities from source entity
         source_node = get_object_or_404(Entity, uid=self.kwargs.get("uid"))
-        comparisons = list(Comparison.objects.filter(
-            poll=self.poll_from_url, user=self.request.user
-        ))
+        comparison_pairs = list(
+            Comparison.objects.filter(
+                poll=self.poll_from_url, user=self.request.user
+            ).values_list("entity_1_id", "entity_2_id")
+        )
 
-        for c in comparisons:
-            self._all_connections_[c.entity_1_id].add(c.entity_2_id)
-            self._all_connections_[c.entity_2_id].add(c.entity_1_id)
+        all_connections = defaultdict(set)
+        already_visited_nodes = set()
 
-        user_related_entities = self.get_related_entities(source_node.id)
+        for (entity_1_id, entity_2_id) in comparison_pairs:
+            all_connections[entity_1_id].add(entity_2_id)
+            all_connections[entity_2_id].add(entity_1_id)
+
+        def get_related_entities(entity_id):
+            already_visited_nodes.add(entity_id)
+            related_entities = set()
+            if entity_id not in all_connections:
+                return set()
+
+            for other_node in all_connections[entity_id]:
+                if other_node not in already_visited_nodes:
+                    related_entities.update(get_related_entities(other_node))
+
+            return all_connections[entity_id].union(related_entities)
+
+        user_related_entities = get_related_entities(source_node.id)
         user_all_entities = set()
 
-        for comparison in comparisons:
-            user_all_entities.add(comparison.entity_1_id)
-            user_all_entities.add(comparison.entity_2_id)
+        for (entity_1_id, entity_2_id) in comparison_pairs:
+            user_all_entities.add(entity_1_id)
+            user_all_entities.add(entity_2_id)
 
-        return Entity.objects \
-            .filter(id__in=user_all_entities - user_related_entities)
+        return Entity.objects.filter(id__in=user_all_entities - user_related_entities)


### PR DESCRIPTION
Some of the data structures (including the set of "visited nodes") would persist across requests. This is due to how in Python, attributes initialized in the class definition are owned by the Class object itself, and not by the instances.

These attributes initialization were expected to be reset for each request (i.e view instances)
```python
    _already_visited_node_ = set()
    _all_connections_ = defaultdict(set)
```

Here it seems less error-prone to instead move the algorithm inside `get_queryset()` and make the scope of these structures more explicit.