### PR TITLE
[front] fix: ignore request results after moving to another tab in EntityTabsBox

### DIFF
--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -41,17 +41,26 @@ const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
       return;
     }
 
+    let aborted = false;
     const loadTab = async () => {
       setStatus(TabStatus.Loading);
       try {
-        setOptions(await tab.fetch());
-        setStatus(TabStatus.Ok);
+        const results = await tab.fetch();
+        if (!aborted) {
+          setOptions(results);
+          setStatus(TabStatus.Ok);
+        }
       } catch {
-        setStatus(TabStatus.Error);
+        if (!aborted) {
+          setStatus(TabStatus.Error);
+        }
       }
     };
 
     loadTab();
+    return () => {
+      aborted = true;
+    };
   }, [tabs, tabValue]);
 
   return (


### PR DESCRIPTION
The `useEffect` cleanup function is used to ignore the response if the tab value has changed.