### PR TITLE
[front] Fix scroll on mobile in EntityTabsBox

### DIFF
--- a/frontend/src/components/LoaderWrapper.tsx
+++ b/frontend/src/components/LoaderWrapper.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Box, CircularProgress, SxProps } from '@mui/material';
 
 interface LoaderProps {
   isLoading: boolean;
   children: React.ReactNode;
+  sx?: SxProps;
 }
 
 /**
@@ -11,7 +12,7 @@ interface LoaderProps {
  * `isLoading`is True. The content will then be displayed as greyed-out,
  * and a circular loader will be visibled in an overlay.
  */
-const LoaderWrapper = ({ isLoading, children }: LoaderProps) => {
+const LoaderWrapper = ({ isLoading, sx = {}, children }: LoaderProps) => {
   return (
     <>
       {isLoading && (
@@ -29,13 +30,14 @@ const LoaderWrapper = ({ isLoading, children }: LoaderProps) => {
         </Box>
       )}
       <Box
-        sx={{
-          ...(isLoading && {
+        sx={[
+          ...(Array.isArray(sx) ? sx : [sx]),
+          isLoading && {
             opacity: '30%',
             filter: 'grayscale(100%) blur(2px)',
             pointerEvents: 'none',
-          }),
-        }}
+          },
+        ]}
       >
         {children}
       </Box>

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -62,11 +62,9 @@ const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
         flexDirection: 'column',
         minHeight: '160px',
         ul: {
-          flexGrow: 1,
           listStyleType: 'none',
           p: 0,
           m: 0,
-          overflowY: 'scroll',
           maxHeight: '40vh',
           '.MuiModal-root &': {
             maxHeight: 'none',
@@ -106,7 +104,10 @@ const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
           <Tab key={name} value={name} label={label} disabled={disabled} />
         ))}
       </Tabs>
-      <LoaderWrapper isLoading={status === TabStatus.Loading}>
+      <LoaderWrapper
+        isLoading={status === TabStatus.Loading}
+        sx={{ overflowY: 'scroll' }}
+      >
         {status === TabStatus.Error ? (
           <TabError message={t('tabsBox.errorOnLoading')} />
         ) : options.length > 0 ? (


### PR DESCRIPTION
The scroll on the mobile view was broken after the list have been wrapped inside `LoaderWrapper` in #856 