### PR TITLE
[back] fix: `validate_meta_filter_field` now raises an HTTP 400 error

### DIFF
--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -49,11 +49,12 @@ class EntityType(ABC):
         ORM features, time-consuming or CPU heavy operations.
         """
         if "__" in field:
-            raise ValidationError(
-                {
-                    "_url_metadata": f'The metatada field `{field}` cannot contain the special string "__".'
-                }
-            )
+            # fmt: off
+            raise ValidationError({
+                "_url_metadata":
+                    f'The metatada field `{field}` cannot contain the special string "__".'
+            })
+            # fmt: on
 
     @classmethod
     def get_allowed_meta_filter_funcs(cls) -> Dict:

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -50,7 +50,9 @@ class EntityType(ABC):
         """
         if "__" in field:
             raise ValidationError(
-                f'The metatada field `{field}` cannot contain the special string "__".'
+                {
+                    "_url_metadata": f'The metatada field `{field}` cannot contain the special string "__".'
+                }
             )
 
     @classmethod

--- a/backend/tournesol/tests/test_api_polls.py
+++ b/backend/tournesol/tests/test_api_polls.py
@@ -263,6 +263,20 @@ class PollsRecommendationsTestCase(TestCase):
         self.assertEqual(resp.data["count"], 0)
         self.assertEqual(resp.data["results"], [])
 
+    def test_anon_cannot_use_forbidden_strings_in_metadata_filter(self):
+        response = self.client.get("/polls/videos/recommendations/?metadata[__]=10")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        response = self.client.get(
+            "/polls/videos/recommendations/?metadata[duration__lte]=10"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        response = self.client.get(
+            "/polls/videos/recommendations/?metadata[duration__lte::int]=10"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_anon_can_list_videos_filtered_by_duration_exact(self):
         response = self.client.get(
             "/polls/videos/recommendations/?metadata[duration]=10"


### PR DESCRIPTION
...instead of the previous HTTP 500.

If the `detail` parameter of the `rest_framework.exceptions.ValidationError` is dict, the view will consider it as a JSON response with a HTTP 400 code, else HTTP 500.

I prefixed the key by `_url_` to make it more clear that the error is not related to a form field, but to a URL parameter.