### PR TITLE
[all] chore: add copyright notices and license disclaimers

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,6 +9,9 @@ We pledge to respect users freedom by using
 Commons licenses, we seek to use licenses
 [approved for Free Cultural Works][cc-freeculturalworks] as much as possible.
 
+You can find the copyright notice of each software and other production in
+their dedicated `README.md` file.
+
 ## GNU Affero General Public License v3.0 or later
 
 ![GNU AGPL v3.0 logo](./docs/logos/agplv3-with-text-162x68.png)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ on [Discord][tournesol-discord-join].
  - [Structure of the repository](#structure-of-the-repository)
  - [Set-up](#set-up)
  - [Contributing](#contributing)
- - [Licenses](#licenses)
+ - [Copyright & Licenses](#copyright--licenses)
 
 ## Structure of the repository
 
@@ -73,12 +73,15 @@ The code source of the project exists thanks to
 
 Thank you very much!
 
-## Licenses
+## Copyright & Licenses
 
 The Tournesol project has chosen to distribute its software and its other
 productions under the terms of different licenses.
 
 See the [LICENSE.md](./LICENSE.md) file for the exhaustive list.
+
+You can find the copyright notice of each software and other production in
+their dedicated `README.md` file.
 
 [tournesol-discord-join]: https://discord.gg/WvcSG55Bf3
 

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,13 +1,17 @@
 # TournesolDataViz
 
-Tournesol data visualization tool is a Streamlit app to visualize [tournesol.app](https://tournesol.app/) data.
+The Tournesol public data visualization tool made with Streamlit.
 
 ## Install
 
-Create a new Python virtual environment, and install the requirements. Be sure to use one virtual environment per Python projects in the Tournesol repository to not mix dependencies.
+Create a new Python virtual environment, and install the requirements. Be sure
+to use one virtual environment per Python projects in the Tournesol repository
+to not mix dependencies.
+
 ```bash
 pip install -r requirements.txt
 ```
+
 ## Run
 
 To run Sreamlit on a localhost:
@@ -15,3 +19,23 @@ To run Sreamlit on a localhost:
 ```bash
 streamlit run analytics.py
 ```
+
+## Copyright & License
+
+Copyright 2021-2022 Association Tournesol and contributors.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Included license:
+ - [AGPL-3.0-or-later](./LICENSE)

--- a/backend/README.md
+++ b/backend/README.md
@@ -11,7 +11,7 @@ The API of the Tournesol platform, made with Python and Django.
 - [Tests](#tests)
 - [Code Quality](#code-quality)
 - [F.A.Q.](#faq)
-- [Copyright & License](#copyright-&-license)
+- [Copyright & License](#copyright--license)
 
 ## Install
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -11,6 +11,7 @@ The API of the Tournesol platform, made with Python and Django.
 - [Tests](#tests)
 - [Code Quality](#code-quality)
 - [F.A.Q.](#faq)
+- [Copyright & License](#copyright-&-license)
 
 ## Install
 
@@ -218,6 +219,26 @@ quality checks manually.
 
 As we do not want to make the developers to have complex and error-prone local
 setups, we decided to add the code quality checks only in the CI for now.
+
+## Copyright & License
+
+Copyright 2021-2022 Association Tournesol and contributors.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Included license:
+ - [AGPL-3.0-or-later](./LICENSE)
 
 [dev-env-readme]: https://github.com/tournesol-app/tournesol/blob/main/dev-env/README.md
 

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -20,8 +20,7 @@ easily add them to their rate-later list.
   - [Code Quality](#code-quality)
   - [Upating the version](#updating-the-version)
 - [Release a new version](#release-a-new-version)
-- [License](#license)
-
+- [Copyright & License](#copyright--license)
 
 ## Development guidelines
 
@@ -70,9 +69,25 @@ Given a version number `MAJOR.MINOR.PATCH`, increment the:
 To release the extension on Chrome or Mozilla Firefox, run the script `./build.sh`
 and upload the generated .zip file in the corresponding extension web store.
 
-## License
+## Copyright & License
 
-See the [LICENSE.md](./src/LICENSE) file.
+Copyright 2021-2022 Association Tournesol and contributors.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Included license:
+ - [AGPL-3.0-or-later](./LICENSE)
 
 [download-chrome]: https://chrome.google.com/webstore/detail/tournesol-extension/nidimbejmadpggdgooppinedbggeacla
 [download-firefox]: https://addons.mozilla.org/en-US/firefox/addon/tournesol-extension/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -82,3 +82,23 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Copyright & License
+
+Copyright 2021-2022 Association Tournesol and contributors.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Included license:
+ - [AGPL-3.0-or-later](./LICENSE)

--- a/infra/README.md
+++ b/infra/README.md
@@ -126,3 +126,23 @@ To import a backup from production to the local tournesol VM:
 ```
 ./ansible/scripts/fetch-and-import-pg-backup.sh --backup-name 2021-11-12-weekly --from tournesol.app --to-ansible-host tournesol-vm
 ```
+
+## Copyright & License
+
+Copyright 2021-2022 Association Tournesol and contributors.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Included license:
+ - [AGPL-3.0-or-later](./LICENSE)


### PR DESCRIPTION
This PR adds, for each sub-folder having a license, a Copyright notice, license disclaimer and a direct link to the license.

I didn't update the `README.md` of sub-folders without license, like the `dev-env` and the `tests`. I'd like to think about what license is appropriate for those folders, even if I think the AGPL will be a very good candidate.

See the main `README.md` here: https://github.com/tournesol-app/tournesol/blob/chore-copyright/README.md#copyright--licenses

See the back end's `README.md` here: https://github.com/tournesol-app/tournesol/blob/chore-copyright/backend/README.md#copyright--license