### PR TITLE
[back] perf: speedup `ExportPublicComparisonsView` with raw SQL

### DIFF
--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -1,25 +1,24 @@
 """
 The public dataset library.
 """
-
 from django.db.models import QuerySet
 
-from tournesol.models.comparisons import Comparison
 
-
-def get_dataset() -> QuerySet:
+def get_dataset(poll_name: str) -> QuerySet:
     """
     Retrieve the public dataset from the database and return a non-evaluated
     Django `RawQuerySet`.
     """
-    Comparison.objects.raw(
+    from tournesol.models.comparisons import Comparison
+
+    return Comparison.objects.raw(
         """
         SELECT
             tournesol_comparison.id,
 
             core_user.username,
-            entity_1.uid AS entity_a,
-            entity_2.uid AS entity_b,
+            entity_1.uid AS uid_a,
+            entity_2.uid AS uid_b,
             comparisoncriteriascore.criteria,
             comparisoncriteriascore.weight,
             comparisoncriteriascore.score
@@ -54,9 +53,10 @@ def get_dataset() -> QuerySet:
           ON rating_2.entity_id = tournesol_comparison.entity_2_id
          AND rating_2.user_id = tournesol_comparison.user_id
 
-        WHERE tournesol_poll.name = 'videos'
+        WHERE tournesol_poll.name = %(poll_name)s
           -- keep only public ratings
           AND rating_1.is_public = true
           AND rating_2.is_public = true
-        """
+        """,
+        {"poll_name": poll_name},
     )

--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -1,0 +1,62 @@
+"""
+The public dataset library.
+"""
+
+from django.db.models import QuerySet
+
+from tournesol.models.comparisons import Comparison
+
+
+def get_dataset() -> QuerySet:
+    """
+    Retrieve the public dataset from the database and return a non-evaluated
+    Django `RawQuerySet`.
+    """
+    Comparison.objects.raw(
+        """
+        SELECT
+            tournesol_comparison.id,
+
+            core_user.username,
+            entity_1.uid AS entity_a,
+            entity_2.uid AS entity_b,
+            comparisoncriteriascore.criteria,
+            comparisoncriteriascore.weight,
+            comparisoncriteriascore.score
+
+        FROM tournesol_comparison
+
+        -- this JOIN allows to filter on the desired poll
+        JOIN tournesol_poll
+          ON tournesol_poll.id = tournesol_comparison.poll_id
+
+        JOIN core_user
+          ON core_user.id = tournesol_comparison.user_id
+
+        JOIN tournesol_comparisoncriteriascore AS comparisoncriteriascore
+          ON comparisoncriteriascore.comparison_id = tournesol_comparison.id
+
+        JOIN tournesol_entity AS entity_1
+          ON entity_1.id = tournesol_comparison.entity_1_id
+
+        JOIN tournesol_entity AS entity_2
+          ON entity_2.id = tournesol_comparison.entity_2_id
+
+        -- this JOIN allows to filter by public ratings for the entity_1
+        -- the poll has been already filtered, no need to filter it again
+        JOIN tournesol_contributorrating AS rating_1
+          ON rating_1.entity_id = tournesol_comparison.entity_1_id
+         AND rating_1.user_id = tournesol_comparison.user_id
+
+        -- this JOIN allows to filter by public ratings for the entity_2
+        -- the poll has been already filtered, no need to filter it again
+        JOIN tournesol_contributorrating AS rating_2
+          ON rating_2.entity_id = tournesol_comparison.entity_2_id
+         AND rating_2.user_id = tournesol_comparison.user_id
+
+        WHERE tournesol_poll.name = 'videos'
+          -- keep only public ratings
+          AND rating_1.is_public = true
+          AND rating_2.is_public = true
+        """
+    )

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -69,7 +69,7 @@ def write_public_comparisons_file(poll_name: str, write_target) -> None:
             "weight": comparison.weight,
             "score": comparison.score,
         }
-        for comparison in get_dataset(poll_name)
+        for comparison in get_dataset(poll_name).iterator()
     )
 
 

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -13,7 +13,7 @@ from rest_framework.views import APIView
 from core.models import User
 from tournesol.entities.base import UID_DELIMITER
 from tournesol.lib.public_dataset import get_dataset
-from tournesol.models import Comparison
+from tournesol.models import Comparison, Poll
 from tournesol.serializers.comparison import ComparisonSerializer
 from tournesol.utils.cache import cache_page_no_i18n
 from tournesol.views.mixins.poll import PollScopedViewMixin
@@ -45,7 +45,7 @@ def write_comparisons_file(request, write_target):
     )
 
 
-def write_public_comparisons_file(write_target) -> None:
+def write_public_comparisons_file(poll_name: str, write_target) -> None:
     """
     Retrieve all public comparisons' data, and write them as CSV in
     `write_target`, an object supporting the Python file API.
@@ -69,7 +69,7 @@ def write_public_comparisons_file(write_target) -> None:
             "weight": comparison.weight,
             "score": comparison.score,
         }
-        for comparison in get_dataset()
+        for comparison in get_dataset(poll_name)
     )
 
 
@@ -102,7 +102,7 @@ class ExportPublicComparisonsView(APIView):
         response[
             "Content-Disposition"
         ] = 'attachment; filename="tournesol_public_export.csv"'
-        write_public_comparisons_file(response)
+        write_public_comparisons_file(Poll.default_poll().name, response)
         return response
 
 

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -60,40 +60,65 @@ def write_public_comparisons_file(request, write_target):
     ]
     writer = csv.DictWriter(write_target, fieldnames=fieldnames)
     writer.writeheader()
-    public_data = (
-        ContributorRating.objects
-        .filter(is_public=True, poll__name=DEFAULT_POLL_NAME)
-        .select_related("user", "entity")
+
+    comparisons = Comparison.objects.raw(
+        """
+        SELECT
+            tournesol_comparison.id,
+
+            core_user.username,
+            entity_1.uid AS entity_a,
+            entity_2.uid AS entity_b,
+            comparisoncriteriascore.criteria,
+            comparisoncriteriascore.weight,
+            comparisoncriteriascore.score
+
+        FROM tournesol_comparison
+
+        -- this JOIN allows to filter on the desired poll
+        JOIN tournesol_poll
+          ON tournesol_poll.id = tournesol_comparison.poll_id
+
+        JOIN core_user
+          ON core_user.id = tournesol_comparison.user_id
+
+        JOIN tournesol_comparisoncriteriascore AS comparisoncriteriascore
+          ON comparisoncriteriascore.comparison_id = tournesol_comparison.id
+
+        JOIN tournesol_entity AS entity_1
+          ON entity_1.id = tournesol_comparison.entity_1_id
+
+        JOIN tournesol_entity AS entity_2
+          ON entity_2.id = tournesol_comparison.entity_2_id
+
+        -- this JOIN allows to filter by public ratings for the entity_1
+        -- the poll has been already filtered, no need to filter it again
+        JOIN tournesol_contributorrating AS rating_1
+          ON rating_1.entity_id = tournesol_comparison.entity_1_id
+         AND rating_1.user_id = tournesol_comparison.user_id
+
+        -- this JOIN allows to filter by public ratings for the entity_2
+        -- the poll has been already filtered, no need to filter it again
+        JOIN tournesol_contributorrating AS rating_2
+          ON rating_2.entity_id = tournesol_comparison.entity_2_id
+         AND rating_2.user_id = tournesol_comparison.user_id
+
+        WHERE tournesol_poll.name = 'videos'
+          -- keep only public ratings
+          AND rating_1.is_public = true
+          AND rating_2.is_public = true;
+        """
     )
-    serialized_comparisons = []
-    public_videos = set((rating.user, rating.entity) for rating in public_data)
-    comparisons = (
-        Comparison.objects
-        .filter(poll__name=DEFAULT_POLL_NAME)
-        .select_related("entity_1", "entity_2", "user")
-        .prefetch_related("criteria_scores")
-    )
-    public_comparisons = [
-        comparison
-        for comparison in comparisons
-        if (
-            (comparison.user, comparison.entity_1) in public_videos
-            and (comparison.user, comparison.entity_2) in public_videos
-        )
-    ]
-    public_usernames = [comparison.user.username for comparison in public_comparisons]
-    serialized_comparisons = ComparisonSerializer(public_comparisons, many=True).data
     writer.writerows(
         {
-            "public_username": public_username,
-            "video_a": comparison["entity_a"]["uid"].split(UID_DELIMITER)[1],
-            "video_b": comparison["entity_b"]["uid"].split(UID_DELIMITER)[1],
-            **criteria_score,
+            "public_username": comparison.username,
+            "video_a": comparison.uid_a.split(UID_DELIMITER)[1],
+            "video_b": comparison.uid_b.split(UID_DELIMITER)[1],
+            "criteria": comparison.criteria,
+            "weight": comparison.weight,
+            "score": comparison.score,
         }
-        for (public_username, comparison) in zip(
-            public_usernames, serialized_comparisons
-        )
-        for criteria_score in comparison["criteria_scores"]
+        for comparison in comparisons
     )
 
 
@@ -169,7 +194,9 @@ class ExportProofOfVoteView(PollScopedViewMixin, APIView):
     def get(self, request, *args, **kwargs):
         poll = self.poll_from_url
         response = HttpResponse(content_type="text/csv")
-        response["Content-Disposition"] = f'attachment; filename="proof_of_vote_{poll.name}.csv"'
+        response[
+            "Content-Disposition"
+        ] = f'attachment; filename="proof_of_vote_{poll.name}.csv"'
 
         fieldnames = [
             "user_id",
@@ -182,12 +209,8 @@ class ExportProofOfVoteView(PollScopedViewMixin, APIView):
         writer.writeheader()
         writer.writerows(
             {**d, "signature": poll.get_proof_of_vote(d["user_id"])}
-            for d in User.objects.filter(comparisons__poll=poll)
-            .values(
-                "username",
-                "email",
-                n_comparisons=Count("*"),
-                user_id=F("id")
+            for d in User.objects.filter(comparisons__poll=poll).values(
+                "username", "email", n_comparisons=Count("*"), user_id=F("id")
             )
         )
         return response

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 
 from core.models import User
 from tournesol.entities.base import UID_DELIMITER
+from tournesol.lib.public_dataset import get_dataset
 from tournesol.models import Comparison
 from tournesol.serializers.comparison import ComparisonSerializer
 from tournesol.utils.cache import cache_page_no_i18n
@@ -59,55 +60,6 @@ def write_public_comparisons_file(write_target) -> None:
     ]
     writer = csv.DictWriter(write_target, fieldnames=fieldnames)
     writer.writeheader()
-
-    comparisons = Comparison.objects.raw(
-        """
-        SELECT
-            tournesol_comparison.id,
-
-            core_user.username,
-            entity_1.uid AS entity_a,
-            entity_2.uid AS entity_b,
-            comparisoncriteriascore.criteria,
-            comparisoncriteriascore.weight,
-            comparisoncriteriascore.score
-
-        FROM tournesol_comparison
-
-        -- this JOIN allows to filter on the desired poll
-        JOIN tournesol_poll
-          ON tournesol_poll.id = tournesol_comparison.poll_id
-
-        JOIN core_user
-          ON core_user.id = tournesol_comparison.user_id
-
-        JOIN tournesol_comparisoncriteriascore AS comparisoncriteriascore
-          ON comparisoncriteriascore.comparison_id = tournesol_comparison.id
-
-        JOIN tournesol_entity AS entity_1
-          ON entity_1.id = tournesol_comparison.entity_1_id
-
-        JOIN tournesol_entity AS entity_2
-          ON entity_2.id = tournesol_comparison.entity_2_id
-
-        -- this JOIN allows to filter by public ratings for the entity_1
-        -- the poll has been already filtered, no need to filter it again
-        JOIN tournesol_contributorrating AS rating_1
-          ON rating_1.entity_id = tournesol_comparison.entity_1_id
-         AND rating_1.user_id = tournesol_comparison.user_id
-
-        -- this JOIN allows to filter by public ratings for the entity_2
-        -- the poll has been already filtered, no need to filter it again
-        JOIN tournesol_contributorrating AS rating_2
-          ON rating_2.entity_id = tournesol_comparison.entity_2_id
-         AND rating_2.user_id = tournesol_comparison.user_id
-
-        WHERE tournesol_poll.name = 'videos'
-          -- keep only public ratings
-          AND rating_1.is_public = true
-          AND rating_2.is_public = true
-        """
-    )
     writer.writerows(
         {
             "public_username": comparison.username,
@@ -117,7 +69,7 @@ def write_public_comparisons_file(write_target) -> None:
             "weight": comparison.weight,
             "score": comparison.score,
         }
-        for comparison in comparisons
+        for comparison in get_dataset()
     )
 
 

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -12,8 +12,7 @@ from rest_framework.views import APIView
 
 from core.models import User
 from tournesol.entities.base import UID_DELIMITER
-from tournesol.models import Comparison, ContributorRating
-from tournesol.models.poll import DEFAULT_POLL_NAME
+from tournesol.models import Comparison
 from tournesol.serializers.comparison import ComparisonSerializer
 from tournesol.utils.cache import cache_page_no_i18n
 from tournesol.views.mixins.poll import PollScopedViewMixin
@@ -45,10 +44,10 @@ def write_comparisons_file(request, write_target):
     )
 
 
-def write_public_comparisons_file(request, write_target):
+def write_public_comparisons_file(write_target) -> None:
     """
-    Writes all public comparisons data as a CSV file to write_target which can be
-    among other options an HttpResponse or a StringIO
+    Retrieve all public comparisons' data, and write them as CSV in
+    `write_target`, an object supporting the Python file API.
     """
     fieldnames = [
         "public_username",
@@ -106,7 +105,7 @@ def write_public_comparisons_file(request, write_target):
         WHERE tournesol_poll.name = 'videos'
           -- keep only public ratings
           AND rating_1.is_public = true
-          AND rating_2.is_public = true;
+          AND rating_2.is_public = true
         """
     )
     writer.writerows(
@@ -151,7 +150,7 @@ class ExportPublicComparisonsView(APIView):
         response[
             "Content-Disposition"
         ] = 'attachment; filename="tournesol_public_export.csv"'
-        write_public_comparisons_file(request, response)
+        write_public_comparisons_file(response)
         return response
 
 


### PR DESCRIPTION
**related to** #988 

---

The PR reworks the way the `ExportPublicComparisonsView` used to retrieve the public dataset.

Instead of doing several non-optimized SQL queries due to the Django's ORM limitations, I used a raw SQL query to directly retrieve the public comparisons.

I created a folder `lib`, to avoid storing the raw SQL query in the view, and to invite us to factorize similar functions when relevant.