### PR TITLE
[front] feat: add a top-right menu

### DIFF
--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { Button, Grid } from '@mui/material';
-import { AccountCircle } from '@mui/icons-material';
+import { AccountCircle, ArrowDropDown, ArrowDropUp } from '@mui/icons-material';
 
 import { useLoginState, useNotifications } from 'src/hooks';
 import { revokeAccessToken } from '../../../login/loginAPI';
@@ -50,7 +50,8 @@ const LoggedInActions = () => {
         color="inherit"
         onClick={handleProfileClick}
         sx={accountLoginButtonSx}
-        endIcon={<AccountCircle sx={{ fontSize: '36px' }} color="action" />}
+        startIcon={<AccountCircle sx={{ fontSize: '36px' }} color="action" />}
+        endIcon={menuAnchor ? <ArrowDropUp /> : <ArrowDropDown />}
       >
         {loginState.username}
       </Button>

--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -51,7 +51,13 @@ const LoggedInActions = () => {
         onClick={handleProfileClick}
         sx={accountLoginButtonSx}
         startIcon={<AccountCircle sx={{ fontSize: '36px' }} color="action" />}
-        endIcon={menuAnchor ? <ArrowDropUp /> : <ArrowDropDown />}
+        endIcon={
+          menuAnchor ? (
+            <ArrowDropUp sx={{ color: 'rgba(0, 0, 0, 0.42)' }} />
+          ) : (
+            <ArrowDropDown sx={{ color: 'rgba(0, 0, 0, 0.42)' }} />
+          )
+        }
       >
         {loginState.username}
       </Button>

--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -2,8 +2,16 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-import { Button, Grid } from '@mui/material';
-import { AccountCircle } from '@mui/icons-material';
+import {
+  Button,
+  Divider,
+  Grid,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from '@mui/material';
+import { AccountCircle, Logout, Settings } from '@mui/icons-material';
 
 import { useLoginState, useNotifications } from 'src/hooks';
 import { revokeAccessToken } from '../../../login/loginAPI';
@@ -22,6 +30,17 @@ const LoggedInActions = () => {
 
   const { logout, loginState } = useLoginState();
 
+  const [menuAnchor, setMenuAnchor] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(menuAnchor);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setMenuAnchor(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setMenuAnchor(null);
+  };
+
   const logoutProcess = async () => {
     if (loginState.refresh_token) {
       await revokeAccessToken(loginState.refresh_token).catch(() => {
@@ -36,26 +55,41 @@ const LoggedInActions = () => {
       <Button
         variant="outlined"
         color="inherit"
+        onClick={handleClick}
         sx={accountLoginButtonSx}
-        onClick={logoutProcess}
-      >
-        {t('logoutButton')}
-      </Button>
-      <Button
-        variant="text"
-        color="secondary"
-        component={Link}
-        to="/settings/profile"
-        sx={{
-          textTransform: 'initial',
-          fontWeight: 'bold',
-          borderWidth: '2px',
-          color: 'text.primary',
-        }}
         endIcon={<AccountCircle sx={{ fontSize: '36px' }} color="action" />}
       >
         {loginState.username}
       </Button>
+      <Menu
+        id="personal-menu"
+        open={open}
+        anchorEl={menuAnchor}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'basic-button',
+        }}
+      >
+        <MenuItem component={Link} to="/settings/profile" onClick={handleClose}>
+          <ListItemIcon>
+            <AccountCircle fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Profile</ListItemText>
+        </MenuItem>
+        <MenuItem component={Link} to="/settings/account" onClick={handleClose}>
+          <ListItemIcon>
+            <Settings fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Account</ListItemText>
+        </MenuItem>
+        <Divider />
+        <MenuItem onClick={logoutProcess}>
+          <ListItemIcon>
+            <Logout fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Logout</ListItemText>
+        </MenuItem>
+      </Menu>
     </>
   );
 };

--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -24,13 +24,20 @@ const LoggedInActions = () => {
   const { logout, loginState } = useLoginState();
 
   const [menuAnchor, setMenuAnchor] = React.useState<null | HTMLElement>(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const handleProfileClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setMenuAnchor(event.currentTarget);
+    // Dynamically define the anchor the first time the user click on the
+    // profile button.
+    if (menuAnchor === null) {
+      setMenuAnchor(event.currentTarget);
+    }
+
+    setIsMenuOpen(true);
   };
 
   const handleMenuClose = () => {
-    setMenuAnchor(null);
+    setIsMenuOpen(false);
   };
 
   const logoutProcess = async () => {
@@ -52,7 +59,7 @@ const LoggedInActions = () => {
         sx={accountLoginButtonSx}
         startIcon={<AccountCircle sx={{ fontSize: '36px' }} color="action" />}
         endIcon={
-          menuAnchor ? (
+          isMenuOpen ? (
             <ArrowDropUp sx={{ color: 'rgba(0, 0, 0, 0.42)' }} />
           ) : (
             <ArrowDropDown sx={{ color: 'rgba(0, 0, 0, 0.42)' }} />
@@ -62,6 +69,7 @@ const LoggedInActions = () => {
         {loginState.username}
       </Button>
       <PersonalMenu
+        open={isMenuOpen}
         menuAnchor={menuAnchor}
         onClose={handleMenuClose}
         onItemClick={handleMenuClose}

--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-import {
-  Button,
-  Divider,
-  Grid,
-  ListItemIcon,
-  ListItemText,
-  Menu,
-  MenuItem,
-} from '@mui/material';
-import { AccountCircle, Logout, Settings } from '@mui/icons-material';
+import { Button, Grid } from '@mui/material';
+import { AccountCircle } from '@mui/icons-material';
 
 import { useLoginState, useNotifications } from 'src/hooks';
 import { revokeAccessToken } from '../../../login/loginAPI';
+import PersonalMenu from './PersonalMenu';
 
 const accountLoginButtonSx = {
   borderColor: 'rgba(0, 0, 0, 0.23)',
@@ -31,13 +24,12 @@ const LoggedInActions = () => {
   const { logout, loginState } = useLoginState();
 
   const [menuAnchor, setMenuAnchor] = React.useState<null | HTMLElement>(null);
-  const open = Boolean(menuAnchor);
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleProfileClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setMenuAnchor(event.currentTarget);
   };
 
-  const handleClose = () => {
+  const handleMenuClose = () => {
     setMenuAnchor(null);
   };
 
@@ -55,41 +47,18 @@ const LoggedInActions = () => {
       <Button
         variant="outlined"
         color="inherit"
-        onClick={handleClick}
+        onClick={handleProfileClick}
         sx={accountLoginButtonSx}
         endIcon={<AccountCircle sx={{ fontSize: '36px' }} color="action" />}
       >
         {loginState.username}
       </Button>
-      <Menu
-        id="personal-menu"
-        open={open}
-        anchorEl={menuAnchor}
-        onClose={handleClose}
-        MenuListProps={{
-          'aria-labelledby': 'basic-button',
-        }}
-      >
-        <MenuItem component={Link} to="/settings/profile" onClick={handleClose}>
-          <ListItemIcon>
-            <AccountCircle fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Profile</ListItemText>
-        </MenuItem>
-        <MenuItem component={Link} to="/settings/account" onClick={handleClose}>
-          <ListItemIcon>
-            <Settings fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Account</ListItemText>
-        </MenuItem>
-        <Divider />
-        <MenuItem onClick={logoutProcess}>
-          <ListItemIcon>
-            <Logout fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Logout</ListItemText>
-        </MenuItem>
-      </Menu>
+      <PersonalMenu
+        menuAnchor={menuAnchor}
+        onClose={handleMenuClose}
+        onItemClick={handleMenuClose}
+        onLogoutClick={logoutProcess}
+      />
     </>
   );
 };

--- a/frontend/src/features/frame/components/topbar/AccountInfo.tsx
+++ b/frontend/src/features/frame/components/topbar/AccountInfo.tsx
@@ -45,6 +45,7 @@ const LoggedInActions = () => {
   return (
     <>
       <Button
+        id="personal-menu-button"
         variant="outlined"
         color="inherit"
         onClick={handleProfileClick}

--- a/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
+++ b/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 
 import {
   Divider,
@@ -26,6 +25,7 @@ const PersonalMenu = ({
   onLogoutClick,
 }: PersonalMenuProps) => {
   const { t } = useTranslation();
+  const location = useLocation();
 
   const open = Boolean(menuAnchor);
 
@@ -43,6 +43,7 @@ const PersonalMenu = ({
         component={RouterLink}
         to="/settings/profile"
         onClick={onItemClick}
+        selected={'/settings/profile' === location.pathname}
       >
         <ListItemIcon>
           <AccountCircle fontSize="small" />
@@ -53,6 +54,7 @@ const PersonalMenu = ({
         component={RouterLink}
         to="/settings/account"
         onClick={onItemClick}
+        selected={'/settings/account' === location.pathname}
       >
         <ListItemIcon>
           <Settings fontSize="small" />

--- a/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
+++ b/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
@@ -10,7 +10,8 @@ import {
   MenuList,
   MenuItem,
 } from '@mui/material';
-import { AccountCircle, Logout, Settings } from '@mui/icons-material';
+import { Logout } from '@mui/icons-material';
+import { TournesolMenuItemType, settingsMenu } from 'src/utils/menus';
 
 interface PersonalMenuProps {
   menuAnchor: null | HTMLElement;
@@ -41,28 +42,21 @@ const PersonalMenu = ({
       }}
     >
       <MenuList dense sx={{ py: 0 }}>
-        <MenuItem
-          component={RouterLink}
-          to="/settings/profile"
-          onClick={onItemClick}
-          selected={'/settings/profile' === location.pathname}
-        >
-          <ListItemIcon>
-            <AccountCircle fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>{t('profile')}</ListItemText>
-        </MenuItem>
-        <MenuItem
-          component={RouterLink}
-          to="/settings/account"
-          onClick={onItemClick}
-          selected={'/settings/account' === location.pathname}
-        >
-          <ListItemIcon>
-            <Settings fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>{t('settings.account')}</ListItemText>
-        </MenuItem>
+        {/* -- settings section -- */}
+        {settingsMenu(t).map((item: TournesolMenuItemType) => (
+          <MenuItem
+            key={item.id}
+            component={RouterLink}
+            to={item.to}
+            onClick={onItemClick}
+            selected={item.to === location.pathname}
+          >
+            <ListItemIcon>
+              <item.icon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>{item.text}</ListItemText>
+          </MenuItem>
+        ))}
         <Divider />
         <MenuItem onClick={onLogoutClick}>
           <ListItemIcon>

--- a/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
+++ b/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Link as RouterLink } from 'react-router-dom';
+
+import {
+  Divider,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from '@mui/material';
+import { AccountCircle, Logout, Settings } from '@mui/icons-material';
+
+interface PersonalMenuProps {
+  menuAnchor: null | HTMLElement;
+  onClose: (event: React.MouseEvent<HTMLElement>) => void;
+  onItemClick: (event: React.MouseEvent<HTMLElement>) => void;
+  onLogoutClick: () => void;
+}
+
+const PersonalMenu = ({
+  menuAnchor,
+  onClose,
+  onItemClick,
+  onLogoutClick,
+}: PersonalMenuProps) => {
+  const { t } = useTranslation();
+
+  const open = Boolean(menuAnchor);
+
+  return (
+    <Menu
+      id="personal-menu"
+      open={open}
+      anchorEl={menuAnchor}
+      onClose={onClose}
+      MenuListProps={{
+        'aria-labelledby': 'basic-button',
+      }}
+    >
+      <MenuItem
+        component={RouterLink}
+        to="/settings/profile"
+        onClick={onItemClick}
+      >
+        <ListItemIcon>
+          <AccountCircle fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>{t('profile')}</ListItemText>
+      </MenuItem>
+      <MenuItem
+        component={RouterLink}
+        to="/settings/account"
+        onClick={onItemClick}
+      >
+        <ListItemIcon>
+          <Settings fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>{t('settings.account')}</ListItemText>
+      </MenuItem>
+      <Divider />
+      <MenuItem onClick={onLogoutClick}>
+        <ListItemIcon>
+          <Logout fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>{t('logoutButton')}</ListItemText>
+      </MenuItem>
+    </Menu>
+  );
+};
+
+export default PersonalMenu;

--- a/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
+++ b/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
@@ -15,6 +15,7 @@ import { TournesolMenuItemType, settingsMenu } from 'src/utils/menus';
 
 interface PersonalMenuProps {
   menuAnchor: null | HTMLElement;
+  open: boolean;
   onClose: (event: React.MouseEvent<HTMLElement>) => void;
   onItemClick: (event: React.MouseEvent<HTMLElement>) => void;
   onLogoutClick: () => void;
@@ -22,14 +23,13 @@ interface PersonalMenuProps {
 
 const PersonalMenu = ({
   menuAnchor,
+  open,
   onClose,
   onItemClick,
   onLogoutClick,
 }: PersonalMenuProps) => {
   const { t } = useTranslation();
   const location = useLocation();
-
-  const open = Boolean(menuAnchor);
 
   return (
     <Menu

--- a/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
+++ b/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
@@ -7,6 +7,7 @@ import {
   ListItemIcon,
   ListItemText,
   Menu,
+  MenuList,
   MenuItem,
 } from '@mui/material';
 import { AccountCircle, Logout, Settings } from '@mui/icons-material';
@@ -39,35 +40,37 @@ const PersonalMenu = ({
         'aria-labelledby': 'basic-button',
       }}
     >
-      <MenuItem
-        component={RouterLink}
-        to="/settings/profile"
-        onClick={onItemClick}
-        selected={'/settings/profile' === location.pathname}
-      >
-        <ListItemIcon>
-          <AccountCircle fontSize="small" />
-        </ListItemIcon>
-        <ListItemText>{t('profile')}</ListItemText>
-      </MenuItem>
-      <MenuItem
-        component={RouterLink}
-        to="/settings/account"
-        onClick={onItemClick}
-        selected={'/settings/account' === location.pathname}
-      >
-        <ListItemIcon>
-          <Settings fontSize="small" />
-        </ListItemIcon>
-        <ListItemText>{t('settings.account')}</ListItemText>
-      </MenuItem>
-      <Divider />
-      <MenuItem onClick={onLogoutClick}>
-        <ListItemIcon>
-          <Logout fontSize="small" />
-        </ListItemIcon>
-        <ListItemText>{t('logoutButton')}</ListItemText>
-      </MenuItem>
+      <MenuList dense sx={{ py: 0 }}>
+        <MenuItem
+          component={RouterLink}
+          to="/settings/profile"
+          onClick={onItemClick}
+          selected={'/settings/profile' === location.pathname}
+        >
+          <ListItemIcon>
+            <AccountCircle fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>{t('profile')}</ListItemText>
+        </MenuItem>
+        <MenuItem
+          component={RouterLink}
+          to="/settings/account"
+          onClick={onItemClick}
+          selected={'/settings/account' === location.pathname}
+        >
+          <ListItemIcon>
+            <Settings fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>{t('settings.account')}</ListItemText>
+        </MenuItem>
+        <Divider />
+        <MenuItem onClick={onLogoutClick}>
+          <ListItemIcon>
+            <Logout fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>{t('logoutButton')}</ListItemText>
+        </MenuItem>
+      </MenuList>
     </Menu>
   );
 };

--- a/frontend/src/features/settings/SettingsMenu.tsx
+++ b/frontend/src/features/settings/SettingsMenu.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
 import { useLocation } from 'react-router';
+import { Link } from 'react-router-dom';
 
-import Paper from '@mui/material/Paper';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import MenuList from '@mui/material/MenuList';
-import MenuItem from '@mui/material/MenuItem';
-import AccountCircle from '@mui/icons-material/AccountCircle';
-import Settings from '@mui/icons-material/Settings';
+import {
+  ListItemIcon,
+  ListItemText,
+  MenuList,
+  MenuItem,
+  Paper,
+} from '@mui/material';
+
+import { settingsMenu, TournesolMenuItemType } from 'src/utils/menus';
 
 export default function SettingsMenu() {
   const { t } = useTranslation();
@@ -17,26 +19,19 @@ export default function SettingsMenu() {
   return (
     <Paper>
       <MenuList>
-        <MenuItem
-          component={Link}
-          to="/settings/profile"
-          selected={'/settings/profile' === location.pathname}
-        >
-          <ListItemIcon>
-            <AccountCircle />
-          </ListItemIcon>
-          <ListItemText>{t('profile')}</ListItemText>
-        </MenuItem>
-        <MenuItem
-          component={Link}
-          to="/settings/account"
-          selected={'/settings/account' === location.pathname}
-        >
-          <ListItemIcon>
-            <Settings />
-          </ListItemIcon>
-          <ListItemText>{t('settings.account')}</ListItemText>
-        </MenuItem>
+        {settingsMenu(t).map((item: TournesolMenuItemType) => (
+          <MenuItem
+            key={item.id}
+            component={Link}
+            to={item.to}
+            selected={item.to === location.pathname}
+          >
+            <ListItemIcon>
+              <item.icon />
+            </ListItemIcon>
+            <ListItemText>{item.text}</ListItemText>
+          </MenuItem>
+        ))}
       </MenuList>
     </Paper>
   );

--- a/frontend/src/utils/menus.tsx
+++ b/frontend/src/utils/menus.tsx
@@ -1,0 +1,30 @@
+/**
+ * Configuration of the Tournesol menus and definition of their related types.
+ */
+
+import { TFunction } from 'react-i18next';
+import { AccountCircle, Settings, SvgIconComponent } from '@mui/icons-material';
+
+export type TournesolMenuItemType = {
+  id: string;
+  text: string;
+  icon: SvgIconComponent;
+  to: string;
+};
+
+export const settingsMenu = (t: TFunction): Array<TournesolMenuItemType> => {
+  return [
+    {
+      id: 'settings-profile',
+      text: t('profile'),
+      icon: AccountCircle,
+      to: '/settings/profile',
+    },
+    {
+      id: 'settings-account',
+      text: t('settings.account'),
+      icon: Settings,
+      to: '/settings/account',
+    },
+  ];
+};

--- a/tests/cypress/integration/frontend/login.ts
+++ b/tests/cypress/integration/frontend/login.ts
@@ -12,7 +12,8 @@ describe('Login', () => {
     cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
     cy.location('pathname').should('equal', '/');
     cy.contains('Log in').should('not.exist');
-    cy.contains('user').click();
+
+    cy.get('button#personal-menu-button').click();
     cy.contains('Logout').should('be.visible');
   })
 
@@ -25,8 +26,10 @@ describe('Login', () => {
     cy.location('pathname').should('equal', '/');
     cy.contains('.MuiToolbar-root', 'user1').should('be.visible');
     cy.contains('Log in').should('not.exist');
-    cy.contains('user').click();
-    cy.contains('Logout').should('be.visible').click();
+
+    cy.get('button#personal-menu-button').click();
+    cy.get('#personal-menu').contains('Logout').click();
+
     cy.contains('Log in').should('be.visible');
   })
 
@@ -39,8 +42,10 @@ describe('Login', () => {
     cy.location('pathname').should('equal', '/');
     cy.contains('.MuiToolbar-root', 'user1').should('be.visible');
     cy.contains('Log in').should('not.exist');
-    cy.contains('user').click();
-    cy.contains('Logout').should('be.visible').click();
+
+    cy.get('button#personal-menu-button').click();
+    cy.get('#personal-menu').contains('Logout').click();
+
     cy.contains('Log in').should('be.visible');
   })
 })

--- a/tests/cypress/integration/frontend/login.ts
+++ b/tests/cypress/integration/frontend/login.ts
@@ -12,8 +12,8 @@ describe('Login', () => {
     cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
     cy.location('pathname').should('equal', '/');
     cy.contains('Log in').should('not.exist');
-    cy.contains('Logout').click();
-    cy.contains('Log in').should('be.visible');
+    cy.contains('user').click();
+    cy.contains('Logout').should('be.visible');
   })
 
   it('can login with email and logout', () => {
@@ -25,7 +25,8 @@ describe('Login', () => {
     cy.location('pathname').should('equal', '/');
     cy.contains('.MuiToolbar-root', 'user1').should('be.visible');
     cy.contains('Log in').should('not.exist');
-    cy.contains('Logout').click();
+    cy.contains('user').click();
+    cy.contains('Logout').should('be.visible').click();
     cy.contains('Log in').should('be.visible');
   })
 
@@ -38,7 +39,8 @@ describe('Login', () => {
     cy.location('pathname').should('equal', '/');
     cy.contains('.MuiToolbar-root', 'user1').should('be.visible');
     cy.contains('Log in').should('not.exist');
-    cy.contains('Logout').click();
+    cy.contains('user').click();
+    cy.contains('Logout').should('be.visible').click();
     cy.contains('Log in').should('be.visible');
   })
 })

--- a/tests/cypress/integration/frontend/resetPassword.ts
+++ b/tests/cypress/integration/frontend/resetPassword.ts
@@ -19,7 +19,7 @@ describe('Password reset', () => {
       // Login with the new password
       cy.get('input[name=username]').type('username-pwreset');
       cy.get('input[name=password]').type('tournesol-new-password').type('{enter}');
-      cy.contains('a[href="/settings/profile"]', 'username-pwreset').should('be.visible');
+      cy.contains('button#personal-menu-button', 'username-pwreset').should('be.visible');
     })
   });
 })

--- a/tests/cypress/integration/frontend/settingsAccountPage.spec.ts
+++ b/tests/cypress/integration/frontend/settingsAccountPage.spec.ts
@@ -61,7 +61,9 @@ describe('Settings - account page', () => {
       cy.get('input[name=password_confirm]').type(newPaswsword).type('{enter}');
       cy.contains('Password changed successfully');
 
-      cy.contains('Logout').click();
+      cy.get('button#personal-menu-button').click();
+      cy.get('#personal-menu').contains('Logout').click();
+
       cy.focused().type(username);
 
       // old password must not work anymore

--- a/tests/cypress/integration/frontend/settingsProfilePage.spec.ts
+++ b/tests/cypress/integration/frontend/settingsProfilePage.spec.ts
@@ -25,7 +25,9 @@ describe('Settings - profile page', () => {
       cy.get('input[name=username]').clear().type(user1NewUsername).type('{enter}');
       cy.contains('Profile changed successfully');
 
-      cy.contains('Logout').click();
+      cy.get('button#personal-menu-button').click();
+      cy.get('#personal-menu').contains('Logout').click();
+
       cy.focused().type(user1username);
 
       // old username must not work anymore
@@ -50,7 +52,9 @@ describe('Settings - profile page', () => {
       cy.get('input[name=username]').clear().type(user2username).type('{enter}');
       cy.contains('A user with that username already exists.');
 
-      cy.contains('Logout').click();
+      cy.get('button#personal-menu-button').click();
+      cy.get('#personal-menu').contains('Logout').click();
+
       cy.focused().type(user2username);
 
       // the desired username must not work (because already taken)


### PR DESCRIPTION
**related to** #998 

---

This PR adds a personal menu, displayed when the logged user click on its profile button.

I deleted the logout button to included it directly in the personal menu:
- it saves space in the top bar, especially on mobile, could be useful for other things (a comparison cart ?)
- the logout action is not part of the main use cases of the application

**to-do**
- [x] move the personal menu in its own component
  - [x] translate this new menu 
  - [x] make the items selected depending on the URL
- [x] use the same configuration to display the `PersonalMenu` and the `SettingsMenu`
- [x] rework the e2e tests

### preview

![capture](https://user-images.githubusercontent.com/39056254/174091639-8a77f590-3aae-4511-b063-6a5504f005a1.png)

![capture2](https://user-images.githubusercontent.com/39056254/174091654-03ece039-f719-4f75-8d02-a07b7b1fea46.png)

