### PR TITLE
[front] feat: make `RecommendationPage` able to display personal reco.

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -163,6 +163,9 @@
   "logoutNonImpactingError": "A non impacting error occurred during your logout.",
   "loginButton": "Log in",
   "joinUsButton": "Join us",
+  "personalMenu": {
+    "yourRecommendations": "My recommendations"
+  },
   "logoutButton": "Logout",
   "topbar": {
     "search": "Search"
@@ -451,6 +454,16 @@
   "myRateLaterListPage": {
     "title": "My rate-later list"
   },
+  "recommendationsPage": {
+    "chips": {
+      "by": "by"
+    },
+    "title": {
+      "results": "Results",
+      "personalRecommendations": "Personal recommendations",
+      "recommendations": "Recommendations"
+    }
+  },
   "noVideoCorrespondsToSearchCriterias": "No video corresponds to your search criterias.",
   "profile": "Profile",
   "signup": {
@@ -558,12 +571,6 @@
     "videos": "videos",
     "entityCandidate": "candidate",
     "entityVideo": "video"
-  },
-  "recommendationsPage": {
-    "title": {
-      "results": "Results",
-      "recommendations": "Recommendations"
-    }
   },
   "presidentielle2022": {
     "dialogs": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -168,6 +168,9 @@
   "logoutNonImpactingError": "Une petite erreur est survenue pendant la déconnexion.",
   "loginButton": "Se connecter",
   "joinUsButton": "S'inscrire",
+  "personalMenu": {
+    "yourRecommendations": "Mes recommandations"
+  },
   "logoutButton": "Se déconnecter",
   "topbar": {
     "search": "Rechercher"
@@ -458,6 +461,16 @@
   "myRateLaterListPage": {
     "title": "À comparer plus tard"
   },
+  "recommendationsPage": {
+    "chips": {
+      "by": "d'après"
+    },
+    "title": {
+      "results": "Résultats",
+      "personalRecommendations": "Recommandations personnelles",
+      "recommendations": "Recommandations"
+    }
+  },
   "noVideoCorrespondsToSearchCriterias": "Aucune vidéo ne correspond à vos critères de recherche.",
   "profile": "Profil",
   "signup": {
@@ -565,12 +578,6 @@
     "videos": "vidéos",
     "entityCandidate": "candidat",
     "entityVideo": "vidéo"
-  },
-  "recommendationsPage": {
-    "title": {
-      "results": "Résultats",
-      "recommendations": "Recommandations"
-    }
   },
   "presidentielle2022": {
     "dialogs": {

--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -30,6 +30,8 @@ const PollRoutes = ({ pollName }: Props) => {
     isReady,
   } = useCurrentPoll();
   const disabledItems = options?.disabledRouteIds ?? [];
+  const allowPublicPersonalRecommendations =
+    options?.allowPublicPersonalRecommendations ?? false;
 
   useEffect(() => {
     if (currentPollName !== pollName || !isReady) {
@@ -53,7 +55,7 @@ const PollRoutes = ({ pollName }: Props) => {
       type: PublicRoute,
     },
     {
-      id: RouteID.Recommendations,
+      id: RouteID.CollectiveRecommendations,
       url: 'recommendations',
       page: RecommendationPage,
       type: PublicRoute,
@@ -95,6 +97,15 @@ const PollRoutes = ({ pollName }: Props) => {
       type: PrivateRoute,
     },
   ];
+
+  if (allowPublicPersonalRecommendations) {
+    routes.push({
+      id: RouteID.PublicPersonalRecommendationsPage,
+      url: 'users/:username/recommendations',
+      page: RecommendationPage,
+      type: PublicRoute,
+    });
+  }
 
   return (
     <Switch>

--- a/frontend/src/components/ContentHeader.tsx
+++ b/frontend/src/components/ContentHeader.tsx
@@ -1,7 +1,23 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Chip, Grid, Typography } from '@mui/material';
 
-const ContentHeader = ({ title }: { title: string }) => {
+/**
+ * Display a header.
+ *
+ * Used to display the main title of nearly every page.
+ *
+ * If `chipLabel` is provided, display a MUI <Chip> at the end of the
+ * header.
+ */
+const ContentHeader = ({
+  title,
+  chipIcon,
+  chipLabel,
+}: {
+  title: string;
+  chipIcon?: React.ReactElement;
+  chipLabel?: string;
+}) => {
   return (
     <Box
       px={[2, 4]}
@@ -10,7 +26,25 @@ const ContentHeader = ({ title }: { title: string }) => {
       bgcolor="background.menu"
       borderBottom="1px solid rgba(0, 0, 0, 0.12)"
     >
-      <Typography variant="h4">{title}</Typography>
+      <Grid container spacing={1} justifyContent="space-between">
+        <Grid item>
+          <Typography variant="h4">{title}</Typography>
+        </Grid>
+        {/* The <ContentHeader> component could use a list of <Chip> instead
+            of only one. */}
+        {chipLabel && (
+          <>
+            <Grid item>
+              <Chip
+                icon={chipIcon}
+                color="secondary"
+                label={chipLabel}
+                variant="outlined"
+              />
+            </Grid>
+          </>
+        )}
+      </Grid>
     </Box>
   );
 };

--- a/frontend/src/features/entity_selector/EntityInput.tsx
+++ b/frontend/src/features/entity_selector/EntityInput.tsx
@@ -17,9 +17,8 @@ import {
   YOUTUBE_POLL_NAME,
 } from 'src/utils/constants';
 import { Entity, UsersService } from 'src/services/openapi';
+import { getRecommendations } from 'src/utils/api/recommendations';
 import { getAllCandidates } from 'src/utils/polls/presidentielle2022';
-import { getRecommendations } from 'src/features/recommendation/RecommendationApi';
-
 import SelectorListBox, { EntitiesTab } from './EntityTabsBox';
 import SelectorPopper from './SelectorPopper';
 import { videoToEntity } from 'src/utils/video';

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -131,7 +131,7 @@ const SideBar = () => {
       displayText: t('menu.home'),
     },
     {
-      id: RouteID.Recommendations,
+      id: RouteID.CollectiveRecommendations,
       targetUrl: `${path}recommendations${defaultRecoSearchParams}`,
       IconComponent:
         pollName === YOUTUBE_POLL_NAME ? VideoLibrary : TableRowsIcon,

--- a/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
+++ b/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
@@ -10,8 +10,9 @@ import {
   MenuList,
   MenuItem,
 } from '@mui/material';
-import { Logout } from '@mui/icons-material';
+import { Logout, VideoLibrary } from '@mui/icons-material';
 import { TournesolMenuItemType, settingsMenu } from 'src/utils/menus';
+import { useCurrentPoll, useLoginState } from 'src/hooks';
 
 interface PersonalMenuProps {
   menuAnchor: null | HTMLElement;
@@ -30,6 +31,11 @@ const PersonalMenu = ({
 }: PersonalMenuProps) => {
   const { t } = useTranslation();
   const location = useLocation();
+  const { baseUrl, options } = useCurrentPoll();
+  const { loginState } = useLoginState();
+
+  const allowPublicPersonalRecommendations =
+    options?.allowPublicPersonalRecommendations ?? false;
 
   return (
     <Menu
@@ -42,6 +48,21 @@ const PersonalMenu = ({
       }}
     >
       <MenuList dense sx={{ py: 0 }}>
+        {/* -- my things section -- */}
+        {allowPublicPersonalRecommendations && [
+          <MenuItem
+            key="public-personal-recommendations"
+            component={RouterLink}
+            to={`${baseUrl}/users/${loginState.username}/recommendations?date=`}
+            onClick={onItemClick}
+          >
+            <ListItemIcon>
+              <VideoLibrary fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>{t('personalMenu.yourRecommendations')}</ListItemText>
+          </MenuItem>,
+          <Divider key="my-things-divider" />,
+        ]}
         {/* -- settings section -- */}
         {settingsMenu(t).map((item: TournesolMenuItemType) => (
           <MenuItem

--- a/frontend/src/features/ratings/RatingsFilter.tsx
+++ b/frontend/src/features/ratings/RatingsFilter.tsx
@@ -32,21 +32,6 @@ function RatingsFilter() {
           <Grid item xs={12} sm={6} md={5}>
             <MarkAllRatingsMenu />
           </Grid>
-          {/*
-          <Grid item xs={12} sm={6} md={5}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={filterParams.get('sortBy') === 'personalScores'}
-                  onChange={(_, checked) => {
-                    setFilter('sortBy', checked ? 'personalScores' : '');
-                  }}
-                />
-              }
-              label={t<string>('ratings.sortByPersonalScore')}
-            />
-          </Grid>
-          */}
         </Grid>
       </Collapse>
     </Box>

--- a/frontend/src/features/recommendation/ScoreModeFilter.tsx
+++ b/frontend/src/features/recommendation/ScoreModeFilter.tsx
@@ -4,8 +4,7 @@ import { useTranslation, Trans } from 'react-i18next';
 import { Link, Tooltip } from '@mui/material';
 import { HelpOutline } from '@mui/icons-material';
 import { ChoicesFilterSection } from 'src/components';
-
-import { ScoreModeEnum } from 'src/features/recommendation/RecommendationApi';
+import { ScoreModeEnum } from 'src/utils/api/recommendations';
 
 interface Props {
   value: string;

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -15,8 +15,8 @@ import {
   YOUTUBE_POLL_NAME,
   PRESIDENTIELLE_2022_POLL_NAME,
 } from 'src/utils/constants';
+import { ScoreModeEnum } from 'src/utils/api/recommendations';
 import { saveRecommendationsLanguages } from 'src/utils/recommendationsLanguages';
-import { ScoreModeEnum } from 'src/features/recommendation/RecommendationApi';
 
 /**
  * Filter options for Videos recommendations

--- a/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.spec.tsx
@@ -13,15 +13,15 @@ import { Router } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 
-import * as RecommendationApi from 'src/features/recommendation/RecommendationApi';
 import { PollProvider } from 'src/hooks/useCurrentPoll';
 import RecommendationPage from 'src/pages/recommendations/RecommendationPage';
+import { PollsService } from 'src/services/openapi';
 import { theme } from 'src/theme';
+import * as RecommendationApi from 'src/utils/api/recommendations';
 import {
   saveRecommendationsLanguages,
   loadRecommendationsLanguages,
 } from 'src/utils/recommendationsLanguages';
-import { PollsService } from 'src/services/openapi';
 
 const EntityList = () => null;
 jest.mock('src/features/entities/EntityList', () => EntityList);

--- a/frontend/src/utils/api/comparisons.ts
+++ b/frontend/src/utils/api/comparisons.ts
@@ -1,3 +1,8 @@
+/**
+ * Functions and shortcuts used to interact with the Tournesol's comparisons
+ * API.
+ */
+
 import { Comparison, UsersService } from 'src/services/openapi';
 
 export async function getUserComparisons(

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -190,11 +190,18 @@ export const getEntityName = (t: TFunction, pollName: string) => {
   }
 };
 
-export const getRecommendationPageName = (t: TFunction, pollName: string) => {
+export const getRecommendationPageName = (
+  t: TFunction,
+  pollName: string,
+  personal?: boolean
+) => {
   switch (pollName) {
     case PRESIDENTIELLE_2022_POLL_NAME:
       return t('recommendationsPage.title.results');
     default:
+      if (personal) {
+        return t('recommendationsPage.title.personalRecommendations');
+      }
       return t('recommendationsPage.title.recommendations');
   }
 };
@@ -232,6 +239,7 @@ export const polls: Array<SelectablePoll> = [
     defaultAnonEntityActions: [],
     defaultRecoLanguageDiscovery: true,
     defaultRecoSearchParams: 'date=Month',
+    allowPublicPersonalRecommendations: true,
     mainCriterionName: 'largely_recommended',
     displayOrder: 10,
     path: '/',

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -37,15 +37,19 @@ export type VideoObject = Video | VideoSerializerWithCriteria;
  * place a route id is required.
  */
 export enum RouteID {
+  // public and collective routes
   Home = 'home',
-  Recommendations = 'recommendations',
+  CollectiveRecommendations = 'collectiveRecommendations',
   EntityAnalysis = 'entityAnalysis',
+  About = 'about',
+  // public yet personal routes
+  PublicPersonalRecommendationsPage = 'publicPersonalRecommendations',
+  // private and personal routes
   Comparison = 'comparison',
   MyComparisons = 'myComparisons',
   MyComparedItems = 'myComparedItems',
   MyRateLaterList = 'myRateLaterList',
   MyFeedback = 'myFeedback',
-  About = 'about',
 }
 
 export type OrderedDialogs = {
@@ -69,6 +73,8 @@ export type SelectablePoll = {
   // the recommendation link. can be date=Month to retrieve the entities
   // uploaded during the last month for instance
   defaultRecoSearchParams?: string;
+  // enable or disable the public personal recommendations feature.
+  allowPublicPersonalRecommendations?: boolean;
   displayOrder: number;
   // the main criteria name. useful in some situations, like when you want
   // to exclude it from the rated high / rated low metric of the `EntityCard`

--- a/tests/cypress/integration/frontend/publicPersonalRecommendationsPage.ts
+++ b/tests/cypress/integration/frontend/publicPersonalRecommendationsPage.ts
@@ -1,0 +1,76 @@
+import { curry } from "cypress/types/lodash";
+
+describe('Public personal recommendations page', () => {
+
+  describe('Poll - videos', () => {
+    describe('for anonymous users', () => {
+      it('displays public personal reco. of users, by URL', () => {
+        cy.visit('/users/user/recommendations');
+        cy.contains('Personal recommendations');
+        cy.contains('by user');
+      });
+    });
+  
+    describe('for authenticated users', () => {
+      it('displays public personal reco. of users, by URL', () => {
+        cy.visit('/');
+        cy.contains('Log in').click();
+        cy.focused().type('user');
+        cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+  
+        cy.visit('/users/user/recommendations');
+        cy.contains('Personal recommendations');
+        cy.contains('by user');
+      });
+  
+      it('displays public personal reco. of users, by personal menu', () => {
+        cy.visit('/');
+        cy.contains('Log in').click();
+        cy.focused().type('user');
+        cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+    
+        cy.get('button#personal-menu-button').click();
+        cy.contains('My recommendations').should('be.visible');
+  
+        cy.contains('My recommendations').click();
+        cy.location('pathname').should('equal', '/users/user/recommendations');
+        // The menu must lead to the all-time recommendations.
+        cy.location('search').should('contain', 'date=');
+        cy.contains('Personal recommendations');
+        cy.contains('by user');
+      });
+    });
+  });
+
+  describe('Poll - presidentielle2022', () => {
+    describe('for anonymous users', () => {
+      it('displays 404 instead of public personal reco.', () => {
+        cy.visit('/presidentielle2022/users/user/recommendations');
+        cy.contains('Sorry, page not found');
+      });
+    });
+  
+    describe('for authenticated users', () => {
+      it('displays 404 instead of public personal reco.', () => {
+        cy.visit('/presidentielle2022');
+        cy.contains('Log in').click();
+        cy.focused().type('user');
+        cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+  
+        cy.visit('/presidentielle2022/users/user/recommendations');
+        cy.contains('Sorry, page not found');
+      });
+
+      it("doesn't the public personal reco. link in the personal menu", () => {
+        cy.visit('/presidentielle2022');
+        cy.contains('Log in').click();
+        cy.focused().type('user');
+        cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+  
+        
+        cy.get('button#personal-menu-button').click();
+        cy.contains('My recommendations').should('not.exist');
+      });
+    });
+  });
+});

--- a/tests/cypress/integration/frontend/recommendationsPage.ts
+++ b/tests/cypress/integration/frontend/recommendationsPage.ts
@@ -1,5 +1,5 @@
 describe('Recommendations page', () => {
-  describe('Poll - video', () => {
+  describe('Poll - videos', () => {
     describe('Search filters', () => {
       it('sets default languages properly and backward navigation works', () => {
         cy.visit('/');


### PR DESCRIPTION
**related to** #1003 

---

This pull request adds the public personal recommendations page.

This page is only accessible if the poll explicitly enables the personal reco. feature. Contrary to the `videos` poll, the `presidentielle2022` poll doesn't allow the users to display personal recommendations. 

**next step:** make the URL easily share-able. 

**note:** Due to a JSON payload difference between the recommendations API and the personal recommendations API, it's not possible to display the notice  `The relevance of this score is uncertain, due to too few contributors.` on the personal recommendations page. We should harmonize those two API to avoid displaying misleading Tournesol score.

**(a)** the `RecommendationPage` must be able to retrieve public personal reco.

- [x] only if the poll has been configured to allow this feature
- [x] only if the requested URL match the public personal reco. scheme
- [x] add a `getPersonalRecommendations` function to the API file
- [x] move the API file elsewhere
- [x] handle properly empty recommendations list

**(b)** the UI must clearly state if the recommendation are collective or personal

- [x] add a title specific to the public personal reco.
- [x] add a MUI `Chip` in the header :heart:  

**(c)** update the `PollRoutes`

- [x] the URL must be `{poll_name}/users/{username}/recommendations`
- [x] handle `{username}` not found properly

When a username doesn't exist, the page simply display the message "Aucune vidéo ne correspond à vos critères de recherche.".

**(d)** update the top-right personal menu

- [x] the new page must be available in the top-right personal menu
  - [x] translate the new item

**(e)** add e2e tests

- [x] add navigation tests
- [x] the personal menu must not display the public personal reco. link for the poll `presidentielle2022`  

**(f)** clean-up

- [x] remove the non-relevant hack in the `src/utils/api/recommendations.getPublicPersonalRecommendations`

### preview

**the menu**

(there is a typo in personelle, a `n` is missing in the preview, but it's fixed in the code)

![capture](https://user-images.githubusercontent.com/39056254/174804259-cab41897-a436-4692-8e2d-2c77b9e95b72.png)

**final state of the page**

![capture](https://user-images.githubusercontent.com/39056254/175039889-bcd746b7-e1f7-4a19-a1a5-74189a4b10a9.png)