### PR TITLE
Contextual recommendations on video analysis page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -219,6 +219,9 @@
     "compareVideosButton": "Compare videos"
   },
   "options": "Options",
+  "contextualRecommendations": {
+    "channel": "Channel"
+  },
   "settings": {
     "typeKeywordDeleteAccount": "Please type the words <1>{{DELETE_ACCOUNT_KEYWORD}}</1> in the text box below to enable deleting your account.",
     "deleteYourAccount": "Delete your account",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -220,7 +220,8 @@
   },
   "options": "Options",
   "contextualRecommendations": {
-    "channel": "Channel"
+    "channel": "Channel",
+    "comparedWith": "Compared with"
   },
   "settings": {
     "typeKeywordDeleteAccount": "Please type the words <1>{{DELETE_ACCOUNT_KEYWORD}}</1> in the text box below to enable deleting your account.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -225,6 +225,9 @@
     "compareVideosButton": "Comparer des vidéos"
   },
   "options": "Options",
+  "contextualRecommendations": {
+    "channel": "Chaîne"
+  },
   "settings": {
     "typeKeywordDeleteAccount": "Écrivez les mots <1>{{DELETE_ACCOUNT_KEYWORD}}</1> dans le champ ci-dessous pour déverrouiller la suppression de votre compte.",
     "deleteYourAccount": "Supprimer votre compte",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -226,7 +226,8 @@
   },
   "options": "Options",
   "contextualRecommendations": {
-    "channel": "Chaîne"
+    "channel": "Chaîne",
+    "comparedWith": "Comparé avec"
   },
   "settings": {
     "typeKeywordDeleteAccount": "Écrivez les mots <1>{{DELETE_ACCOUNT_KEYWORD}}</1> dans le champ ci-dessous pour déverrouiller la suppression de votre compte.",

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -154,7 +154,13 @@ const EntityCard = ({
   );
 };
 
-export const RowEntityCard = ({ entity }: { entity: RelatedEntityObject }) => {
+export const RowEntityCard = ({
+  entity,
+  withLink = false,
+}: {
+  entity: RelatedEntityObject;
+  withLink?: boolean;
+}) => {
   return (
     <Box
       display="flex"
@@ -170,7 +176,7 @@ export const RowEntityCard = ({ entity }: { entity: RelatedEntityObject }) => {
           config={{
             [TypeEnum.VIDEO]: {
               displayPlayer: false,
-              thumbnailLink: false,
+              thumbnailLink: withLink,
             },
           }}
         />
@@ -180,7 +186,7 @@ export const RowEntityCard = ({ entity }: { entity: RelatedEntityObject }) => {
           uid={entity.uid}
           title={entity.metadata.name}
           titleMaxLines={1}
-          withLink={false}
+          withLink={withLink}
           fontSize="1em"
         />
         {entity.type == TypeEnum.VIDEO && (

--- a/frontend/src/features/entity_selector/EntityInput.tsx
+++ b/frontend/src/features/entity_selector/EntityInput.tsx
@@ -171,7 +171,11 @@ const VideoInput = ({ value, onChange, otherUid }: Props) => {
           anchorEl={inputRef.current}
           onClose={() => setSuggestionsOpen(false)}
         >
-          <SelectorListBox tabs={tabs} onSelectEntity={handleOptionClick} />
+          <SelectorListBox
+            tabs={tabs}
+            onSelectEntity={handleOptionClick}
+            elevation={10}
+          />
         </SelectorPopper>
       </Box>
     </ClickAwayListener>

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -8,6 +8,7 @@ import LoaderWrapper from 'src/components/LoaderWrapper';
 interface Props {
   tabs: EntitiesTab[];
   onSelectEntity: (entityUid: string) => void;
+  width?: string | number;
 }
 
 export interface EntitiesTab {
@@ -29,7 +30,11 @@ const TabError = ({ message }: { message: string }) => (
   </Typography>
 );
 
-const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
+const EntityTabsBox = ({
+  tabs,
+  onSelectEntity,
+  width = 'min(700px, 100vw)',
+}: Props) => {
   const { t } = useTranslation();
   const [tabValue, setTabValue] = useState(tabs[0]?.name);
   const [status, setStatus] = useState<TabStatus>(TabStatus.Ok);
@@ -88,7 +93,7 @@ const EntityTabsBox = ({ tabs, onSelectEntity }: Props) => {
             marginTop: 1,
           },
         },
-        width: 'min(700px, 100vw)',
+        width: width,
         bgcolor: 'white',
         overflow: 'hidden',
         flexGrow: 1,

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -9,6 +9,7 @@ interface Props {
   tabs: EntitiesTab[];
   onSelectEntity: (entityUid: string) => void;
   width?: string | number;
+  maxHeight?: string | number;
 }
 
 export interface EntitiesTab {
@@ -34,6 +35,7 @@ const EntityTabsBox = ({
   tabs,
   onSelectEntity,
   width = 'min(700px, 100vw)',
+  maxHeight = '40vh',
 }: Props) => {
   const { t } = useTranslation();
   const [tabValue, setTabValue] = useState(tabs[0]?.name);
@@ -79,7 +81,7 @@ const EntityTabsBox = ({
           listStyleType: 'none',
           p: 0,
           m: 0,
-          maxHeight: '40vh',
+          maxHeight,
           '.MuiModal-root &': {
             maxHeight: 'none',
           },

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -9,6 +9,7 @@ interface Props {
   tabs: EntitiesTab[];
   onSelectEntity?: (entityUid: string) => void;
   width?: string | number;
+  elevation?: number;
   maxHeight?: string | number;
   withLink?: boolean;
 }
@@ -36,6 +37,7 @@ const EntityTabsBox = ({
   tabs,
   onSelectEntity,
   width = 'min(700px, 100vw)',
+  elevation = 1,
   maxHeight = '40vh',
   withLink = false,
 }: Props) => {
@@ -74,7 +76,7 @@ const EntityTabsBox = ({
 
   return (
     <Paper
-      elevation={10}
+      elevation={elevation}
       sx={{
         display: 'flex',
         flexDirection: 'column',

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -7,9 +7,10 @@ import LoaderWrapper from 'src/components/LoaderWrapper';
 
 interface Props {
   tabs: EntitiesTab[];
-  onSelectEntity: (entityUid: string) => void;
+  onSelectEntity?: (entityUid: string) => void;
   width?: string | number;
   maxHeight?: string | number;
+  withLink?: boolean;
 }
 
 export interface EntitiesTab {
@@ -36,6 +37,7 @@ const EntityTabsBox = ({
   onSelectEntity,
   width = 'min(700px, 100vw)',
   maxHeight = '40vh',
+  withLink = false,
 }: Props) => {
   const { t } = useTranslation();
   const [tabValue, setTabValue] = useState(tabs[0]?.name);
@@ -87,7 +89,7 @@ const EntityTabsBox = ({
           },
         },
         li: {
-          cursor: 'pointer',
+          cursor: onSelectEntity && 'pointer',
           '&:hover': {
             bgcolor: 'grey.100',
           },
@@ -129,8 +131,11 @@ const EntityTabsBox = ({
         ) : options.length > 0 ? (
           <ul>
             {options.map((entity) => (
-              <li key={entity.uid} onClick={() => onSelectEntity(entity.uid)}>
-                <RowEntityCard entity={entity} />
+              <li
+                key={entity.uid}
+                onClick={onSelectEntity && (() => onSelectEntity(entity.uid))}
+              >
+                <RowEntityCard entity={entity} withLink={withLink} />
               </li>
             ))}
           </ul>

--- a/frontend/src/features/recommendation/ContextualRecommendations.tsx
+++ b/frontend/src/features/recommendation/ContextualRecommendations.tsx
@@ -15,8 +15,6 @@ const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
 
-  const handleEntitySelect = () => undefined;
-
   const tabs: EntitiesTab[] = useMemo(() => {
     const tabs = [];
     if (uploader)
@@ -54,14 +52,7 @@ const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
     return tabs;
   }, [t, pollName, uploader, contextUid]);
 
-  return (
-    <SelectorListBox
-      tabs={tabs}
-      onSelectEntity={handleEntitySelect}
-      width="auto"
-      maxHeight="none"
-    />
-  );
+  return <SelectorListBox tabs={tabs} width="auto" maxHeight="none" withLink />;
 };
 
 export default ContextualRecommendations;

--- a/frontend/src/features/recommendation/ContextualRecommendations.tsx
+++ b/frontend/src/features/recommendation/ContextualRecommendations.tsx
@@ -1,0 +1,51 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import SelectorListBox, {
+  EntitiesTab,
+} from 'src/features/entity_selector/EntityTabsBox';
+import { PollsService } from 'src/services/openapi';
+import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+
+interface Props {
+  contextUid: string;
+  uploader?: string;
+}
+
+const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
+  const { t } = useTranslation();
+  const { name: pollName } = useCurrentPoll();
+
+  const handleEntitySelect = () => undefined;
+
+  const tabs: EntitiesTab[] = useMemo(() => {
+    const tabs = [];
+    if (uploader)
+      tabs.push({
+        name: 'channel',
+        label: t('contextualRecommendations.channel'),
+        fetch: async () => {
+          const response = await PollsService.pollsRecommendationsList({
+            name: pollName,
+            limit: 20,
+            metadata: {
+              uploader,
+            },
+            unsafe: true,
+          });
+          const results = response.results ?? [];
+          return results.filter((entity) => entity.uid !== contextUid);
+        },
+      });
+    return tabs;
+  }, [t, pollName, uploader, contextUid]);
+
+  return (
+    <SelectorListBox
+      tabs={tabs}
+      onSelectEntity={handleEntitySelect}
+      width="auto"
+    />
+  );
+};
+
+export default ContextualRecommendations;

--- a/frontend/src/features/recommendation/ContextualRecommendations.tsx
+++ b/frontend/src/features/recommendation/ContextualRecommendations.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import SelectorListBox, {
   EntitiesTab,
 } from 'src/features/entity_selector/EntityTabsBox';
-import { PollsService } from 'src/services/openapi';
+import { PollsService, UsersService } from 'src/services/openapi';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
 interface Props {
@@ -36,6 +36,21 @@ const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
           return results.filter((entity) => entity.uid !== contextUid);
         },
       });
+    tabs.push({
+      name: 'comparedWith',
+      label: t('contextualRecommendations.comparedWith'),
+      fetch: async () => {
+        const response = await UsersService.usersMeComparisonsListFiltered({
+          pollName,
+          uid: contextUid,
+          limit: 20,
+        });
+        const results = response.results ?? [];
+        return results.map(({ entity_a, entity_b }) =>
+          entity_a.uid === contextUid ? entity_b : entity_a
+        );
+      },
+    });
     return tabs;
   }, [t, pollName, uploader, contextUid]);
 

--- a/frontend/src/features/recommendation/ContextualRecommendations.tsx
+++ b/frontend/src/features/recommendation/ContextualRecommendations.tsx
@@ -30,7 +30,6 @@ const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
             metadata: {
               uploader,
             },
-            unsafe: true,
           });
           const results = response.results ?? [];
           return results.filter((entity) => entity.uid !== contextUid);

--- a/frontend/src/features/recommendation/ContextualRecommendations.tsx
+++ b/frontend/src/features/recommendation/ContextualRecommendations.tsx
@@ -44,6 +44,7 @@ const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
       tabs={tabs}
       onSelectEntity={handleEntitySelect}
       width="auto"
+      maxHeight="none"
     />
   );
 };

--- a/frontend/src/features/recommendation/ContextualRecommendations.tsx
+++ b/frontend/src/features/recommendation/ContextualRecommendations.tsx
@@ -5,6 +5,7 @@ import SelectorListBox, {
 } from 'src/features/entity_selector/EntityTabsBox';
 import { PollsService, UsersService } from 'src/services/openapi';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import { useLoginState } from 'src/hooks/useLoginState';
 
 interface Props {
   contextUid: string;
@@ -14,6 +15,7 @@ interface Props {
 const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
+  const { isLoggedIn } = useLoginState();
 
   const tabs: EntitiesTab[] = useMemo(() => {
     const tabs = [];
@@ -48,9 +50,10 @@ const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
           entity_a.uid === contextUid ? entity_b : entity_a
         );
       },
+      disabled: !isLoggedIn,
     });
     return tabs;
-  }, [t, pollName, uploader, contextUid]);
+  }, [t, pollName, uploader, contextUid, isLoggedIn]);
 
   return <SelectorListBox tabs={tabs} width="auto" maxHeight="none" withLink />;
 };

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -26,6 +26,7 @@ import PersonalScoreCheckbox from 'src/components/PersonalScoreCheckbox';
 import { CompareNowAction, AddToRateLaterList } from 'src/utils/action';
 import linkifyStr from 'linkify-string';
 import { SelectedCriterionProvider } from 'src/hooks/useSelectedCriterion';
+import ContextualRecommendations from 'src/features/recommendation/ContextualRecommendations';
 
 export const VideoAnalysis = ({
   video,
@@ -46,102 +47,116 @@ export const VideoAnalysis = ({
   const linkifiedDescription = linkifyStr(video.description || '', linkifyOpts);
 
   return (
-    <Container sx={{ maxWidth: '1000px !important' }}>
+    <Container sx={{ maxWidth: '1300px !important' }}>
       <Box py={2}>
-        {/* Top level section, containing links and maybe more in the future. */}
-        <Box mb={2} display="flex" justifyContent="flex-end">
-          <Button
-            color="secondary"
-            variant="contained"
-            endIcon={<CompareIcon />}
-            component={RouterLink}
-            to={`${baseUrl}/comparison?uidA=${uid}`}
-          >
-            {t('entityAnalysisPage.generic.compare')}
-          </Button>
-        </Box>
+        <Grid container spacing={1}>
+          <Grid item md={9} sm={12}>
+            {/* Top level section, containing links and maybe more in the future. */}
+            <Box mb={2} display="flex" justifyContent="flex-end">
+              <Button
+                color="secondary"
+                variant="contained"
+                endIcon={<CompareIcon />}
+                component={RouterLink}
+                to={`${baseUrl}/comparison?uidA=${uid}`}
+              >
+                {t('entityAnalysisPage.generic.compare')}
+              </Button>
+            </Box>
 
-        {/* Entity section, with its player, title, scores and actions. */}
-        <Grid container spacing={2} justifyContent="center">
-          <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
-            <VideoPlayer
-              videoId={video.video_id}
-              duration={video.duration}
-              controls
+            {/* Entity section, with its player, title, scores and actions. */}
+            <Grid container spacing={2} justifyContent="center">
+              <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
+                <VideoPlayer
+                  videoId={video.video_id}
+                  duration={video.duration}
+                  controls
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <VideoCard video={video} actions={actions} showPlayer={false} />
+              </Grid>
+              <Grid item xs={12}>
+                <CollapseButton
+                  expanded={descriptionCollapsed}
+                  onClick={() => {
+                    setDescriptionCollapsed(!descriptionCollapsed);
+                  }}
+                >
+                  {t('entityAnalysisPage.video.description')}
+                </CollapseButton>
+                <Collapse
+                  in={descriptionCollapsed}
+                  timeout="auto"
+                  unmountOnExit
+                >
+                  <Typography paragraph>
+                    <Box
+                      style={
+                        descriptionCollapsed
+                          ? { display: 'block' }
+                          : { display: 'none' }
+                      }
+                      dangerouslySetInnerHTML={{ __html: linkifiedDescription }}
+                      fontSize="0.9em"
+                      whiteSpace="pre-wrap"
+                    />
+                  </Typography>
+                </Collapse>
+              </Grid>
+
+              {/* Data visualization. */}
+              {shouldDisplayCharts && (
+                <SelectedCriterionProvider>
+                  <Grid item xs={12} sm={12} md={6}>
+                    <Paper>
+                      <Box
+                        p={1}
+                        bgcolor="rgb(238, 238, 238)"
+                        display="flex"
+                        justifyContent="center"
+                      >
+                        <Typography variant="h5">
+                          {t('entityAnalysisPage.chart.criteriaScores.title')}
+                        </Typography>
+                      </Box>
+                      <PersonalCriteriaScoresContextProvider uid={uid}>
+                        <Box px={2} pt={1}>
+                          <PersonalScoreCheckbox />
+                        </Box>
+                        <Box p={1}>
+                          <CriteriaBarChart video={video} />
+                        </Box>
+                      </PersonalCriteriaScoresContextProvider>
+                    </Paper>
+                  </Grid>
+                  <Grid item xs={12} sm={12} md={6}>
+                    <Paper>
+                      <Box
+                        p={1}
+                        bgcolor="rgb(238, 238, 238)"
+                        display="flex"
+                        justifyContent="center"
+                      >
+                        <Typography variant="h5">
+                          {t('criteriaScoresDistribution.title')}
+                        </Typography>
+                      </Box>
+                      <Box p={1}>
+                        <CriteriaScoresDistribution uid={uid} />
+                      </Box>
+                    </Paper>
+                  </Grid>
+                </SelectedCriterionProvider>
+              )}
+            </Grid>
+          </Grid>
+          <Grid item md={3} sm={12}>
+            <ContextualRecommendations
+              contextUid={uid}
+              uploader={video.uploader || undefined}
             />
           </Grid>
-          <Grid item xs={12}>
-            <VideoCard video={video} actions={actions} showPlayer={false} />
-          </Grid>
-          <Grid item xs={12}>
-            <CollapseButton
-              expanded={descriptionCollapsed}
-              onClick={() => {
-                setDescriptionCollapsed(!descriptionCollapsed);
-              }}
-            >
-              {t('entityAnalysisPage.video.description')}
-            </CollapseButton>
-            <Collapse in={descriptionCollapsed} timeout="auto" unmountOnExit>
-              <Typography paragraph>
-                <Box
-                  style={
-                    descriptionCollapsed
-                      ? { display: 'block' }
-                      : { display: 'none' }
-                  }
-                  dangerouslySetInnerHTML={{ __html: linkifiedDescription }}
-                  fontSize="0.9em"
-                  whiteSpace="pre-wrap"
-                />
-              </Typography>
-            </Collapse>
-          </Grid>
-
-          {/* Data visualization. */}
-          {shouldDisplayCharts && (
-            <SelectedCriterionProvider>
-              <Grid item xs={12} sm={12} md={6}>
-                <Paper>
-                  <Box
-                    p={1}
-                    bgcolor="rgb(238, 238, 238)"
-                    display="flex"
-                    justifyContent="center"
-                  >
-                    <Typography variant="h5">
-                      {t('entityAnalysisPage.chart.criteriaScores.title')}
-                    </Typography>
-                  </Box>
-                  <PersonalCriteriaScoresContextProvider uid={uid}>
-                    <Box px={2} pt={1}>
-                      <PersonalScoreCheckbox />
-                    </Box>
-                    <Box p={1}>
-                      <CriteriaBarChart video={video} />
-                    </Box>
-                  </PersonalCriteriaScoresContextProvider>
-                </Paper>
-              </Grid>
-              <Grid item xs={12} sm={12} md={6}>
-                <Paper>
-                  <Box
-                    p={1}
-                    bgcolor="rgb(238, 238, 238)"
-                    display="flex"
-                    justifyContent="center"
-                  >
-                    <Typography variant="h5">
-                      {t('criteriaScoresDistribution.title')}
-                    </Typography>
-                  </Box>
-                  <Box p={1}>
-                    <CriteriaScoresDistribution uid={uid} />
-                  </Box>
-                </Paper>
-              </Grid>
-            </SelectedCriterionProvider>
-          )}
         </Grid>
       </Box>
     </Container>

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -40,7 +40,7 @@ export const VideoAnalysis = ({
 
   return (
     <Box p={2}>
-      <Grid container spacing={1}>
+      <Grid container spacing={2}>
         <Grid item md={8} sm={12}>
           {/* Top level section, containing links and maybe more in the future. */}
           <Box mb={2} display="flex" justifyContent="flex-end">

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -2,15 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, Link as RouterLink } from 'react-router-dom';
 
-import {
-  Box,
-  Button,
-  Collapse,
-  Container,
-  Grid,
-  Paper,
-  Typography,
-} from '@mui/material';
+import { Box, Button, Collapse, Grid, Paper, Typography } from '@mui/material';
 import CompareIcon from '@mui/icons-material/Compare';
 
 import CollapseButton from 'src/components/CollapseButton';
@@ -47,119 +39,113 @@ export const VideoAnalysis = ({
   const linkifiedDescription = linkifyStr(video.description || '', linkifyOpts);
 
   return (
-    <Container sx={{ maxWidth: '1300px !important' }}>
-      <Box py={2}>
-        <Grid container spacing={1}>
-          <Grid item md={9} sm={12}>
-            {/* Top level section, containing links and maybe more in the future. */}
-            <Box mb={2} display="flex" justifyContent="flex-end">
-              <Button
-                color="secondary"
-                variant="contained"
-                endIcon={<CompareIcon />}
-                component={RouterLink}
-                to={`${baseUrl}/comparison?uidA=${uid}`}
+    <Box p={2}>
+      <Grid container spacing={1}>
+        <Grid item md={8} sm={12}>
+          {/* Top level section, containing links and maybe more in the future. */}
+          <Box mb={2} display="flex" justifyContent="flex-end">
+            <Button
+              color="secondary"
+              variant="contained"
+              endIcon={<CompareIcon />}
+              component={RouterLink}
+              to={`${baseUrl}/comparison?uidA=${uid}`}
+            >
+              {t('entityAnalysisPage.generic.compare')}
+            </Button>
+          </Box>
+
+          {/* Entity section, with its player, title, scores and actions. */}
+          <Grid container spacing={2} justifyContent="center">
+            <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
+              <VideoPlayer
+                videoId={video.video_id}
+                duration={video.duration}
+                controls
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <VideoCard video={video} actions={actions} showPlayer={false} />
+            </Grid>
+            <Grid item xs={12}>
+              <CollapseButton
+                expanded={descriptionCollapsed}
+                onClick={() => {
+                  setDescriptionCollapsed(!descriptionCollapsed);
+                }}
               >
-                {t('entityAnalysisPage.generic.compare')}
-              </Button>
-            </Box>
+                {t('entityAnalysisPage.video.description')}
+              </CollapseButton>
+              <Collapse in={descriptionCollapsed} timeout="auto" unmountOnExit>
+                <Typography paragraph>
+                  <Box
+                    style={
+                      descriptionCollapsed
+                        ? { display: 'block' }
+                        : { display: 'none' }
+                    }
+                    dangerouslySetInnerHTML={{ __html: linkifiedDescription }}
+                    fontSize="0.9em"
+                    whiteSpace="pre-wrap"
+                  />
+                </Typography>
+              </Collapse>
+            </Grid>
 
-            {/* Entity section, with its player, title, scores and actions. */}
-            <Grid container spacing={2} justifyContent="center">
-              <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
-                <VideoPlayer
-                  videoId={video.video_id}
-                  duration={video.duration}
-                  controls
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <VideoCard video={video} actions={actions} showPlayer={false} />
-              </Grid>
-              <Grid item xs={12}>
-                <CollapseButton
-                  expanded={descriptionCollapsed}
-                  onClick={() => {
-                    setDescriptionCollapsed(!descriptionCollapsed);
-                  }}
-                >
-                  {t('entityAnalysisPage.video.description')}
-                </CollapseButton>
-                <Collapse
-                  in={descriptionCollapsed}
-                  timeout="auto"
-                  unmountOnExit
-                >
-                  <Typography paragraph>
+            {/* Data visualization. */}
+            {shouldDisplayCharts && (
+              <SelectedCriterionProvider>
+                <Grid item xs={12} sm={12} md={6}>
+                  <Paper>
                     <Box
-                      style={
-                        descriptionCollapsed
-                          ? { display: 'block' }
-                          : { display: 'none' }
-                      }
-                      dangerouslySetInnerHTML={{ __html: linkifiedDescription }}
-                      fontSize="0.9em"
-                      whiteSpace="pre-wrap"
-                    />
-                  </Typography>
-                </Collapse>
-              </Grid>
-
-              {/* Data visualization. */}
-              {shouldDisplayCharts && (
-                <SelectedCriterionProvider>
-                  <Grid item xs={12} sm={12} md={6}>
-                    <Paper>
-                      <Box
-                        p={1}
-                        bgcolor="rgb(238, 238, 238)"
-                        display="flex"
-                        justifyContent="center"
-                      >
-                        <Typography variant="h5">
-                          {t('entityAnalysisPage.chart.criteriaScores.title')}
-                        </Typography>
-                      </Box>
-                      <PersonalCriteriaScoresContextProvider uid={uid}>
-                        <Box px={2} pt={1}>
-                          <PersonalScoreCheckbox />
-                        </Box>
-                        <Box p={1}>
-                          <CriteriaBarChart video={video} />
-                        </Box>
-                      </PersonalCriteriaScoresContextProvider>
-                    </Paper>
-                  </Grid>
-                  <Grid item xs={12} sm={12} md={6}>
-                    <Paper>
-                      <Box
-                        p={1}
-                        bgcolor="rgb(238, 238, 238)"
-                        display="flex"
-                        justifyContent="center"
-                      >
-                        <Typography variant="h5">
-                          {t('criteriaScoresDistribution.title')}
-                        </Typography>
+                      p={1}
+                      bgcolor="rgb(238, 238, 238)"
+                      display="flex"
+                      justifyContent="center"
+                    >
+                      <Typography variant="h5">
+                        {t('entityAnalysisPage.chart.criteriaScores.title')}
+                      </Typography>
+                    </Box>
+                    <PersonalCriteriaScoresContextProvider uid={uid}>
+                      <Box px={2} pt={1}>
+                        <PersonalScoreCheckbox />
                       </Box>
                       <Box p={1}>
-                        <CriteriaScoresDistribution uid={uid} />
+                        <CriteriaBarChart video={video} />
                       </Box>
-                    </Paper>
-                  </Grid>
-                </SelectedCriterionProvider>
-              )}
-            </Grid>
-          </Grid>
-          <Grid item md={3} sm={12}>
-            <ContextualRecommendations
-              contextUid={uid}
-              uploader={video.uploader || undefined}
-            />
+                    </PersonalCriteriaScoresContextProvider>
+                  </Paper>
+                </Grid>
+                <Grid item xs={12} sm={12} md={6}>
+                  <Paper>
+                    <Box
+                      p={1}
+                      bgcolor="rgb(238, 238, 238)"
+                      display="flex"
+                      justifyContent="center"
+                    >
+                      <Typography variant="h5">
+                        {t('criteriaScoresDistribution.title')}
+                      </Typography>
+                    </Box>
+                    <Box p={1}>
+                      <CriteriaScoresDistribution uid={uid} />
+                    </Box>
+                  </Paper>
+                </Grid>
+              </SelectedCriterionProvider>
+            )}
           </Grid>
         </Grid>
-      </Box>
-    </Container>
+        <Grid item md={4} sm={12}>
+          <ContextualRecommendations
+            contextUid={uid}
+            uploader={video.uploader || undefined}
+          />
+        </Grid>
+      </Grid>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Related issue: #938 

![image](https://user-images.githubusercontent.com/28259/174858632-70ce2299-261b-4019-8d93-e4feb2c6a0d4.png)

It adds a side panel to the video analysis page with 2 tabs : videos of the same channel and videos it has already been compared to.

Some notes:
* I added `unsafe: true` to the same channel request to get results in dev-env, but I don't know if it should be used in production.
* I added some style props to `EntityTabsBox` to have a correct width and height. You may prefer another way to do it.
* I also added a `withLink` prop to `EntityTabsBox` to have real links (instead of a `onClick` that would change the URL). The link is only on the thumbnail and title like in video cards.
* The layout is not exactly the one in #928. I made the side panel continue on the whole page instead of only up to the collapsible description, because doing it like in #928 is more difficult (we probably need a dynamic max height) so I wanted to check first whether that's really what we want.