### PR TITLE
[analytics] chore: bump `numpy` from v1.22.0 to v1.22.4

### DIFF
--- a/analytics/requirements.txt
+++ b/analytics/requirements.txt
@@ -1,8 +1,9 @@
 streamlit==1.10.0
-numpy==1.22.0 
+numpy==1.22.4
 seaborn==0.11.1
 matplotlib==3.3.4
 pillow==9.0.1
 plotly==5.5.0
 scikit-learn==0.24.2
 requests==2.25.1
+


### PR DESCRIPTION
The version 1.22.4 includes several bug fixes.

Release notes:
- 1.22.1: https://github.com/numpy/numpy/releases/tag/v1.22.1
- 1.22.2: https://github.com/numpy/numpy/releases/tag/v1.22.2
- 1.22.3: https://github.com/numpy/numpy/releases/tag/v1.22.3
- 1.22.4: https://github.com/numpy/numpy/releases/tag/v1.22.4