### PR TITLE
[back] fix: vouching made more human-readable

### DIFF
--- a/backend/vouch/tests/test_trust_algo.py
+++ b/backend/vouch/tests/test_trust_algo.py
@@ -69,14 +69,14 @@ class TrustAlgoTestCse(TestCase):
             ]
         )
 
-    def test_normalize_trust_values(self):
+    def test_normalize_vouch_matrix(self):
         vouch_matrix = np.random.rand(self._nb_users, self._nb_users)
         user_trust = np.random.randint(2, size=self._nb_users)
         normalized_vouch_matrix = normalize_vouch_matrix(vouch_matrix, user_trust)
         for user in range(self._nb_users):
             self.assertAlmostEqual(np.sum(normalized_vouch_matrix[user]), 1)
 
-    def test_get_trust_vector(self):
+    def test_compute_relative_posttrust(self):
         vouch_matrix = np.random.rand(self._nb_users, self._nb_users)
         pretrust = np.random.randint(2, size=self._nb_users)
         relative_pretrust = pretrust/np.sum(pretrust)
@@ -98,7 +98,7 @@ class TrustAlgoTestCse(TestCase):
         relative_posttrust = compute_relative_posttrust(normalized_vouch_matrix, relative_pretrust)
         self.assertAlmostEqual(relative_posttrust[untrusted_user], 0)
 
-    def test_rescale(self):
+    def test_compute_voting_rights(self):
         posttrust = np.random.randint(0, 100, self._nb_users)
         relative_posttrust = posttrust/np.sum(posttrust)
         pretrust = np.random.randint(2, size=self._nb_users)

--- a/backend/vouch/trust_algo.py
+++ b/backend/vouch/trust_algo.py
@@ -4,107 +4,115 @@ from vouch.models import Voucher
 from core.models import user
 from django.db.models import Q
 
-# Hyperparameters of the algorithm - select them wisely
+"""
+In this algorithm, we leverage pretrust (e.g., based on email domains) and vouching
+to securely assign voting rights to a wider set of contributors.
+The algorithm inputs pretrust status and a vouching directed graph.
+"""
 
-# The minimum ratio of trust that is left to pre-trusted users.
-A = 0.2
-EPS = 1e-8
-# How much voting weight goes to pre-trusted users for each user.
-ALPHA = 0.1
+# If PRETRUST_BIAS == 1, then vouching yields no voting rights to non-pretrusted users.
+# If PRETRUST_BIAS is close to 0, then pre-trust vanishes (which is very unsafe).
+PRETRUST_BIAS = 0.2
+
+# Voting rights are computed iteratively, which yields an approximate solution. 
+APPROXIMATION_ERROR = 1e-8
+
+# In our model, users that vouch for few (if any) implicitly vouch for pre-trusted users.
+# IMPLICIT_PRETRUST_VOUCH is the implicit amount of vouch given to pretrusted, 
+# as opposed to the explicit vouches, each of which is of unit value
+IMPLICIT_PRETRUST_VOUCH = 0.1
 
 
-def normalize_trust_values(C: NDArray, trust_status: NDArray) -> NDArray:
+def normalize_vouch_matrix(vouch_matrix: NDArray, pretrust: NDArray) -> NDArray:
     """
-    Normalize the trust values per user, and make users vouch for the
-    pre-trusted set. If they vouch for other people, shift some of their
-    vouching weight to others.
+    Vouch matrix normalization guarantees three properties:
+    - The sum of normalized vouches given by a voucher equals 1.
+    - Each voucher vouchees for pretrusted users.
+    - Vouchers that explicitly vouch for many barely vouch for pretrusted users
 
     Keyword arguments:
-    C -- A 2 dimensional array of trust values. The 1st dimension represents
-         the emitters, and the 2nd dimension represents the receivers.
-    trust_status -- TODO: describe this argument.
+    vouch_matrix -- A 2 dimensional array of vouch values. 
+         The 1st dimension is the voucher, the 2nd is the vouchee.
+         vouch_matrix[voucher][vouchee] > 0 if voucher vouched for vouchee.
+    pretrust -- pretrust[u] > 0 if u is pretrusted.
     """
-    # Size of the pre-trusted set.
-    trust_size = np.sum(np.array(trust_status) > 0, axis=0)
+    normalized_vouch_matrix = np.zeros(vouch_matrix.shape)
+    
+    nb_users = len(pretrust)                                 # Number of users
+    nb_pretrusted = np.sum(np.array(pretrust) > 0, axis=0)   # Number of pretrusted users
 
-    for i in range(len(C[0])):
-        vouching_size = np.sum(np.array(C[i]) > 0, axis=0)
-        for j in range(len(C[0])):
-            trust_indic = int(trust_status[j] > 0)
-            vouch_indic = int(C[i][j] > 0)
-            C[i][j] = ALPHA / (ALPHA * trust_size + vouching_size) * trust_indic
-            C[i][j] += 1 / (ALPHA * trust_size + vouching_size) * vouch_indic
-    return C
+    for voucher in range(nb_users):
+        n_vouches_by_voucher = np.sum(np.array(vouch_matrix[voucher]) > 0, axis=0)
+        normalization_constant = IMPLICIT_PRETRUST_VOUCH * nb_pretrusted + n_vouches_by_voucher
+        for vouchee in range(nb_users):
+            if pretrust[vouchee] > 0:
+                normalized_vouch_matrix[voucher][vouchee] += IMPLICIT_PRETRUST_VOUCH / normalization_constant
+            if vouch_matrix[voucher][vouchee] > 0:
+                normalized_vouch_matrix[voucher][vouchee] += 1 / normalization_constant
+    return normalized_vouch_matrix
 
 
-def get_trust_vector(C, p):
+def compute_relative_posttrust(normalized_vouch_matrix, relative_pretrust:NDArray):
     """
     Return a vector of global trust values per user, given the vouchers in the
     network and the set of pre-trusted users. This part comes directly from
     EigenTrust.
     """
-    t = p
-    newt = t
+    relative_trust = relative_pretrust
+    new_relative_trust = relative_trust
     delta = 10
-    while delta >= EPS:
-        newt = C.T.dot(t)
-        newt = (1 - A) * newt + A * p
-        delta = np.linalg.norm(newt - t)
-        t = newt
-    return newt
+    while delta >= APPROXIMATION_ERROR:
+        new_relative_trust = normalized_vouch_matrix.T.dot(relative_trust)
+        new_relative_trust = (1 - PRETRUST_BIAS) * new_relative_trust + PRETRUST_BIAS * relative_pretrust
+        delta = np.linalg.norm(new_relative_trust - relative_trust)
+        relative_trust = new_relative_trust
+    return new_relative_trust
 
 
-def rescale(trust_vector, trust_status):
+def compute_voting_rights(relative_trust, pretrust):
     """
     Go from ratio of trust to actual voting weight that should be assigned to
     users given the trust the network puts in them.
     """
-    mint = np.amin(
-        [trust_vector[i] for i in range(len(trust_vector)) if trust_status[i] > 0]
+    min_relative_trust_of_pretrusted = np.amin(
+        [relative_trust[u] for u in range(len(relative_trust)) if pretrust[u] > 0]
     )
-    return np.array(trust_vector) / mint
+    return np.array(relative_trust) / min_relative_trust_of_pretrusted
 
 
 def trust_algo():
     """
     Improved version of the EigenTrust algorithm.
 
-    Compute a global trust score for each user, based on the set of
-    pre-trusted users* and on vouching made between users.
+    Compute a global trust score for all users, based on the set of
+    pre-trusted users and on vouching made between users.
 
     (* the ones with an email from a trusted domain).
     """
-    # List of users, list of their trust status (regarding their email) in the
-    # same order, and number of users.
+    # Import users and pretrust status
     users = list(
         user.User.objects.all().annotate(
             _is_trusted=Q(pk__in=user.User.trusted_users())
         )
     )
-    trust_status = [int(u._is_trusted) for u in users]
+    pretrust = [int(u._is_trusted) for u in users]
     nb_users = len(users)
 
-    # Create a matrix C where entry c_ij is the trust value a user i gave to
-    # a user j.
-    C_ = np.zeros([nb_users, nb_users], dtype=float)
+    # Import vouching matrix
+    vouch_matrix = np.zeros([nb_users, nb_users], dtype=float)
     for v in Voucher.objects.iterator():
-        i = users.index(v.by)
-        j = users.index(v.to)
-        C_[i][j] = v.trust_value
+        voucher = users.index(v.by)
+        vouchee = users.index(v.to)
+        vouch_matrix[voucher][vouchee] = v.trust_value
 
-    # Improved eigen trust algorithm.
-    p = trust_status
-    p = p / np.sum(p)
-    # Make the matrix to make it stochastic and give trust of users who didn't
-    # vouch much to pre-trusted set.
-    C = normalize_trust_values(C_, trust_status)
-    # Get the a vector of trust given to each user by the network.
-    trust_vector = get_trust_vector(C, p)
-
-    # Normalize and rescale it.
-    trust_vector = trust_vector / np.sum(trust_vector)
-    voting_weight = rescale(trust_vector, trust_status)
-    for k, u in enumerate(users):
-        u.trust_score = float(voting_weight[k])
+    # Compute relative posttrust
+    normalized_vouch_matrix = normalize_vouch_matrix(vouch_matrix, pretrust)
+    relative_pretrust = pretrust / np.sum(pretrust)
+    relative_posttrust = compute_relative_posttrust(normalized_vouch_matrix, relative_pretrust)
+    
+    # Turn relative_posttrust into voting rights
+    voting_rights = compute_voting_rights(relative_posttrust, pretrust)
+    for user_no, u in enumerate(users):
+        u.trust_score = float(voting_rights[user_no])
         u.save(update_fields=["trust_score"])
     return True

--- a/backend/vouch/trust_algo.py
+++ b/backend/vouch/trust_algo.py
@@ -80,13 +80,13 @@ def compute_voting_rights(relative_posttrusts, pretrusts):
     users given the trust the network puts in them.
     """
     min_relative_trusts_of_pretrusteds = np.amin(
-        [relative_posttrusts[u] for u in range(len(relative_posttrusts)) if pretrusts[u] > 0]
+        relative_posttrusts,
+        where=pretrusts > 0,
+        initial=MIN_PRETRUST_VOTING_RIGHT,
     )
     scale = MIN_PRETRUST_VOTING_RIGHT / min_relative_trusts_of_pretrusteds
     scaled_relative_trusts = np.array(relative_posttrusts) * scale
-    clipped_relative_trusts = np.array([
-        min(scaled_relative_trusts[u], 1) for u in range(len(relative_posttrusts))
-    ])
+    clipped_relative_trusts = scaled_relative_trusts.clip(max=1)
     return clipped_relative_trusts
 
 
@@ -105,7 +105,7 @@ def trust_algo():
             _is_trusted=Q(pk__in=user.User.trusted_users())
         )
     )
-    pretrusts = [int(u._is_trusted) for u in users]
+    pretrusts = np.array([int(u._is_trusted) for u in users])
     nb_users = len(users)
 
     # Import vouching matrix

--- a/backend/vouch/trust_algo.py
+++ b/backend/vouch/trust_algo.py
@@ -14,12 +14,12 @@ The algorithm inputs pretrust status and a vouching directed graph.
 # If PRETRUST_BIAS is close to 0, then pre-trust vanishes (which is very unsafe).
 PRETRUST_BIAS = 0.2
 
-# Voting rights are computed iteratively, which yields an approximate solution. 
+# Voting rights are computed iteratively, which yields an approximate solution.
 APPROXIMATION_ERROR = 1e-8
 
 # In our model, users that vouch for few (if any) implicitly vouch for pre-trusted users.
-# IMPLICIT_PRETRUST_VOUCH is the implicit amount of vouch given to pretrusted, 
-# as opposed to the explicit vouches, each of which is of unit value
+# IMPLICIT_PRETRUST_VOUCH is the implicit amount of vouch given to pretrusted,
+# as opposed to the explicit vouches, each of which is of unit value.
 IMPLICIT_PRETRUST_VOUCH = 0.1
 
 
@@ -31,13 +31,13 @@ def normalize_vouch_matrix(vouch_matrix: NDArray, pretrust: NDArray) -> NDArray:
     - Vouchers that explicitly vouch for many barely vouch for pretrusted users
 
     Keyword arguments:
-    vouch_matrix -- A 2 dimensional array of vouch values. 
+    vouch_matrix -- A 2 dimensional array of vouch values.
          The 1st dimension is the voucher, the 2nd is the vouchee.
          vouch_matrix[voucher][vouchee] > 0 if voucher vouched for vouchee.
     pretrust -- pretrust[u] > 0 if u is pretrusted.
     """
     normalized_vouch_matrix = np.zeros(vouch_matrix.shape)
-    
+
     nb_users = len(pretrust)                                 # Number of users
     nb_pretrusted = np.sum(np.array(pretrust) > 0, axis=0)   # Number of pretrusted users
 
@@ -46,13 +46,14 @@ def normalize_vouch_matrix(vouch_matrix: NDArray, pretrust: NDArray) -> NDArray:
         normalization_constant = IMPLICIT_PRETRUST_VOUCH * nb_pretrusted + n_vouches_by_voucher
         for vouchee in range(nb_users):
             if pretrust[vouchee] > 0:
-                normalized_vouch_matrix[voucher][vouchee] += IMPLICIT_PRETRUST_VOUCH / normalization_constant
+                normalized_vouch_matrix[voucher][vouchee] \
+                    += IMPLICIT_PRETRUST_VOUCH / normalization_constant
             if vouch_matrix[voucher][vouchee] > 0:
                 normalized_vouch_matrix[voucher][vouchee] += 1 / normalization_constant
     return normalized_vouch_matrix
 
 
-def compute_relative_posttrust(normalized_vouch_matrix, relative_pretrust:NDArray):
+def compute_relative_posttrust(normalized_vouch_matrix, relative_pretrust: NDArray):
     """
     Return a vector of global trust values per user, given the vouchers in the
     network and the set of pre-trusted users. This part comes directly from
@@ -63,7 +64,8 @@ def compute_relative_posttrust(normalized_vouch_matrix, relative_pretrust:NDArra
     delta = 10
     while delta >= APPROXIMATION_ERROR:
         new_relative_trust = normalized_vouch_matrix.T.dot(relative_trust)
-        new_relative_trust = (1 - PRETRUST_BIAS) * new_relative_trust + PRETRUST_BIAS * relative_pretrust
+        new_relative_trust = (1 - PRETRUST_BIAS) * new_relative_trust \
+            + PRETRUST_BIAS * relative_pretrust
         delta = np.linalg.norm(new_relative_trust - relative_trust)
         relative_trust = new_relative_trust
     return new_relative_trust
@@ -109,7 +111,7 @@ def trust_algo():
     normalized_vouch_matrix = normalize_vouch_matrix(vouch_matrix, pretrust)
     relative_pretrust = pretrust / np.sum(pretrust)
     relative_posttrust = compute_relative_posttrust(normalized_vouch_matrix, relative_pretrust)
-    
+
     # Turn relative_posttrust into voting rights
     voting_rights = compute_voting_rights(relative_posttrust, pretrust)
     for user_no, u in enumerate(users):


### PR DESCRIPTION
I rewrote the code to make it more human-readable. I verified that it successfully pass the tests.
There may be a need to go further to avoid ambiguities, as the word "trust" is used with too many slightly different meanings.
    
In particular, I would suggest:
1. The user's field "trust_score" could be replaced with "voting_right".
2. The vouch's field "trust_value" could be replaced by "vouch_value".
3. The vouch's field "by" could be replaced by "from".
    
As a result, while "trust" remains not fully well defined (currently, in the code, it only matters if it is > 0), the word "relative_trust" implies a sum of all users' relative trusts equals 1. Conversely, a user's "voting_right" an take any positive number. Moreover pretrusted users (by email domains) are guaranteed to have a voting right of at least 1.

What do you think?