### PR TITLE
[front] fix: flex layout on analysis page not good on mobile

### DIFF
--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -47,9 +47,7 @@ export const VideoAnalysis = ({
       gap="16px"
       justifyContent="space-between"
     >
-      <Box
-        width={{ sm: '100%', xs: '100%', md: '65%', lg: '64.9%', xl: '64.8%' }}
-      >
+      <Box flex={2} minWidth={{ xs: '100%', md: null }}>
         {/* Top level section, containing links and maybe more in the future. */}
         <Box mb={2} display="flex" justifyContent="flex-end">
           <Button
@@ -146,9 +144,7 @@ export const VideoAnalysis = ({
           )}
         </Grid>
       </Box>
-      <Box
-        width={{ sm: '100%', xs: '100%', md: '33%', lg: '33.5%', xl: '34%' }}
-      >
+      <Box flex={1}>
         <ContextualRecommendations
           contextUid={uid}
           uploader={video.uploader || undefined}

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -39,112 +39,117 @@ export const VideoAnalysis = ({
   const linkifiedDescription = linkifyStr(video.description || '', linkifyOpts);
 
   return (
-    <Box p={2}>
-      <Grid container spacing={2}>
-        <Grid item md={8} sm={12}>
-          {/* Top level section, containing links and maybe more in the future. */}
-          <Box mb={2} display="flex" justifyContent="flex-end">
-            <Button
-              color="secondary"
-              variant="contained"
-              endIcon={<CompareIcon />}
-              component={RouterLink}
-              to={`${baseUrl}/comparison?uidA=${uid}`}
+    <Box
+      p={2}
+      display="flex"
+      flexDirection="row"
+      flexWrap="wrap"
+      gap="16px"
+      justifyContent="space-between"
+    >
+      <Box width={{ sm: '100%', xs: '100%', md: '65%', lg: '65%' }}>
+        {/* Top level section, containing links and maybe more in the future. */}
+        <Box mb={2} display="flex" justifyContent="flex-end">
+          <Button
+            color="secondary"
+            variant="contained"
+            endIcon={<CompareIcon />}
+            component={RouterLink}
+            to={`${baseUrl}/comparison?uidA=${uid}`}
+          >
+            {t('entityAnalysisPage.generic.compare')}
+          </Button>
+        </Box>
+
+        {/* Entity section, with its player, title, scores and actions. */}
+        <Grid container spacing={2} justifyContent="center">
+          <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
+            <VideoPlayer
+              videoId={video.video_id}
+              duration={video.duration}
+              controls
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <VideoCard video={video} actions={actions} showPlayer={false} />
+          </Grid>
+          <Grid item xs={12}>
+            <CollapseButton
+              expanded={descriptionCollapsed}
+              onClick={() => {
+                setDescriptionCollapsed(!descriptionCollapsed);
+              }}
             >
-              {t('entityAnalysisPage.generic.compare')}
-            </Button>
-          </Box>
+              {t('entityAnalysisPage.video.description')}
+            </CollapseButton>
+            <Collapse in={descriptionCollapsed} timeout="auto" unmountOnExit>
+              <Typography paragraph>
+                <Box
+                  style={
+                    descriptionCollapsed
+                      ? { display: 'block' }
+                      : { display: 'none' }
+                  }
+                  dangerouslySetInnerHTML={{ __html: linkifiedDescription }}
+                  fontSize="0.9em"
+                  whiteSpace="pre-wrap"
+                />
+              </Typography>
+            </Collapse>
+          </Grid>
 
-          {/* Entity section, with its player, title, scores and actions. */}
-          <Grid container spacing={2} justifyContent="center">
-            <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
-              <VideoPlayer
-                videoId={video.video_id}
-                duration={video.duration}
-                controls
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <VideoCard video={video} actions={actions} showPlayer={false} />
-            </Grid>
-            <Grid item xs={12}>
-              <CollapseButton
-                expanded={descriptionCollapsed}
-                onClick={() => {
-                  setDescriptionCollapsed(!descriptionCollapsed);
-                }}
-              >
-                {t('entityAnalysisPage.video.description')}
-              </CollapseButton>
-              <Collapse in={descriptionCollapsed} timeout="auto" unmountOnExit>
-                <Typography paragraph>
+          {/* Data visualization. */}
+          {shouldDisplayCharts && (
+            <SelectedCriterionProvider>
+              <Grid item xs={12} sm={12} md={6}>
+                <Paper>
                   <Box
-                    style={
-                      descriptionCollapsed
-                        ? { display: 'block' }
-                        : { display: 'none' }
-                    }
-                    dangerouslySetInnerHTML={{ __html: linkifiedDescription }}
-                    fontSize="0.9em"
-                    whiteSpace="pre-wrap"
-                  />
-                </Typography>
-              </Collapse>
-            </Grid>
-
-            {/* Data visualization. */}
-            {shouldDisplayCharts && (
-              <SelectedCriterionProvider>
-                <Grid item xs={12} sm={12} md={6}>
-                  <Paper>
-                    <Box
-                      p={1}
-                      bgcolor="rgb(238, 238, 238)"
-                      display="flex"
-                      justifyContent="center"
-                    >
-                      <Typography variant="h5">
-                        {t('entityAnalysisPage.chart.criteriaScores.title')}
-                      </Typography>
-                    </Box>
-                    <PersonalCriteriaScoresContextProvider uid={uid}>
-                      <Box px={2} pt={1}>
-                        <PersonalScoreCheckbox />
-                      </Box>
-                      <Box p={1}>
-                        <CriteriaBarChart video={video} />
-                      </Box>
-                    </PersonalCriteriaScoresContextProvider>
-                  </Paper>
-                </Grid>
-                <Grid item xs={12} sm={12} md={6}>
-                  <Paper>
-                    <Box
-                      p={1}
-                      bgcolor="rgb(238, 238, 238)"
-                      display="flex"
-                      justifyContent="center"
-                    >
-                      <Typography variant="h5">
-                        {t('criteriaScoresDistribution.title')}
-                      </Typography>
+                    p={1}
+                    bgcolor="rgb(238, 238, 238)"
+                    display="flex"
+                    justifyContent="center"
+                  >
+                    <Typography variant="h5">
+                      {t('entityAnalysisPage.chart.criteriaScores.title')}
+                    </Typography>
+                  </Box>
+                  <PersonalCriteriaScoresContextProvider uid={uid}>
+                    <Box px={2} pt={1}>
+                      <PersonalScoreCheckbox />
                     </Box>
                     <Box p={1}>
-                      <CriteriaScoresDistribution uid={uid} />
+                      <CriteriaBarChart video={video} />
                     </Box>
-                  </Paper>
-                </Grid>
-              </SelectedCriterionProvider>
-            )}
-          </Grid>
+                  </PersonalCriteriaScoresContextProvider>
+                </Paper>
+              </Grid>
+              <Grid item xs={12} sm={12} md={6}>
+                <Paper>
+                  <Box
+                    p={1}
+                    bgcolor="rgb(238, 238, 238)"
+                    display="flex"
+                    justifyContent="center"
+                  >
+                    <Typography variant="h5">
+                      {t('criteriaScoresDistribution.title')}
+                    </Typography>
+                  </Box>
+                  <Box p={1}>
+                    <CriteriaScoresDistribution uid={uid} />
+                  </Box>
+                </Paper>
+              </Grid>
+            </SelectedCriterionProvider>
+          )}
         </Grid>
-        <Grid item md={4} sm={12}>
-          <ContextualRecommendations
-            contextUid={uid}
-            uploader={video.uploader || undefined}
-          />
-        </Grid>
-      </Grid>
+      </Box>
+      <Box width={{ sm: '100%', xs: '100%', md: '33%', lg: '33%' }}>
+        <ContextualRecommendations
+          contextUid={uid}
+          uploader={video.uploader || undefined}
+        />
+      </Box>
     </Box>
   );
 };

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -47,7 +47,9 @@ export const VideoAnalysis = ({
       gap="16px"
       justifyContent="space-between"
     >
-      <Box width={{ sm: '100%', xs: '100%', md: '65%', lg: '65%' }}>
+      <Box
+        width={{ sm: '100%', xs: '100%', md: '65%', lg: '64.9%', xl: '64.8%' }}
+      >
         {/* Top level section, containing links and maybe more in the future. */}
         <Box mb={2} display="flex" justifyContent="flex-end">
           <Button
@@ -144,7 +146,9 @@ export const VideoAnalysis = ({
           )}
         </Grid>
       </Box>
-      <Box width={{ sm: '100%', xs: '100%', md: '33%', lg: '33%' }}>
+      <Box
+        width={{ sm: '100%', xs: '100%', md: '33%', lg: '33.5%', xl: '34%' }}
+      >
         <ContextualRecommendations
           contextUid={uid}
           uploader={video.uploader || undefined}


### PR DESCRIPTION
This PR removes the horizontal scroll of the analysis page when displayed on mobile.

The usage of `<Box>` instead of `<Grid>` did the trick.

The width definition of the two flex items are a bit verbose. I wanted to make the first item (the video) take approx 65 % and I expected the second item (the contextual recommendations) to take the remaining space thanks to `flexGrow={1}` but I didn't manage to make it work.

Without the `flexGrow` the layout is still nice but there is and extra blank space at the end of the flex container that could be used by the contextual recommendations (for now, I moved this space between the items with `justifyContent="space-between"`, but it doesn't solve the problem).

![capture](https://user-images.githubusercontent.com/39056254/176008373-b8f19e5e-1034-4689-9769-db420b7fc0f7.png)

