### PR TITLE
[front] feat: add a copy URI button on the analysis page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1,4 +1,22 @@
 {
+  "entityAnalysisPage": {
+    "generic": {
+      "copy": "Copy URI",
+      "copied": "Copied!",
+      "compare": "Compare"
+    },
+    "candidate": {
+      "goToGlobalRanking": "Go to global ranking"
+    },
+    "chart": {
+      "criteriaScores": {
+        "title": "Scores per criterion"
+      }
+    },
+    "video": {
+      "description": "Description (from YouTube)"
+    }
+  },
   "components": {
     "filtersButton": "filters"
   },
@@ -143,9 +161,9 @@
     "storageErrorReloadPageAfterApplyingChanges": "After applying these changes, please reload this page."
   },
   "logoutNonImpactingError": "A non impacting error occurred during your logout.",
-  "logoutButton": "Logout",
   "loginButton": "Log in",
   "joinUsButton": "Join us",
+  "logoutButton": "Logout",
   "topbar": {
     "search": "Search"
   },
@@ -249,15 +267,14 @@
     "profileChangedSuccessfully": "Profile changed successfully",
     "captionUsernameWillAppearInPublicDatabase": "Your username will appear in the Tournesol public database if you choose to make any of your data on Tournesol public. You can change it at any time.",
     "updateProfile": "Update profile",
-    "account": "Account",
     "title": "Settings",
+    "account": "Account",
     "changeEmailAddress": "Change email address",
     "changePassword": "Change password",
     "exportAllData": "Export all data",
     "deleteAccount": "Delete account"
   },
   "username": "Username",
-  "profile": "Profile",
   "metrics": {
     "evolutionDuringTheLast30Days": "Evolution during the last 30 days."
   },
@@ -355,22 +372,6 @@
     "title": "My comparisons",
     "listHasNbComparisons_many": "You already did <1>{{comparisonCount}}</1> comparisons."
   },
-  "entityAnalysisPage": {
-    "candidate": {
-      "goToGlobalRanking": "Go to global ranking"
-    },
-    "chart": {
-      "criteriaScores": {
-        "title": "Scores per criterion"
-      }
-    },
-    "generic": {
-      "compare": "Compare"
-    },
-    "video": {
-      "description": "Description (from YouTube)"
-    }
-  },
   "entityNotFound": {
     "404": {
       "title": "Not found",
@@ -440,6 +441,7 @@
     "title": "My rate-later list"
   },
   "noVideoCorrespondsToSearchCriterias": "No video corresponds to your search criterias.",
+  "profile": "Profile",
   "signup": {
     "successMessage": "Success!<1></1>A verification link has been sent to <3>{{email}}</3> .",
     "title": "Account creation",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -1,4 +1,22 @@
 {
+  "entityAnalysisPage": {
+    "generic": {
+      "copy": "Copier URI",
+      "copied": "Copié !",
+      "compare": "Comparer"
+    },
+    "candidate": {
+      "goToGlobalRanking": "Voir le classement global"
+    },
+    "chart": {
+      "criteriaScores": {
+        "title": "Scores par critère"
+      }
+    },
+    "video": {
+      "description": "Description (provenant de YouTube)"
+    }
+  },
   "components": {
     "filtersButton": "filtres"
   },
@@ -148,9 +166,9 @@
     "storageErrorReloadPageAfterApplyingChanges": "Après avoir appliqué ces changements, veuillez rafraîchir cette page."
   },
   "logoutNonImpactingError": "Une petite erreur est survenue pendant la déconnexion.",
-  "logoutButton": "Se déconnecter",
   "loginButton": "Se connecter",
   "joinUsButton": "S'inscrire",
+  "logoutButton": "Se déconnecter",
   "topbar": {
     "search": "Rechercher"
   },
@@ -255,15 +273,14 @@
     "profileChangedSuccessfully": "Profil bien mis à jour.",
     "captionUsernameWillAppearInPublicDatabase": "Votre nom d'utilisateur apparaîtra dans les données publiques de Tournesol, si vous choisissez de rendre publique au moins l'une de vos données. Vous pouvez le changer à n'importe quel moment.",
     "updateProfile": "Mettre à jour le profil",
-    "account": "Compte",
     "title": "Paramètres",
+    "account": "Compte",
     "changeEmailAddress": "Changer d'adresse e-mail",
     "changePassword": "Changer de mot de passe",
     "exportAllData": "Télécharger vos données",
     "deleteAccount": "Supprimer votre compte"
   },
   "username": "Nom d'utilisateur",
-  "profile": "Profil",
   "metrics": {
     "evolutionDuringTheLast30Days": "Evolution au cours des 30 derniers jours."
   },
@@ -361,22 +378,6 @@
     "listHasNbComparisons_other": "Vous avez déjà fait <1>{{comparisonCount}}</1> comparaisons.",
     "title": "Mes comparaisons"
   },
-  "entityAnalysisPage": {
-    "candidate": {
-      "goToGlobalRanking": "Voir le classement global"
-    },
-    "chart": {
-      "criteriaScores": {
-        "title": "Scores par critère"
-      }
-    },
-    "generic": {
-      "compare": "Comparer"
-    },
-    "video": {
-      "description": "Description (provenant de YouTube)"
-    }
-  },
   "entityNotFound": {
     "404": {
       "title": "Non trouvée",
@@ -447,6 +448,7 @@
     "title": "À comparer plus tard"
   },
   "noVideoCorrespondsToSearchCriterias": "Aucune vidéo ne correspond à vos critères de recherche.",
+  "profile": "Profil",
   "signup": {
     "successMessage": "Bravo !<1></1>Un lien de vérification vient d'être envoyé à <3>{{email}}</3> .",
     "title": "Inscription",

--- a/frontend/src/components/buttons/CopyToClipboardButton.tsx
+++ b/frontend/src/components/buttons/CopyToClipboardButton.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@mui/material';
+import { Check, ContentCopy } from '@mui/icons-material';
+
+// in milliseconds
+const DISPLAY_DELAY = 1200;
+
+/**
+ * A button that copies the current URI to the browser clipboard when clicked.
+ */
+const CopyToClipboardButton = () => {
+  const { t } = useTranslation();
+
+  const [text, setText] = useState(t('entityAnalysisPage.generic.copy'));
+  const [feedback, setFeedback] = useState(false);
+
+  const copyUriToClipboard = () => {
+    navigator.clipboard.writeText(window.location.toString());
+
+    // Do not trigger any additionnal rendering when the user clicks
+    // repeatedly on the button.
+    if (feedback) {
+      return;
+    }
+
+    setFeedback(true);
+    setText(t('entityAnalysisPage.generic.copied'));
+
+    setTimeout(() => {
+      setFeedback(false);
+      setText(t('entityAnalysisPage.generic.copy'));
+    }, DISPLAY_DELAY);
+  };
+
+  return (
+    <Button
+      color="secondary"
+      variant="outlined"
+      endIcon={feedback ? <Check /> : <ContentCopy />}
+      onClick={copyUriToClipboard}
+    >
+      {text}
+    </Button>
+  );
+};
+
+export default CopyToClipboardButton;

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -3,8 +3,9 @@ import { useTranslation } from 'react-i18next';
 import { useParams, Link as RouterLink } from 'react-router-dom';
 
 import { Box, Button, Collapse, Grid, Paper, Typography } from '@mui/material';
-import CompareIcon from '@mui/icons-material/Compare';
+import { Compare } from '@mui/icons-material';
 
+import CopyToClipboardButton from 'src/components/buttons/CopyToClipboardButton';
 import CollapseButton from 'src/components/CollapseButton';
 import CriteriaBarChart from 'src/components/CriteriaBarChart';
 import { VideoPlayer } from 'src/components/entity/EntityImagery';
@@ -49,11 +50,12 @@ export const VideoAnalysis = ({
     >
       <Box flex={2} minWidth={{ xs: '100%', md: null }}>
         {/* Top level section, containing links and maybe more in the future. */}
-        <Box mb={2} display="flex" justifyContent="flex-end">
+        <Box mb={2} display="flex" justifyContent="flex-end" gap="8px">
+          <CopyToClipboardButton />
           <Button
             color="secondary"
             variant="contained"
-            endIcon={<CompareIcon />}
+            endIcon={<Compare />}
             component={RouterLink}
             to={`${baseUrl}/comparison?uidA=${uid}`}
           >


### PR DESCRIPTION
**related to** #915

**estimated BL** 10 per year

---

This PR adds a button on the video analysis page, that allows to directly copy the current URI to the browser clipboard.

This is the first step of the issue #915. This button could be replaced in the future by a proper share button, as described in the issue.

https://user-images.githubusercontent.com/39056254/176186724-022f58a7-a3cb-4ca9-99d7-31ea33abb3d1.mp4
