### PR TITLE
[front] feat: use only 5 min. max videos for the tutorial

### DIFF
--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -5,7 +5,7 @@ import DialogBox from 'src/components/DialogBox';
 import LoaderWrapper from 'src/components/LoaderWrapper';
 import Comparison, { UID_PARAMS } from 'src/features/comparisons/Comparison';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { Entity } from 'src/services/openapi';
+import { Entity, Recommendation } from 'src/services/openapi';
 import { alreadyComparedWith, selectRandomEntity } from 'src/utils/entity';
 import { getUserComparisons } from 'src/utils/api/comparisons';
 import { OrderedDialogs } from 'src/utils/types';
@@ -19,7 +19,7 @@ const MIN_LENGTH = 2;
 interface Props {
   dialogs?: OrderedDialogs;
   generateInitial?: boolean;
-  getAlternatives?: () => Promise<Array<Entity>>;
+  getAlternatives?: () => Promise<Array<Entity | Recommendation>>;
   length: number;
   // redirect to this URL when the series is over
   redirectTo?: string;
@@ -63,7 +63,9 @@ const ComparisonSeries = ({
   // tell the `Comparison` to refresh the left entity, or the right one
   const [refreshLeft, setRefreshLeft] = useState(false);
   // a limited list of entities that can be used to suggest new comparisons
-  const [alternatives, setAlternatives] = useState<Array<Entity>>([]);
+  const [alternatives, setAlternatives] = useState<
+    Array<Entity | Recommendation>
+  >([]);
   // an array of already made comparisons, allowing to not suggest two times the
   // same comparison to a user, formatted like this ['uidA/uidB', 'uidA/uidC']
   const [comparisonsMade, setComparisonsMade] = useState<Array<string>>([]);
@@ -87,7 +89,9 @@ const ComparisonSeries = ({
    * series.
    */
   useEffect(() => {
-    async function getAlternativesAsync(getAlts: () => Promise<Array<Entity>>) {
+    async function getAlternativesAsync(
+      getAlts: () => Promise<Array<Entity | Recommendation>>
+    ) {
       const alts = await getAlts();
       if (alts.length > 0) {
         setAlternatives(alts);
@@ -197,7 +201,7 @@ const ComparisonSeries = ({
    * @param uidB The current value of the `uidB` URL parameter
    */
   const genInitialComparisonParams = (
-    from: Array<Entity>,
+    from: Array<Entity | Recommendation>,
     comparisons: Array<string>,
     uidA: string,
     uidB: string

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -243,7 +243,7 @@ export const polls: Array<SelectablePoll> = [
     tutorialLength: 4,
     tutorialAlternatives: getTutorialVideos,
     tutorialDialogs: getVideosTutorialDialogs,
-    tutorialRedirectTo: '/comparison',
+    tutorialRedirectTo: '/comparisons',
   },
 ];
 

--- a/frontend/src/utils/entity.ts
+++ b/frontend/src/utils/entity.ts
@@ -40,9 +40,9 @@ export const videoWithScoresFromRecommendation = (
  * Return a random entity with uid not included in the `exclude` array.
  */
 export const selectRandomEntity = (
-  entities: Array<Entity>,
+  entities: Array<Entity | Recommendation>,
   exclude: string[]
-): Entity => {
+): Entity | Recommendation => {
   const filtered = entities.filter((entity) => !exclude.includes(entity.uid));
 
   return filtered[Math.floor(Math.random() * filtered.length)];

--- a/frontend/src/utils/polls/videos.ts
+++ b/frontend/src/utils/polls/videos.ts
@@ -1,16 +1,37 @@
 import { TFunction } from 'react-i18next';
-import { EntitiesService, Entity, TypeEnum } from 'src/services/openapi';
+import { PollsService, Recommendation } from 'src/services/openapi';
 import { OrderedDialogs } from 'src/utils/types';
 
-let VIDEOS: Promise<Entity[]> | null = null;
+let VIDEOS: Promise<Recommendation[]> | null = null;
 
-export function getTutorialVideos(): Promise<Entity[]> {
+/**
+ * Return a list of `Recommendation` for the tutorial.
+ *
+ * The recommendations returned:
+ *   - are safe recommendations
+ *   - are in the TOP 40 of all-time recommendations
+ *   - have a maximum duration of 5 minutes
+ *
+ * TODO:
+ *   - make the recommendations' language match the user language
+ *   - if no reco. are available in this language, use `en`?
+ */
+export function getTutorialVideos(): Promise<Recommendation[]> {
   if (VIDEOS != null) {
     return VIDEOS;
   }
-  VIDEOS = EntitiesService.entitiesList({
-    type: TypeEnum.VIDEO,
-    limit: 8,
+
+  const minutesMax = 5;
+  const top = 40;
+
+  const metadata = {
+    'duration:lte:int': 60 * minutesMax,
+  };
+
+  VIDEOS = PollsService.pollsRecommendationsList({
+    name: 'videos',
+    metadata: metadata,
+    limit: top,
   }).then((data) => data.results ?? []);
   return VIDEOS;
 }

--- a/frontend/src/utils/polls/videos.ts
+++ b/frontend/src/utils/polls/videos.ts
@@ -9,8 +9,8 @@ let VIDEOS: Promise<Recommendation[]> | null = null;
  *
  * The recommendations returned:
  *   - are safe recommendations
- *   - are in the TOP 40 of all-time recommendations
- *   - have a maximum duration of 5 minutes
+ *   - are in the TOP 100 of all-time recommendations...
+ *   - ...having a maximum duration of 5 minutes
  *
  * TODO:
  *   - make the recommendations' language match the user language
@@ -22,7 +22,7 @@ export function getTutorialVideos(): Promise<Recommendation[]> {
   }
 
   const minutesMax = 5;
-  const top = 40;
+  const top = 100;
 
   const metadata = {
     'duration:lte:int': 60 * minutesMax,

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -88,7 +88,7 @@ export type SelectablePoll = {
   tutorialLength?: number;
   // can be used by comparison series to limit the pool of entities
   // that are suggested after each comparison
-  tutorialAlternatives?: () => Promise<Array<Entity>>;
+  tutorialAlternatives?: () => Promise<Array<Entity | Recommendation>>;
   tutorialDialogs?: (t: TFunction) => OrderedDialogs;
   // redirect to this page after the last comparison is submitted
   tutorialRedirectTo?: string;


### PR DESCRIPTION
**related to** #844 

---

This PR changes the type of entity recommended by the `videos` tutorial.

Suggested entities:
- are now **safe recommendations**
- are in the **top 40 of all-time** recommendations...
- ...having a maximum duration of **5 minutes**

After having submitted their last comparison in the `videos` tutorial, the users were abruptly redirected to a blank comparison page, without any message or feedback of any kind. Even for me, as a confirmed user, it was unexpected and confusing. I didn't know if my last comparison was successfully submitted or not.

In this PR I decided to redirect the users to their own comparisons page, to allow them to see their progress, and to confirm their last comparison was correctly saved.

To create a virtuous circle, we could add the same feature we added in the `presidentielle2022` feedback page: add a button compare on the top right corner of the My comparisons page, allowing the users to continue comparing after the tutorial. I think it will help a lot to have a button like this, so that the users don't have to adventure themselves in the sidebar to explore the application.

```
tutorial -- (auto redirect) --> feedback with My comparisons page -- (a button invite to) --> comparison page
```

to-do
- [x] check if the `presidentielle2022` tuto still works
- [x] check if there is enough diversity in production with those criteria ( safe & less than 5 minutes )
  - at the time of writing, there are 116 safe reco. with a duration inferior to 5 minutes
  - it seems enough for a tutorial of 4 comparisons

### technical points

The tutorial are now compatible with both the entities API and the recommendations API. This allows to have a tutorial for polls similar to `presidentielle2022` using the entities API (small amount of alternatives, all alternatives are suggested regardless of their score), and for polls similar to `videos` (a lot of alternatives, not all of them are recommendable).

### next steps

**to-do**

Add a link in the home page to the tutorial, if the user has not finished it yet (same behaviour as in the `presidentielle2022` poll).

Use the user's language to determine the language of the suggested videos.

See #844