### PR TITLE
[front] fix: disable the duration filter

### DIFF
--- a/frontend/src/features/recommendation/SearchFilter.spec.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.spec.tsx
@@ -99,8 +99,8 @@ describe('Filters feature', () => {
     expect(queryAllByTestId(languageFilter, 'autocomplete')).toHaveLength(1);
 
     // Check the duration filter presence
-    expect(screen.getByTestId('filter-duration-lte')).toBeVisible();
-    expect(screen.getByTestId('filter-duration-gte')).toBeVisible();
+    // expect(screen.getByTestId('filter-duration-lte')).toBeVisible();
+    // expect(screen.getByTestId('filter-duration-gte')).toBeVisible();
 
     // Check criteria filters presence
     expect(screen.getByLabelText('multiple criteria')).toBeVisible();
@@ -230,6 +230,8 @@ describe('Filters feature', () => {
       expectInUrl: '',
     });
   });
+  /* TODO:
+    - enable these tests when the DurationFilter is fixed
 
   it('Can select a maximum duration', async () => {
     clickOnShowMore();
@@ -265,7 +267,7 @@ describe('Filters feature', () => {
     expect(pushSpy).toHaveBeenLastCalledWith({
       search: 'duration_lte=&duration_gte=20',
     });
-  });
+  });*/
 
   it('Can fold and unfold the multiple criteria', () => {
     clickOnShowMore();

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -17,7 +17,7 @@ import {
 } from 'src/utils/constants';
 import { saveRecommendationsLanguages } from 'src/utils/recommendationsLanguages';
 import { ScoreModeEnum } from 'src/features/recommendation/RecommendationApi';
-import DurationFilter from './DurationFilter';
+
 /**
  * Filter options for Videos recommendations
  *
@@ -99,6 +99,10 @@ function SearchFilter() {
                   value={filterParams.get(recommendationFilters.language) ?? ''}
                   onChange={handleLanguageChange}
                 />
+                {/* TOFIX:
+                  - the min filter doesn't work on Firefox desktop
+                  - the pagination doesn't work when the filter is active
+
                 <Box mt={2}>
                   <DurationFilter
                     valueMax={filterParams.get('duration_lte') ?? ''}
@@ -108,6 +112,7 @@ function SearchFilter() {
                     }
                   />
                 </Box>
+                */}
               </Grid>
             </>
           )}


### PR DESCRIPTION
* the min field doesn't work on Firefox desktop

* the pagination doesn't work when the duration filter is active