### PR TITLE
[front] fix: prevent `DurationFilter` infinite rendering

### DIFF
--- a/frontend/src/features/recommendation/DurationFilter.tsx
+++ b/frontend/src/features/recommendation/DurationFilter.tsx
@@ -10,8 +10,8 @@ import { TitledSection } from 'src/components';
 const TYPING_DELAY = 300;
 
 interface DurationFilterProps {
-  valueMax: string;
   valueMin: string;
+  valueMax: string;
   onChangeCallback: (filter: { param: string; value: string }) => void;
 }
 
@@ -23,14 +23,14 @@ interface DurationFilterProps {
  * before triggering the callback.
  */
 function DurationFilter({
-  valueMax,
   valueMin,
+  valueMax,
   onChangeCallback,
 }: DurationFilterProps) {
   const { t } = useTranslation();
 
-  const [maxDuration, setMaxDuration] = useState<string>(valueMax);
   const [minDuration, setMinDuration] = useState<string>(valueMin);
+  const [maxDuration, setMaxDuration] = useState<string>(valueMax);
 
   const handleChangeMax = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value: string = event.target.value;
@@ -42,14 +42,14 @@ function DurationFilter({
     setMinDuration(value);
   };
 
-  const clearMaxDuration = () => {
-    setMaxDuration('');
-    onChangeCallback({ param: 'duration_lte', value: '' });
-  };
-
   const clearMinDuration = () => {
     setMinDuration('');
     onChangeCallback({ param: 'duration_gte', value: '' });
+  };
+
+  const clearMaxDuration = () => {
+    setMaxDuration('');
+    onChangeCallback({ param: 'duration_lte', value: '' });
   };
 
   useEffect(() => {

--- a/frontend/src/features/recommendation/DurationFilter.tsx
+++ b/frontend/src/features/recommendation/DurationFilter.tsx
@@ -32,14 +32,14 @@ function DurationFilter({
   const [minDuration, setMinDuration] = useState<string>(valueMin);
   const [maxDuration, setMaxDuration] = useState<string>(valueMax);
 
-  const handleChangeMax = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value: string = event.target.value;
-    setMaxDuration(value);
-  };
-
   const handleChangeMin = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value: string = event.target.value;
     setMinDuration(value);
+  };
+
+  const handleChangeMax = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value: string = event.target.value;
+    setMaxDuration(value);
   };
 
   const clearMinDuration = () => {
@@ -52,14 +52,22 @@ function DurationFilter({
     onChangeCallback({ param: 'duration_lte', value: '' });
   };
 
+  /**
+   * This effect ensures the states of the component are updated when the
+   * props are updated.
+   *
+   * This case happens when the user goes back in the navigation history after
+   * having set a `minDuration` or a `maxDuration`.
+   */
   useEffect(() => {
-    const timeOutId = setTimeout(
-      () => onChangeCallback({ param: 'duration_lte', value: maxDuration }),
-      TYPING_DELAY
-    );
-
-    return () => clearTimeout(timeOutId);
-  }, [maxDuration, onChangeCallback]);
+    if (valueMin !== minDuration) {
+      setMinDuration(valueMin);
+    }
+    if (valueMax !== maxDuration) {
+      setMaxDuration(valueMax);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [valueMin, valueMax]);
 
   useEffect(() => {
     const timeOutId = setTimeout(
@@ -68,7 +76,18 @@ function DurationFilter({
     );
 
     return () => clearTimeout(timeOutId);
-  }, [minDuration, onChangeCallback]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [minDuration]);
+
+  useEffect(() => {
+    const timeOutId = setTimeout(
+      () => onChangeCallback({ param: 'duration_lte', value: maxDuration }),
+      TYPING_DELAY
+    );
+
+    return () => clearTimeout(timeOutId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [maxDuration]);
 
   return (
     <TitledSection title={t('filter.duration.title')}>

--- a/frontend/src/features/recommendation/SearchFilter.spec.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.spec.tsx
@@ -99,8 +99,8 @@ describe('Filters feature', () => {
     expect(queryAllByTestId(languageFilter, 'autocomplete')).toHaveLength(1);
 
     // Check the duration filter presence
-    // expect(screen.getByTestId('filter-duration-lte')).toBeVisible();
-    // expect(screen.getByTestId('filter-duration-gte')).toBeVisible();
+    expect(screen.getByTestId('filter-duration-lte')).toBeVisible();
+    expect(screen.getByTestId('filter-duration-gte')).toBeVisible();
 
     // Check criteria filters presence
     expect(screen.getByLabelText('multiple criteria')).toBeVisible();
@@ -230,8 +230,6 @@ describe('Filters feature', () => {
       expectInUrl: '',
     });
   });
-  /* TODO:
-    - enable these tests when the DurationFilter is fixed
 
   it('Can select a maximum duration', async () => {
     clickOnShowMore();
@@ -267,7 +265,7 @@ describe('Filters feature', () => {
     expect(pushSpy).toHaveBeenLastCalledWith({
       search: 'duration_lte=&duration_gte=20',
     });
-  });*/
+  });
 
   it('Can fold and unfold the multiple criteria', () => {
     clickOnShowMore();

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -3,6 +3,7 @@ import { Collapse, Grid, Box } from '@mui/material';
 
 import { CollapseButton } from 'src/components';
 import { useCurrentPoll, useListFilter } from 'src/hooks';
+import DurationFilter from 'src/features/recommendation/DurationFilter';
 import LanguageFilter from './LanguageFilter';
 import DateFilter from './DateFilter';
 import CriteriaFilter from './CriteriaFilter';
@@ -46,6 +47,11 @@ function SearchFilter() {
       saveRecommendationsLanguages(value);
       setFilter(recommendationFilters.language, value);
     },
+    [setFilter]
+  );
+
+  const setFilterCallback = useCallback(
+    (filter) => setFilter(filter.param, filter.value),
     [setFilter]
   );
 
@@ -99,20 +105,13 @@ function SearchFilter() {
                   value={filterParams.get(recommendationFilters.language) ?? ''}
                   onChange={handleLanguageChange}
                 />
-                {/* TOFIX:
-                  - the min filter doesn't work on Firefox desktop
-                  - the pagination doesn't work when the filter is active
-
                 <Box mt={2}>
                   <DurationFilter
                     valueMax={filterParams.get('duration_lte') ?? ''}
                     valueMin={filterParams.get('duration_gte') ?? ''}
-                    onChangeCallback={(filter) =>
-                      setFilter(filter.param, filter.value)
-                    }
+                    onChangeCallback={setFilterCallback}
                   />
                 </Box>
-                */}
               </Grid>
             </>
           )}

--- a/frontend/src/hooks/useListFilter.ts
+++ b/frontend/src/hooks/useListFilter.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { useLocation, useHistory } from 'react-router';
 
 export const useListFilter = ({
@@ -11,22 +10,18 @@ export const useListFilter = ({
   const history = useHistory();
   const searchParams = new URLSearchParams(location.search);
 
-  const setFilter = useCallback(
-    (key: string, value: string) => {
-      if (value || setEmptyValues) {
-        searchParams.set(key, value);
-      } else {
-        searchParams.delete(key);
-      }
-      // Reset pagination if filters change
-      if (key !== 'offset') {
-        searchParams.delete('offset');
-      }
-      history.push({ search: searchParams.toString() });
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [setEmptyValues]
-  );
+  const setFilter = (key: string, value: string) => {
+    if (value || setEmptyValues) {
+      searchParams.set(key, value);
+    } else {
+      searchParams.delete(key);
+    }
+    // Reset pagination if filters change
+    if (key !== 'offset') {
+      searchParams.delete('offset');
+    }
+    history.push({ search: searchParams.toString() });
+  };
 
   return [searchParams, setFilter];
 };

--- a/frontend/src/hooks/useListFilter.ts
+++ b/frontend/src/hooks/useListFilter.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useLocation, useHistory } from 'react-router';
 
 export const useListFilter = ({
@@ -10,18 +11,22 @@ export const useListFilter = ({
   const history = useHistory();
   const searchParams = new URLSearchParams(location.search);
 
-  const setFilter = (key: string, value: string) => {
-    if (value || setEmptyValues) {
-      searchParams.set(key, value);
-    } else {
-      searchParams.delete(key);
-    }
-    // Reset pagination if filters change
-    if (key !== 'offset') {
-      searchParams.delete('offset');
-    }
-    history.push({ search: searchParams.toString() });
-  };
+  const setFilter = useCallback(
+    (key: string, value: string) => {
+      if (value || setEmptyValues) {
+        searchParams.set(key, value);
+      } else {
+        searchParams.delete(key);
+      }
+      // Reset pagination if filters change
+      if (key !== 'offset') {
+        searchParams.delete('offset');
+      }
+      history.push({ search: searchParams.toString() });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [setEmptyValues]
+  );
 
   return [searchParams, setFilter];
 };


### PR DESCRIPTION
This PR fixes the infinite rendering loop caused by the `<DurationFilter>`.

This should fix:
- the `<DurationFilter>` filter on Firefox
- the reset pagination bug, when clicking on next with a duration filter active

To achieve this I removed the `onChangeCallback` from the `<DurationFilter>` effects' dependencies.

(I also moved the code responsible of the state `min` before the state `max` just to please my brain.)