### PR TITLE
mehestan: Disable individual scores update on comparison submission

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -376,6 +376,8 @@ VIDEO_METADATA_EXPIRE_SECONDS = 2 * 24 * 3600  # 2 days
 
 RECOMMENDATIONS_MIN_CONTRIBUTORS = 2
 
+UPDATE_MEHESTAN_SCORES_ON_COMPARISON = False
+
 # Configuration of the app `core`
 # See the documentation for the complete description.
 APP_CORE = {

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 from django.db.models import ObjectDoesNotExist, Q
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -998,6 +998,7 @@ class ComparisonWithMehestanTest(TransactionTestCase):
 
         self.client = APIClient()
 
+    @override_settings(UPDATE_MEHESTAN_SCORES_ON_COMPARISON=True)
     def test_update_individual_scores_after_new_comparison(self):
         call_command("ml_train")
 

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -2,6 +2,7 @@
 API endpoints to interact with the contributor's comparisons.
 """
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import ObjectDoesNotExist, Q
 from django.http import Http404
@@ -121,7 +122,7 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
         comparison.entity_2.update_n_ratings()
         comparison.entity_2.inner.refresh_metadata()
         comparison.entity_2.auto_remove_from_rate_later(self.request.user)
-        if poll.algorithm == ALGORITHM_MEHESTAN:
+        if settings.UPDATE_MEHESTAN_SCORES_ON_COMPARISON and poll.algorithm == ALGORITHM_MEHESTAN:
             update_user_scores(poll, user=self.request.user)
 
 
@@ -214,13 +215,13 @@ class ComparisonDetailApi(
     def perform_update(self, serializer):
         super().perform_update(serializer)
         poll = self.poll_from_url
-        if poll.algorithm == ALGORITHM_MEHESTAN:
+        if settings.UPDATE_MEHESTAN_SCORES_ON_COMPARISON and poll.algorithm == ALGORITHM_MEHESTAN:
             update_user_scores(poll, user=self.request.user)
 
     def perform_destroy(self, instance):
         super().perform_destroy(instance)
         poll = self.poll_from_url
-        if poll.algorithm == ALGORITHM_MEHESTAN:
+        if settings.UPDATE_MEHESTAN_SCORES_ON_COMPARISON and poll.algorithm == ALGORITHM_MEHESTAN:
             update_user_scores(poll, user=self.request.user)
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
With the current implementation, computing and writing all individual scores may be a bit slow (up to a few seconds) for users with a large number of comparisons. 

As a lighter implementation is being worked on in #1010 to update the scores "online", this PR disables this mechanism temporarily (controlled by a new setting `UPDATE_MEHESTAN_SCORES_ON_COMPARISON`).

In the future, we could also consider running this kind of update in a background task (ideally with minimal additional complexity in the architecture).