### PR TITLE
[front] feat: analysis URLs are now accepted by the entity selector

### DIFF
--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -3,8 +3,15 @@ import { YOUTUBE_POLL_NAME } from './constants';
 import { RelatedEntityObject, VideoObject } from './types';
 
 export function extractVideoId(idOrUrl: string) {
+  const host = process.env.PUBLIC_URL || location.host;
+  const escapedCurrentHost = host.replace(/[.\\]/g, '\\$&');
+
   const matchUrl = idOrUrl.match(
-    /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu.be\/|tournesol\.app\/entities\/yt:)([A-Za-z0-9-_]+)/
+    new RegExp(
+      '(?:https?:\\/\\/)?(?:www\\.)?(?:youtube\\.com\\/watch\\?v=|youtu\\.be\\/|' +
+        escapedCurrentHost +
+        '\\/entities\\/yt:)([A-Za-z0-9-_]+)'
+    )
   );
   const id = matchUrl ? matchUrl[1] : idOrUrl.trim();
   if (isVideoIdValid(id)) {

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -4,7 +4,7 @@ import { RelatedEntityObject, VideoObject } from './types';
 
 export function extractVideoId(idOrUrl: string) {
   const matchUrl = idOrUrl.match(
-    /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu.be\/)([A-Za-z0-9-_]+)/
+    /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu.be\/|tournesol\.app\/entities\/yt:)([A-Za-z0-9-_]+)/
   );
   const id = matchUrl ? matchUrl[1] : idOrUrl.trim();
   if (isVideoIdValid(id)) {


### PR DESCRIPTION
**related to** #1013

---

I kept the original way, just improved the RegExp in `./frontend/src/utils/video.ts`

You can visualize the new RegExp workflow [here](https://regexper.com/#%2F%28%3F%3Ahttps%3F%3A%5C%2F%5C%2F%29%3F%28%3F%3Awww%5C.%29%3F%28%3F%3Ayoutube%5C.com%5C%2Fwatch%5C%3Fv%3D%7Cyoutu.be%5C%2F%7Ctournesol%5C.app%5C%2Fentities%5C%2Fyt%3A%29%28%5BA-Za-z0-9-_%5D%2B%29%2F)  on [RegExper.com](url)