### PR TITLE
[back] refactor: include collective `n_comparisons` and `n_contributors`...

### DIFF
--- a/backend/tournesol/serializers/contributor_recommendations.py
+++ b/backend/tournesol/serializers/contributor_recommendations.py
@@ -6,19 +6,22 @@ from tournesol.serializers.rating import ContributorCriteriaScore
 
 
 class ContributorRecommendationsSerializer(RecommendationSerializer):
+    """
+    An entity recommended by a user.
+
+    In addition to the fields inherited from `RecommendationSerializer`, this
+    serializer also display the public status of the `ContributorRating`
+    related to the trio poll / entity / user.
+
+    Note that the fields `n_comparisons` and `n_contributors` contain
+    the collective values, and are not specific to the user.
+    """
     is_public = SerializerMethodField()
     criteria_scores = SerializerMethodField()
 
     class Meta(RecommendationSerializer.Meta):
-        # By default, `n_comparisons` and `n_contributors` take all
-        # contributors into account, so they are removed here to not add
-        # confusion in the contributor recommendations. We could choose to
-        # display the `n_comparisons` of the selected contributor by computing
-        # it here.
         fields = list(
             set(RecommendationSerializer.Meta.fields)
-            - {"n_comparisons"}
-            - {"n_contributors"}
             | {"is_public"}
         )
 

--- a/backend/tournesol/tests/test_api_contributor_recommendations.py
+++ b/backend/tournesol/tests/test_api_contributor_recommendations.py
@@ -92,8 +92,14 @@ class ContributorRecommendationsApiTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 1)
 
-        for entity in response.data["results"]:
+        results = response.data["results"]
+        for entity in results:
             self.assertEqual(entity["is_public"], True)
+
+        # The collective metadata `n_comparisons` and `n_contributors` must
+        # be present in the response of the public personal reco. endpoint.
+        self.assertEqual(results[0]["n_comparisons"], 0)
+        self.assertEqual(results[0]["n_contributors"], 0)
 
         response = self.client.get(
             f"/users/{self.user2.username}/recommendations/{self.poll.name}",
@@ -103,8 +109,14 @@ class ContributorRecommendationsApiTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 2)
 
-        for entity in response.data["results"]:
+        results = response.data["results"]
+        for entity in results:
             self.assertEqual(entity["is_public"], True)
+
+        # The collective metadata `n_comparisons` and `n_contributors` must
+        # be present in the response of the public personal reco. endpoint.
+        self.assertEqual(results[0]["n_comparisons"], 0)
+        self.assertEqual(results[0]["n_contributors"], 0)
 
     def test_recommendations_privacy_anon(self):
         """


### PR DESCRIPTION
**related to** #1036 

---

... in the public personal reco. endpoint.

This might feel counter intuitive, please refer to the original issue #1036. Feedback are obviously always welcome : ) 