### PR TITLE
[back][ml] Fix raw scores mehestan

### DIFF
--- a/backend/ml/mehestan/global_scores.py
+++ b/backend/ml/mehestan/global_scores.py
@@ -49,7 +49,7 @@ def get_significantly_different_pairs(scores: pd.DataFrame):
     that are significantly different, according to the contributor scores.
     (Used for collaborative preference scaling)
     """
-    scores = scores[["uid", "score", "uncertainty"]]
+    scores = scores[["uid", "raw_score", "raw_uncertainty"]]
     left, right = np.triu_indices(len(scores), k=1)
     pairs = (
         scores.iloc[left]
@@ -62,8 +62,8 @@ def get_significantly_different_pairs(scores: pd.DataFrame):
     )
     pairs.set_index(["uid_a", "uid_b"], inplace=True)
     return pairs.loc[
-        np.abs(pairs.score_a - pairs.score_b)
-        >= 2 * (pairs.uncertainty_a + pairs.uncertainty_b)
+        np.abs(pairs.raw_score_a - pairs.raw_score_b)
+        >= 2 * (pairs.raw_uncertainty_a + pairs.raw_uncertainty_b)
     ]
 
 
@@ -115,20 +115,20 @@ def compute_scaling(
             ABnm = ABn_all.join(ABm, how="inner", lsuffix="_n", rsuffix="_m")
             if len(ABnm) == 0:
                 continue
-            s_nqmab = np.abs(ABnm.score_a_m - ABnm.score_b_m) / np.abs(
-                ABnm.score_a_n - ABnm.score_b_n
+            s_nqmab = np.abs(ABnm.raw_score_a_m - ABnm.raw_score_b_m) / np.abs(
+                ABnm.raw_score_a_n - ABnm.raw_score_b_n
             )
 
             delta_s_nqmab = (
                 (
-                    np.abs(ABnm.score_a_m - ABnm.score_b_m)
-                    + ABnm.uncertainty_a_m
-                    + ABnm.uncertainty_b_m
+                    np.abs(ABnm.raw_score_a_m - ABnm.raw_score_b_m)
+                    + ABnm.raw_uncertainty_a_m
+                    + ABnm.raw_uncertainty_b_m
                 )
                 / (
-                    np.abs(ABnm.score_a_n - ABnm.score_b_n)
-                    - ABnm.uncertainty_a_n
-                    - ABnm.uncertainty_b_n
+                    np.abs(ABnm.raw_score_a_n - ABnm.raw_score_b_n)
+                    - ABnm.raw_uncertainty_a_n
+                    - ABnm.raw_uncertainty_b_n
                 )
             ) - s_nqmab
 
@@ -138,7 +138,7 @@ def compute_scaling(
             s_weights.append(scaling_weights[user_m])
 
         s_weights = np.array(s_weights)
-        theta_inf = np.max(user_scores.score.abs())
+        theta_inf = np.max(user_scores.raw_score.abs())
         s_nqm = np.array(s_nqm)
         delta_s_nqm = np.array(delta_s_nqm)
         if compute_uncertainties:
@@ -176,11 +176,11 @@ def compute_scaling(
             n_scores = user_scores.set_index("uid").loc[common_uids]
 
             tau_nqmab = (
-                s_dict.get(user_m, 1) * m_scores.score - s_dict[user_n] * n_scores.score
+                s_dict.get(user_m, 1) * m_scores.raw_score - s_dict[user_n] * n_scores.raw_score
             )
             delta_tau_nqmab = (
-                s_dict[user_n] * n_scores.uncertainty
-                + s_dict.get(user_m, 1) * m_scores.uncertainty
+                s_dict[user_n] * n_scores.raw_uncertainty
+                + s_dict.get(user_m, 1) * m_scores.raw_uncertainty
             )
 
             tau = QrMed(1, 1, tau_nqmab, delta_tau_nqmab)
@@ -230,6 +230,8 @@ def compute_scaled_scores(
         - scaled individual scores: Dataframe with columns
             * `user_id`
             * `entity_id`
+            * `raw_score`
+            * `raw_uncertainty`
             * `score`
             * `uncertainty`
             * `is_public`
@@ -246,6 +248,8 @@ def compute_scaled_scores(
             columns=[
                 "user_id",
                 "entity_id",
+                "raw_score",
+                "raw_uncertainty",
                 "score",
                 "uncertainty",
                 "is_public",
@@ -255,7 +259,6 @@ def compute_scaled_scores(
         )
         scalings = pd.DataFrame(columns=["s", "tau", "delta_s", "delta_tau"])
         return scores, scalings
-
     supertrusted_scaling = get_scaling_for_supertrusted(ml_input, individual_scores)
     rp = ml_input.get_ratings_properties()
 
@@ -271,8 +274,8 @@ def compute_scaled_scores(
     df = df.join(supertrusted_scaling, on="user_id")
     df["s"].fillna(1, inplace=True)
     df["tau"].fillna(0, inplace=True)
-    df["score"] = df["s"] * df["score"] + df["tau"]
-    df["uncertainty"] *= df["s"]
+    df["score"] = df["s"] * df["raw_score"] + df["tau"]
+    df["uncertainty"] = df["raw_uncertainty"] * df["s"]
     df.drop(["s", "tau"], axis=1, inplace=True)
 
     logging.debug(
@@ -294,23 +297,19 @@ def compute_scaled_scores(
     df["delta_s"].fillna(0, inplace=True)
     df["delta_tau"].fillna(0, inplace=True)
     df["uncertainty"] = (
-        df["s"] * df["uncertainty"]
-        + df["delta_s"] * df["score"].abs()
+        df["s"] * df["raw_uncertainty"]
+        + df["delta_s"] * df["raw_score"].abs()
         + df["delta_tau"]
     )
-    df["score"] = df["score"] * df["s"] + df["tau"]
+    df["score"] = df["raw_score"] * df["s"] + df["tau"]
     df.drop(["s", "tau", "delta_s", "delta_tau"], axis=1, inplace=True)
 
     all_scalings = pd.concat([supertrusted_scaling, non_supertrusted_scaling])
     return df, all_scalings
 
 
-def get_global_scores(
-    scaled_individual_scores: pd.DataFrame,
-    score_mode: ScoreMode
-):
+def get_global_scores(scaled_individual_scores: pd.DataFrame, score_mode: ScoreMode):
     df = scaled_individual_scores.copy(deep=False)
-
     if score_mode == ScoreMode.TRUSTED_ONLY:
         df = df[df["is_trusted"]]
         df["voting_weight"] = 1

--- a/backend/ml/mehestan/global_scores.py
+++ b/backend/ml/mehestan/global_scores.py
@@ -115,20 +115,20 @@ def compute_scaling(
             ABnm = ABn_all.join(ABm, how="inner", lsuffix="_n", rsuffix="_m")
             if len(ABnm) == 0:
                 continue
-            s_nqmab = np.abs(ABnm.raw_score_a_m - ABnm.raw_score_b_m) / np.abs(
-                ABnm.raw_score_a_n - ABnm.raw_score_b_n
+            s_nqmab = np.abs(ABnm.score_a_m - ABnm.score_b_m) / np.abs(
+                ABnm.score_a_n - ABnm.score_b_n
             )
 
             delta_s_nqmab = (
                 (
-                    np.abs(ABnm.raw_score_a_m - ABnm.raw_score_b_m)
-                    + ABnm.raw_uncertainty_a_m
-                    + ABnm.raw_uncertainty_b_m
+                    np.abs(ABnm.score_a_m - ABnm.score_b_m)
+                    + ABnm.uncertainty_a_m
+                    + ABnm.uncertainty_b_m
                 )
                 / (
-                    np.abs(ABnm.raw_score_a_n - ABnm.raw_score_b_n)
-                    - ABnm.raw_uncertainty_a_n
-                    - ABnm.raw_uncertainty_b_n
+                    np.abs(ABnm.score_a_n - ABnm.score_b_n)
+                    - ABnm.uncertainty_a_n
+                    - ABnm.uncertainty_b_n
                 )
             ) - s_nqmab
 
@@ -138,7 +138,7 @@ def compute_scaling(
             s_weights.append(scaling_weights[user_m])
 
         s_weights = np.array(s_weights)
-        theta_inf = np.max(user_scores.raw_score.abs())
+        theta_inf = np.max(user_scores.score.abs())
         s_nqm = np.array(s_nqm)
         delta_s_nqm = np.array(delta_s_nqm)
         if compute_uncertainties:
@@ -176,12 +176,11 @@ def compute_scaling(
             n_scores = user_scores.set_index("uid").loc[common_uids]
 
             tau_nqmab = (
-                s_dict.get(user_m, 1) * m_scores.raw_score
-                - s_dict[user_n] * n_scores.raw_score
+                s_dict.get(user_m, 1) * m_scores.score - s_dict[user_n] * n_scores.score
             )
             delta_tau_nqmab = (
-                s_dict[user_n] * n_scores.raw_uncertainty
-                + s_dict.get(user_m, 1) * m_scores.raw_uncertainty
+                s_dict[user_n] * n_scores.uncertainty
+                + s_dict.get(user_m, 1) * m_scores.uncertainty
             )
 
             tau = QrMed(1, 1, tau_nqmab, delta_tau_nqmab)
@@ -220,6 +219,8 @@ def get_scaling_for_supertrusted(ml_input: MlInput, individual_scores: pd.DataFr
     rp.set_index(["user_id", "entity_id"], inplace=True)
     rp = rp[rp.is_supertrusted]
     df = individual_scores.join(rp, on=["user_id", "entity_id"], how="inner")
+    df["score"]=df["raw_score"]
+    df["uncertainty"]=df["raw_uncertainty"]
     return compute_scaling(df, ml_input=ml_input)
 
 

--- a/backend/ml/mehestan/global_scores.py
+++ b/backend/ml/mehestan/global_scores.py
@@ -49,7 +49,7 @@ def get_significantly_different_pairs(scores: pd.DataFrame):
     that are significantly different, according to the contributor scores.
     (Used for collaborative preference scaling)
     """
-    scores = scores[["uid", "raw_score", "raw_uncertainty"]]
+    scores = scores[["uid", "score", "uncertainty"]]
     left, right = np.triu_indices(len(scores), k=1)
     pairs = (
         scores.iloc[left]

--- a/backend/ml/mehestan/global_scores.py
+++ b/backend/ml/mehestan/global_scores.py
@@ -62,8 +62,8 @@ def get_significantly_different_pairs(scores: pd.DataFrame):
     )
     pairs.set_index(["uid_a", "uid_b"], inplace=True)
     return pairs.loc[
-        np.abs(pairs.raw_score_a - pairs.raw_score_b)
-        >= 2 * (pairs.raw_uncertainty_a + pairs.raw_uncertainty_b)
+        np.abs(pairs.score_a - pairs.score_b)
+        >= 2 * (pairs.uncertainty_a + pairs.uncertainty_b)
     ]
 
 
@@ -219,8 +219,8 @@ def get_scaling_for_supertrusted(ml_input: MlInput, individual_scores: pd.DataFr
     rp.set_index(["user_id", "entity_id"], inplace=True)
     rp = rp[rp.is_supertrusted]
     df = individual_scores.join(rp, on=["user_id", "entity_id"], how="inner")
-    df["score"]=df["raw_score"]
-    df["uncertainty"]=df["raw_uncertainty"]
+    df["score"] = df["raw_score"]
+    df["uncertainty"] = df["raw_uncertainty"]
     return compute_scaling(df, ml_input=ml_input)
 
 

--- a/backend/ml/mehestan/individual.py
+++ b/backend/ml/mehestan/individual.py
@@ -61,8 +61,8 @@ def compute_individual_score(scores: pd.DataFrame):
 
     result = pd.DataFrame(
         {
-            "score": theta_star,
-            "uncertainty": delta_star,
+            "raw_score": theta_star,
+            "aw_uncertainty": delta_star,
         }
     )
     result.index.name = "entity_id"

--- a/backend/ml/mehestan/individual.py
+++ b/backend/ml/mehestan/individual.py
@@ -62,7 +62,7 @@ def compute_individual_score(scores: pd.DataFrame):
     result = pd.DataFrame(
         {
             "raw_score": theta_star,
-            "aw_uncertainty": delta_star,
+            "raw_uncertainty": delta_star,
         }
     )
     result.index.name = "entity_id"

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -45,10 +45,10 @@ def get_individual_scores(
         individual_scores.append(scores.reset_index())
 
     if len(individual_scores) == 0:
-        return pd.DataFrame(columns=["user_id", "entity_id", "score", "uncertainty"])
+        return pd.DataFrame(columns=["user_id", "entity_id", "raw_score", "raw_uncertainty"])
 
     result = pd.concat(individual_scores, ignore_index=True, copy=False)
-    return result[["user_id", "entity_id", "score", "uncertainty"]]
+    return result[["user_id", "entity_id", "raw_score", "raw_uncertainty"]]
 
 
 def update_user_scores(poll: Poll, user: User):
@@ -131,13 +131,11 @@ def run_mehestan_for_criterion(
         )
 
     scale_function = poll.scale_function
-    scaled_scores["raw_score"] = scaled_scores["score"]
-    scaled_scores["raw_uncertainty"] = scaled_scores["uncertainty"]
     scaled_scores["uncertainty"] = 0.5 * (
-        scale_function(scaled_scores["raw_score"] + scaled_scores["raw_uncertainty"])
-        - scale_function(scaled_scores["raw_score"] - scaled_scores["raw_uncertainty"])
+        scale_function(scaled_scores["score"] + scaled_scores["uncertainty"])
+        - scale_function(scaled_scores["score"] - scaled_scores["uncertainty"])
     )
-    scaled_scores["score"] = scale_function(scaled_scores["raw_score"])
+    scaled_scores["score"] = scale_function(scaled_scores["score"])
     scaled_scores["criteria"] = criteria
     save_contributor_scores(poll, scaled_scores, single_criteria=criteria)
 


### PR DESCRIPTION
PR goal : fix raw_scores save in Mehestan Algorithm

Currently, individual scaled scores are saved into raw_scores (along with uncertainty) [tournesol_contributorratingcriteriascore] when computing post scaling operations 
(see https://github.com/tournesol-app/tournesol/blob/main/backend/ml/mehestan/run.py#L134)

As discussed with @amatissart , these two lines are not intended in the poll scaling mehestan algorithm.

In order to save properly the individual contributions [tournesol_contributorratingcriteriascore] , 
the function "save_contributor_scores" need as input a dataframe with raw_score and raw_uncertainty
(see https://github.com/tournesol-app/tournesol/blob/main/backend/ml/outputs.py#L135)

However, in the mehestan algorithm, the steps are the following for each criteria: 
1 - compute individual scores  [namely, raw_score and raw_uncertainty]
2 - compute individual scaled scores [from raw_score and raw_uncertainty, we compute scale factor and translation intercept]
3 - compute global scores for entities
3.5 - compute sigmoid scale for poll scaling if main_criteria
4 - apply poll scaling to global scores and individual scores
(see https://github.com/tournesol-app/tournesol/blob/main/backend/ml/mehestan/run.py#L71)

I'd suggest to keep save_contributor_scores as is, and to ensure that the dataframe has raw_score/raw_uncertainty
In order to do so, scaled_scores dataframe should have these columns


