### PR TITLE
[back] feat: unconnected entities are now ordered by n_comparisons

### DIFF
--- a/backend/tournesol/tests/test_api_unconnected_entities.py
+++ b/backend/tournesol/tests/test_api_unconnected_entities.py
@@ -8,10 +8,10 @@ from tournesol.tests.factories.comparison import ComparisonFactory
 from tournesol.tests.factories.entity import VideoFactory
 
 
-class SimpleAllConnectedTest(TestCase):
+class SimpleAllConnectedTestCase(TestCase):
     """
-    TestCase for the unconnected entities API.
-    In this simple test, all video are connected to the user.
+    A test case of the unconnected entities API, where all video are
+    connected to the tested user.
     """
 
     def setUp(self):
@@ -50,7 +50,10 @@ class SimpleAllConnectedTest(TestCase):
             entity_2=video_5,
         )
 
-    def test_not_authenticated_cannot_show_unconnected_entities(self):
+    def test_anon_get_401(self):
+        """
+        An anonymous user must not be able to list its unconnected entities.
+        """
         response = self.client.get(
             f"{self.user_base_url}/{self.video_source.uid}/",
             format="json",
@@ -58,7 +61,7 @@ class SimpleAllConnectedTest(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_without_uid_show_not_found(self):
+    def test_auth_get_404_with_no_uid(self):
         self.client.force_authenticate(self.user_1)
 
         response = self.client.get(
@@ -68,7 +71,7 @@ class SimpleAllConnectedTest(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_with_unknown_uid_show_not_found(self):
+    def test_auth_get_404_with_unknown_uid(self):
         self.client.force_authenticate(self.user_1)
 
         response = self.client.get(
@@ -78,7 +81,7 @@ class SimpleAllConnectedTest(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_all_connected_video_shouldnt_return_entities(self):
+    def test_auth_get_empty_when_all_entities_are_connected(self):
         self.client.force_authenticate(self.user_1)
 
         response = self.client.get(
@@ -88,7 +91,7 @@ class SimpleAllConnectedTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 
-        # Make sure that no side-effect affects subsequent requests
+        # Make sure that no side-effect affects subsequent requests.
         response = self.client.get(
             f"{self.user_base_url}/{self.video_source.uid}/",
             format="json",
@@ -140,10 +143,10 @@ class NonConnectedEntityTest(TestCase):
         self.assertEqual(response.data["count"], 3)
 
 
-class AdvancedAllConnectedTest(TestCase):
+class AdvancedAllConnectedTestCase(TestCase):
     """
-    TestCase for the unconnected entities API. 
-    In this Advanced test, all video are not necessarily connected to the user.
+    A test case of the unconnected entities API, where all video are
+    not necessarily connected to the tested user.
     """
 
     def setUp(self):
@@ -187,7 +190,7 @@ class AdvancedAllConnectedTest(TestCase):
         self.assertEqual(response.data["count"], 0)
 
 
-class SimpleNotAllConnectedTest(TestCase):
+class SimpleNotAllConnectedTestCase(TestCase):
     """
     TestCase for the unconnected entities API.
     """

--- a/backend/tournesol/tests/test_api_unconnected_entities.py
+++ b/backend/tournesol/tests/test_api_unconnected_entities.py
@@ -10,8 +10,8 @@ from tournesol.tests.factories.entity import VideoFactory
 
 class SimpleAllConnectedTest(TestCase):
     """
-    TestCase for the unconnected entities API. ``
-    In this simple test, all video are connected to the user
+    TestCase for the unconnected entities API.
+    In this simple test, all video are connected to the user.
     """
 
     def setUp(self):
@@ -99,7 +99,7 @@ class SimpleAllConnectedTest(TestCase):
 
 class NonConnectedEntityTest(TestCase):
     """
-    TestCase for the unconnected entities API where an entity don't have any comparison
+    TestCase for the unconnected entities API where an entity don't have any comparison.
     """
 
     def setUp(self):
@@ -143,7 +143,7 @@ class NonConnectedEntityTest(TestCase):
 class AdvancedAllConnectedTest(TestCase):
     """
     TestCase for the unconnected entities API. 
-    In this Advanced test, all video are not necessary connecter to the user
+    In this Advanced test, all video are not necessarily connected to the user.
     """
 
     def setUp(self):

--- a/backend/tournesol/tests/test_api_unconnected_entities.py
+++ b/backend/tournesol/tests/test_api_unconnected_entities.py
@@ -8,10 +8,12 @@ from tournesol.tests.factories.comparison import ComparisonFactory
 from tournesol.tests.factories.entity import VideoFactory
 
 
-class SimpleAllConnectedTestCase(TestCase):
+class SingleGraphAllConnectedToAllTestCase(TestCase):
     """
-    A test case of the unconnected entities API, where all entities are
-    connected with each other by the tested user.
+    A test case of the unconnected entities API.
+
+    Here, all entities are connected with each other by the tested user,
+    forming a single graph.
     """
 
     def setUp(self):
@@ -100,10 +102,12 @@ class SimpleAllConnectedTestCase(TestCase):
         self.assertEqual(response.data["count"], 0)
 
 
-class NonConnectedEntityTestCase(TestCase):
+class SingleGraphOneIsolatedEntityTestCase(TestCase):
     """
-    A test case of the unconnected entities API, where an entity doesn't have
-    any comparison.
+    A test case of the unconnected entities API.
+
+    Here, there is an entity that doesn't have any comparison with the tested
+    user's graph.
     """
 
     def setUp(self):
@@ -144,10 +148,12 @@ class NonConnectedEntityTestCase(TestCase):
         self.assertEqual(response.data["count"], 3)
 
 
-class AdvancedAllConnectedTestCase(TestCase):
+class SingleGraphAllConnectedTestCase(TestCase):
     """
-    A test case of the unconnected entities API, where all video are
-    not necessarily connected together to by tested user.
+    A test case of the unconnected entities API.
+
+    Here, all entities are not necessarily connected together to by the tested
+    user, yet forming a single graph.
     """
 
     def setUp(self):
@@ -196,9 +202,12 @@ class AdvancedAllConnectedTestCase(TestCase):
         self.assertEqual(response.data["count"], 0)
 
 
-class SimpleNotAllConnectedTestCase(TestCase):
+class TwoIsolatedGraphsTestCase(TestCase):
     """
-    TestCase for the unconnected entities API.
+    A test case of the unconnected entities API.
+
+    Here, we test two graphs of connected entities that have no connection
+    with each other.
     """
 
     def setUp(self):

--- a/backend/tournesol/tests/test_api_unconnected_entities.py
+++ b/backend/tournesol/tests/test_api_unconnected_entities.py
@@ -10,8 +10,8 @@ from tournesol.tests.factories.entity import VideoFactory
 
 class SimpleAllConnectedTestCase(TestCase):
     """
-    A test case of the unconnected entities API, where all video are
-    connected to the tested user.
+    A test case of the unconnected entities API, where all entities are
+    connected with each other by the tested user.
     """
 
     def setUp(self):
@@ -100,9 +100,10 @@ class SimpleAllConnectedTestCase(TestCase):
         self.assertEqual(response.data["count"], 0)
 
 
-class NonConnectedEntityTest(TestCase):
+class NonConnectedEntityTestCase(TestCase):
     """
-    TestCase for the unconnected entities API where an entity don't have any comparison.
+    A test case of the unconnected entities API, where an entity doesn't have
+    any comparison.
     """
 
     def setUp(self):
@@ -111,7 +112,7 @@ class NonConnectedEntityTest(TestCase):
         self.poll_videos = Poll.default_poll()
         self.user_base_url = f"/users/me/unconnected_entities/{self.poll_videos.name}"
 
-        # Create video without comparison
+        # Create video without comparison.
         video_1 = VideoFactory()
         video_2 = VideoFactory()
         video_3 = VideoFactory()
@@ -146,7 +147,7 @@ class NonConnectedEntityTest(TestCase):
 class AdvancedAllConnectedTestCase(TestCase):
     """
     A test case of the unconnected entities API, where all video are
-    not necessarily connected to the tested user.
+    not necessarily connected together to by tested user.
     """
 
     def setUp(self):
@@ -179,6 +180,11 @@ class AdvancedAllConnectedTestCase(TestCase):
         )
 
     def test_all_linked_should_return_empty(self):
+        """
+        An authenticated user must get an empty list, when all of its compared
+        entities are connected, even if they are not individually connected to
+        each other.
+        """
         self.client.force_authenticate(self.user_1)
 
         response = self.client.get(

--- a/backend/tournesol/tests/test_api_unconnected_entities.py
+++ b/backend/tournesol/tests/test_api_unconnected_entities.py
@@ -136,7 +136,7 @@ class SingleGraphOneIsolatedEntityTestCase(TestCase):
             entity_2=video_4,
         )
 
-    def test_no_link_should_return_all(self):
+    def test_no_link_must_return_all(self):
         self.client.force_authenticate(self.user_1)
 
         response = self.client.get(
@@ -185,7 +185,7 @@ class SingleGraphAllConnectedTestCase(TestCase):
             entity_2=video_3,
         )
 
-    def test_all_linked_should_return_empty(self):
+    def test_all_linked_must_return_empty(self):
         """
         An authenticated user must get an empty list, when all of its compared
         entities are connected, even if they are not individually connected to
@@ -247,7 +247,7 @@ class TwoIsolatedGraphsTestCase(TestCase):
             entity_2=video_5,
         )
 
-    def test_should_return_non_connected_entity(self):
+    def test_must_return_non_connected_entities(self):
         self.client.force_authenticate(self.user_1)
 
         response = self.client.get(
@@ -318,7 +318,7 @@ class AdvancedNotAllConnectedTest(TestCase):
             entity_2=video_1,
         )
 
-    def test_should_return_non_connected_entity(self):
+    def test_must_return_non_connected_entities(self):
         self.client.force_authenticate(self.user_1)
 
         response = self.client.get(


### PR DESCRIPTION
The goal is to invite the users to compare the entities with the least comparisons first, and to make the list of unconnected entities dynamic.

Before, the front end tab "to connect" always displayed the same videos, when called with a never compared video. This was not satisfying, as it could suggest videos that have been already compared several times by the user. Now the users will see a more diverse list of videos, as its order will change after each new comparison with an unconnected entity.

I took the time to add more comments in the tests and to rename some methods, so it's now explicit what the test cases are testing: a single well connected graph, two isolated graphs, a single graph with too distant entities, etc.

**to-do**
- [x] write a test