### PR TITLE
[front] feat: `videos` tuto accessible on Home

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -212,13 +212,13 @@
     "uploadDate": "Uploaded",
     "duration": {
       "title": "Duration (minutes)",
-      "max": {
-        "label": "max",
-        "clearAriaLabel": "Clear the max duration"
-      },
       "min": {
         "label": "min",
         "clearAriaLabel": "Clear the min duration"
+      },
+      "max": {
+        "label": "max",
+        "clearAriaLabel": "Clear the max duration"
       }
     },
     "allLanguages": "All languages",
@@ -404,11 +404,13 @@
       "tournesolDescription": "Tournesol is an open source platform which proposes a tool for collaborative decision.",
       "whyCompareCandidates": "Initially developped to identify top videos of public utility, Tournesol now enables you to compare the French presidential election candidates. And so you will receive feedback and insights from Tournesol's algorithms about your explicited preferences.",
       "dataUsage": "Submitted data will never be revealed to other users, and will only be used to help research on the ethics of algorithms and artificial intelligence.",
+      "respondToSurvey": "Respond to survey"
+    },
+    "generic": {
       "createAccount": "Create account",
       "start": "Start",
       "pollIsClosed": "The poll is now closed.",
-      "seeResults": "See the results",
-      "respondToSurvey": "Respond to survey"
+      "seeResults": "See the results"
     },
     "contributeTitle": "Contribute!",
     "contributeDetail": "Tournesol identifies high quality content from comparisons provided by the community. To contribute, you must compare videos that you have watched. First copy paste two links to videos, then tell us which video you think should be largely recommended. If you want to you can also compare the videos in more details based on the multiple comparison criterias.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -218,13 +218,13 @@
     "uploadDate": "Mises en ligne depuis",
     "duration": {
       "title": "Durée (minutes)",
-      "max": {
-        "label": "max",
-        "clearAriaLabel": "Effacer la durée max"
-      },
       "min": {
         "label": "min",
         "clearAriaLabel": "Effacer la durée min"
+      },
+      "max": {
+        "label": "max",
+        "clearAriaLabel": "Effacer la durée max"
       }
     },
     "allLanguages": "Toutes",
@@ -410,11 +410,13 @@
       "tournesolDescription": "Tournesol est une plateforme libre et open source qui propose un outil de décision collaboratif transparent.",
       "whyCompareCandidates": "Initialement conçue pour la recommendation de vidéos d'utilité publique, Tournesol vous propose aujourd'hui de comparer les candidats à l'élection présidentielle française 2022. Ainsi, vous obtiendrez un aperçu de la façon dont les algorithmes de Tournesol analysent les préférences que vous exprimez.",
       "dataUsage": "Les données enregistrées ne seront jamais dévoilées aux autres utilisateurs, et ne serviront  qu'à la recherche dans l'éthique des algorithmes et en intelligence artificielle.",
+      "respondToSurvey": "Répondre au sondage"
+    },
+    "generic": {
       "createAccount": "Créer un compte",
       "start": "Commencer",
       "pollIsClosed": "Le scrutin est maintenant fermé.",
-      "seeResults": "Voir les résultats",
-      "respondToSurvey": "Répondre au sondage"
+      "seeResults": "Voir les résultats"
     },
     "contributeTitle": "Participez !",
     "contributeDetail": "Vous aussi, participez en donnant votre avis sur les vidéos YouTube que vous avez regardées. D'après vous, lesquelles devraient être les plus largement recommandées selon les différents critères identifiés par Tournesol ?",

--- a/frontend/src/pages/home/presidentielle2022/HomePresidentielle2022.tsx
+++ b/frontend/src/pages/home/presidentielle2022/HomePresidentielle2022.tsx
@@ -46,7 +46,7 @@ const HomePresidentielle2022Page = () => {
                   fontSize: '120%',
                 }}
               >
-                {t('home.presidentielle2022.createAccount')}
+                {t('home.generic.createAccount')}
               </Button>
             )}
             <Button
@@ -60,14 +60,14 @@ const HomePresidentielle2022Page = () => {
                 fontSize: '120%',
               }}
             >
-              {t('home.presidentielle2022.start')}
+              {t('home.generic.start')}
             </Button>
           </Stack>
         ) : (
           <Box width="100%">
             <Divider sx={{ my: 1 }} />
             <Typography paragraph color="#666">
-              {t('home.presidentielle2022.pollIsClosed')}
+              {t('home.generic.pollIsClosed')}
             </Typography>
             <Stack spacing={2} direction="row">
               <Button
@@ -81,7 +81,7 @@ const HomePresidentielle2022Page = () => {
                   fontSize: '120%',
                 }}
               >
-                {t('home.presidentielle2022.seeResults')}
+                {t('home.generic.seeResults')}
               </Button>
               {isLoggedIn && (
                 <Button

--- a/frontend/src/pages/home/videos/HomeVideos.tsx
+++ b/frontend/src/pages/home/videos/HomeVideos.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation, Trans } from 'react-i18next';
-import { Typography } from '@mui/material';
+
+import { Box, Button, Divider, Stack, Typography } from '@mui/material';
 
 import UsageStatsSection from 'src/features/statistics/UsageStatsSection';
+import { useCurrentPoll, useLoginState } from 'src/hooks';
 import ExtensionSection from 'src/pages/home/videos/ExtensionSection';
 import ContributeSection from 'src/pages/home/videos/ContributeSection';
 import TitleSection from 'src/pages/home/TitleSection';
@@ -11,6 +14,8 @@ import AlternatingBackgroundColorSectionList from 'src/pages/home/AlternatingBac
 
 const HomeVideosPage = () => {
   const { t } = useTranslation();
+  const { isLoggedIn } = useLoginState();
+  const { baseUrl, active } = useCurrentPoll();
 
   return (
     <AlternatingBackgroundColorSectionList>
@@ -26,19 +31,59 @@ const HomeVideosPage = () => {
           </Trans>
         </Typography>
 
-        {/* uncomment ONLY when the videos tutorial is ready
-        <Button
-          color="primary"
-          variant="contained"
-          component={Link}
-          to="/comparison?series=true"
-          sx={{
-            px: 4,
-            fontSize: '120%',
-          }}
-        >
-          {t('home.videos.start')}
-        </Button> */}
+        {active ? (
+          <Stack spacing={2} direction="row">
+            {!isLoggedIn && (
+              <Button
+                size="large"
+                color="inherit"
+                variant="outlined"
+                component={Link}
+                to={`/signup`}
+                sx={{
+                  px: 4,
+                  textAlign: 'center',
+                  fontSize: '120%',
+                }}
+              >
+                {t('home.generic.createAccount')}
+              </Button>
+            )}
+            <Button
+              size="large"
+              color="primary"
+              variant="contained"
+              component={Link}
+              to={`${baseUrl}/comparison?series=true`}
+              sx={{
+                px: 4,
+                fontSize: '120%',
+              }}
+            >
+              {t('home.generic.start')}
+            </Button>
+          </Stack>
+        ) : (
+          <Box width="100%">
+            <Divider sx={{ my: 1 }} />
+            <Typography paragraph>{t('home.generic.pollIsClosed')}</Typography>
+            <Stack spacing={2} direction="row">
+              <Button
+                size="large"
+                color="primary"
+                variant="contained"
+                component={Link}
+                to={`${baseUrl}/recommendations`}
+                sx={{
+                  px: 4,
+                  fontSize: '120%',
+                }}
+              >
+                {t('home.generic.seeResults')}
+              </Button>
+            </Stack>
+          </Box>
+        )}
       </TitleSection>
       <ExtensionSection />
       <ContributeSection />

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -251,7 +251,7 @@ export const polls: Array<SelectablePoll> = [
     tutorialLength: 4,
     tutorialAlternatives: getTutorialVideos,
     tutorialDialogs: getVideosTutorialDialogs,
-    tutorialRedirectTo: '/comparisons',
+    tutorialRedirectTo: '/comparison',
   },
 ];
 

--- a/tests/cypress/integration/frontend/home.ts
+++ b/tests/cypress/integration/frontend/home.ts
@@ -1,0 +1,59 @@
+describe('Home', () => {
+  describe('Poll - videos', () => {
+
+    describe('anonymous users', () => {
+      it('contains a link to signup', () => {
+        cy.visit('/');
+        cy.contains('Create account').should('be.visible');
+        cy.contains('Create account').click()
+        cy.location('pathname').should('equal', '/signup');
+      });
+
+      it('contains a link to the tutorial', () => {
+        cy.visit('/');
+        
+        cy.contains('Start').should('be.visible');
+        cy.contains('Create account').should('be.visible');
+  
+        cy.contains('Start').click()
+        cy.location('pathname').should('equal', '/login');
+      });
+    });
+
+    describe('authenticated users', () => {
+      before(() => {
+        cy.recreateUser("new-user-no-comp", "new-user-no-comp@domain.test", "tournesol");
+      })
+
+      it('doesnt contain a link to signup', () => {
+        cy.visit('/');
+        cy.contains('Create account').should('not.exist');
+      });
+
+      it('contains a link to the tutorial', () => {
+        cy.visit('/');
+        cy.contains('Start').click()
+  
+        cy.focused().type('user1');
+        cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+        
+        // Users having already several comparisons are considered as having
+        // already finished the tutorial, and should be redirected to the
+        // comparison page without the parameter ?series=true.
+        cy.location('pathname').should('equal', '/comparison');
+        cy.location('search').should('equal', '');
+      });
+
+      it('contains a link to the tutorial - new user', () => {
+        cy.visit('/');
+        cy.contains('Start').click()
+  
+        cy.focused().type('new-user-no-comp');
+        cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+  
+        cy.location('pathname').should('equal', '/comparison');
+        cy.location('search').should('equal', '?series=true');
+      });
+    });
+  });
+});


### PR DESCRIPTION
**related to** #1046 

---

The behaviour matches the `presidentielle2022`:
- users are always invited to contribute thanks to the button Start
- anonymous users are invited to create an account
- if the poll is closed, a message is displayed and a link to the recommendations 

I finally reverted my change concerning the redirection. I didn't want users having already a lot of comparisons, being redirected  to their own list of comparisons when they click on `Start`. The start button should allow them to start to compare quickly, not to see their previous comparisons, having to expand the menu and click on Compare (3 clicks).

Drawback of this revert: new users are abruptly redirected to an empty comparison page after having submitted the last comparison of the tutorial. This was the main motivation of my change, but I think I/we could find another solution to fix the problem.

**to-do**
- [x] do it
- [x] make the translations generic
- [x] add e2e tests  

![capture](https://user-images.githubusercontent.com/39056254/178936560-b8a977c0-6242-4e06-b6e1-0f264d5b0ed9.png)
