### PR TITLE
Update of dev-env, notably for Windows compatibility (#993)

### DIFF
--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -4,6 +4,22 @@
 * `docker-compose-plugin` (or `docker-compose`)
 * curl
 
+
+## On Windows
+
+It is recommended on Windows to install:
+* WSL2, with a Linux distribution (from a Powershell as administrator: `wsl --install`)
+* Docker Desktop (which includes `docker-compose`)
+
+For the frontend dynamic updates to work properly, the git repository should be **cloned inside the WSL2 file system**
+
+If `git diff` displays unexpected modifications (`old mode 100755 new mode 100644`), you can execute 
+`git config core.filemode false` to indicate Git to ignore the executable bit in files permissions.
+
+Beware that `./run-docker-compose.sh` in Windows may use a shortcut to the MinGW64 bash (also called Git bash).
+If so, type `bash run-docker-compose.sh` to use the WSL2 bash instead.
+
+
 ## Start the containers
 
 ```bash
@@ -30,6 +46,7 @@ Then, the application is accessible on http://localhost:3000.
 
 The created database includes metadata about ~ 5000 videos, as well as 5 sample accounts with usernames
 `user1`, `user2`, `user3`, `user4` and `user5`, and password `tournesol`.
+
 
 ## Rebuild the containers while preserving the database
 

--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -1,12 +1,10 @@
-# Create a development environment with `docker-compose`
+# Starting the development environment
 
-## Quick start
-
-### Requirements:
+## Requirements:
 * `docker-compose-plugin` (or `docker-compose`)
 * curl
 
-### Start the containers
+## Start the containers
 
 ```bash
 ./run-docker-compose.sh
@@ -33,7 +31,7 @@ Then, the application is accessible on http://localhost:3000.
 The created database includes metadata about ~ 5000 videos, as well as 5 sample accounts with usernames
 `user1`, `user2`, `user3`, `user4` and `user5`, and password `tournesol`.
 
-#### Rebuild the containers while preserving the database
+## Rebuild the containers while preserving the database
 
 By default, the database content is initialized with test data.
 To recreate the containers (e.g to update the backend dependencies) while preserving the data, use:

--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -8,16 +8,18 @@
 ## On Windows
 
 It is recommended on Windows to install:
-* WSL2, with a Linux distribution (from a Powershell as administrator: `wsl --install`)
-* Docker Desktop (which includes `docker-compose`)
+* **WSL2**, with a Linux distribution (just execute `wsl --install` in a Powershell as administrator. More info here: https://docs.microsoft.com/en-us/windows/wsl/install)
+* **Docker Desktop** (which includes `docker-compose`. The default configuration should be fine. More info here: https://docs.docker.com/desktop/windows/wsl/)
 
-For the frontend dynamic updates to work properly, the git repository should be **cloned inside the WSL2 file system**
 
-If `git diff` displays unexpected modifications (`old mode 100755 new mode 100644`), you can execute 
-`git config core.filemode false` to indicate Git to ignore the executable bit in files permissions.
+For the frontend dynamic updates to work properly, the git repository should be **cloned inside the WSL2 file system**.
 
 Beware that `./run-docker-compose.sh` in Windows may use a shortcut to the MinGW64 bash (also called Git bash).
 If so, type `bash run-docker-compose.sh` to use the WSL2 bash instead.
+
+If `run-docker-compose.sh` returns the error `rm: cannot remove 'db-data': Permission denied`, db-data can be deleted by executing `sudo rm -R db-data` in the WSL bash.
+
+If `git diff` displays unexpected modifications (`old mode 100755 new mode 100644`), you can execute `git config core.filemode false` to indicate Git to ignore the executable bit in files permissions.
 
 
 ## Start the containers

--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -21,6 +21,8 @@ If `run-docker-compose.sh` returns the error `rm: cannot remove 'db-data': Permi
 
 If `git diff` displays unexpected modifications (`old mode 100755 new mode 100644`), you can execute `git config core.filemode false` to indicate Git to ignore the executable bit in files permissions.
 
+If `compose up` fails with `=> ERROR resolve image config for docker.io/docker/dockerfile:1`, a solution is usually to delete the Docker config.json in WSL2: `bash -c 'rm ~/.docker/config.json'`
+
 
 ## Start the containers
 

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -67,23 +67,8 @@ function wait_for() {
   exit 1
 }
 
-system_info=$(uname -a)
-system_info=${system_info,,} # Lowercase
-if [[ "$system_info" =~ "wsl" ]] || 
-   [[ "$system_info" =~ "mingw" ]] || 
-   [[ "$system_info" =~ "msys" ]]; then
-  echo "Windows detected"
-  if [[ "$system_info" =~ "wsl" ]]; then
-    echo "Warning: using the WSL bash can cause issues"
-    echo "It is recommended to use the Git bash (MINGW64) instead: './run-docker-compose.sh')"
-  fi
-  # On Windows, don't change the postgres uid or gid
-  export DB_UID=0
-  export DB_GID=0
-else
-  export DB_UID=$(id -u)
-  export DB_GID=$(id -g)
-fi
+export DB_UID=$(id -u)
+export DB_GID=$(id -g)
 
 if [[ "${1:-""}" == 'restart' ]]; then
   echo "Recreating dev containers..."

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 
 DB_DIR="db-data"
 
-CURRENT_DIR="$(realpath -e "$(dirname "$0")")"
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$CURRENT_DIR"
 
 function is_db_ready() {
@@ -19,27 +19,15 @@ function is_front_ready() {
   curl -s localhost:3000 --max-time 1 -o /dev/null
 }
 
-function compose_up_with_docker_compose() {
-  DB_UID=$(id -u) \
-  DB_GID=$(id -g) \
-  docker-compose up --build --force-recreate -d "$@"
-}
-
-function compose_up_with_compose_plugin() {
-  DB_UID=$(id -u) \
-  DB_GID=$(id -g) \
-  docker compose up --build --force-recreate -d "$@"
-}
-
 function compose_up(){
   if docker compose version 2>/dev/null; then
       echo "compose_up : docker-compose-plugin found"
-      compose_up_with_compose_plugin "$@"
+      docker compose up --build --force-recreate -d "$@"
   else
     echo "compose_up : docker-compose-plugin not found, trying to find docker-compose command"
     if command -v docker-compose ; then
       echo "compose_up : docker-compose found"
-      compose_up_with_docker_compose "$@"
+      docker-compose up --build --force-recreate -d "$@"
     else
       echo "please install either docker-compose or docker-compose-plugin "
       exit 1
@@ -47,27 +35,15 @@ function compose_up(){
   fi
 }
 
-function compose_stop_with_docker_compose() {
-  DB_UID=$(id -u) \
-  DB_GID=$(id -g) \
-  docker-compose stop
-}
-
-function compose_stop_with_compose_plugin() {
-  DB_UID=$(id -u) \
-  DB_GID=$(id -g) \
-  docker compose stop
-}
-
 function compose_stop(){
   if docker compose version 2>/dev/null; then
       echo "compose_stop: docker-compose-plugin found"
-      compose_stop_with_compose_plugin
+      docker compose stop
   else
     echo "compose_stop : docker-compose-plugin not found, trying to find docker-compose command"
     if command -v docker-compose ; then
       echo "compose_stop : docker-compose found"
-      compose_stop_with_docker_compose
+      docker-compose stop
     else
       echo "please install either docker-compose or docker-compose-plugin "
       exit 1
@@ -90,6 +66,24 @@ function wait_for() {
   echo "$service_name is unreachable."
   exit 1
 }
+
+system_info=$(uname -a)
+system_info=${system_info,,} # Lowercase
+if [[ "$system_info" =~ "wsl" ]] || 
+   [[ "$system_info" =~ "mingw" ]] || 
+   [[ "$system_info" =~ "msys" ]]; then
+  echo "Windows detected"
+  if [[ "$system_info" =~ "wsl" ]]; then
+    echo "Warning: using the WSL bash can cause issues"
+    echo "It is recommended to use the Git bash (MINGW64) instead: './run-docker-compose.sh')"
+  fi
+  # On Windows, don't change the postgres uid or gid
+  export DB_UID=0
+  export DB_GID=0
+else
+  export DB_UID=$(uid -u)
+  export DB_GID=$(uid -g)
+fi
 
 if [[ "${1:-""}" == 'restart' ]]; then
   echo "Recreating dev containers..."
@@ -124,10 +118,10 @@ compose_up db
 wait_for is_db_ready "db"
 
 echo 'Importing dev-env dump'
-tar xvf "$CURRENT_DIR"/dump-for-dev-env.sql.tgz
-mv dump.sql "$CURRENT_DIR"/$DB_DIR/
+tar xvf "$CURRENT_DIR/dump-for-dev-env.sql.tgz"
+mv dump.sql "$CURRENT_DIR/$DB_DIR/"
 docker exec --env PGPASSWORD=password tournesol-dev-db bash -c "psql -1 -q -d tournesol -U tournesol < /var/lib/postgresql/data/dump.sql"
-rm "$CURRENT_DIR"/$DB_DIR/dump.sql
+rm "$CURRENT_DIR/$DB_DIR/dump.sql"
 
 compose_up
 wait_for is_api_ready "api"

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -81,8 +81,8 @@ if [[ "$system_info" =~ "wsl" ]] ||
   export DB_UID=0
   export DB_GID=0
 else
-  export DB_UID=$(uid -u)
-  export DB_GID=$(uid -g)
+  export DB_UID=$(id -u)
+  export DB_GID=$(id -g)
 fi
 
 if [[ "${1:-""}" == 'restart' ]]; then


### PR DESCRIPTION
### Modifications
1 - Not using realpath, which can give problematic results in Windows (e.g. paths that start with "C:/" instead of "/c/" in MinGW)
2 - Exporting DB_UID and DB_GID, to simplify the code => check that it doesn't have side effects on child scripts
3 - Changing the position of the "", just because it looks cleaner

It's very possible that it doesn't work on every environment, or that there still are bugs, or that it's not a clean solution.
I'll first call JST as a reviewer for his opinion, then ask someone with other OS (Mac, Windows), to see if it's an improvements and if there is no regression.
**Don't hesitate to report any remaining issue with dev-env.**

### The case of Windows
In Windows, the postgres uid and gid are fixed to 999, and can't be easily changed. So, if `$(id -u)` and `$(id -g)` were returning values different from 0 (root), or 999 (postgres), this was leading to permission issues during the container's creation. Since DB_UID  and DB_GID are now set to 0 for Windows, this should not be a problem anymore (tell me if this patch should also be applied for Mac).

So using `./run-docker-compose.sh` or `./dev-env/run-docker-compose.sh` in a Powershell or cmd should now work. At least if the shortcut to the Git bash (also called MinGW bash) `./` exists. 

However, `bash run-docker-compose.sh` or `wsl run-docker-compose.sh` should still not work. Because they will be based on WSL2, and I encountered at least 2 other issues with Docker on WSL2. It's better to stick with the Git bash than to make dirty patches to make it work on WSL2. I chose not to make a section in the README.md to explain this, it may lead to more confusion than understanding.