### PR TITLE
[front] feat: add copy to clipboard action on the reco. pages

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1,5 +1,5 @@
 {
-  "copyToClipboard": {
+  "copyUriToClipboard": {
     "copy": "Copy URI",
     "copied": "Copied!"
   },
@@ -165,6 +165,9 @@
   },
   "usernameOrEmail": "Username or Email address",
   "password": "Password",
+  "shareMenu": {
+    "copyAddress": "Copy the page address"
+  },
   "ratelater": {
     "videoIdOrURL": "Video id or URL",
     "addToMyRateLaterList": "Add to my rate later list",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1,21 +1,7 @@
 {
-  "entityAnalysisPage": {
-    "generic": {
-      "copy": "Copy URI",
-      "copied": "Copied!",
-      "compare": "Compare"
-    },
-    "candidate": {
-      "goToGlobalRanking": "Go to global ranking"
-    },
-    "chart": {
-      "criteriaScores": {
-        "title": "Scores per criterion"
-      }
-    },
-    "video": {
-      "description": "Description (from YouTube)"
-    }
+  "copyToClipboard": {
+    "copy": "Copy URI",
+    "copied": "Copied!"
   },
   "components": {
     "filtersButton": "filters"
@@ -386,6 +372,22 @@
     "title": "My comparisons",
     "listHasNbComparisons_many": "You already did <1>{{comparisonCount}}</1> comparisons."
   },
+  "entityAnalysisPage": {
+    "candidate": {
+      "goToGlobalRanking": "Go to global ranking"
+    },
+    "chart": {
+      "criteriaScores": {
+        "title": "Scores per criterion"
+      }
+    },
+    "generic": {
+      "compare": "Compare"
+    },
+    "video": {
+      "description": "Description (from YouTube)"
+    }
+  },
   "entityNotFound": {
     "404": {
       "title": "Not found",
@@ -513,61 +515,6 @@
     "backfire_risk": "Is it adapted to viewers with opposing beliefs? Does it prevent misconceptions or undesirable reactions?",
     "reliability": "Is the presented information trustworthy, robustly backed and properly nuanced?"
   },
-  "language": {
-    "af": "Afrikaans",
-    "ar": "Arabic",
-    "bg": "Bulgarian",
-    "bn": "Bengali",
-    "ca": "Catalan",
-    "cs": "Czech",
-    "cy": "Welsh",
-    "da": "Danish",
-    "de": "German",
-    "el": "Greek",
-    "en": "English",
-    "es": "Spanish",
-    "et": "Estonian",
-    "fa": "Persian",
-    "fi": "Finnish",
-    "fr": "French",
-    "gu": "Gujarati",
-    "he": "Hebrew",
-    "hi": "Hindi",
-    "hr": "Croatian",
-    "hu": "Hungarian",
-    "id": "Indonesian",
-    "it": "Italian",
-    "ja": "Japanese",
-    "kn": "Kannada",
-    "ko": "Korean",
-    "lt": "Lithuanian",
-    "lv": "Latvian",
-    "mk": "Macedonian",
-    "ml": "Malayalam",
-    "mr": "Marathi",
-    "ne": "Nepali",
-    "nl": "Dutch",
-    "no": "Norwegian",
-    "pa": "Punjabi",
-    "pl": "Polish",
-    "pt": "Portuguese",
-    "ro": "Romanian",
-    "ru": "Russian",
-    "sk": "Slovak",
-    "sl": "Slovenian",
-    "so": "Somali",
-    "sq": "Albanian",
-    "sv": "Swedish",
-    "sw": "Swahili",
-    "ta": "Tamil",
-    "te": "Telugu",
-    "th": "Thai",
-    "tl": "Tagalog",
-    "tr": "Turkish",
-    "uk": "Ukrainian",
-    "ur": "Urdu",
-    "vi": "Vietnamese"
-  },
   "poll": {
     "presidential2022": "election FR 2022",
     "videos": "videos",
@@ -651,5 +598,60 @@
         }
       }
     }
+  },
+  "language": {
+    "af": "Afrikaans",
+    "ar": "Arabic",
+    "bg": "Bulgarian",
+    "bn": "Bengali",
+    "ca": "Catalan",
+    "cs": "Czech",
+    "cy": "Welsh",
+    "da": "Danish",
+    "de": "German",
+    "el": "Greek",
+    "en": "English",
+    "es": "Spanish",
+    "et": "Estonian",
+    "fa": "Persian",
+    "fi": "Finnish",
+    "fr": "French",
+    "gu": "Gujarati",
+    "he": "Hebrew",
+    "hi": "Hindi",
+    "hr": "Croatian",
+    "hu": "Hungarian",
+    "id": "Indonesian",
+    "it": "Italian",
+    "ja": "Japanese",
+    "kn": "Kannada",
+    "ko": "Korean",
+    "lt": "Lithuanian",
+    "lv": "Latvian",
+    "mk": "Macedonian",
+    "ml": "Malayalam",
+    "mr": "Marathi",
+    "ne": "Nepali",
+    "nl": "Dutch",
+    "no": "Norwegian",
+    "pa": "Punjabi",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "ro": "Romanian",
+    "ru": "Russian",
+    "sk": "Slovak",
+    "sl": "Slovenian",
+    "so": "Somali",
+    "sq": "Albanian",
+    "sv": "Swedish",
+    "sw": "Swahili",
+    "ta": "Tamil",
+    "te": "Telugu",
+    "th": "Thai",
+    "tl": "Tagalog",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "ur": "Urdu",
+    "vi": "Vietnamese"
   }
 }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -1,5 +1,5 @@
 {
-  "copyToClipboard": {
+  "copyUriToClipboard": {
     "copy": "Copier URI",
     "copied": "Copié !"
   },
@@ -170,6 +170,9 @@
   },
   "usernameOrEmail": "Nom d'utilisateur ou E-mail",
   "password": "Mot de passe",
+  "shareMenu": {
+    "copyAddress": "Copier l'adresse de la page"
+  },
   "ratelater": {
     "videoIdOrURL": "ID de vidéo ou URL",
     "addToMyRateLaterList": "Ajouter à ma liste",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -1,21 +1,7 @@
 {
-  "entityAnalysisPage": {
-    "generic": {
-      "copy": "Copier URI",
-      "copied": "Copié !",
-      "compare": "Comparer"
-    },
-    "candidate": {
-      "goToGlobalRanking": "Voir le classement global"
-    },
-    "chart": {
-      "criteriaScores": {
-        "title": "Scores par critère"
-      }
-    },
-    "video": {
-      "description": "Description (provenant de YouTube)"
-    }
+  "copyToClipboard": {
+    "copy": "Copier URI",
+    "copied": "Copié !"
   },
   "components": {
     "filtersButton": "filtres"
@@ -392,6 +378,22 @@
     "listHasNbComparisons_other": "Vous avez déjà fait <1>{{comparisonCount}}</1> comparaisons.",
     "title": "Mes comparaisons"
   },
+  "entityAnalysisPage": {
+    "candidate": {
+      "goToGlobalRanking": "Voir le classement global"
+    },
+    "chart": {
+      "criteriaScores": {
+        "title": "Scores par critère"
+      }
+    },
+    "generic": {
+      "compare": "Comparer"
+    },
+    "video": {
+      "description": "Description (provenant de YouTube)"
+    }
+  },
   "entityNotFound": {
     "404": {
       "title": "Non trouvée",
@@ -520,61 +522,6 @@
     "backfire_risk": "Est-ce adapté aux spectateurs ayant des opinions opposées? Le risque de malentendus ou de réactions indésirables est-il faible?",
     "reliability": "Les informations présentées sont-elles dignes de confiance et correctement nuancées? Reposent-elles sur des bases solides?"
   },
-  "language": {
-    "af": "Afrikaans",
-    "ar": "Arabe",
-    "bg": "Bulgare",
-    "bn": "Bengali",
-    "ca": "Catalan",
-    "cs": "Tchèque",
-    "cy": "Gallois",
-    "da": "Danois",
-    "de": "Allemand",
-    "el": "Grec",
-    "en": "Anglais",
-    "es": "Espagnol",
-    "et": "Estonien",
-    "fa": "Perse",
-    "fi": "Finlandais",
-    "fr": "Français",
-    "gu": "Gujarati",
-    "he": "Hébreu",
-    "hi": "Hindi",
-    "hr": "Croate",
-    "hu": "Hongrois",
-    "id": "Indonésien",
-    "it": "Italien",
-    "ja": "Japonais",
-    "kn": "Kannada",
-    "ko": "Coréen",
-    "lt": "Lituanien",
-    "lv": "Letton",
-    "mk": "Macédonien",
-    "ml": "Malayalam",
-    "mr": "Marathi",
-    "ne": "Népalais",
-    "nl": "Hollandais",
-    "no": "Norvégien",
-    "pa": "Penjabi",
-    "pl": "Polonais",
-    "pt": "Portugais",
-    "ro": "Roumain",
-    "ru": "Russe",
-    "sk": "Slovaque",
-    "sl": "Slovène",
-    "so": "Somali",
-    "sq": "Albanais",
-    "sv": "Suédois",
-    "sw": "Swahili",
-    "ta": "Tamoul",
-    "te": "Télougou",
-    "th": "Thaï",
-    "tl": "Tagalog",
-    "tr": "Turc",
-    "uk": "Ukrainien",
-    "ur": "Ourdou",
-    "vi": "Vietnamien"
-  },
   "poll": {
     "presidential2022": "présidentielle FR 2022",
     "videos": "vidéos",
@@ -658,5 +605,60 @@
         }
       }
     }
+  },
+  "language": {
+    "af": "Afrikaans",
+    "ar": "Arabe",
+    "bg": "Bulgare",
+    "bn": "Bengali",
+    "ca": "Catalan",
+    "cs": "Tchèque",
+    "cy": "Gallois",
+    "da": "Danois",
+    "de": "Allemand",
+    "el": "Grec",
+    "en": "Anglais",
+    "es": "Espagnol",
+    "et": "Estonien",
+    "fa": "Perse",
+    "fi": "Finlandais",
+    "fr": "Français",
+    "gu": "Gujarati",
+    "he": "Hébreu",
+    "hi": "Hindi",
+    "hr": "Croate",
+    "hu": "Hongrois",
+    "id": "Indonésien",
+    "it": "Italien",
+    "ja": "Japonais",
+    "kn": "Kannada",
+    "ko": "Coréen",
+    "lt": "Lituanien",
+    "lv": "Letton",
+    "mk": "Macédonien",
+    "ml": "Malayalam",
+    "mr": "Marathi",
+    "ne": "Népalais",
+    "nl": "Hollandais",
+    "no": "Norvégien",
+    "pa": "Penjabi",
+    "pl": "Polonais",
+    "pt": "Portugais",
+    "ro": "Roumain",
+    "ru": "Russe",
+    "sk": "Slovaque",
+    "sl": "Slovène",
+    "so": "Somali",
+    "sq": "Albanais",
+    "sv": "Suédois",
+    "sw": "Swahili",
+    "ta": "Tamoul",
+    "te": "Télougou",
+    "th": "Thaï",
+    "tl": "Tagalog",
+    "tr": "Turc",
+    "uk": "Ukrainien",
+    "ur": "Ourdou",
+    "vi": "Vietnamien"
   }
 }

--- a/frontend/src/components/buttons/CopyToClipboardButton.tsx
+++ b/frontend/src/components/buttons/CopyToClipboardButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Button, IconButton } from '@mui/material';
+import { Button } from '@mui/material';
 import { Check, ContentCopy } from '@mui/icons-material';
 
 // in milliseconds
@@ -10,10 +10,10 @@ const DISPLAY_DELAY = 1200;
 /**
  * A button that copies the current URI to the browser clipboard when clicked.
  */
-export const CopyToClipboardButton = () => {
+const CopyToClipboardButton = () => {
   const { t } = useTranslation();
 
-  const [text, setText] = useState(t('copyToClipboard.copy'));
+  const [text, setText] = useState(t('copyUriToClipboard.copy'));
   const [feedback, setFeedback] = useState(false);
 
   const copyUriToClipboard = () => {
@@ -26,11 +26,11 @@ export const CopyToClipboardButton = () => {
     }
 
     setFeedback(true);
-    setText(t('copyToClipboard.copied'));
+    setText(t('copyUriToClipboard.copied'));
 
     setTimeout(() => {
       setFeedback(false);
-      setText(t('copyToClipboard.copy'));
+      setText(t('copyUriToClipboard.copy'));
     }, DISPLAY_DELAY);
   };
 
@@ -43,36 +43,6 @@ export const CopyToClipboardButton = () => {
     >
       {text}
     </Button>
-  );
-};
-
-/**
- * An icon button that copies the current URI to the browser clipboard when
- * clicked.
- */
-export const CopyToClipboardIconButton = () => {
-  const [feedback, setFeedback] = useState(false);
-
-  const copyUriToClipboard = () => {
-    navigator.clipboard.writeText(window.location.toString());
-
-    // Do not trigger any additionnal rendering when the user clicks
-    // repeatedly on the button.
-    if (feedback) {
-      return;
-    }
-
-    setFeedback(true);
-
-    setTimeout(() => {
-      setFeedback(false);
-    }, DISPLAY_DELAY);
-  };
-
-  return (
-    <IconButton onClick={copyUriToClipboard}>
-      {feedback ? <Check /> : <ContentCopy />}
-    </IconButton>
   );
 };
 

--- a/frontend/src/components/buttons/CopyToClipboardButton.tsx
+++ b/frontend/src/components/buttons/CopyToClipboardButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Button } from '@mui/material';
+import { Button, IconButton } from '@mui/material';
 import { Check, ContentCopy } from '@mui/icons-material';
 
 // in milliseconds
@@ -10,10 +10,10 @@ const DISPLAY_DELAY = 1200;
 /**
  * A button that copies the current URI to the browser clipboard when clicked.
  */
-const CopyToClipboardButton = () => {
+export const CopyToClipboardButton = () => {
   const { t } = useTranslation();
 
-  const [text, setText] = useState(t('entityAnalysisPage.generic.copy'));
+  const [text, setText] = useState(t('copyToClipboard.copy'));
   const [feedback, setFeedback] = useState(false);
 
   const copyUriToClipboard = () => {
@@ -26,11 +26,11 @@ const CopyToClipboardButton = () => {
     }
 
     setFeedback(true);
-    setText(t('entityAnalysisPage.generic.copied'));
+    setText(t('copyToClipboard.copied'));
 
     setTimeout(() => {
       setFeedback(false);
-      setText(t('entityAnalysisPage.generic.copy'));
+      setText(t('copyToClipboard.copy'));
     }, DISPLAY_DELAY);
   };
 
@@ -43,6 +43,36 @@ const CopyToClipboardButton = () => {
     >
       {text}
     </Button>
+  );
+};
+
+/**
+ * An icon button that copies the current URI to the browser clipboard when
+ * clicked.
+ */
+export const CopyToClipboardIconButton = () => {
+  const [feedback, setFeedback] = useState(false);
+
+  const copyUriToClipboard = () => {
+    navigator.clipboard.writeText(window.location.toString());
+
+    // Do not trigger any additionnal rendering when the user clicks
+    // repeatedly on the button.
+    if (feedback) {
+      return;
+    }
+
+    setFeedback(true);
+
+    setTimeout(() => {
+      setFeedback(false);
+    }, DISPLAY_DELAY);
+  };
+
+  return (
+    <IconButton onClick={copyUriToClipboard}>
+      {feedback ? <Check /> : <ContentCopy />}
+    </IconButton>
   );
 };
 

--- a/frontend/src/features/menus/ShareMenu.tsx
+++ b/frontend/src/features/menus/ShareMenu.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuList,
+  MenuItem,
+} from '@mui/material';
+import { ContentCopy } from '@mui/icons-material';
+
+interface ContextualMenuProps {
+  menuAnchor: null | HTMLElement;
+  open: boolean;
+  onClose: (event: React.MouseEvent<HTMLElement>) => void;
+}
+
+const ShareMenu = ({ menuAnchor, open, onClose }: ContextualMenuProps) => {
+  const { t } = useTranslation();
+
+  const copyUriToClipboard = (event: React.MouseEvent<HTMLElement>) => {
+    navigator.clipboard.writeText(window.location.toString());
+    onClose(event);
+  };
+
+  return (
+    <Menu
+      id="contextual-menu"
+      open={open}
+      anchorEl={menuAnchor}
+      onClose={onClose}
+      MenuListProps={{
+        'aria-labelledby': 'basic-button',
+      }}
+    >
+      <MenuList dense sx={{ py: 0 }}>
+        <MenuItem onClick={copyUriToClipboard}>
+          <ListItemIcon>
+            <ContentCopy fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>{t('shareMenu.copyAddress')}</ListItemText>
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  );
+};
+
+export default ShareMenu;

--- a/frontend/src/features/menus/ShareMenu.tsx
+++ b/frontend/src/features/menus/ShareMenu.tsx
@@ -15,6 +15,9 @@ interface ContextualMenuProps {
   onClose: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
+/**
+ * A `Menu` displaying several sharing options.
+ */
 const ShareMenu = ({ menuAnchor, open, onClose }: ContextualMenuProps) => {
   const { t } = useTranslation();
 

--- a/frontend/src/features/menus/ShareMenuButton.tsx
+++ b/frontend/src/features/menus/ShareMenuButton.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+
+import { Share } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+
+import ShareMenu from 'src/features/menus/ShareMenu';
+
+/**
+ * An `IconButton` displaying the `ShareMenu` when clicked.
+ */
+const ShareMenuButton = () => {
+  const [menuAnchor, setMenuAnchor] = React.useState<null | HTMLElement>(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const handleShareMenuClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    // Define the anchor the first time the user click on the button.
+    if (menuAnchor === null) {
+      setMenuAnchor(event.currentTarget);
+    }
+    setIsMenuOpen(true);
+  };
+
+  const handleMenuClose = () => {
+    setIsMenuOpen(false);
+  };
+
+  return (
+    <>
+      <IconButton aria-label="Share button" onClick={handleShareMenuClick}>
+        <Share />
+      </IconButton>
+      <ShareMenu
+        menuAnchor={menuAnchor}
+        open={isMenuOpen}
+        onClose={handleMenuClose}
+      />
+    </>
+  );
+};
+
+export default ShareMenuButton;

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useLocation, useHistory, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-import { Box } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { Person } from '@mui/icons-material';
 
 import { ContentBox, ContentHeader, LoaderWrapper } from 'src/components';
+import { CopyToClipboardIconButton } from 'src/components/buttons/CopyToClipboardButton';
 import Pagination from 'src/components/Pagination';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import EntityList from 'src/features/entities/EntityList';
@@ -161,7 +162,18 @@ function RecommendationsPage() {
       )}
       <ContentBox noMinPaddingX maxWidth="lg">
         <Box px={{ xs: 2, sm: 0 }}>
-          <SearchFilter />
+          <Grid container>
+            {/* Filters section. */}
+            <Grid item xs={12} sm={12} md={11}>
+              <SearchFilter />
+            </Grid>
+            {/* Contextual page menu. */}
+            <Grid item xs={12} sm={12} md={1}>
+              <Box display="flex" flexDirection="row" justifyContent="flex-end">
+                <CopyToClipboardIconButton />
+              </Box>
+            </Grid>
+          </Grid>
         </Box>
         <LoaderWrapper isLoading={isLoading}>
           <EntityList

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -2,15 +2,15 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useLocation, useHistory, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Grid } from '@mui/material';
-import { Person } from '@mui/icons-material';
+import { Box, Grid, IconButton } from '@mui/material';
+import { Person, Share } from '@mui/icons-material';
 
 import { ContentBox, ContentHeader, LoaderWrapper } from 'src/components';
-import { CopyToClipboardIconButton } from 'src/components/buttons/CopyToClipboardButton';
 import Pagination from 'src/components/Pagination';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import EntityList from 'src/features/entities/EntityList';
 import SearchFilter from 'src/features/recommendation/SearchFilter';
+import ShareMenu from 'src/features/menus/ShareMenu';
 import type {
   PaginatedContributorRecommendationsList,
   PaginatedRecommendationList,
@@ -38,6 +38,11 @@ function RecommendationsPage() {
   const location = useLocation();
   const { baseUrl, name: pollName, criterias, options } = useCurrentPoll();
   const [isLoading, setIsLoading] = useState(true);
+
+  // ShareMenu states.
+  const [shareMenuAnchor, setShareMenuAnchor] =
+    React.useState<null | HTMLElement>(null);
+  const [isShareMenuOpen, setIsShareMenuOpen] = useState(false);
 
   const allowPublicPersonalRecommendations =
     options?.allowPublicPersonalRecommendations ?? false;
@@ -149,6 +154,19 @@ function RecommendationsPage() {
     username,
   ]);
 
+  const handleShareMenuClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    // Dynamically define the anchor the first time the user click on the
+    // button.
+    if (shareMenuAnchor === null) {
+      setShareMenuAnchor(event.currentTarget);
+    }
+    setIsShareMenuOpen(true);
+  };
+
+  const handleMenuClose = () => {
+    setIsShareMenuOpen(false);
+  };
+
   return (
     <>
       {displayPersonalRecommendations ? (
@@ -170,7 +188,17 @@ function RecommendationsPage() {
             {/* Contextual page menu. */}
             <Grid item xs={12} sm={12} md={1}>
               <Box display="flex" flexDirection="row" justifyContent="flex-end">
-                <CopyToClipboardIconButton />
+                <IconButton
+                  aria-label="Share button"
+                  onClick={handleShareMenuClick}
+                >
+                  <Share />
+                </IconButton>
+                <ShareMenu
+                  menuAnchor={shareMenuAnchor}
+                  open={isShareMenuOpen}
+                  onClose={handleMenuClose}
+                />
               </Box>
             </Grid>
           </Grid>

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -2,15 +2,15 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useLocation, useHistory, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Grid, IconButton } from '@mui/material';
-import { Person, Share } from '@mui/icons-material';
+import { Box, Grid } from '@mui/material';
+import { Person } from '@mui/icons-material';
 
 import { ContentBox, ContentHeader, LoaderWrapper } from 'src/components';
 import Pagination from 'src/components/Pagination';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import EntityList from 'src/features/entities/EntityList';
 import SearchFilter from 'src/features/recommendation/SearchFilter';
-import ShareMenu from 'src/features/menus/ShareMenu';
+import ShareMenuButton from 'src/features/menus/ShareMenuButton';
 import type {
   PaginatedContributorRecommendationsList,
   PaginatedRecommendationList,
@@ -38,11 +38,6 @@ function RecommendationsPage() {
   const location = useLocation();
   const { baseUrl, name: pollName, criterias, options } = useCurrentPoll();
   const [isLoading, setIsLoading] = useState(true);
-
-  // ShareMenu states.
-  const [shareMenuAnchor, setShareMenuAnchor] =
-    React.useState<null | HTMLElement>(null);
-  const [isShareMenuOpen, setIsShareMenuOpen] = useState(false);
 
   const allowPublicPersonalRecommendations =
     options?.allowPublicPersonalRecommendations ?? false;
@@ -154,19 +149,6 @@ function RecommendationsPage() {
     username,
   ]);
 
-  const handleShareMenuClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    // Dynamically define the anchor the first time the user click on the
-    // button.
-    if (shareMenuAnchor === null) {
-      setShareMenuAnchor(event.currentTarget);
-    }
-    setIsShareMenuOpen(true);
-  };
-
-  const handleMenuClose = () => {
-    setIsShareMenuOpen(false);
-  };
-
   return (
     <>
       {displayPersonalRecommendations ? (
@@ -188,17 +170,7 @@ function RecommendationsPage() {
             {/* Contextual page menu. */}
             <Grid item xs={12} sm={12} md={1}>
               <Box display="flex" flexDirection="row" justifyContent="flex-end">
-                <IconButton
-                  aria-label="Share button"
-                  onClick={handleShareMenuClick}
-                >
-                  <Share />
-                </IconButton>
-                <ShareMenu
-                  menuAnchor={shareMenuAnchor}
-                  open={isShareMenuOpen}
-                  onClose={handleMenuClose}
-                />
+                <ShareMenuButton />
               </Box>
             </Grid>
           </Grid>

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -5,11 +5,11 @@ import { useParams, Link as RouterLink } from 'react-router-dom';
 import { Box, Button, Collapse, Grid, Paper, Typography } from '@mui/material';
 import { Compare } from '@mui/icons-material';
 
-import CopyToClipboardButton from 'src/components/buttons/CopyToClipboardButton';
 import CollapseButton from 'src/components/CollapseButton';
 import CriteriaBarChart from 'src/components/CriteriaBarChart';
 import { VideoPlayer } from 'src/components/entity/EntityImagery';
 import CriteriaScoresDistribution from 'src/features/charts/CriteriaScoresDistribution';
+import ShareMenuButton from 'src/features/menus/ShareMenuButton';
 import { useVideoMetadata } from 'src/features/videos/VideoApi';
 import VideoCard from 'src/features/videos/VideoCard';
 import { useCurrentPoll, useLoginState } from 'src/hooks';
@@ -50,8 +50,8 @@ export const VideoAnalysis = ({
     >
       <Box flex={2} minWidth={{ xs: '100%', md: null }}>
         {/* Top level section, containing links and maybe more in the future. */}
-        <Box mb={2} display="flex" justifyContent="flex-end" gap="8px">
-          <CopyToClipboardButton />
+        <Box mb={2} display="flex" justifyContent="flex-end" gap={2}>
+          <ShareMenuButton />
           <Button
             color="secondary"
             variant="contained"


### PR DESCRIPTION
**related to** #1056 

---

This PR adds a `ShareMenuButton` that can be used everywhere in the application.

This new component uses and intern `ShareMenu` that can display several sharing options. For now, only `Copy the page address` is available.

The share menu is displayed:
- on the collective recommendations page
- on the public personal recommendations page
- and on the video analysis page

### preview

![capture2](https://user-images.githubusercontent.com/39056254/180002000-54053f14-9c90-44cc-ba95-6806ce21316f.png)

![capture](https://user-images.githubusercontent.com/39056254/180002083-a365b65f-4516-4497-a67b-e2d44be64ead.png)


