### PR TITLE
[front] fix: misleading "Active users" metric name

### DIFF
--- a/backend/tournesol/views/stats.py
+++ b/backend/tournesol/views/stats.py
@@ -10,9 +10,8 @@ from rest_framework.response import Response
 
 from core.models import User
 from core.utils.time import time_ago
+from tournesol.models import Comparison, Entity, Poll
 from tournesol.serializers.stats import StatisticsSerializer
-
-from ..models import Comparison, Entity, Poll
 
 
 class ActiveUsersStatistics:

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -284,7 +284,7 @@
   "stats": {
     "ratedVideos": "Rated videos",
     "ratedCandidates": "Rated candidates",
-    "activeUsers": "Active users",
+    "activatedAccounts": "Activated accounts",
     "comparisons": "Comparisons"
   },
   "notifications": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -290,7 +290,7 @@
   "stats": {
     "ratedVideos": "Vidéos notées",
     "ratedCandidates": "Candidats notés",
-    "activeUsers": "Utilisateurs actifs",
+    "activatedAccounts": "Comptes activés",
     "comparisons": "Comparaisons"
   },
   "notifications": {

--- a/frontend/src/features/statistics/UsageStatsSection.tsx
+++ b/frontend/src/features/statistics/UsageStatsSection.tsx
@@ -97,7 +97,7 @@ const StatsSection = () => {
       <Grid container sx={{ maxWidth: 1000 }}>
         <Grid item xs={12} sm={4}>
           <Metrics
-            text={t('stats.activeUsers')}
+            text={t('stats.activatedAccounts')}
             count={data.userCount}
             lastMonthCount={data.lastMonthUserCount}
           />


### PR DESCRIPTION
The front end used to display the metric active users.

Active users could be:
- users that have done comparisons on a regular basis
- users that still do comparisons on a regular basis
- users with a least few comparisons
- etc.

It was a bit misleading and I remember Lê asking for the meaning of this metric during a live on Discord or YouTube.

I think **activated accounts** is more appropriate. 