### PR TITLE
[twitterbot] create systemd service and define schedule for automated tweets

### DIFF
--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -174,6 +174,10 @@ all:
           tournesol_api_cleartokens_schedule: "*-*-* 02:00:00" # daily at 2am
           tournesol_api_deleteinactiveusers_schedule: "*-*-* 02:20:00" # daily at 2:20am
 
+          # twitterbot: the service script is responsible for running the bot in
+          # different languages depending on the day of the week.
+          tournesol_twitterbot_schedule: "*-*-* 16:03:00" # daily.
+
           ml_train_schedule: "*-*-* 0,6,12,18:20:00" # every 6 hours
 
           mediawiki_backup_schedule: "*-*-* 0,6,12,18:10:00" # every 6 hours

--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -176,7 +176,7 @@ all:
 
           # twitterbot: the service script is responsible for running the bot in
           # different languages depending on the day of the week.
-          tournesol_twitterbot_schedule: "*-*-* 16:03:00" # daily.
+          tournesol_twitterbot_schedule: "*-*-* 18:03:00 Europe/Zurich" # daily.
 
           ml_train_schedule: "*-*-* 0,6,12,18:20:00" # every 6 hours
 

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -238,3 +238,28 @@
     state: started
     enabled: yes
     daemon_reload: yes
+
+# scheduled task: Twitterbot
+
+- name: Copy twitterbot failure alert script
+  template:
+    dest: /usr/local/bin/discord-twitterbot-fail-alert.sh
+    src: discord-twitterbot-fail-alert.sh.j2
+    mode: a=rx
+
+- name: Copy twitterbot service
+  template:
+    dest: /etc/systemd/system/tournesol-twitterbot.service
+    src: tournesol-twitterbot.service.j2
+
+- name: Copy Tournesol API delete-inactive-users timer
+  template:
+    dest: /etc/systemd/system/tournesol-twitterbot.timer
+    src: tournesol-twitterbot.timer.j2
+
+- name: Enable and start Tournesol twitterbot timer
+  systemd:
+    name: tournesol-twitterbot.timer
+    state: "{{ 'started' if tournesol_twitterbot_schedule is defined else 'stopped' }}"
+    enabled: "{{ 'yes' if tournesol_twitterbot_schedule is defined else 'no' }}"
+    daemon_reload: yes

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -252,7 +252,7 @@
     dest: /etc/systemd/system/tournesol-twitterbot.service
     src: tournesol-twitterbot.service.j2
 
-- name: Copy Tournesol API delete-inactive-users timer
+- name: Copy twitterbot timer
   template:
     dest: /etc/systemd/system/tournesol-twitterbot.timer
     src: tournesol-twitterbot.timer.j2

--- a/infra/ansible/roles/django/templates/discord-twitterbot-fail-alert.sh.j2
+++ b/infra/ansible/roles/django/templates/discord-twitterbot-fail-alert.sh.j2
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+{% if discord_alerting_webhook is defined and discord_alerting_webhook != "" %}
+wget -qO /dev/null \
+--post-data='{"content": "run_twitterbot job failed for {{domain_name}}"}' \
+--header='Content-Type:application/json' \
+'{{discord_alerting_webhook}}?wait=true'
+echo "alert sent"
+{% endif %}

--- a/infra/ansible/roles/django/templates/tournesol-twitterbot.service.j2
+++ b/infra/ansible/roles/django/templates/tournesol-twitterbot.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=Tournesol twitterbot
+
+[Service]
+Type=oneshot
+User=gunicorn
+Group=gunicorn
+WorkingDirectory=/srv/tournesol-backend
+Environment="SETTINGS_FILE=/etc/tournesol/settings.yaml"
+ExecStart=/usr/bin/bash -c "DAY_OF_WEEK=$(date +%u) \
+    source venv/bin/activate \
+    && case $DAY_OF_WEEK in \
+        1|2|4|5) \
+            python manage.py run_twitterbot -y --bot-name '@TournesolBotFR';; \
+        3) \
+            python manage.py run_twitterbot -y --bot-name '@TournesolBot';; \
+        *) ;;
+    esac"
+ExecStopPost=/usr/bin/bash -c "if [ "$$EXIT_STATUS" != 0 ]; then /usr/local/bin/discord-twitterbot-fail-alert.sh; fi"

--- a/infra/ansible/roles/django/templates/tournesol-twitterbot.service.j2
+++ b/infra/ansible/roles/django/templates/tournesol-twitterbot.service.j2
@@ -7,13 +7,14 @@ User=gunicorn
 Group=gunicorn
 WorkingDirectory=/srv/tournesol-backend
 Environment="SETTINGS_FILE=/etc/tournesol/settings.yaml"
-ExecStart=/usr/bin/bash -c "DAY_OF_WEEK=$(date +%u) \
-    source venv/bin/activate \
-    && case $DAY_OF_WEEK in \
+ExecStart=/usr/bin/bash -c "source venv/bin/activate && \
+    # Run different bots depending on the day of the week.
+    # '%' needs to be escaped into '%%', since '%u' is replaced with the username by Systemd
+    case $(date +%%u) in \
         1|2|4|5) \
             python manage.py run_twitterbot -y --bot-name '@TournesolBotFR';; \
         3) \
             python manage.py run_twitterbot -y --bot-name '@TournesolBot';; \
-        *) ;;
+        *) ;; \
     esac"
 ExecStopPost=/usr/bin/bash -c "if [ "$$EXIT_STATUS" != 0 ]; then /usr/local/bin/discord-twitterbot-fail-alert.sh; fi"

--- a/infra/ansible/roles/django/templates/tournesol-twitterbot.timer.j2
+++ b/infra/ansible/roles/django/templates/tournesol-twitterbot.timer.j2
@@ -2,7 +2,7 @@
 Description=Tournesol twitterbot schedule
 
 [Timer]
-OnCalendar={{tournesol_twitterbot_schedule | default('') }}
+OnCalendar={{tournesol_twitterbot_schedule | default('@0') }}
 Persistent=yes
 
 [Install]

--- a/infra/ansible/roles/django/templates/tournesol-twitterbot.timer.j2
+++ b/infra/ansible/roles/django/templates/tournesol-twitterbot.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Tournesol twitterbot schedule
+
+[Timer]
+OnCalendar={{tournesol_twitterbot_schedule | default('') }}
+Persistent=yes
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The new "oneshot service" will run daily at 18:03 (Swiss time).  

On Monday, Tuesday, Thursday, Friday a tweet will be sent in French.
On Wednesday, a tweet will be sent in English. 

This new schedule is defined for production only. The timer is inactive on other environments (where twitter credentials are unavailable anyway).