### PR TITLE
2 backend tests were failing when YOUTUBE_API_KEY was set (#1044)

### DIFF
--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -311,6 +311,7 @@ class ComparisonApiTestCase(TestCase):
         )
         self.assertEqual(comparison_criteria_scores[0].weight, 1)
 
+    @patch('tournesol.utils.api_youtube.youtube', None)
     def test_authenticated_can_create_with_non_existing_entity(self):
         """
         An authenticated user can create a comparison involving entities that

--- a/backend/tournesol/tests/test_api_rate_later.py
+++ b/backend/tournesol/tests/test_api_rate_later.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY
+from unittest.mock import patch, ANY
 
 from django.db import transaction
 from django.test import TestCase
@@ -638,6 +638,7 @@ class LegacyRateLaterApi(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
 
+    @patch('tournesol.utils.api_youtube.youtube', None)
     def test_authenticated_can_create_with_new_video_id(self):
         """
         An authenticated user can add in its own rate later list a video

--- a/backend/tournesol/tests/test_api_rate_later.py
+++ b/backend/tournesol/tests/test_api_rate_later.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, ANY
+from unittest.mock import ANY, patch
 
 from django.db import transaction
 from django.test import TestCase
@@ -153,6 +153,7 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    @patch('tournesol.utils.api_youtube.youtube', None)
     def test_auth_201_create(self) -> None:
         """
         An authenticated user can add an entity to its rate-later list from a
@@ -177,6 +178,7 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
             RateLater.objects.filter(poll=other_poll, user=self.user).count(), 0
         )
 
+    @patch('tournesol.utils.api_youtube.youtube', None)
     def test_auth_409_create_two_times(self) -> None:
         """
         An authenticated user cannot add two times the same entity to a


### PR DESCRIPTION
Overriding YOUTUBE_API_KEY was not sufficient, because it does not cause the "youtube" variable in api_youtube.py to be recreated.