### PR TITLE
[back] chore: `Pylint` upgrade and 1st wave of warnings corrections

### DIFF
--- a/backend/.pylintrc
+++ b/backend/.pylintrc
@@ -1,4 +1,22 @@
-[MASTER]
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
@@ -11,24 +29,46 @@ extension-pkg-allow-list=
 # for backward compatibility.)
 extension-pkg-whitelist=
 
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
 # Specify a score threshold to be exceeded before program exits with error.
 fail-under=8.5
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
 
 # Files or directories to be skipped. They should be base names, not paths.
 ignore=CVS,
        migrations,
-       tests
+       tests,
+       serializers
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
 
 # Files or directories matching the regex patterns are skipped. The regex
-# matches against base names, not paths.
+# matches against base names, not paths. The default value ignores Emacs file
+# locks
 ignore-patterns=
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 #init-hook=
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
-# number of processors available to use.
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
 jobs=1
 
 # Control the amount of potential inferred values when inferring a single
@@ -43,6 +83,13 @@ load-plugins=pylint_django
 # Pickle collected data for later comparisons.
 persistent=yes
 
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.9
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
 suggestion-mode=yes
@@ -51,129 +98,27 @@ suggestion-mode=yes
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
-
-[MESSAGES CONTROL]
-
-# Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
-confidence=
-
-# Disable the message, report, category or checker with the given id(s). You
-# can either give multiple identifiers separated by comma (,) or put this
-# option multiple times (only on the command line, not in the configuration
-# file where it should appear only once). You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
-# you want to run only the similarities checker, you can use "--disable=all
-# --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use "--disable=all --enable=classes
-# --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
-        bad-inline-option,
-        locally-disabled,
-        file-ignored,
-        suppressed-message,
-        useless-suppression,
-        deprecated-pragma,
-        use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape,
-        django-not-configured,
-        fixme,
-        missing-function-docstring,
-
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time (only on the command line, not in the configuration file where
-# it should appear only once). See also the "--disable" option for examples.
-enable=c-extension-no-member
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
 
 
 [REPORTS]
 
 # Python expression which should return a score less than or equal to 10. You
-# have access to the variables 'error', 'warning', 'refactor', and 'convention'
-# which contain the number of messages in each category, as well as 'statement'
-# which is the total number of statements analyzed. This score is used by the
-# global evaluation report (RP0004).
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details.
-#msg-template=
+msg-template=
 
 # Set the output format. Available formats are text, parseable, colorized, json
 # and msvs (visual studio). You can also give a reporter class, e.g.
 # mypackage.mymodule.MyReporterClass.
-output-format=text
+#output-format=
 
 # Tells whether to display a full report or only the messages.
 reports=no
@@ -182,27 +127,103 @@ reports=no
 score=yes
 
 
-[REFACTORING]
+[MESSAGES CONTROL]
 
-# Maximum number of nested blocks for function / method body
-max-nested-blocks=5
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
 
-# Complete name of functions that never returns. When checking for
-# inconsistent-return-statements if a never returning function is called then
-# it will be considered as an explicit return statement and no message will be
-# printed.
-never-returning-functions=sys.exit,argparse.parse_error
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        django-not-configured,
+        fixme,
+        missing-function-docstring,
+        missing-module-docstring,
+        too-many-ancestors,
+        too-few-public-methods,
+        use-maxsplit-arg,
+        cyclic-import
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
 
 
-[LOGGING]
+[EXCEPTIONS]
 
-# The type of string formatting that logging methods do. `old` means using %
-# formatting, `new` is for `{}` formatting.
-logging-format-style=old
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=BaseException,
+                       Exception
 
-# Logging modules to check that the string format arguments are in logging
-# function parameter format.
-logging-modules=logging
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
 
 
 [SPELLING]
@@ -215,7 +236,7 @@ max-spelling-suggestions=4
 spelling-dict=
 
 # List of comma separated words that should be considered directives if they
-# appear and the beginning of a comment and should not be checked.
+# appear at the beginning of a comment and should not be checked.
 spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
 
 # List of comma separated words that should not be checked.
@@ -229,70 +250,228 @@ spelling-private-dict-file=
 spelling-store-unknown-words=no
 
 
-[MISCELLANEOUS]
+[BASIC]
 
-# List of note tags to take in consideration, separated by a comma.
-notes=FIXME,
-      XXX,
-      TODO
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
 
-# Regular expression of note tags to take in consideration.
-#notes-rgx=
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
 
 
-[TYPECHECK]
+[DESIGN]
 
-# List of decorators that produce context managers, such as
-# contextlib.contextmanager. Add to this list to register other decorators that
-# produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
 
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members=
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
 
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
+# Maximum number of arguments for function / method.
+max-args=5
 
-# Tells whether to warn about missing members when the owner of the attribute
-# is inferred to be None.
-ignore-none=yes
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
 
-# This flag controls whether pylint should warn about no-member and similar
-# checks whenever an opaque object is returned when inferring. The inference
-# can return multiple potential results while evaluating a Python object, but
-# some branches might not be evaluated, which results in partial inference. In
-# that case, it might be useful to still emit no-member and other checks for
-# the rest of the inferred objects.
-ignore-on-opaque-inference=yes
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
 
-# List of class names for which member attributes should not be checked (useful
-# for classes with dynamically set attributes). This supports the use of
-# qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+# Maximum number of branch for function / method body.
+max-branches=12
 
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis). It
-# supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+# Maximum number of locals for function / method body.
+max-locals=15
 
-# Show a hint with possible names when a member name was not found. The aspect
-# of finding the hint is based on edit distance.
-missing-member-hint=yes
+# Maximum number of parents for a class (see R0901).
+max-parents=7
 
-# The minimum edit distance a name should have in order to be considered a
-# similar match for a missing member name.
-missing-member-hint-distance=1
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
 
-# The total number of similar names that should be taken in consideration when
-# showing a hint for a missing member.
-missing-member-max-choices=1
+# Maximum number of return / yield for function / method body.
+max-returns=6
 
-# List of decorators that change the signature of a decorated function.
-signature-mutators=
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
 
 
 [VARIABLES]
@@ -328,6 +507,72 @@ init-import=no
 redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
 
 
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
 [FORMAT]
 
 # Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
@@ -360,257 +605,23 @@ single-line-if-stmt=no
 
 [SIMILARITIES]
 
-# Ignore comments when computing similarities.
+# Comments are removed from the similarity computation
 ignore-comments=yes
 
-# Ignore docstrings when computing similarities.
+# Docstrings are removed from the similarity computation
 ignore-docstrings=yes
 
-# Ignore imports when computing similarities.
+# Imports are removed from the similarity computation
 ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4
 
 
-[BASIC]
+[DJANGO FOREIGN KEYS REFERENCED BY STRINGS]
 
-# Naming style matching correct argument names.
-argument-naming-style=snake_case
-
-# Regular expression matching correct argument names. Overrides argument-
-# naming-style.
-#argument-rgx=
-
-# Naming style matching correct attribute names.
-attr-naming-style=snake_case
-
-# Regular expression matching correct attribute names. Overrides attr-naming-
-# style.
-#attr-rgx=
-
-# Bad variable names which should always be refused, separated by a comma.
-bad-names=foo,
-          bar,
-          baz,
-          toto,
-          tutu,
-          tata
-
-# Bad variable names regexes, separated by a comma. If names match any regex,
-# they will always be refused
-bad-names-rgxs=
-
-# Naming style matching correct class attribute names.
-class-attribute-naming-style=any
-
-# Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style.
-#class-attribute-rgx=
-
-# Naming style matching correct class constant names.
-class-const-naming-style=UPPER_CASE
-
-# Regular expression matching correct class constant names. Overrides class-
-# const-naming-style.
-#class-const-rgx=
-
-# Naming style matching correct class names.
-class-naming-style=PascalCase
-
-# Regular expression matching correct class names. Overrides class-naming-
-# style.
-#class-rgx=
-
-# Naming style matching correct constant names.
-const-naming-style=UPPER_CASE
-
-# Regular expression matching correct constant names. Overrides const-naming-
-# style.
-#const-rgx=
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
-
-# Naming style matching correct function names.
-function-naming-style=snake_case
-
-# Regular expression matching correct function names. Overrides function-
-# naming-style.
-#function-rgx=
-
-# Good variable names which should always be accepted, separated by a comma.
-good-names=i,
-           j,
-           k,
-           ex,
-           Run,
-           _
-
-# Good variable names regexes, separated by a comma. If names match any regex,
-# they will always be accepted
-good-names-rgxs=
-
-# Include a hint for the correct naming format with invalid-name.
-include-naming-hint=no
-
-# Naming style matching correct inline iteration names.
-inlinevar-naming-style=any
-
-# Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style.
-#inlinevar-rgx=
-
-# Naming style matching correct method names.
-method-naming-style=snake_case
-
-# Regular expression matching correct method names. Overrides method-naming-
-# style.
-#method-rgx=
-
-# Naming style matching correct module names.
-module-naming-style=snake_case
-
-# Regular expression matching correct module names. Overrides module-naming-
-# style.
-#module-rgx=
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group=
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=^_
-
-# List of decorators that produce properties, such as abc.abstractproperty. Add
-# to this list to register other decorators that produce valid properties.
-# These decorators are taken in consideration only for invalid-name.
-property-classes=abc.abstractproperty
-
-# Naming style matching correct variable names.
-variable-naming-style=snake_case
-
-# Regular expression matching correct variable names. Overrides variable-
-# naming-style.
-#variable-rgx=
-
-
-[STRING]
-
-# This flag controls whether inconsistent-quotes generates a warning when the
-# character used as a quote delimiter is used inconsistently within a module.
-check-quote-consistency=no
-
-# This flag controls whether the implicit-str-concat should generate a warning
-# on implicit string concatenation in sequences defined over several lines.
-check-str-concat-over-line-jumps=no
-
-
-[IMPORTS]
-
-# List of modules that can be imported at any level, not just the top level
-# one.
-allow-any-import-level=
-
-# Allow wildcard imports from modules that define __all__.
-allow-wildcard-with-all=no
-
-# Analyse import fallback blocks. This can be used to support both Python 2 and
-# 3 compatible code, which means that the block might have code that exists
-# only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
-
-# Deprecated modules which should not be used, separated by a comma.
-deprecated-modules=optparse,tkinter.tix
-
-# Output a graph (.gv or any supported image format) of external dependencies
-# to the given file (report RP0402 must not be disabled).
-ext-import-graph=
-
-# Output a graph (.gv or any supported image format) of all (i.e. internal and
-# external) dependencies to the given file (report RP0402 must not be
-# disabled).
-import-graph=
-
-# Output a graph (.gv or any supported image format) of internal dependencies
-# to the given file (report RP0402 must not be disabled).
-int-import-graph=
-
-# Force import order to recognize a module as part of the standard
-# compatibility libraries.
-known-standard-library=
-
-# Force import order to recognize a module as part of a third party library.
-known-third-party=enchant
-
-# Couples of modules and preferred modules, separated by a comma.
-preferred-modules=
-
-
-[CLASSES]
-
-# Warn about protected attribute access inside special methods
-check-protected-access-in-special-methods=no
-
-# List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,
-                      __new__,
-                      setUp,
-                      __post_init__
-
-# List of member names, which should be excluded from the protected access
-# warning.
-exclude-protected=_asdict,
-                  _fields,
-                  _replace,
-                  _source,
-                  _make
-
-# List of valid names for the first argument in a class method.
-valid-classmethod-first-arg=cls
-
-# List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=cls
-
-
-[DESIGN]
-
-# Maximum number of arguments for function / method.
-max-args=5
-
-# Maximum number of attributes for a class (see R0902).
-max-attributes=7
-
-# Maximum number of boolean expressions in an if statement (see R0916).
-max-bool-expr=5
-
-# Maximum number of branch for function / method body.
-max-branches=12
-
-# Maximum number of locals for function / method body.
-max-locals=15
-
-# Maximum number of parents for a class (see R0901).
-max-parents=7
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods=20
-
-# Maximum number of return / yield for function / method body.
-max-returns=6
-
-# Maximum number of statements in function / method body.
-max-statements=50
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods=2
-
-
-[EXCEPTIONS]
-
-# Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+# A module containing Django settings to be used while linting.
+#django-settings-module=

--- a/backend/.pylintrc
+++ b/backend/.pylintrc
@@ -34,8 +34,8 @@ extension-pkg-whitelist=
 # specified are enabled, while categories only check already-enabled messages.
 fail-on=
 
-# Specify a score threshold to be exceeded before program exits with error.
-fail-under=8.5
+# Specify a score threshold under which the program will exit with error.
+fail-under=10.0
 
 # Interpret the stdin as a python script, whose filename needs to be passed as
 # the module_or_package argument.
@@ -44,16 +44,17 @@ fail-under=8.5
 # Files or directories to be skipped. They should be base names, not paths.
 ignore=CVS,
        migrations,
-       tests,
-       serializers
+       tests
 
-# Add files or directories matching the regex patterns to the ignore-list. The
-# regex matches against paths and can be in Posix or Windows format.
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\' represents the directory delimiter on Windows systems, it
+# can't be used as an escape character.
 ignore-paths=
 
-# Files or directories matching the regex patterns are skipped. The regex
-# matches against base names, not paths. The default value ignores Emacs file
-# locks
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
 ignore-patterns=
 
 # List of module names for which member attributes should not be checked
@@ -159,6 +160,8 @@ disable=raw-checker-failed,
         fixme,
         missing-function-docstring,
         missing-module-docstring,
+        missing-class-docstring,
+        abstract-method,
         too-many-ancestors,
         too-few-public-methods,
         use-maxsplit-arg,
@@ -386,6 +389,13 @@ variable-naming-style=snake_case
 #variable-rgx=
 
 
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
 [DESIGN]
 
 # List of regular expressions of class ancestor names to ignore when counting
@@ -495,8 +505,7 @@ callbacks=cb_,
 # not be used).
 dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore.
+# Argument names that match this expression will be ignored.
 ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -15,10 +15,11 @@ from .models import Degree, EmailDomain, Expertise, ExpertiseKeyword, User, Veri
 
 @admin.register(Degree)
 class DegreeAdmin(admin.ModelAdmin):
-    pass
+    """Interface to manage degrees (feature not developed yet)"""
 
 
 class IsTrustedFilter(admin.SimpleListFilter):
+    """Filter for displaying only trusted or untrusted users"""
     title = "is trusted"
     parameter_name = "is_trusted"
 
@@ -44,6 +45,7 @@ class IsTrustedFilter(admin.SimpleListFilter):
 
 @admin.register(User)
 class UserAdmin(DjangoUserAdmin):
+    """Interface to manage general data about users."""
     ordering = ["-date_joined"]
     list_filter = DjangoUserAdmin.list_filter + (IsTrustedFilter,)
     list_display = (
@@ -77,7 +79,7 @@ class UserAdmin(DjangoUserAdmin):
         qs = super().get_queryset(request)
         return qs.annotate(n_comparisons=Count("comparisons"))
 
-    def get_fieldsets(self, request, obj) -> List[Tuple]:
+    def get_fieldsets(self, request, obj=None) -> List[Tuple]:
         fieldsets = super().get_fieldsets(request, obj=obj)
         if not obj:
             return fieldsets
@@ -106,12 +108,12 @@ class UserAdmin(DjangoUserAdmin):
 
 @admin.register(Expertise)
 class ExpertiseAdmin(admin.ModelAdmin):
-    pass
+    """Interface to manage expertise (feature not developed yet)"""
 
 
 @admin.register(ExpertiseKeyword)
 class ExpertiseKeywordAdmin(admin.ModelAdmin):
-    pass
+    """Interface to manage expertise keywords (feature not developed yet)"""
 
 
 @admin.action(description="Mark selected domains as accepted")
@@ -126,6 +128,7 @@ def make_rejected(modeladmin, request, queryset):
 
 @admin.register(EmailDomain)
 class EmailDomainAdmin(admin.ModelAdmin):
+    """Interface to manage domains and their trust status"""
     list_display = (
         "domain",
         "status",
@@ -140,7 +143,7 @@ class EmailDomainAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         qst = super().get_queryset(request)
         qst = qst.annotate(
-            _user_number=Subquery(
+            user_number=Subquery(
                 User.objects.filter(email__iendswith=OuterRef("domain"))
                 .annotate(count=Func("id", function="Count"))
                 .values("count")
@@ -150,9 +153,9 @@ class EmailDomainAdmin(admin.ModelAdmin):
 
     @admin.display(ordering="-_user_number", description="# users")
     def user_number(self, obj):
-        return obj._user_number
+        return obj.user_number
 
 
 @admin.register(VerifiableEmail)
 class VerifiableEmailAdmin(admin.ModelAdmin):
-    pass
+    """Interface to manage individual emails verified or waiting to be verified"""

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -42,6 +42,8 @@ class IsTrustedFilter(admin.SimpleListFilter):
         if self.value() == "0":
             return queryset.exclude(pk__in=User.trusted_users())
 
+        return queryset
+
 
 @admin.register(User)
 class UserAdmin(DjangoUserAdmin):
@@ -117,12 +119,12 @@ class ExpertiseKeywordAdmin(admin.ModelAdmin):
 
 
 @admin.action(description="Mark selected domains as accepted")
-def make_accepted(modeladmin, request, queryset):
+def make_accepted(modeladmin, request, queryset):  # pylint: disable=unused-argument
     queryset.update(status=EmailDomain.STATUS_ACCEPTED)
 
 
 @admin.action(description="Mark selected domains as rejected")
-def make_rejected(modeladmin, request, queryset):
+def make_rejected(modeladmin, request, queryset):  # pylint: disable=unused-argument
     queryset.update(status=EmailDomain.STATUS_REJECTED)
 
 
@@ -151,7 +153,7 @@ class EmailDomainAdmin(admin.ModelAdmin):
         )
         return qst
 
-    @admin.display(ordering="-_user_number", description="# users")
+    @admin.display(ordering="-user_number", description="# users")
     def user_number(self, obj):
         return obj.user_number
 

--- a/backend/core/models/user.py
+++ b/backend/core/models/user.py
@@ -286,6 +286,8 @@ class User(AbstractUser):
             users = users.exclude(username=username)
 
         if users.exists():
+            # f-strings are incompatible with Django translations ("_")
+            # pylint: disable=consider-using-f-string
             raise ValidationError(
                 _(
                     "A user with an email starting with '%(email)s' already exists"

--- a/backend/core/models/user.py
+++ b/backend/core/models/user.py
@@ -22,6 +22,13 @@ logger = logging.getLogger(__name__)
 
 
 class User(AbstractUser):
+    """
+    Administrative, social and profile information about users.
+    (most of these fields are actually still unused)
+
+    Contains methods for retrieving trusted and supertrusted users.
+    """
+
     # Fields used by django-rest-registation to find a user.
     # Used by reset password mechanism.
     LOGIN_FIELDS = ("username", "email")
@@ -319,11 +326,11 @@ class User(AbstractUser):
 
         try:
             User.validate_email_unique_with_plus(value, self.username)
-        except ValidationError as err:
+        except ValidationError as error:
             # Catching the exception here allows us to add the email key, and
             # makes the message display near the email field in the admin
             # interface.
-            raise ValidationError({"email": err.message})
+            raise ValidationError({"email": error.message}) from error
 
     def save(self, *args, **kwargs):
         update_fields = kwargs.get("update_fields")

--- a/backend/core/oauth_validator.py
+++ b/backend/core/oauth_validator.py
@@ -8,6 +8,7 @@ from oauth2_provider.oauth2_validators import OAuth2Validator
 
 
 class CustomOAuth2Validator(OAuth2Validator):
+    """Manage user authentication"""
     def get_additional_claims(self, request):
         return {
             "sub": request.user.username,

--- a/backend/core/utils/models.py
+++ b/backend/core/utils/models.py
@@ -56,7 +56,7 @@ class WithEmbedding:
         try:
             decoded = base64.b64decode(getattr(self, self._EMBEDDING_FIELD))
             array = pickle.loads(decoded)
-        except BaseException:
+        except Exception:  # pylint: disable=broad-except
             return None
         if not isinstance(array, np.ndarray):
             return None
@@ -83,7 +83,7 @@ def filter_reduce(lst, fcn, name="_"):
     lst = [x for x in lst if x is not None]
     if not lst:
         logging.warning(
-            f"{name} query with en empty list of operands, returning None: {lst_orig}"
+            "%s query returned None due to an empty list of operands: %s", name, lst_orig
         )
         return None
     return reduce(fcn, lst)

--- a/backend/core/utils/models.py
+++ b/backend/core/utils/models.py
@@ -23,7 +23,7 @@ class WithDynamicFields:
     fields_created = False
 
     @staticmethod
-    def _create_fields(self):
+    def create_fields():
         """Override this method to create dynamic fields."""
 
     @staticmethod
@@ -33,7 +33,7 @@ class WithDynamicFields:
         for scl in subclasses:
             if not scl.fields_created:
                 scl.fields_created = True
-                scl._create_fields()
+                scl.create_fields()
 
 
 class WithEmbedding:

--- a/backend/core/utils/validators.py
+++ b/backend/core/utils/validators.py
@@ -13,4 +13,4 @@ def validate_avatar(fieldfile_obj, mb_limit=5):
     # print("VALIDATION", fieldfile_obj, fieldfile_obj.size)
     filesize = fieldfile_obj.size
     if filesize > mb_limit * 1024 * 1024:
-        raise ValidationError({"avatar": "Max file size is %s MB" % str(mb_limit)})
+        raise ValidationError({"avatar": f"Max file size is {mb_limit} MB"})

--- a/backend/documentation/python_dependency.md
+++ b/backend/documentation/python_dependency.md
@@ -28,11 +28,6 @@ https://pypi.org/project/Pyllow/
 
 Required for using imagefield in django
 
-### django-language-field
-https://github.com/audiolion/django-language-field
-
-Give a field with all language in Choicies
-
 ### django-computed-property
 https://github.com/brechin/django-computed-property/
 
@@ -53,7 +48,7 @@ https://github.com/adamchainz/django-cors-headers
 
 CORS middleware
 
-### django-prometheus
+### django-prometheus
 https://github.com/korfuri/django-prometheus
 
 Used to provide django metrics for monitoring
@@ -66,4 +61,4 @@ Used to generate OpenAPI documentation exposed by Swagger UI
 ### langdetect
 https://github.com/Mimino666/langdetect
 
-Use to detect language from video titles and descptions
+Use to detect language from video titles and descriptions

--- a/backend/scripts/ci/lint-fix.sh
+++ b/backend/scripts/ci/lint-fix.sh
@@ -3,4 +3,4 @@ set -euxo pipefail
 
 # Python Code Quality Fixes
 
-isort --settings-path .isort.cfg ${@:-core faq ml settings tournesol}
+isort --settings-path .isort.cfg ${@:-core faq ml settings tournesol twitterbot}

--- a/backend/scripts/ci/lint.sh
+++ b/backend/scripts/ci/lint.sh
@@ -6,13 +6,13 @@ set -uxo pipefail
 # return 0 if all checks return 0
 # 1 instead
 
-isort --settings-path .isort.cfg --check-only ${@:-core faq ml settings tournesol}
+isort --settings-path .isort.cfg --check-only ${@:-core faq ml settings tournesol twitterbot}
 chk1=$?
 
 flake8 --config=.flake8 ${@:-}
 chk2=$?
 
-pylint --rcfile=.pylintrc ${@:-core faq tournesol}
+pylint --rcfile=.pylintrc ${@:-core faq tournesol twitterbot}
 chk3=$?
 
 ! (( chk1 || chk2 || chk3 ))

--- a/backend/tests/requirements.txt
+++ b/backend/tests/requirements.txt
@@ -1,15 +1,15 @@
 # Code quality
 bandit==1.7.4
-flake8==5.0.0
+flake8==5.0.4
 flake8-html==0.4.2
 isort==5.10.1
-pylint==2.14.5
+pylint==2.15.3
 pylint-django==2.5.3
 pylint-json2html==0.4.0
 
 # Unit tests tools
 faker==13.15.1
-pytest==7.1.2
+pytest==7.1.3
 pytest-html==3.1.1
 pytest-mock==3.8.2
 

--- a/backend/tests/requirements.txt
+++ b/backend/tests/requirements.txt
@@ -1,23 +1,20 @@
 # Code quality
-bandit==1.7.0
-flake8==3.9.2
-flake8-html==0.4.1
+bandit==1.7.4
+flake8==5.0.0
+flake8-html==0.4.2
 isort==5.10.1
-pylint==2.8.3
-pylint-django==2.4.4
-pylint-json2html==0.3.0
+pylint==2.14.5
+pylint-django==2.5.3
+pylint-json2html==0.4.0
 
 # Unit tests tools
-faker==8.8.2
-pytest==6.2.4
+faker==13.15.1
+pytest==7.1.2
 pytest-html==3.1.1
-pytest-mock==3.6.1
+pytest-mock==3.8.2
 
 # Pytest for django
 pytest-django==4.5.2
 
 # Factory tools
 factory-boy==3.2.1
-
-# Until flake8-html release a version > 0.4.1
-jinja2<=3.0.3

--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -45,19 +45,18 @@ class MetadataFieldFilter(SimpleListFilter):
         """Filter the queryset according to the selected metadata filter"""
         if self.value():
             json_field_query = {f"metadata__{self.metadata_key}": self.value()}
-            queryset = queryset.filter(**json_field_query)
-        elif self.value() == "":
+            return queryset.filter(**json_field_query)
+        if self.value() == "":
             json_field_query = (
                 Q(**{f"metadata__{self.metadata_key}": ""})
                 | Q(**{f"metadata__{self.metadata_key}": None})
             )
-            queryset = queryset.filter(json_field_query)
-
+            return queryset.filter(json_field_query)
         return queryset
 
 
 class EntityLanguageFilter(MetadataFieldFilter):
-    """Enables the language filter in the entities' interface"""
+    """Enables the language filter in the entities' admin interface"""
     title = "language"
     parameter_name = "metadataLanguage"
     metadata_key = "language"
@@ -65,7 +64,6 @@ class EntityLanguageFilter(MetadataFieldFilter):
 
 @admin.register(Entity)
 class EntityAdmin(admin.ModelAdmin):
-    """Admin management interface for entities"""
     readonly_fields = ("tournesol_score",)
     list_display = (
         "uid",
@@ -123,7 +121,6 @@ class EntityAdmin(admin.ModelAdmin):
 
 @admin.register(EntityCriteriaScore)
 class EntityCriteriaScoreAdmin(admin.ModelAdmin):
-    """Admin management interface for entities' criteria scores"""
     list_display = ("entity", "poll", "criteria", "score_mode", "score")
     list_filter = (
         "poll",
@@ -135,7 +132,6 @@ class EntityCriteriaScoreAdmin(admin.ModelAdmin):
 
 @admin.register(ContributorRating)
 class ContributorRatingAdmin(admin.ModelAdmin):
-    """Admin management interface for contributor ratings"""
     list_display = (
         "user",
         "entity",
@@ -163,7 +159,6 @@ class ContributorRatingAdmin(admin.ModelAdmin):
 
 @admin.register(ContributorRatingCriteriaScore)
 class ContributorRatingCriteriaScoreAdmin(admin.ModelAdmin):
-    """Admin management interface for contributor rating criteria scores"""
     list_filter = ("contributor_rating__poll__name",)
     list_display = ("id", "contributor_rating", "criteria", "score")
     readonly_fields = ("contributor_rating",)
@@ -172,7 +167,6 @@ class ContributorRatingCriteriaScoreAdmin(admin.ModelAdmin):
 
 @admin.register(ContributorScaling)
 class ContributorScalingAdmin(admin.ModelAdmin):
-    """Admin management interface for contributor scaling"""
     search_fields = (
         "criteria",
         "user__username",
@@ -184,7 +178,6 @@ class ContributorScalingAdmin(admin.ModelAdmin):
 
 @admin.register(Comparison)
 class ComparisonAdmin(admin.ModelAdmin):
-    """Admin management interface for comparisons"""
     list_display = (
         "pk",
         "user",
@@ -212,7 +205,6 @@ class ComparisonAdmin(admin.ModelAdmin):
 
 @admin.register(ComparisonCriteriaScore)
 class ComparisonCriteriaScoreAdmin(admin.ModelAdmin):
-    """Admin management interface for comparison criteria scores"""
     list_filter = ("comparison__poll__name",)
     list_display = ("id", "comparison", "criteria", "score")
     readonly_fields = ("comparison",)
@@ -224,7 +216,7 @@ class ComparisonCriteriaScoreAdmin(admin.ModelAdmin):
 
 
 class CriteriasInline(admin.TabularInline):
-    """Used to display the criteria in the poll's admin interface"""
+    """Used to display the criteria in the polls' admin interface"""
     model = CriteriaRank
     extra = 0
 
@@ -237,7 +229,6 @@ class CriteriaLocalesInline(admin.TabularInline):
 
 @admin.register(Poll)
 class PollAdmin(admin.ModelAdmin):
-    """Admin management interface for polls"""
     list_display = (
         "name",
         "active",
@@ -289,5 +280,4 @@ class PollAdmin(admin.ModelAdmin):
 
 @admin.register(Criteria)
 class CriteriaAdmin(admin.ModelAdmin):
-    """Admin management interface for criteria"""
     inlines = (CriteriaLocalesInline,)

--- a/backend/tournesol/apps.py
+++ b/backend/tournesol/apps.py
@@ -8,4 +8,6 @@ class TournesolConfig(AppConfig):
     name = "tournesol"
 
     def ready(self):
-        from . import signals  # noqa: F401
+        """Register the signal handlers at the start of the app, via import"""
+        # pylint: disable=import-outside-toplevel,unused-import
+        from . import signals  # noqa

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -269,6 +269,7 @@ class EntityType(ABC):
         This can take dozens of seconds and is usually not necessary
         because search_vector is automatically updated after a save.
         """
+        # pylint: disable=import-outside-toplevel
         from tournesol.entities import ENTITY_TYPE_NAME_TO_CLASS
 
         for entity in models.Entity.objects.iterator():

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -15,6 +15,9 @@ UID_DELIMITER = ":"
 
 
 class EntityType(ABC):
+    """
+    Abstract base class for the processing specific to each entity type (mainly about metadata).
+    """
 
     # The 'name' of this entity type corresponds
     # to the `type` field in Entity,
@@ -176,12 +179,12 @@ class EntityType(ABC):
         return qst
 
     @classmethod
-    def filter_date_lte(cls, qs, dt):
-        return qs.filter(add_time__lte=dt)
+    def filter_date_lte(cls, qs, max_date):
+        return qs.filter(add_time__lte=max_date)
 
     @classmethod
-    def filter_date_gte(cls, qs, dt):
-        return qs.filter(add_time__gte=dt)
+    def filter_date_gte(cls, qs, min_date):
+        return qs.filter(add_time__gte=min_date)
 
     @classmethod
     @abstractmethod

--- a/backend/tournesol/entities/candidate.py
+++ b/backend/tournesol/entities/candidate.py
@@ -15,6 +15,11 @@ WIKIDATA_API_BASE_URL = "https://www.wikidata.org/w/api.php"
 
 
 class CandidateEntity(EntityType):
+    """
+    Election candidate entity type
+
+    Handles the metadata specific to candidates.
+    """
     name = TYPE_CANDIDATE
     metadata_serializer_class = CandidateMetadata
 

--- a/backend/tournesol/entities/candidate.py
+++ b/backend/tournesol/entities/candidate.py
@@ -5,6 +5,7 @@ from django.contrib.postgres.search import SearchVector
 from django.db.models.fields.json import KeyTextTransform
 
 from tournesol.serializers.metadata import CandidateMetadata
+from tournesol.utils.constants import REQUEST_TIMEOUT
 
 from .base import EntityType
 
@@ -43,6 +44,7 @@ class CandidateEntity(EntityType):
                 "ids": self.wikidata_id,
                 "format": "json",
             },
+            timeout=REQUEST_TIMEOUT,
         )
         resp.raise_for_status()
         wd_item = resp.json()["entities"][self.wikidata_id]

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -42,6 +42,7 @@ class VideoEntity(EntityType):
         return ''
 
     def update_metadata_field(self) -> None:
+        # pylint: disable=import-outside-toplevel
         from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata
         try:
             metadata = get_video_metadata(
@@ -70,6 +71,7 @@ class VideoEntity(EntityType):
 
     @classmethod
     def update_search_vector(cls, entity) -> None:
+        # pylint: disable=import-outside-toplevel
         from tournesol.utils.video_language import language_to_postgres_config
 
         language_config = language_to_postgres_config(entity.metadata["language"])

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -19,16 +19,21 @@ YOUTUBE_UID_REGEX = (
 
 
 class VideoEntity(EntityType):
+    """
+    Video entity type
+
+    Handles the metadata specific to videos, retrieved from the YouTube API.
+    """
     name = TYPE_VIDEO
     metadata_serializer_class = VideoMetadata
 
     @classmethod
-    def filter_date_lte(cls, qs, dt):
-        return qs.filter(metadata__publication_date__lte=dt.date().isoformat())
+    def filter_date_lte(cls, qs, max_date):
+        return qs.filter(metadata__publication_date__lte=max_date.date().isoformat())
 
     @classmethod
-    def filter_date_gte(cls, qs, dt):
-        return qs.filter(metadata__publication_date__gte=dt.date().isoformat())
+    def filter_date_gte(cls, qs, min_date):
+        return qs.filter(metadata__publication_date__gte=min_date.date().isoformat())
 
     @classmethod
     def get_uid_regex(cls, namespace: str) -> str:

--- a/backend/tournesol/errors.py
+++ b/backend/tournesol/errors.py
@@ -3,4 +3,7 @@ from rest_framework.exceptions import APIException
 
 
 class ConflictError(APIException):
+    """
+    Usually occurs when the data of an HTTP PUT is inconsistent with the database's state
+    """
     status_code = status.HTTP_409_CONFLICT

--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -9,7 +9,7 @@ def get_dataset(poll_name: str) -> QuerySet:
     Retrieve the public dataset from the database and return a non-evaluated
     Django `RawQuerySet`.
     """
-    from tournesol.models.comparisons import Comparison
+    from tournesol.models.comparisons import Comparison  # pylint: disable=import-outside-toplevel
 
     return Comparison.objects.raw(
         """

--- a/backend/tournesol/models/comparisons.py
+++ b/backend/tournesol/models/comparisons.py
@@ -76,8 +76,8 @@ class Comparison(models.Model):
     @property
     def entity_first_second(self):
         """String representing two entity PKs in sorted order."""
-        a, b = sorted([self.entity_1_id, self.entity_2_id])
-        return f"{a}_{b}"
+        entity_1, entity_2 = sorted([self.entity_1_id, self.entity_2_id])
+        return f"{entity_1}_{entity_2}"
 
     @staticmethod
     def get_comparison(user, poll_id, uid_a, uid_b):
@@ -123,9 +123,9 @@ class ComparisonCriteriaScore(models.Model):
         on_delete=models.CASCADE,
     )
     criteria = models.TextField(
+        db_index=True,
         max_length=32,
         help_text="Name of the criteria",
-        db_index=True,
     )
     score = models.FloatField(
         help_text="Score for the given comparison",

--- a/backend/tournesol/models/comparisons.py
+++ b/backend/tournesol/models/comparisons.py
@@ -110,7 +110,7 @@ class Comparison(models.Model):
         return comparison, True
 
     def __str__(self):
-        return "%s [%s/%s]" % (self.user, self.entity_1, self.entity_2)
+        return f"{self.user} [{self.entity_1}/{self.entity_2}]"
 
 
 class ComparisonCriteriaScore(models.Model):

--- a/backend/tournesol/models/criteria.py
+++ b/backend/tournesol/models/criteria.py
@@ -7,6 +7,11 @@ from .poll import Poll
 
 
 class Criteria(models.Model):
+    """
+    Model that just contains the name of the criteria.
+
+    The same criteria name can be used in multiple polls, and for multiple languages.
+    """
     name = models.SlugField(unique=True)
 
     def __str__(self) -> str:
@@ -37,6 +42,7 @@ class CriteriaRank(models.Model):
 
 
 class CriteriaLocale(models.Model):
+    """Criteria localization model"""
     class Meta:
         unique_together = ["criteria", "language"]
 

--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -242,14 +242,14 @@ class Entity(models.Model):
         return self.metadata.get("video_id")
 
     @property
-    def best_text(self, min_len=5):
+    def best_text(self):
         """Return description, otherwise title."""
         priorities = [self.metadata.get("description"), self.metadata.get("name")]
 
         # going over all priorities
         for priority in priorities:
             # selecting one that exists
-            if priority is not None and len(priority) >= min_len:
+            if priority is not None:
                 return priority
         return None
 
@@ -306,8 +306,8 @@ class Entity(models.Model):
         # Create object
         criteria_distributions = []
         for key, values in scores_dict.items():
-            range = (min_score_base, max_score_base)
-            distribution, bins = np.histogram(np.clip(values, *range), range=range)
+            score_range = (min_score_base, max_score_base)
+            distribution, bins = np.histogram(np.clip(values, *score_range), range=score_range)
 
             criteria_distributions.append(CriteriaDistributionScore(
                 key, distribution, bins))
@@ -321,40 +321,42 @@ class Entity(models.Model):
         """
         from .poll import Poll
 
-        CRITERIAS = Poll.default_poll().criterias_list()
-        quantiles_by_feature_by_id = {f: {} for f in CRITERIAS}
+        criteria_list = Poll.default_poll().criterias_list()
+        quantiles_by_feature_by_id = {criteria: {} for criteria in criteria_list}
 
         # go over all features
-        # logging.warning("Computing quantiles...")
-        for f in tqdm(CRITERIAS):
+        for criteria in tqdm(criteria_list):
             # order by feature (descenting, because using the top quantile)
-            qs = Entity.objects.filter(**{f + "__isnull": False}).order_by("-" + f)
-            quantiles_f = np.linspace(0.0, 1.0, len(qs))
-            for i, v in tqdm(enumerate(qs)):
-                quantiles_by_feature_by_id[f][v.id] = quantiles_f[i]
+            qs = Entity.objects.filter(**{criteria + "__isnull": False}).order_by("-" + criteria)
+            quantiles_slicing = np.linspace(0.0, 1.0, len(qs))
+            for current_slice, video in tqdm(enumerate(qs)):
+                quantiles_by_feature_by_id[criteria][video.id] = quantiles_slicing[current_slice]
 
         logging.warning("Writing quantiles...")
         video_objects = []
         # TODO: use batched updates with bulk_update
-        for v in tqdm(Entity.objects.all()):
-            for f in CRITERIAS:
+        for entity in tqdm(Entity.objects.all()):
+            for criteria in criteria_list:
                 setattr(
-                    v, f + "_quantile", quantiles_by_feature_by_id[f].get(v.id, None)
+                    entity,
+                    criteria + "_quantile",
+                    quantiles_by_feature_by_id[criteria].get(entity.id, None),
                 )
-            video_objects.append(v)
+            video_objects.append(entity)
 
         Entity.objects.bulk_update(
-            video_objects, batch_size=200, fields=[f + "_quantile" for f in CRITERIAS]
+            video_objects,
+            batch_size=200,
+            fields=[criteria + "_quantile" for criteria in criteria_list],
         )
 
     @classmethod
     def create_from_video_id(cls, video_id):
-        from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata
+        from tournesol.utils.api_youtube import get_video_metadata
 
-        try:
-            extra_data = get_video_metadata(video_id)
-        except VideoNotFound:
-            raise
+        # Returns nothing if no YOUTUBE_API_KEY is not configured.
+        # Can also raise VideoNotFound if the video is private or not found by YouTube.
+        extra_data = get_video_metadata(video_id)
 
         serializer = VideoMetadata(
             data={
@@ -399,7 +401,6 @@ class Entity(models.Model):
 
     @property
     def criteria_scores(self) -> List["EntityCriteriaScore"]:
-        from .entity_score import ScoreMode
         if hasattr(self, "_prefetched_criteria_scores"):
             return list(self._prefetched_criteria_scores)
         return list(self.all_criteria_scores.filter(score_mode=ScoreMode.DEFAULT))

--- a/backend/tournesol/models/poll.py
+++ b/backend/tournesol/models/poll.py
@@ -97,7 +97,6 @@ class Poll(models.Model):
     @property
     def scale_function(self):
         if self.algorithm == ALGORITHM_MEHESTAN and self.sigmoid_scale is not None:
-            def scale(x):
-                return 4 * MEHESTAN_MAX_SCALED_SCORE / TAU * np.arctan(self.sigmoid_scale * x)
-            return scale
+            return lambda x: (4 * MEHESTAN_MAX_SCALED_SCORE / TAU) * \
+                             np.arctan(self.sigmoid_scale * x)
         return lambda x: x

--- a/backend/tournesol/models/ratings.py
+++ b/backend/tournesol/models/ratings.py
@@ -52,8 +52,8 @@ class ContributorRatingCriteriaScore(models.Model):
     )
     criteria = models.TextField(
         max_length=32,
-        help_text="Name of the criteria",
         db_index=True,
+        help_text="Name of the criteria",
     )
     score = models.FloatField(
         default=0,

--- a/backend/tournesol/models/ratings.py
+++ b/backend/tournesol/models/ratings.py
@@ -38,7 +38,7 @@ class ContributorRating(models.Model):
         unique_together = ["user", "entity", "poll"]
 
     def __str__(self):
-        return "%s on %s" % (self.user, self.entity)
+        return f"{self.user} on {self.entity}"
 
 
 class ContributorRatingCriteriaScore(models.Model):

--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -65,7 +65,7 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
         Display the opposite of each criteria scores if the comparison is
         requested in the reverse order.
         """
-        ret = super(ComparisonSerializer, self).to_representation(instance)
+        ret = super().to_representation(instance)
 
         if self.context.get("reverse", False):
             ret["entity_a"], ret["entity_b"] = ret["entity_b"], ret["entity_a"]
@@ -126,7 +126,7 @@ class ComparisonUpdateSerializer(ComparisonSerializerMixin, ModelSerializer):
         Also add `entity_a` and `entity_b` fields to make the representation
         consistent across all comparison serializers.
         """
-        ret = super(ComparisonUpdateSerializer, self).to_representation(instance)
+        ret = super().to_representation(instance)
 
         if self.context.get("reverse", False):
             ret["entity_a"], ret["entity_b"] = ret["entity_b"], ret["entity_a"]
@@ -143,7 +143,7 @@ class ComparisonUpdateSerializer(ComparisonSerializerMixin, ModelSerializer):
         Save the comparison in the order expected by the model, even if the
         comparison is provided reversed.
         """
-        ret = super(ComparisonUpdateSerializer, self).to_internal_value(data)
+        ret = super().to_internal_value(data)
 
         if self.context.get("reverse", False):
             ret["criteria_scores"] = self.reverse_criteria_scores(

--- a/backend/tournesol/serializers/contributor_recommendations.py
+++ b/backend/tournesol/serializers/contributor_recommendations.py
@@ -20,10 +20,7 @@ class ContributorRecommendationsSerializer(RecommendationSerializer):
     criteria_scores = SerializerMethodField()
 
     class Meta(RecommendationSerializer.Meta):
-        fields = list(
-            set(RecommendationSerializer.Meta.fields)
-            | {"is_public"}
-        )
+        fields = RecommendationSerializer.Meta.fields + ["is_public"]
 
     @extend_schema_field(ContributorCriteriaScore(many=True))
     def get_criteria_scores(self, obj):

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -30,6 +30,7 @@ class RecommendationSerializer(ModelSerializer):
     # on the parameters of an api request. Should it be treated differently?
     total_score = serializers.FloatField()
 
+    # pylint: disable=duplicate-code
     class Meta:
         model = Entity
         fields = [

--- a/backend/tournesol/serializers/rate_later.py
+++ b/backend/tournesol/serializers/rate_later.py
@@ -26,9 +26,9 @@ class RateLaterSerializer(ModelSerializer):
                 entity=entity,
                 **validated_data,
             )
-        except IntegrityError:
+        except IntegrityError as error:
             raise ConflictError(
                 _("The entity is already in the rate-later list of this poll.")
-            )
+            ) from error
 
         return rate_later

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -44,7 +44,7 @@ class ContributorRatingSerializer(ModelSerializer):
         """
         Determine the poll according to the context provided by the view.
         """
-        ret = super(ContributorRatingSerializer, self).to_internal_value(data)
+        ret = super().to_internal_value(data)
         ret["poll_id"] = self.context.get("poll").id
         return ret
 

--- a/backend/tournesol/signals.py
+++ b/backend/tournesol/signals.py
@@ -4,6 +4,7 @@ from django.dispatch import receiver
 from tournesol.models import Comparison, ContributorRating
 
 
+# pylint: disable=unused-argument
 @receiver(post_save, sender=Comparison)
 def initialize_ratings_on_comparison_creation(sender, instance, created, **kwargs):
     if not created:

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -311,7 +311,7 @@ class ComparisonApiTestCase(TestCase):
         )
         self.assertEqual(comparison_criteria_scores[0].weight, 1)
 
-    @patch('tournesol.utils.api_youtube.youtube', None)
+    @patch('tournesol.utils.api_youtube.YOUTUBE', None)
     def test_authenticated_can_create_with_non_existing_entity(self):
         """
         An authenticated user can create a comparison involving entities that

--- a/backend/tournesol/tests/test_api_preview.py
+++ b/backend/tournesol/tests/test_api_preview.py
@@ -15,7 +15,7 @@ def raise_(exception):
     raise exception
 
 
-def mock_yt_thumbnail_response(url) -> Response:
+def mock_yt_thumbnail_response(url, timeout=None) -> Response:
     resp = Response()
     resp.status_code = 200
     resp._content = Image.new("1", (1, 1)).tobitmap()
@@ -170,7 +170,7 @@ class DynamicWebsitePreviewEntityTestCase(TestCase):
             'inline; filename="tournesol_screenshot_og.png"',
         )
 
-    @patch("requests.get", lambda x: raise_(ConnectionError))
+    @patch("requests.get", lambda x, timeout=None: raise_(ConnectionError))
     @patch("tournesol.entities.video.VideoEntity.update_search_vector", lambda x: None)
     def test_anon_200_get_with_yt_connection_error(self):
         """

--- a/backend/tournesol/tests/test_api_rate_later.py
+++ b/backend/tournesol/tests/test_api_rate_later.py
@@ -155,7 +155,7 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    @patch("tournesol.utils.api_youtube.youtube", None)
+    @patch("tournesol.utils.api_youtube.YOUTUBE", None)
     def test_auth_201_create(self) -> None:
         """
         An authenticated user can add an entity to its rate-later list from a
@@ -180,7 +180,7 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
             RateLater.objects.filter(poll=other_poll, user=self.user).count(), 0
         )
 
-    @patch("tournesol.utils.api_youtube.youtube", None)
+    @patch("tournesol.utils.api_youtube.YOUTUBE", None)
     def test_auth_409_create_two_times(self) -> None:
         """
         An authenticated user cannot add two times the same entity to a

--- a/backend/tournesol/utils/api_youtube.py
+++ b/backend/tournesol/utils/api_youtube.py
@@ -15,7 +15,7 @@ API_VERSION = "v3"
 YOUTUBE = None
 YOUTUBE_API_KEY = settings.YOUTUBE_API_KEY
 if YOUTUBE_API_KEY:
-    youtube = googleapiclient.discovery.build(
+    YOUTUBE = googleapiclient.discovery.build(
         API_SERVICE_NAME, API_VERSION, developerKey=YOUTUBE_API_KEY
     )
 
@@ -34,6 +34,7 @@ def get_youtube_video_details(video_id):
             "YouTube client not initialized, did you provide an API key?"
         )
 
+    # pylint: disable=no-member
     request = YOUTUBE.videos().list(
         part="snippet,contentDetails,statistics,status", id=video_id
     )
@@ -45,7 +46,7 @@ def get_video_metadata(video_id, compute_language=True):
         yt_response = get_youtube_video_details(video_id)
     except YoutubeNotConfiguredError:
         return {}
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         logger.error("Failed to retrieve video metadata from Youtube", exc_info=True)
         return {}
 

--- a/backend/tournesol/utils/api_youtube.py
+++ b/backend/tournesol/utils/api_youtube.py
@@ -9,14 +9,14 @@ from tournesol.utils.video_language import compute_video_language
 logger = logging.getLogger(__name__)
 
 # Get credentials and create an API client
-api_service_name = "youtube"
-api_version = "v3"
+API_SERVICE_NAME = "youtube"
+API_VERSION = "v3"
 
-youtube = None
+YOUTUBE = None
 YOUTUBE_API_KEY = settings.YOUTUBE_API_KEY
 if YOUTUBE_API_KEY:
     youtube = googleapiclient.discovery.build(
-        api_service_name, api_version, developerKey=YOUTUBE_API_KEY
+        API_SERVICE_NAME, API_VERSION, developerKey=YOUTUBE_API_KEY
     )
 
 
@@ -29,12 +29,12 @@ class YoutubeNotConfiguredError(Exception):
 
 
 def get_youtube_video_details(video_id):
-    if not youtube:
+    if not YOUTUBE:
         raise YoutubeNotConfiguredError(
             "YouTube client not initialized, did you provide an API key?"
         )
 
-    request = youtube.videos().list(
+    request = YOUTUBE.videos().list(
         part="snippet,contentDetails,statistics,status", id=video_id
     )
     return request.execute()

--- a/backend/tournesol/utils/constants.py
+++ b/backend/tournesol/utils/constants.py
@@ -8,6 +8,9 @@ YOUTUBE_VIDEO_ID_REGEX_SYMBOL = "[A-Za-z0-9-_]"
 # The whole video ID
 YOUTUBE_VIDEO_ID_REGEX = rf"{YOUTUBE_VIDEO_ID_REGEX_SYMBOL}{{11}}"
 
+# 10 seconds timeout to avoid staying blocked if an outgoing HTTP request fails
+REQUEST_TIMEOUT = 10
+
 # Maximal entity score after poll scaling is applied
 MEHESTAN_MAX_SCALED_SCORE = 100.0
 

--- a/backend/tournesol/utils/video_language.py
+++ b/backend/tournesol/utils/video_language.py
@@ -67,7 +67,7 @@ def languages_detection(title, description):
 
 
 def compute_video_language(uploader, title, description):
-    from tournesol.models.entity import Entity
+    from tournesol.models.entity import Entity  # pylint: disable=import-outside-toplevel
 
     # Get language(s) from other videos of the same uploader
     lang_list = (

--- a/backend/tournesol/utils/video_language.py
+++ b/backend/tournesol/utils/video_language.py
@@ -4,7 +4,7 @@ from collections import Counter
 from django.conf import settings
 from langdetect import DetectorFactory, detect, lang_detect_exception
 
-LANGUAGE_CODE_TO_NAME_MATCHING = {code: name for code, name in settings.LANGUAGES}
+LANGUAGE_CODE_TO_NAME_MATCHING = dict(settings.LANGUAGES)
 ACCEPTED_LANGUAGE_CODES = set(LANGUAGE_CODE_TO_NAME_MATCHING.keys())
 
 # Language configurations supported by Postgres full-text search

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -40,10 +40,7 @@ class ComparisonApiMixin:
         except ObjectDoesNotExist:
             return False
 
-        if comparison:
-            return True
-        else:
-            return False
+        return bool(comparison)
 
 
 class ComparisonListBaseApi(
@@ -194,8 +191,8 @@ class ComparisonDetailApi(
                 self.kwargs["uid_a"],
                 self.kwargs["uid_b"],
             )
-        except ObjectDoesNotExist:
-            raise Http404
+        except ObjectDoesNotExist as error:
+            raise Http404 from error
 
         if reverse:
             self._select_serialization(straight=False)
@@ -218,7 +215,7 @@ class ComparisonDetailApi(
         return self.DEFAULT_SERIALIZER
 
     def get_serializer_context(self):
-        context = super(ComparisonDetailApi, self).get_serializer_context()
+        context = super().get_serializer_context()
         context["reverse"] = self.currently_reversed
         context["poll"] = self.poll_from_url
         return context

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -107,10 +107,8 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
 
         if self.comparison_already_exists(poll.pk, self.request):
             raise exceptions.ValidationError(
-                "You've already compared {0} with {1}.".format(
-                    self.request.data["entity_a"]["uid"],
-                    self.request.data["entity_b"]["uid"],
-                )
+                f"You've already compared {self.request.data['entity_a']['uid']} "
+                f"with {self.request.data['entity_b']['uid']}."
             )
         comparison: Comparison = serializer.save()
 

--- a/backend/tournesol/views/contributor_recommendations.py
+++ b/backend/tournesol/views/contributor_recommendations.py
@@ -41,13 +41,12 @@ class ContributorRecommendationsBaseView(PollRecommendationsBaseAPIView):
         ).filter(total_score__isnull=False)
 
     def filter_unsafe(self, queryset, filters):
-        show_unsafe = filters["unsafe"]
-        if not show_unsafe:
-            # Ignore RECOMMENDATIONS_MIN_CONTRIBUTORS, only filter on the
-            # total score
-            queryset = queryset.filter(tournesol_score__gt=0)
+        if filters["unsafe"]:
+            return queryset
 
-        return queryset
+        # Ignore RECOMMENDATIONS_MIN_CONTRIBUTORS, only filter on the
+        # total score
+        return queryset.filter(tournesol_score__gt=0)
 
 
 class PrivateContributorRecommendationsView(ContributorRecommendationsBaseView):

--- a/backend/tournesol/views/contributor_recommendations.py
+++ b/backend/tournesol/views/contributor_recommendations.py
@@ -42,12 +42,12 @@ class ContributorRecommendationsBaseView(PollRecommendationsBaseAPIView):
 
     def filter_unsafe(self, queryset, filters):
         show_unsafe = filters["unsafe"]
-        if show_unsafe:
-            return queryset
-        else:
+        if not show_unsafe:
             # Ignore RECOMMENDATIONS_MIN_CONTRIBUTORS, only filter on the
             # total score
-            return queryset.filter(tournesol_score__gt=0)
+            queryset = queryset.filter(tournesol_score__gt=0)
+
+        return queryset
 
 
 class PrivateContributorRecommendationsView(ContributorRecommendationsBaseView):

--- a/backend/tournesol/views/criteria_correlations.py
+++ b/backend/tournesol/views/criteria_correlations.py
@@ -30,6 +30,7 @@ def get_linregress(scores_1: dict, scores_2: dict):
 
 
 class ContributorCriteriaCorrelationsSerializer(serializers.Serializer):
+    """Contains the criterias, and the matrices of correlations and slopes"""
     criterias = serializers.ListField(child=serializers.CharField())
     correlations = serializers.ListField(
         child=serializers.ListField(child=serializers.FloatField())
@@ -40,6 +41,9 @@ class ContributorCriteriaCorrelationsSerializer(serializers.Serializer):
 
 
 class ContributorCriteriaCorrelationsView(PollScopedViewMixin, GenericAPIView):
+    """
+    Return Matrices of correlation and slope between criteria, based on scipy's linregress
+    """
 
     @staticmethod
     def clean(value):
@@ -64,8 +68,8 @@ class ContributorCriteriaCorrelationsView(PollScopedViewMixin, GenericAPIView):
 
         scores = {criteria: {} for criteria in criterias}
         for comp in comparisons:
-            for s in comp.criteria_scores.all():
-                scores[s.criteria][comp.id] = s.score
+            for crit_score in comp.criteria_scores.all():
+                scores[crit_score.criteria][comp.id] = crit_score.score
 
         linear_regressions = {
             c1: {c2: get_linregress(scores[c1], scores[c2]) for c2 in criterias}

--- a/backend/tournesol/views/entities_to_compare.py
+++ b/backend/tournesol/views/entities_to_compare.py
@@ -13,7 +13,7 @@ from tournesol.views import PollScopedViewMixin
 
 @extend_schema_view(
     get=extend_schema(
-        description="Retrieve a list of recommendations to compare for the logged user",
+        description="Retrieve suggested entities to compare for the logged user",
         parameters=[
             OpenApiParameter(
                 "first_entity_uid", OpenApiTypes.STR, OpenApiParameter.QUERY
@@ -22,9 +22,12 @@ from tournesol.views import PollScopedViewMixin
     )
 )
 class EntitiesToCompareView(PollScopedViewMixin, ListAPIView):
+    """
+    Return suggestions of entities to compare for the logged user.
+    """
     serializer_class = EntityNoExtraFieldSerializer
 
-    def list(self, request, **kwargs):
+    def list(self, request, *args, **kwargs):
         poll = self.poll_from_url
         if poll.name != DEFAULT_POLL_NAME:
             raise ValidationError({"detail": "only poll 'videos' is supported"})

--- a/backend/tournesol/views/inconsistencies.py
+++ b/backend/tournesol/views/inconsistencies.py
@@ -146,7 +146,7 @@ class Length3Cycles(PollScopedViewMixin, GenericAPIView):
         """
         cycles_count = 0
         comparison_trios_count = 0
-        for entity_1 in self.all_connections.keys():
+        for entity_1 in self.all_connections:
             # Search the cycles
             for entity_2 in self.outgoing_connections[entity_1]:
                 # Count only when entity_1 has the lowest uid,to count each cycle only once

--- a/backend/tournesol/views/inconsistencies.py
+++ b/backend/tournesol/views/inconsistencies.py
@@ -237,17 +237,17 @@ class ScoreInconsistencies(PollScopedViewMixin, GenericAPIView):
         return Response(ScoreInconsistenciesSerializer(response).data)
 
     @staticmethod
-    def _list_inconsistent_comparisons(criteria_comparisons: list,
-                                       criteria_ratings: list,
-                                       threshold: float,
-                                       criteria_list: list) -> dict:
+    def _list_inconsistent_comparisons(  # pylint: disable=too-many-locals
+        criteria_comparisons: list,
+        criteria_ratings: list,
+        threshold: float,
+        criteria_list: list
+    ) -> dict:
         """
         For each comparison criteria, search the corresponding rating,
         calculate the inconsistency, and check if it crosses the threshold.
         Then prepare the HTTP response.
         """
-        response = {}
-
         comparisons_analysed_count = dict.fromkeys(criteria_list, 0)
         inconsistent_comparisons_count = dict.fromkeys(criteria_list, 0)
         inconsistency_sum = dict.fromkeys(criteria_list, 0.0)
@@ -302,9 +302,11 @@ class ScoreInconsistencies(PollScopedViewMixin, GenericAPIView):
 
         inconsistent_criteria_comparisons.sort(key=lambda d: d['inconsistency'], reverse=True)
 
-        response["count"] = len(inconsistent_criteria_comparisons)
-        response["results"] = inconsistent_criteria_comparisons
-        response["stats"] = {}
+        response = {
+            "count": len(inconsistent_criteria_comparisons),
+            "results": inconsistent_criteria_comparisons,
+            "stats": {},
+        }
         for criteria in criteria_list:
             mean_inconsistency = 0.0
             if comparisons_analysed_count[criteria] > 0:

--- a/backend/tournesol/views/mixins/poll.py
+++ b/backend/tournesol/views/mixins/poll.py
@@ -21,8 +21,8 @@ class PollScopedViewMixin:
         poll_name = request_kwargs[self.poll_parameter]
         try:
             return Poll.objects.get(name=poll_name)
-        except ObjectDoesNotExist:
-            raise NotFound("The requested poll {0} doesn't exist.".format(poll_name))
+        except ObjectDoesNotExist as error:
+            raise NotFound(f"The requested poll {poll_name} doesn't exist.") from error
 
     def initial(self, request, *args, **kwargs):
         """

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -139,14 +139,13 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
         This method requires a queryset annotated with the entities weighted
         total score.
         """
-        show_unsafe = filters["unsafe"]
-        if not show_unsafe:
-            queryset = queryset.filter(
-                rating_n_contributors__gte=settings.RECOMMENDATIONS_MIN_CONTRIBUTORS,
-                tournesol_score__gt=0,
-            )
+        if filters["unsafe"]:
+            return queryset
 
-        return queryset
+        return queryset.filter(
+            rating_n_contributors__gte=settings.RECOMMENDATIONS_MIN_CONTRIBUTORS,
+            tournesol_score__gt=0,
+        )
 
     def sort_results(self, queryset, filters):
         """
@@ -180,8 +179,8 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
                 * (F("relevance") + self.search_score_coef * normalized_total_score)
             )
             return queryset.order_by("-search_score", "-pk")
-        else:
-            return queryset.order_by("-total_score", "-pk")
+
+        return queryset.order_by("-total_score", "-pk")
 
     def _build_criteria_weight_condition(
         self, request, poll: Poll, when="criteria_scores__criteria"

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -133,19 +133,20 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
         return queryset, filters
 
     def filter_unsafe(self, queryset, filters):
-        """Filter the queryset according to the `unsafe` URL parameters.
+        """
+        Filter the queryset according to the `unsafe` URL parameters.
 
         This method requires a queryset annotated with the entities weighted
         total score.
         """
         show_unsafe = filters["unsafe"]
-        if show_unsafe:
-            return queryset
-        else:
-            return queryset.filter(
+        if not show_unsafe:
+            queryset = queryset.filter(
                 rating_n_contributors__gte=settings.RECOMMENDATIONS_MIN_CONTRIBUTORS,
                 tournesol_score__gt=0,
             )
+
+        return queryset
 
     def sort_results(self, queryset, filters):
         """
@@ -263,10 +264,10 @@ class PollsRecommendationsView(PollRecommendationsBaseAPIView):
         raw_score_mode = request.query_params.get("score_mode", ScoreMode.DEFAULT)
         try:
             score_mode = ScoreMode(raw_score_mode)
-        except ValueError:
+        except ValueError as error:
             raise serializers.ValidationError(
                 {"score_mode": f"Accepted values are: {','.join(ScoreMode.values)}"}
-            )
+            ) from error
 
         criteria_weight = self._build_criteria_weight_condition(
             request, poll, when="all_criteria_scores__criteria"

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -31,19 +31,23 @@ def get_annotated_ratings():
 
 @extend_schema_view(
     get=extend_schema(
-        description="Retrieve the logged-in user's ratings for a specific video "
-        "in a given poll (computed automatically from the user's comparisons)."
+        description="Retrieve the logged-in user's ratings for a specific entity "
+        "(computed automatically from the user's comparisons)."
     ),
     put=extend_schema(
         description="Update public / private status of the logged-in user ratings "
-        "for a specific video, in a given poll."
+        "for a specific entity."
     ),
     patch=extend_schema(
         description="Update public / private status of the logged-in user ratings "
-        "for a specific video, in a given poll."
+        "for a specific entity."
     ),
 )
 class ContributorRatingDetail(PollScopedViewMixin, generics.RetrieveUpdateAPIView):
+    """
+    Get or update the current user's rating for the designated entity.
+    Used in particular to get or update the is_public attribute.
+    """
     serializer_class = ContributorRatingSerializer
 
     def get_object(self):
@@ -69,6 +73,7 @@ class ContributorRatingDetail(PollScopedViewMixin, generics.RetrieveUpdateAPIVie
     ),
 )
 class ContributorRatingList(PollScopedViewMixin, generics.ListCreateAPIView):
+    """List the contributor's rated entities on the given poll and their scores."""
     queryset = ContributorRating.objects.none()
 
     def get_serializer_class(self):

--- a/backend/tournesol/views/stats.py
+++ b/backend/tournesol/views/stats.py
@@ -1,6 +1,7 @@
 """
 API endpoints to show public statistics
 """
+from dataclasses import dataclass
 from typing import List
 
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -14,22 +15,22 @@ from tournesol.models import Comparison, Entity, Poll
 from tournesol.serializers.stats import StatisticsSerializer
 
 
+@dataclass
 class ActiveUsersStatistics:
-    def __init__(self, total, joined_last_month):
-        self.total = total
-        self.joined_last_month = joined_last_month
+    total: int
+    joined_last_month: int
 
 
+@dataclass
 class ComparedEntitiesStatistics:
-    def __init__(self, total, added_last_month):
-        self.total = total
-        self.added_last_month = added_last_month
+    total: int
+    added_last_month: int
 
 
+@dataclass
 class ComparisonsStatistics:
-    def __init__(self, total, added_last_month):
-        self.total = total
-        self.added_last_month = added_last_month
+    total: int
+    added_last_month: int
 
 
 class PollStatistics:

--- a/backend/tournesol/views/stats.py
+++ b/backend/tournesol/views/stats.py
@@ -88,6 +88,7 @@ class Statistics:
     get=extend_schema(description="Fetch all Tournesol's public statistics.")
 )
 class StatisticsView(generics.GenericAPIView):
+    """Return popularity statistics about Tournesol"""
     permission_classes = [AllowAny]
     serializer_class = StatisticsSerializer
 

--- a/backend/tournesol/views/user.py
+++ b/backend/tournesol/views/user.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class CurrentUserView(APIView):
+    """Manage the deletion of the authenticated user."""
     permission_classes = [IsAuthenticated]
 
     @extend_schema(responses={204: None})

--- a/backend/tournesol/views/video.py
+++ b/backend/tournesol/views/video.py
@@ -83,6 +83,7 @@ class VideoViewSet(
     mixins.ListModelMixin,
     GenericViewSet,
 ):
+    """Obsolete view for video recommendations."""
     queryset = Entity.objects.filter(type=TYPE_VIDEO)
     pagination_class = LimitOffsetPagination
     permission_classes = [IsAuthenticatedOrReadOnly]
@@ -138,15 +139,15 @@ class VideoViewSet(
             try:
                 date_lte = self.parse_datetime(date_lte)
                 queryset = VideoEntity.filter_date_lte(queryset, date_lte)
-            except ValueError:
-                raise ValidationError('"date_lte" is an invalid datetime.')
+            except ValueError as error:
+                raise ValidationError('"date_lte" is an invalid datetime.') from error
         date_gte = request.query_params.get("date_gte") or ""
         if date_gte:
             try:
                 date_gte = self.parse_datetime(date_gte)
                 queryset = VideoEntity.filter_date_gte(queryset, date_gte)
-            except ValueError:
-                raise ValidationError('"date_gte" is an invalid datetime')
+            except ValueError as error:
+                raise ValidationError('"date_gte" is an invalid datetime') from error
 
         language = request.query_params.get("language")
         if language:

--- a/backend/twitterbot/tests/test_get_twitter_account.py
+++ b/backend/twitterbot/tests/test_get_twitter_account.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from twitterbot.uploader_twitter_account import get_twitter_account_from_channel_id, get_twitter_handles_from_html
+from twitterbot.uploader_twitter_account import (
+    get_twitter_account_from_channel_id,
+    get_twitter_handles_from_html,
+)
 
 
 @patch("twitterbot.uploader_twitter_account.requests.get")

--- a/backend/twitterbot/tournesolbot.py
+++ b/backend/twitterbot/tournesolbot.py
@@ -13,8 +13,8 @@ from twitterbot.twitter_api import TwitterBot
 from twitterbot.uploader_twitter_account import get_twitter_account_from_video_id
 
 
-def get_best_criteria(video, n):
-    """Get the n best criteria"""
+def get_best_criteria(video, nb_criteria):
+    """Get the nb_criteria best-rated criteria"""
 
     criteria_list = (
         video.all_criteria_scores.filter(
@@ -22,10 +22,10 @@ def get_best_criteria(video, n):
             score_mode=ScoreMode.DEFAULT,
         )
         .exclude(criteria="largely_recommended")
-        .order_by("-score")[:n]
+        .order_by("-score")[:nb_criteria]
     )
 
-    if len(criteria_list) < n:
+    if len(criteria_list) < nb_criteria:
         raise ValueError("Not enough criteria to show!")
 
     return [(crit.criteria, crit.score) for crit in criteria_list]

--- a/backend/twitterbot/tournesolbot.py
+++ b/backend/twitterbot/tournesolbot.py
@@ -129,7 +129,11 @@ def select_a_video(tweetable_videos):
     tournesol_score_list = [v.tournesol_score for v in tweetable_videos]
 
     # Chose a random video weighted by tournesol score
-    selected_video = random.choices(tweetable_videos, weights=tournesol_score_list)[0]
+
+    selected_video = random.choices(  # nosec - not a cryptographic use, ignore bandit B311 here
+        tweetable_videos,
+        weights=tournesol_score_list
+    )[0]
 
     return selected_video
 

--- a/backend/twitterbot/twitter_api.py
+++ b/backend/twitterbot/twitter_api.py
@@ -17,6 +17,7 @@ class TwitterBot:
         self.consumer_secret = account_cred["CONSUMER_SECRET"]
         self.access_token = account_cred["ACCESS_TOKEN"]
         self.access_token_secret = account_cred["ACCESS_TOKEN_SECRET"]
+        self.api = None
 
     def authenticate(self):
 

--- a/backend/twitterbot/uploader_twitter_account.py
+++ b/backend/twitterbot/uploader_twitter_account.py
@@ -4,7 +4,7 @@ Used for the Tournesol twitter bot.
 """
 
 import re
-from urllib.parse import urlparse, unquote
+from urllib.parse import unquote, urlparse
 
 import requests
 
@@ -27,7 +27,7 @@ def get_twitter_account_from_channel_id(channel_id):
 
     uploader_url = f"https://www.youtube.com/channel/{channel_id}/about"
 
-    resp = requests.get(uploader_url, headers={"user-agent": "curl/7.68.0"})
+    resp = requests.get(uploader_url, headers={"user-agent": "curl/7.68.0"}, timeout=10)
     twitter_names = get_twitter_handles_from_html(resp.text)
 
     if len({name.lower() for name in twitter_names}) == 1:


### PR DESCRIPTION
Here is a first shot at pylint warnings, after upgrading the pylint version. I'm waiting for some feedback to know if I should continue.

Do we want to have a zero-warnings strategy and include it in the continuous integration? (is it productive? pylint warnings can be more tricky to solve than flake8 warnings)
If yes, which warnings to disable?

On our previous configuration file, .pylintrc, we made no customization. The .pylintrc generated with the new Pylint version looks very different, but the only important difference is about the "disable" variable (indicating ignored warning types) => fewer warning types are ignored by default. 
Here is what I modified from the default pylint config:
- I added serializers to the list of ignored directories names (I estimated that the warnings there were not really interesting to "solve" ; the only 2 types of warnings there were missing-class-docstring and abstract-method)
- I disabled the warning types:
	* missing-module-docstring (we didn't get the habit to make module docstrings)
	* too-many-ancestors (sometimes when inheriting from Django classes, the inheritance level can quickly get high and it's hard to find a workaround anyway)
	* too-few-public-methods (some classes are used just to store data and don't have methods, and it's not so much an issue, I still fixed it using the decorator dataclass when it was relevant)
	* use-maxsplit-arg (only appeared once: published_date.split("T")[0] => it's just as easy to solve the warning, but I don't find it very meaningful either as a performance improvement)
	
Warnings are by default disabled on the repertories called "tests".
I did not add the machine learning (ml) to the directories checked by Pylint in lint.sh. Like with the serializers, most of the warnings there don't really look interesting.

bandit was also upgraded, and gave a single warning due to the use of random.choices. I deactivated the warning, because although there are alternatives to random.choice (e.g. in the library secrets), there doesn't seem to be an alternative to random.choices, with a "s".

Some other checkers that we could chose to disable:
- missing-class-docstring
- import-outside-toplevel (hard to really solve)
- consider-using-f-string (I suspect it was usually done on purpose, not using f-strings)
- broad-except (broadly catching exceptions might be legitimate sometimes)
- abstract-method (usually not so useful)
- logging-fstring-interpolation (apparently, this is mostly useful for log aggregators, but I don't think we are using one)
	
	
Warnings can be disabled per file or per line, for example with "# pylint: disable=missing-class-docstring, too-many-arguments"


If you don't like some docstrings or other corrections, feel free to modify it directly in my branch. 
And of course, you can disagree with my decisions for disabled warning types and for disabling analysis on serializers, no problem with that.

Here are the current logs:
[logs_pylint.txt](https://github.com/tournesol-app/tournesol/files/9337971/logs_pylint.txt)
 