### PR TITLE
[ext] refactor: use the generic rate later API

### DIFF
--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.1.11",
+  "version": "2.2.0",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -59,9 +59,9 @@ export const fetchTournesolApi = async (url, method, data) => {
 
 export const addRateLater = async (video_id) => {
   const ratingStatusReponse = await fetchTournesolApi(
-    'users/me/video_rate_later/',
+    'users/me/rate_later/videos/',
     'POST',
-    { video: { video_id: video_id } }
+    { entity: { uid: "yt:" + video_id } }
   );
   if (ratingStatusReponse && ratingStatusReponse.ok) {
     return {

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -61,7 +61,7 @@ export const addRateLater = async (video_id) => {
   const ratingStatusReponse = await fetchTournesolApi(
     'users/me/rate_later/videos/',
     'POST',
-    { entity: { uid: "yt:" + video_id } }
+    { entity: { uid: 'yt:' + video_id } }
   );
   if (ratingStatusReponse && ratingStatusReponse.ok) {
     return {


### PR DESCRIPTION
**indirectly related to** #606

---

This PR makes the extension use the new generic rate later API instead of the deprecated one.