### PR TITLE
[twitterbot] fix: incorrect handle when twitter link has extra params

### DIFF
--- a/backend/twitterbot/tests/test_get_twitter_account.py
+++ b/backend/twitterbot/tests/test_get_twitter_account.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from twitterbot.uploader_twitter_account import get_twitter_account_from_channel_id
+from twitterbot.uploader_twitter_account import get_twitter_account_from_channel_id, get_twitter_handles_from_html
 
 
 @patch("twitterbot.uploader_twitter_account.requests.get")
@@ -22,3 +22,8 @@ def test_get_twitter_account_from_channel_id(mock_requests):
     mock_requests.return_value = MagicMock(status_code=200, text=mock_bad_resp)
 
     assert get_twitter_account_from_channel_id("UC0NCbj8CxzeCGIF6sOZZZZZ") is None
+
+
+def test_twitter_account_from_html_with_extra_params():
+    html = 'q=https%3A%2F%2Ftwitter.com%2FKurz_Gesagt%3Fref_src%3Dtwsrc%255Egoogle%257Ctwcamp%255Eserp%257Ctwgr%255Eauthor"'
+    assert get_twitter_handles_from_html(html) == ["Kurz_Gesagt"]

--- a/backend/twitterbot/uploader_twitter_account.py
+++ b/backend/twitterbot/uploader_twitter_account.py
@@ -4,10 +4,22 @@ Used for the Tournesol twitter bot.
 """
 
 import re
+from urllib.parse import urlparse, unquote
 
 import requests
 
 from tournesol.utils.api_youtube import get_video_metadata
+
+
+def get_twitter_handles_from_html(html_text):
+    urls = re.findall(r"(https\%3A\%2F\%2Ftwitter.com\%2F.*?)\"", html_text, re.IGNORECASE)
+    handles = []
+    for raw_url in urls:
+        url = unquote(raw_url)
+        handle = urlparse(url).path.strip('/')
+        if handle:
+            handles.append(handle)
+    return handles
 
 
 def get_twitter_account_from_channel_id(channel_id):
@@ -16,9 +28,7 @@ def get_twitter_account_from_channel_id(channel_id):
     uploader_url = f"https://www.youtube.com/channel/{channel_id}"
 
     resp = requests.get(uploader_url, headers={"user-agent": "curl/7.68.0"})
-
-    twitter_names = re.findall(r"twitter.com\%2F(.*?)\"", resp.text)
-    twitter_names = [name for name in twitter_names if name != ""]
+    twitter_names = get_twitter_handles_from_html(resp.text)
 
     if len({name.lower() for name in twitter_names}) == 1:
         return "@" + twitter_names[0]

--- a/backend/twitterbot/uploader_twitter_account.py
+++ b/backend/twitterbot/uploader_twitter_account.py
@@ -12,7 +12,7 @@ from tournesol.utils.api_youtube import get_video_metadata
 
 
 def get_twitter_handles_from_html(html_text):
-    urls = re.findall(r"(https\%3A\%2F\%2Ftwitter.com\%2F.*?)\"", html_text, re.IGNORECASE)
+    urls = re.findall(r"(https%3A%2F%2Ftwitter.com%2F.*?)\"", html_text, re.IGNORECASE)
     handles = []
     for raw_url in urls:
         url = unquote(raw_url)


### PR DESCRIPTION
On a YT channel page, the link to twitter account may contain extra params, which should be ignored to extract to the twitter account handle. (See unit test for details).