### PR TITLE
[infra] sec: back end's admin is now accessible only from localhost

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -98,6 +98,45 @@ You can do the same with another VM or a different username:
 source ./ansible/scripts/get-vm-secrets.sh "tournesol-vm" "jst"
 ```
 
+## Accessing the back end admin interface
+
+To protect the back end's admin interface, its access is restricted to
+HTTP requests coming from its own host.
+
+Users having an account on the server can access this interface by using an
+SSH tunnel.
+
+### Example: accessing the staging admin
+
+First, edit your own `/etc/hosts` or equivalent. This is required to make our
+requests reach the correct NGINX virtual host, and not the default one.
+
+```
+127.0.0.1    api.staging.tournesol.app
+```
+
+Then create an SSH tunnel to the server.
+
+```shell
+sudo ssh -L 443:staging.tournesol.app:443 {duser}@staging.tournesol.app -i /home/{luser}/.ssh/private_key
+```
+
+Where:
+- `{duser}` is your username on the distant server ;
+- `{luser}` is the username on your local host able to connect to the distant server.
+
+The bound local port must be 443 to avoid CSRF error when connecting to the
+administration interface through the tunnel. To bind the port 443, superuser
+privileges are required, hence the usage of `sudo`.
+
+You can now connect to the back end with by using this URL in your web browser:
+
+```
+https://api.staging.tournesol.app/admin/
+```
+
+Exit the tunnel you are done.
+
 ## Dump Tournesol DB
 
 ```bash

--- a/infra/README.md
+++ b/infra/README.md
@@ -135,7 +135,7 @@ You can now connect to the back end with by using this URL in your web browser:
 https://api.staging.tournesol.app/admin/
 ```
 
-Exit the tunnel you are done.
+Exit the tunnel when you are done.
 
 ## Dump Tournesol DB
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -108,7 +108,7 @@ SSH connection and a SOCKS proxy.
 
 ### Example: accessing the staging admin
 
-First, you need to configure in your web browser a local proxy SOCKS using
+First, you need to configure in your web browser a local SOCKS proxy using
 SOCKS v5 at `127.0.0.1:8080`. To greatly ease the configuration you can use
 a browser extention instead of using the default browser interface.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -104,14 +104,13 @@ To protect the back end admin interface, its access is restricted to HTTP
 requests coming from its own host.
 
 Users having an account on the server can access this interface by using an
-SSH connection.
+SSH connection and a SOCKS proxy.
 
 ### Example: accessing the staging admin
 
 First, you need to configure in your web browser a local proxy SOCKS using
-SOCKS v5 at `127.0.0.1:8080`. To avoid sending all your web traffic to the
-staging server, you can use a browser extention to easily configure your
-proxy.
+SOCKS v5 at `127.0.0.1:8080`. To greatly ease the configuration you can use
+a browser extention instead of using the default browser interface.
 
 - Mozilla Firefox: [FoxyProxy Standard][foxy-proxy-firefox]
 - Google Chrome: [FoxyProxy Standard][foxy-proxy-chromium]
@@ -124,27 +123,27 @@ proxy (use the wildcard mode):
 - api.tournesol.app
 - api.staging.tournesol.app
 
-Your proxy is now available in your browser actions. Select the option use
-proxies based on their predefined patterns and priorities, in order to
-automatically use the created proxy when the requested URLs match the defined
-patterns.
+Your proxy is now available in your browser actions, but an SSH connection to
+the staging server is still required to complete the process.
 
-Now create an SSH connection to the target server by using an
+Finally create an SSH connection to the target server by using an
 application-level port fowarding. This will forward all connections to the
-local port 8080 over the secure channel.
+local port `8080` over the secure channel.
 
 ```shell
 sudo ssh -N -D 8080 staging.tournesol.app
 ```
 
-Run this command in addition each time you want to access the back end admin
-interface.
+Run this command in a terminal and activate the proxy from your browser
+actions to make the admin interface accessible (use the option "use proxies
+based on their predefined patterns and priorities" to proxy only requests
+targetting the configured HTTP addresses).
 
 ```
 https://api.staging.tournesol.app/admin/
 ```
 
-Close the SSH connection when you are done.
+Close the SSH connection and disable the proxy when you are done.
 
 ## Dump Tournesol DB
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -100,8 +100,8 @@ source ./ansible/scripts/get-vm-secrets.sh "tournesol-vm" "jst"
 
 ## Accessing the back end admin interface
 
-To protect the back end's admin interface, its access is restricted to
-HTTP requests coming from its own host.
+To protect the back end admin interface, its access is restricted to HTTP
+requests coming from its own host.
 
 Users having an account on the server can access this interface by using an
 SSH connection.
@@ -119,7 +119,7 @@ proxy.
 Install FoxyProxy Standard, and configure a new manual proxy at `127.0.0.1`
 using the port `8080`, and the SOCKS protocol v5. In the proxy settings, add
 two inclusive URL patterns to specify which addresses are allowed to use the
-proxy:
+proxy (use the wildcard mode):
 
 - api.tournesol.app
 - api.staging.tournesol.app

--- a/infra/README.md
+++ b/infra/README.md
@@ -131,7 +131,7 @@ application-level port fowarding. This will forward all connections to the
 local port `8080` over the secure channel.
 
 ```shell
-sudo ssh -N -D 8080 staging.tournesol.app
+ssh -N -D 8080 staging.tournesol.app
 ```
 
 Run this command in a terminal and activate the proxy from your browser

--- a/infra/README.md
+++ b/infra/README.md
@@ -104,38 +104,47 @@ To protect the back end's admin interface, its access is restricted to
 HTTP requests coming from its own host.
 
 Users having an account on the server can access this interface by using an
-SSH tunnel.
+SSH connection.
 
 ### Example: accessing the staging admin
 
-First, edit your own `/etc/hosts` or equivalent. This is required to make our
-requests reach the correct NGINX virtual host, and not the default one.
+First, you need to configure in your web browser a local proxy SOCKS using
+SOCKS v5 at `127.0.0.1:8080`. To avoid sending all your web traffic to the
+staging server, you can use a browser extention to easily configure your
+proxy.
 
-```
-127.0.0.1    api.staging.tournesol.app
-```
+- Mozilla Firefox: [FoxyProxy Standard][foxy-proxy-firefox]
+- Google Chrome: [FoxyProxy Standard][foxy-proxy-chromium]
 
-Then create an SSH tunnel to the server.
+Install FoxyProxy Standard, and configure a new manual proxy at `127.0.0.1`
+using the port `8080`, and the SOCKS protocol v5. In the proxy settings, add
+two inclusive URL patterns to specify which addresses are allowed to use the
+proxy:
+
+- api.tournesol.app
+- api.staging.tournesol.app
+
+Your proxy is now available in your browser actions. Select the option use
+proxies based on their predefined patterns and priorities, in order to
+automatically use the created proxy when the requested URLs match the defined
+patterns.
+
+Now create an SSH connection to the target server by using an
+application-level port fowarding. This will forward all connections to the
+local port 8080 over the secure channel.
 
 ```shell
-sudo ssh -L 443:staging.tournesol.app:443 {duser}@staging.tournesol.app -i /home/{luser}/.ssh/private_key
+sudo ssh -N -D 8080 staging.tournesol.app
 ```
 
-Where:
-- `{duser}` is your username on the distant server ;
-- `{luser}` is the username on your local host able to connect to the distant server.
-
-The bound local port must be 443 to avoid CSRF error when connecting to the
-administration interface through the tunnel. To bind the port 443, superuser
-privileges are required, hence the usage of `sudo`.
-
-You can now connect to the back end with by using this URL in your web browser:
+Run this command in addition each time you want to access the back end admin
+interface.
 
 ```
 https://api.staging.tournesol.app/admin/
 ```
 
-Exit the tunnel when you are done.
+Close the SSH connection when you are done.
 
 ## Dump Tournesol DB
 
@@ -185,3 +194,7 @@ Copyright 2021-2022 Association Tournesol and contributors.
 
 Included license:
  - [AGPL-3.0-or-later](./LICENSE)
+
+
+[foxy-proxy-firefox]: https://addons.mozilla.org/en-US/firefox/addon/foxyproxy-standard/
+[foxy-proxy-chromium]: https://chrome.google.com/webstore/detail/foxyproxy-standard/gcknhkkoolaabfmlnjonogaaifnjlfnp

--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -89,6 +89,24 @@ server {
         proxy_pass http://unix:/run/gunicorn.sock;
     }
 
+    # Secure the admin interface, by making
+    # it accessible only from the local host.
+    location /admin/ {
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_pass http://unix:/run/gunicorn.sock;
+    }
+
     location / {
         {% if maintenance %}
             return 503;


### PR DESCRIPTION
This PR aims to increase the security of our back end by limiting the access to its administration interface to HTTP requests coming from its own host.

Users having an account on the server can access the interface by using an SSH tunnel and a browser extension as described in the `README.md`.