### PR TITLE
[twitterbot] fix: accept http link when extracting twitter account

### DIFF
--- a/backend/twitterbot/tests/test_get_twitter_account.py
+++ b/backend/twitterbot/tests/test_get_twitter_account.py
@@ -27,3 +27,7 @@ def test_get_twitter_account_from_channel_id(mock_requests):
 def test_twitter_account_from_html_with_extra_params():
     html = 'q=https%3A%2F%2Ftwitter.com%2FKurz_Gesagt%3Fref_src%3Dtwsrc%255Egoogle%257Ctwcamp%255Eserp%257Ctwgr%255Eauthor"'
     assert get_twitter_handles_from_html(html) == ["Kurz_Gesagt"]
+
+def test_twitter_account_from_html_with_http():
+    html = 'q=http%3A%2F%2Ftwitter.com%2Fveritasium"'
+    assert get_twitter_handles_from_html(html) == ["veritasium"]

--- a/backend/twitterbot/uploader_twitter_account.py
+++ b/backend/twitterbot/uploader_twitter_account.py
@@ -12,7 +12,7 @@ from tournesol.utils.api_youtube import get_video_metadata
 
 
 def get_twitter_handles_from_html(html_text):
-    urls = re.findall(r"(https%3A%2F%2F(?:www\.)?twitter\.com%2F.*?)\"", html_text, re.IGNORECASE)
+    urls = re.findall(r"(https?%3A%2F%2F(?:www\.)?twitter\.com%2F.*?)\"", html_text, re.IGNORECASE)
     handles = []
     for raw_url in urls:
         url = unquote(raw_url)


### PR DESCRIPTION
One more edge-case to fix, following #1093 and #1095 
