### PR TITLE
[front] fix: more involving tutorial messages

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -574,14 +574,14 @@
       "tutorial": {
         "title1": "Welcome to Tournesol 🌻",
         "message1": {
-          "p10": "This tutorial will guide you step by step through a series of four comparisons.",
+          "p10": "This tutorial will guide you, step by step, through a series of four comparisons to enrich the project.",
           "p20": "To compare two videos you watched, move the main handle and save when your choice is made.",
           "p30": "The more your opinion is clear-cut on a criterion, the more the handle should be close to the slider extremity.",
           "p40": "If you find the videos similar, the handle should remain close to the center."
         },
         "title2": "Bravo ! 🥳",
         "message2": {
-          "p10": "You have made your first comparison",
+          "p10": "You have made your first comparison. Each of them allows Tournesol to fine-tune its recommendations.",
           "p20": "Note that you can choose yourself the videos to compare by pasting their YouTube URL in the fields above the thumbnails.",
           "p30": "Try to unfold and use the optional criteria to give a more complete opinion about the videos.",
           "p40": "You can also choose to not vote on the optional criteria by unchecking it.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -574,14 +574,14 @@
       "tutorial": {
         "title1": "Welcome to Tournesol 🌻",
         "message1": {
-          "p10": "This tutorial will guide you, step by step, through a series of four comparisons to enrich the project.",
+          "p10": "This tutorial will guide you, step by step, through a series of four comparisons to help you contribute to the Tournesol project.",
           "p20": "To compare two videos you watched, move the main handle and save when your choice is made.",
           "p30": "The more your opinion is clear-cut on a criterion, the more the handle should be close to the slider extremity.",
           "p40": "If you find the videos similar, the handle should remain close to the center."
         },
         "title2": "Bravo ! 🥳",
         "message2": {
-          "p10": "You have made your first comparison. Each of them allows Tournesol to fine-tune its recommendations.",
+          "p10": "You have made your first comparison. Each comparison helps Tournesol to improve its video recommendations.",
           "p20": "Note that you can choose yourself the videos to compare by pasting their YouTube URL in the fields above the thumbnails.",
           "p30": "Try to unfold and use the optional criteria to give a more complete opinion about the videos.",
           "p40": "You can also choose to not vote on the optional criteria by unchecking it.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -581,14 +581,14 @@
       "tutorial": {
         "title1": "Bienvenue sur Tournesol 🌻",
         "message1": {
-          "p10": "Ce tutoriel va vous guider pas à pas à travers une série de quatre comparaisons, qui vont enrichir le projet.",
+          "p10": "Ce tutoriel va vous guider pas à pas à travers une série de quatre comparaisons, afin de vous aider à contribuer au projet Tournesol.",
           "p20": "Pour comparer deux vidéos que vous avez regardées, déplacez le curseur principal, puis enregistrez quand votre choix est fait.",
           "p30": "Plus votre avis est tranché plus le curseur devrait être proche de l'extrémité.",
           "p40": "Si vous trouvez les vidéos similaires, le curseur devrait rester proche du centre."
         },
         "title2": "Bravo ! 🥳",
         "message2": {
-          "p10": "Vous avez effectué votre première comparaison. Chacune d'entre elles permet à Tournesol d'affiner ses recommandations.",
+          "p10": "Vous avez effectué votre première comparaison. Chaque comparaison aide Tournesol à améliorer ses recommandations de vidéo.",
           "p20": "Notez que vous pouvez choisir vous-même les vidéos à comparer en collant leurs URLs YouTube dans les champs qui se trouvent au dessus des miniatures.",
           "p30": "Essayez maintenant de dérouler les critères optionnels pour donner un avis plus complet sur les vidéos.",
           "p40": "Vous pouvez choisir de ne pas vous exprimer sur un critère optionnel en le décochant.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -581,22 +581,22 @@
       "tutorial": {
         "title1": "Bienvenue sur Tournesol 🌻",
         "message1": {
-          "p10": "Ce tutoriel va vous guider pas à pas à travers une série de quatre comparaisons.",
+          "p10": "Ce tutoriel va vous guider pas à pas à travers une série de quatre comparaisons, qui vont enrichir le projet.",
           "p20": "Pour comparer deux vidéos que vous avez regardées, déplacez le curseur principal, puis enregistrez quand votre choix est fait.",
           "p30": "Plus votre avis est tranché plus le curseur devrait être proche de l'extrémité.",
           "p40": "Si vous trouvez les vidéos similaires, le curseur devrait rester proche du centre."
         },
         "title2": "Bravo ! 🥳",
         "message2": {
-          "p10": "Vous avez effectué votre première comparaison.",
-          "p20": "Notez que vous pouvez choisir vous-même les vidéos à comparer en collant leurs URL YouTube dans les champs qui se trouvent au dessus des miniatures.",
+          "p10": "Vous avez effectué votre première comparaison. Chacune d'entre elles permet à Tournesol d'affiner ses recommandations.",
+          "p20": "Notez que vous pouvez choisir vous-même les vidéos à comparer en collant leurs URLs YouTube dans les champs qui se trouvent au dessus des miniatures.",
           "p30": "Essayez maintenant de dérouler les critères optionnels pour donner un avis plus complet sur les vidéos.",
           "p40": "Vous pouvez choisir de ne pas vous exprimer sur un critère optionnel en le décochant.",
           "p50": "Bon à savoir, il est toujours possible de modifier ultérieurement vos comparaisons si vous n'êtes pas sûr·e de vous."
         },
         "title3": "Comment fonctionne Tournesol ? 🤖",
         "message3": {
-          "p10": "Tournesol calcule un score pour chaque vidéo, en agrégeant les jugements des contributeurs et contributrices sur les différents critères.",
+          "p10": "Tournesol calcule un score pour chaque vidéo, en agrégeant les jugements des contributeur·trices sur les différents critères.",
           "p20": "Le score final représente alors un équilibre, qui est au milieu des préférences des différentes personnes votantes.",
           "p30": "Vous pouvez à tout moment consulter la description d'un critère en passant votre souris dessus. Pour obtenir encore plus information, cliquer sur un critère permet de consulter sa page wiki dédiée."
         },


### PR DESCRIPTION
**related to** #1099


This small PR adds few words in the tutorial to make it clear that:
- a **comparison is actually a contribution** to the project
- Tournesol uses comparisons **to make recommendations**
- going through the tutorial **helps** the Tournesol project

We might want one day to review the tutorial texts in details, in the meantime this is my subjective attempt to make the tutorial more clear without increasing its size and without adding too much text.

Hope it helps : )