### PR TITLE
[ml] chore: upgrade torch to 1.12.1 for compatibility with Apple silicon

### DIFF
--- a/backend/ml/ml_requirements.txt
+++ b/backend/ml/ml_requirements.txt
@@ -1,5 +1,5 @@
 # production
-torch==1.9.1
+torch==1.12.1
 gin-config==0.4.0
 Bottleneck==1.3.4
 


### PR DESCRIPTION
PyTorch 1.9.1 is not distributed for arm CPUs and Apple silicon (M1, M2).  
@aidanjungo As a quick fix, could you check if this upgrades solves your problem on MacOS?

_Side note: PyTorch is used on (deprecated) Licchavi only.   
On a separate branch, I will have a look at how this dependency could be removed completely._ 
