### PR TITLE
[back] tests: fix flaky tests about trust_algo and cover edge cases

### DIFF
--- a/backend/scripts/ci/lint-fix.sh
+++ b/backend/scripts/ci/lint-fix.sh
@@ -3,4 +3,4 @@ set -euxo pipefail
 
 # Python Code Quality Fixes
 
-isort --settings-path .isort.cfg ${@:-core faq ml settings tournesol twitterbot}
+isort --settings-path .isort.cfg ${@:-core faq ml settings tournesol twitterbot vouch}

--- a/backend/vouch/trust_algo.py
+++ b/backend/vouch/trust_algo.py
@@ -1,9 +1,12 @@
+import logging
 import numpy as np
 from django.db.models import Q
 from numpy.typing import NDArray
 
 from core.models.user import User
 from vouch.models import Voucher
+
+logger = logging.getLogger(__name__)
 
 # In this algorithm, we leverage pretrust (e.g., based on email domains) and vouching
 # to securely assign voting rights to a wider set of contributors.
@@ -119,6 +122,10 @@ def trust_algo():
         user.id: user_index for user_index, user in enumerate(users)
     }
     pretrusts = np.array([int(u.in_trusted_users) for u in users])
+    if np.sum(pretrusts) == 0:
+        logger.warning("Voting right cannot be computed: no pretrusted user exists")
+        return
+
     nb_users = len(users)
 
     # Import vouching matrix
@@ -140,4 +147,3 @@ def trust_algo():
     for user_no, user_model in enumerate(users):
         user_model.voting_right = float(voting_rights[user_no])
     User.objects.bulk_update(users, ["voting_right"])
-    return True

--- a/backend/vouch/trust_algo.py
+++ b/backend/vouch/trust_algo.py
@@ -1,4 +1,5 @@
 import logging
+
 import numpy as np
 from django.db.models import Q
 from numpy.typing import NDArray


### PR DESCRIPTION
* split tests about trust_algo into 2 classes
* ensute that at lest 1 pretrusted user exists in "pretrusts" vector used in unit tests
* cover edge cases in tests: no pretrusted user, no voucher in database