### PR TITLE
[front] chore: upgrade lib and remove workaround related to single quotes in openapi.yml

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,7 +80,7 @@
     "fetch-mock-jest": "^1.5.1",
     "husky": "^7.0.1",
     "i18next-parser": "^5.3.0",
-    "openapi-typescript-codegen": "^0.19.0",
+    "openapi-typescript-codegen": "^0.23.0",
     "prettier": "^2.3.2",
     "react-test-renderer": "^17.0.2",
     "redux-mock-store": "^1.5.4"

--- a/frontend/scripts/generate-services-from-openapi.sh
+++ b/frontend/scripts/generate-services-from-openapi.sh
@@ -15,7 +15,3 @@ fi
 cd ..
 yarn run openapi
 # rm -rf tmp
-
-# workaround for bug in quote handling
-sed -i 's/Côte d'\''Ivoire/Côte d\\'\''Ivoire/' src/services/openapi/models/NationalityEnum.ts
-sed -i 's/Côte d'\''Ivoire/Côte d\\'\''Ivoire/' src/services/openapi/models/ResidenceEnum.ts

--- a/frontend/scripts/generate-services-from-openapi.sh
+++ b/frontend/scripts/generate-services-from-openapi.sh
@@ -10,8 +10,5 @@ else
     source "../.env.development"
 fi
 
-# mkdir -p tmp
-# wget -O tmp/openapi.yaml "$REACT_APP_API_URL/schema/"
 cd ..
 yarn run openapi
-# rm -rf tmp

--- a/frontend/src/pages/personal/vouchers/VouchersPage.spec.tsx
+++ b/frontend/src/pages/personal/vouchers/VouchersPage.spec.tsx
@@ -102,6 +102,10 @@ describe('VouchersPage', () => {
   it('handles error on form submit', async () => {
     const error = new ApiError(
       {
+        method: 'GET',
+        url: 'some url',
+      },
+      {
         url: 'some url',
         ok: false,
         status: 400,
@@ -174,6 +178,10 @@ describe('VouchersPage', () => {
 
   it('handles error on given voucher deletion', async () => {
     const error = new ApiError(
+      {
+        method: 'GET',
+        url: 'some url',
+      },
       {
         url: 'some url',
         ok: false,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3705,10 +3705,10 @@ commander@^8.3.0, commander@~8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
-commander@^9.0.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
-  integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
+commander@^9.3.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
+  integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
 
 common-path-prefix@^3.0.0:
   version "3.0.0"
@@ -5319,7 +5319,7 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-fs-extra@^10.0.0:
+fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
@@ -5568,7 +5568,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars@^4.7.6:
+handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -6855,7 +6855,7 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
-json-schema-ref-parser@^9.0.7:
+json-schema-ref-parser@^9.0.9:
   version "9.0.9"
   resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz#66ea538e7450b12af342fa3d5b8458bc1e1e013f"
   integrity sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==
@@ -7619,15 +7619,16 @@ open@^8.0.9, open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-openapi-typescript-codegen@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/openapi-typescript-codegen/-/openapi-typescript-codegen-0.19.0.tgz#b374e8822fd7a9f91de95c1e11b3f91051820a1b"
-  integrity sha512-zH5SVslIKCmMWaieMa16VR95afLj1LrV39w1mAY1pwIFF1mdaD/q/DJ+N4fIIrTrc1L1WtaR0lvpqiv4umzwkQ==
+openapi-typescript-codegen@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-codegen/-/openapi-typescript-codegen-0.23.0.tgz#702a651eefc536b27e87e4ad54a80a31d36487f0"
+  integrity sha512-gOJXy5g3H3HlLpVNN+USrNK2i2KYBmDczk9Xk34u6JorwrGiDJZUj+al4S+i9TXdfUQ/ZaLxE59Xf3wqkxGfqA==
   dependencies:
     camelcase "^6.3.0"
-    commander "^9.0.0"
-    handlebars "^4.7.6"
-    json-schema-ref-parser "^9.0.7"
+    commander "^9.3.0"
+    fs-extra "^10.1.0"
+    handlebars "^4.7.7"
+    json-schema-ref-parser "^9.0.9"
 
 optionator@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
The bug related to single quotes has been fixed in recent versions of "openapi-typescript-codegen"  
See: https://github.com/ferdikoomen/openapi-typescript-codegen/blob/v0.23.0/CHANGELOG.md

This change also removes the usage of `sed` in "generate-services-from-openapi.sh", which was known to cause compatibility issues on MacOS.