### PR TITLE
[back] fix: prevent a `Voucher` to be saved with the same `by` and `to`

### DIFF
--- a/backend/core/locale/fr/LC_MESSAGES/django.po
+++ b/backend/core/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-19 09:10+0000\n"
+"POT-Creation-Date: 2022-09-21 12:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: core/models/user.py:29
+#: core/models/user.py:36
 msgid "email address"
 msgstr "adresse e-mail"
 
-#: core/models/user.py:284
+#: core/models/user.py:294
 #, python-format
 msgid ""
 "A user with an email starting with '%(email)s' already exists in this domain."
@@ -30,7 +30,7 @@ msgstr ""
 "Un utilisateur avec un e-mail commençant par '%(email)s' existe déjà dans ce "
 "domaine."
 
-#: core/models/user.py:317 core/serializers/user.py:19
+#: core/models/user.py:327 core/serializers/user.py:19
 msgid "A user with this email address already exists."
 msgstr "Un utilisateur avec cet e-mail existe déjà."
 
@@ -103,6 +103,10 @@ msgstr "Oui"
 #: faq/admin.py:18
 msgid "No"
 msgstr "Non"
+
+#: vouch/models.py:58
+msgid "A user cannot vouch for himself."
+msgstr "Un utilisateur ne peut pas se porter garant pour lui-même."
 
 #: vouch/serializers.py:37
 msgid "You have already vouched for this user."

--- a/backend/tournesol/locale/fr/LC_MESSAGES/django.po
+++ b/backend/tournesol/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-19 09:10+0000\n"
+"POT-Creation-Date: 2022-09-21 12:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: tournesol/admin.py:91
+#: tournesol/admin.py:94
 #, python-format
 msgid "Successfully refreshed the metadata of %(count)s entities."
 msgstr "Les métadonnées de %(count)s entités ont été mises à jour."

--- a/backend/vouch/models.py
+++ b/backend/vouch/models.py
@@ -2,7 +2,9 @@
 Models related to the vouching system.
 """
 
+from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from core.models.user import User
 
@@ -50,6 +52,10 @@ class Voucher(models.Model):
     def get_given_to(user):
         vouchers = Voucher.objects.filter(to=user)
         return vouchers, vouchers.exists()
+
+    def clean(self):
+        if self.by == self.to:
+            raise ValidationError(_("A user cannot vouch for himself."))
 
     def save(self, *args, **kwargs):
         if self.pk:

--- a/backend/vouch/tests/test_model_voucher.py
+++ b/backend/vouch/tests/test_model_voucher.py
@@ -23,7 +23,7 @@ class VoucherTestCase(TestCase):
     _user_3 = "username_3"
     _user_4 = "username_4"
 
-    def setUp(self) -> None:
+    def setUp(self):
         self.user_0 = UserFactory(username=self._user_0)
         self.user_1 = UserFactory(username=self._user_1)
         self.user_2 = UserFactory(username=self._user_2)
@@ -45,7 +45,18 @@ class VoucherTestCase(TestCase):
             ]
         )
 
-    def test_get_given_to_with_one(self) -> None:
+    def test_clean(self):
+        """
+        Test the `clean` method of the model.
+        """
+
+        voucher = Voucher(by=self.user_1, to=self.user_1)
+
+        # A user cannot vouch for him/herself.
+        with self.assertRaises(ValidationError):
+            voucher.clean()
+
+    def test_get_given_to_with_one(self):
         """
         Test `get_given_to` returns the expected voucher when a user has only
         one voucher.
@@ -57,7 +68,7 @@ class VoucherTestCase(TestCase):
         self.assertEqual(vouchers[0].to, self.user_3)
         self.assertEqual(exists, True)
 
-    def test_get_given_to_with_several(self) -> None:
+    def test_get_given_to_with_several(self):
         """
         Test `get_given_to` returns only the expected vouchers when a user has
         several vouchers.
@@ -73,7 +84,7 @@ class VoucherTestCase(TestCase):
             self.assertIn(voucher.by, [self.user_1, self.user_3])
             self.assertIn(voucher.value, [12, 32])
 
-    def test_get_given_to_with_zero(self) -> None:
+    def test_get_given_to_with_zero(self):
         """
         Test `get_given_to` returns no voucher when a user has no voucher.
         """
@@ -81,7 +92,7 @@ class VoucherTestCase(TestCase):
         self.assertEqual(vouchers.count(), 0)
         self.assertEqual(exists, False)
 
-    def test_get_given_by_with_one(self) -> None:
+    def test_get_given_by_with_one(self):
         """
         Test `get_given_by` returns the expected voucher when a user has given
         only one voucher.
@@ -93,7 +104,7 @@ class VoucherTestCase(TestCase):
         self.assertEqual(vouchers[0].to, self.user_2)
         self.assertEqual(exists, True)
 
-    def test_get_given_by_with_several(self) -> None:
+    def test_get_given_by_with_several(self):
         """
         Test `get_given_by` returns only the expected vouchers when a user has
         given several vouchers.
@@ -109,7 +120,7 @@ class VoucherTestCase(TestCase):
             self.assertIn(voucher.to, [self.user_1, self.user_2, self.user_4])
             self.assertIn(voucher.value, [31, 32, 34])
 
-    def test_get_given_by_with_zero(self) -> None:
+    def test_get_given_by_with_zero(self):
         """
         Test `get_given_by` returns no voucher when a user has given no
         voucher.
@@ -118,7 +129,7 @@ class VoucherTestCase(TestCase):
         self.assertEqual(vouchers.count(), 0)
         self.assertEqual(exists, False)
 
-    def test_user_cant_vouch_twice_for_the_same_target(self) -> None:
+    def test_user_cant_vouch_twice_for_the_same_target(self):
         """
         Only one voucher can be created for the couple `by` and `to`.
         """


### PR DESCRIPTION
It should not be possible for a user to vouch for him/herself.

The `clean()` method will ensure saving a model through the administration interface, of by code, will raise a proper `ValidationError` with a translated message.