### PR TITLE
[back] ci: apply the linters on the `vouch` app

### DIFF
--- a/backend/scripts/ci/lint.sh
+++ b/backend/scripts/ci/lint.sh
@@ -6,13 +6,13 @@ set -uxo pipefail
 # return 0 if all checks return 0
 # 1 instead
 
-isort --settings-path .isort.cfg --check-only ${@:-core faq ml settings tournesol twitterbot}
+isort --settings-path .isort.cfg --check-only ${@:-core faq ml settings tournesol twitterbot vouch}
 chk1=$?
 
 flake8 --config=.flake8 ${@:-}
 chk2=$?
 
-pylint --rcfile=.pylintrc ${@:-core faq tournesol twitterbot}
+pylint --rcfile=.pylintrc ${@:-core faq tournesol twitterbot vouch}
 chk3=$?
 
 ! (( chk1 || chk2 || chk3 ))

--- a/backend/vouch/trust_algo.py
+++ b/backend/vouch/trust_algo.py
@@ -112,13 +112,13 @@ def trust_algo():
     # Import users and pretrust status
     users = list(
         User.objects.all()
-        .annotate(_is_trusted=Q(pk__in=User.trusted_users()))
+        .annotate(in_trusted_users=Q(pk__in=User.trusted_users()))
         .only("id")
     )
     users_index__user_id = {
         user.id: user_index for user_index, user in enumerate(users)
     }
-    pretrusts = np.array([int(u._is_trusted) for u in users])
+    pretrusts = np.array([int(u.in_trusted_users) for u in users])
     nb_users = len(users)
 
     # Import vouching matrix


### PR DESCRIPTION
Now that `Pylint` has been upgraded the code cleaned, we can easily add the `vouch` app to the list of folders monitored by our linters.

I had to rename an annotation to get rid of the starting underscore. I changed the name of the variable to avoid shadowing the `User.is_trusted` property.