### PR TITLE
[front] feat: display the FAQ

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -404,10 +404,10 @@
     }
   },
   "faqPage": {
+    "iDidFindTheAnswers": "I didn't find the answer to my questions",
     "comeAndAskYourQuestionsOnDiscord": "Join our Discord server to ask directly your questions. Reccuring questions will be added to the FAQ.",
     "joinUsOnDiscord": "Join Us on Discord",
-    "tableOfContent": "Table of Content",
-    "itSeemsThereIsNoQuestionInFaq": "It seems that there is no question in the FAQ yet."
+    "tableOfContent": "Table of Content"
   },
   "home": {
     "exploreTournesolPossibilities": "Explore Tournesol's Possibilities",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -403,10 +403,11 @@
       "message": "An unexpected error has occured."
     }
   },
-  "faq": {
+  "faqPage": {
+    "comeAndAskYourQuestionsOnDiscord": "Join our Discord server to ask directly your questions. Reccuring questions will be added to the FAQ.",
+    "joinUsOnDiscord": "Join Us on Discord",
     "tableOfContent": "Table of Content",
-    "itSeemsThereIsNoQuestionInFaq": "It seems that there is no question in the FAQ yet.",
-    "comeAndAskYourQuestionsOnDiscord": "Join our Discord server to ask directly your questions. Reccuring questions will be added to the FAQ."
+    "itSeemsThereIsNoQuestionInFaq": "It seems that there is no question in the FAQ yet."
   },
   "home": {
     "exploreTournesolPossibilities": "Explore Tournesol's Possibilities",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -405,7 +405,7 @@
   },
   "faqPage": {
     "iDidFindTheAnswers": "I didn't find the answer to my questions",
-    "comeAndAskYourQuestionsOnDiscord": "Join our Discord server to ask directly your questions. Reccuring questions will be added to the FAQ.",
+    "comeAndAskYourQuestionsOnDiscord": "Join our Discord server to ask directly your questions. Recurring questions will be added to the FAQ.",
     "joinUsOnDiscord": "Join Us on Discord",
     "tableOfContent": "Table of Content"
   },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -403,6 +403,11 @@
       "message": "An unexpected error has occured."
     }
   },
+  "faq": {
+    "tableOfContent": "Table of Content",
+    "itSeemsThereIsNoQuestionInFaq": "It seems that there is no question in the FAQ yet.",
+    "comeAndAskYourQuestionsOnDiscord": "Join our Discord server to ask directly your questions. Reccuring questions will be added to the FAQ."
+  },
   "home": {
     "exploreTournesolPossibilities": "Explore Tournesol's Possibilities",
     "tournesolToComparedMultipleTypesOfAlternatives": "Tournesol is used to compare multiple types of alternatives. See the list below and choose the Tournesol that is best for you:",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -134,6 +134,7 @@
     "comparedItems": "My compared items",
     "myRateLaterList": "My rate later list",
     "myResults": "My results",
+    "faq": "FAQ",
     "about": "About"
   },
   "frame": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -410,10 +410,10 @@
     }
   },
   "faqPage": {
+    "iDidFindTheAnswers": "Je n'ai pas trouvé la réponse à mes questions",
     "comeAndAskYourQuestionsOnDiscord": "Vennez poser vos questions directement sur notre serveur Discord. Les questions qui reviennent souvent seront ajoutées à la FAQ.",
     "joinUsOnDiscord": "Rejoignez-nous sur Discord",
-    "tableOfContent": "Table des Matières",
-    "itSeemsThereIsNoQuestionInFaq": "Il semble qu'il n'y ait pas encore de question dans la FAQ."
+    "tableOfContent": "Table des Matières"
   },
   "home": {
     "exploreTournesolPossibilities": "Découvrez toutes les possibilités de Tournesol",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -409,6 +409,11 @@
       "message": "Une erreur innatendu est survenue."
     }
   },
+  "faq": {
+    "tableOfContent": "Table des Matières",
+    "itSeemsThereIsNoQuestionInFaq": "Il semble qu'il n'y ait pas encore de question dans la FAQ.",
+    "comeAndAskYourQuestionsOnDiscord": "Vennez poser vos questions directement sur notre serveur Discord. Les questions qui reviennent souvent seront ajoutées à la FAQ."
+  },
   "home": {
     "exploreTournesolPossibilities": "Découvrez toutes les possibilités de Tournesol",
     "tournesolToComparedMultipleTypesOfAlternatives": "Tournesol permet de comparer toutes sortes de choses. Avec les boutons ci-dessous vous pouvez basculer d'un univers à un autre:",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -409,10 +409,11 @@
       "message": "Une erreur innatendu est survenue."
     }
   },
-  "faq": {
+  "faqPage": {
+    "comeAndAskYourQuestionsOnDiscord": "Vennez poser vos questions directement sur notre serveur Discord. Les questions qui reviennent souvent seront ajoutées à la FAQ.",
+    "joinUsOnDiscord": "Rejoignez-nous sur Discord",
     "tableOfContent": "Table des Matières",
-    "itSeemsThereIsNoQuestionInFaq": "Il semble qu'il n'y ait pas encore de question dans la FAQ.",
-    "comeAndAskYourQuestionsOnDiscord": "Vennez poser vos questions directement sur notre serveur Discord. Les questions qui reviennent souvent seront ajoutées à la FAQ."
+    "itSeemsThereIsNoQuestionInFaq": "Il semble qu'il n'y ait pas encore de question dans la FAQ."
   },
   "home": {
     "exploreTournesolPossibilities": "Découvrez toutes les possibilités de Tournesol",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -139,6 +139,7 @@
     "comparedItems": "Élements comparés",
     "myRateLaterList": "À comparer plus tard",
     "myResults": "Mes résultats",
+    "faq": "FAQ",
     "about": "À propos"
   },
   "frame": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -411,7 +411,7 @@
   },
   "faqPage": {
     "iDidFindTheAnswers": "Je n'ai pas trouvé la réponse à mes questions",
-    "comeAndAskYourQuestionsOnDiscord": "Vennez poser vos questions directement sur notre serveur Discord. Les questions qui reviennent souvent seront ajoutées à la FAQ.",
+    "comeAndAskYourQuestionsOnDiscord": "Venez poser vos questions directement sur notre serveur Discord. Les questions qui reviennent souvent seront ajoutées à la FAQ.",
     "joinUsOnDiscord": "Rejoignez-nous sur Discord",
     "tableOfContent": "Table des Matières"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { LoginState } from './features/login/LoginState.model';
 import { polls } from './utils/constants';
 import PollRoutes from './app/PollRoutes';
 import { PollProvider } from './hooks/useCurrentPoll';
+import FAQ from './pages/faq/FAQ';
 
 // The Analysis Page uses recharts which is a rather big library,
 // thus we choose to load it lazily.
@@ -63,6 +64,9 @@ function App() {
       <Frame>
         <Switch>
           {/* About routes */}
+          <PublicRoute path="/faq">
+            <FAQ />
+          </PublicRoute>
           <PublicRoute path="/about/privacy_policy">
             <PrivacyPolicy />
           </PublicRoute>

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -21,6 +21,7 @@ import { topBarHeight } from '../topbar/TopBar';
 import {
   Compare as CompareIcon,
   EmojiEvents as EmojiEventsIcon,
+  Help as HelpIcon,
   Home as HomeIcon,
   Info as InfoIcon,
   ListAlt as ListIcon,
@@ -169,6 +170,12 @@ const SideBar = () => {
       displayText: t('menu.myResults'),
     },
     { displayText: 'divider_2' },
+    {
+      id: RouteID.FAQ,
+      targetUrl: '/faq',
+      IconComponent: HelpIcon,
+      displayText: t('menu.faq'),
+    },
     {
       id: RouteID.About,
       targetUrl: '/about',

--- a/frontend/src/pages/faq/FAQ.tsx
+++ b/frontend/src/pages/faq/FAQ.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ContentBox, ContentHeader } from 'src/components';
+import { useNotifications } from 'src/hooks/useNotifications';
 import FAQTableOfContent from 'src/pages/faq/FAQTableOfContent';
 import FAQEntryList from 'src/pages/faq/FAQEntryList';
 import { FAQEntry, FaqService } from 'src/services/openapi';
@@ -14,6 +15,8 @@ import { FAQEntry, FaqService } from 'src/services/openapi';
  */
 const FAQ = () => {
   const { i18n } = useTranslation();
+  const { contactAdministrator } = useNotifications();
+
   const [entries, setEntries] = useState<Array<FAQEntry>>([]);
 
   const currentLang = i18n.resolvedLanguage;
@@ -26,12 +29,12 @@ const FAQ = () => {
           setEntries(faq.results);
         }
       } catch (error) {
-        // do something
+        contactAdministrator('error');
       }
     }
 
     getFaqEntries();
-  }, [currentLang, setEntries]);
+  }, [currentLang, contactAdministrator, setEntries]);
 
   return (
     <>

--- a/frontend/src/pages/faq/FAQ.tsx
+++ b/frontend/src/pages/faq/FAQ.tsx
@@ -14,8 +14,10 @@ import { ContentBox, ContentHeader } from 'src/components';
 import { FAQEntry, FaqService } from 'src/services/openapi';
 
 const FAQ = () => {
-  const { t } = useTranslation();
+  const { i18n, t } = useTranslation();
   const [entries, setEntries] = useState<Array<FAQEntry>>([]);
+
+  const currentLang = i18n.resolvedLanguage;
 
   useEffect(() => {
     async function getFaqEntries() {
@@ -30,9 +32,8 @@ const FAQ = () => {
     }
 
     getFaqEntries();
-  }, [setEntries]);
+  }, [currentLang, setEntries]);
 
-  console.log(entries);
   return (
     <>
       <ContentHeader title="Frequently Asked Questions" />

--- a/frontend/src/pages/faq/FAQ.tsx
+++ b/frontend/src/pages/faq/FAQ.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { Typography } from '@mui/material';
+
+import { ContentBox, ContentHeader } from 'src/components';
+
+const FAQ = () => {
+  return (
+    <>
+      <ContentHeader title="Frequently Asked Questions" />
+      <ContentBox maxWidth="md">
+        <Typography variant="h4" gutterBottom>
+          Can you explain what is Tournesol again?
+        </Typography>
+        <Typography paragraph textAlign="justify">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </Typography>
+
+        <Typography variant="h4" gutterBottom>
+          Why should I participate?
+        </Typography>
+        <Typography paragraph textAlign="justify">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </Typography>
+
+        <Typography variant="h4" gutterBottom>
+          I like both video Im comparing, what should I do?
+        </Typography>
+        <Typography paragraph textAlign="justify">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </Typography>
+      </ContentBox>
+    </>
+  );
+};
+
+export default FAQ;

--- a/frontend/src/pages/faq/FAQ.tsx
+++ b/frontend/src/pages/faq/FAQ.tsx
@@ -1,44 +1,62 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { Typography } from '@mui/material';
+import {
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Typography,
+} from '@mui/material';
 
 import { ContentBox, ContentHeader } from 'src/components';
+import { FAQEntry, FaqService } from 'src/services/openapi';
 
 const FAQ = () => {
+  const [entries, setEntries] = useState<Array<FAQEntry>>([]);
+
+  useEffect(() => {
+    async function getFaqEntries() {
+      try {
+        const faq = await FaqService.faqList({});
+        if (faq.results) {
+          setEntries(faq.results);
+        }
+      } catch (error) {
+        // do something
+      }
+    }
+
+    getFaqEntries();
+  }, []);
+
+  console.log(entries);
   return (
     <>
       <ContentHeader title="Frequently Asked Questions" />
       <ContentBox maxWidth="md">
-        <Typography variant="h4" gutterBottom>
-          Can you explain what is Tournesol again?
-        </Typography>
-        <Typography paragraph textAlign="justify">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat. Duis aute irure dolor in
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-          culpa qui officia deserunt mollit anim id est laborum.
-        </Typography>
-
-        <Typography variant="h4" gutterBottom>
-          Why should I participate?
-        </Typography>
-        <Typography paragraph textAlign="justify">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </Typography>
-
-        <Typography variant="h4" gutterBottom>
-          I like both video Im comparing, what should I do?
-        </Typography>
-        <Typography paragraph textAlign="justify">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </Typography>
+        <Paper
+          square
+          sx={{ color: '#fff', p: 2, pb: 2, mb: 2, backgroundColor: '#1282B2' }}
+        >
+          <Typography variant="h6">Table of Content</Typography>
+          <List dense={true}>
+            {entries.map((entry) => (
+              <ListItemButton key={entry.name} component="a">
+                <ListItemText>{entry.question}</ListItemText>
+              </ListItemButton>
+            ))}
+          </List>
+        </Paper>
+        {entries.map((entry) => (
+          <React.Fragment key={entry.name}>
+            <Typography variant="h4" gutterBottom>
+              {entry.question}
+            </Typography>
+            <Typography paragraph textAlign="justify">
+              {entry.answer}
+            </Typography>
+          </React.Fragment>
+        ))}
       </ContentBox>
     </>
   );

--- a/frontend/src/pages/faq/FAQ.tsx
+++ b/frontend/src/pages/faq/FAQ.tsx
@@ -51,16 +51,27 @@ const FAQ = () => {
             ))}
           </List>
         </Paper>
-        {entries.map((entry) => (
-          <React.Fragment key={entry.name}>
-            <Typography id={entry.name} variant="h4" gutterBottom>
-              {entry.question}
-            </Typography>
-            <Typography paragraph textAlign="justify">
-              {entry.answer}
-            </Typography>
-          </React.Fragment>
-        ))}
+        {entries.map((entry) => {
+          const answerParagraphs = entry.answer.split('\n');
+          return (
+            <React.Fragment key={entry.name}>
+              <Typography id={entry.name} variant="h4" gutterBottom>
+                {entry.question}
+              </Typography>
+
+              {/* An answer can be composed of several paragraphs. */}
+              {answerParagraphs.map((paragraph, index) => (
+                <Typography
+                  key={`${entry.name}_p${index}`}
+                  paragraph
+                  textAlign="justify"
+                >
+                  {paragraph}
+                </Typography>
+              ))}
+            </React.Fragment>
+          );
+        })}
       </ContentBox>
     </>
   );

--- a/frontend/src/pages/faq/FAQ.tsx
+++ b/frontend/src/pages/faq/FAQ.tsx
@@ -1,20 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import {
-  Box,
-  List,
-  ListItemButton,
-  ListItemText,
-  Paper,
-  Typography,
-} from '@mui/material';
-
 import { ContentBox, ContentHeader } from 'src/components';
+import FAQTableOfContent from 'src/pages/faq/FAQTableOfContent';
+import FAQEntryList from 'src/pages/faq/FAQEntryList';
 import { FAQEntry, FaqService } from 'src/services/openapi';
 
+/**
+ * The FAQ page.
+ *
+ * If no entry is returned from the API, the page invite the users to ask
+ * their questions directly on Discord.
+ */
 const FAQ = () => {
-  const { i18n, t } = useTranslation();
+  const { i18n } = useTranslation();
   const [entries, setEntries] = useState<Array<FAQEntry>>([]);
 
   const currentLang = i18n.resolvedLanguage;
@@ -38,58 +37,8 @@ const FAQ = () => {
     <>
       <ContentHeader title="Frequently Asked Questions" />
       <ContentBox maxWidth="md">
-        <Paper
-          square
-          sx={{ color: '#fff', p: 2, pb: 2, mb: 2, backgroundColor: '#1282B2' }}
-        >
-          <Typography variant="h6">{t('faq.tableOfContent')}</Typography>
-
-          {entries.length > 0 ? (
-            <List dense={true}>
-              {entries.map((entry) => (
-                <ListItemButton
-                  key={entry.name}
-                  component="a"
-                  href={`#${entry.name}`}
-                >
-                  <ListItemText>{entry.question}</ListItemText>
-                </ListItemButton>
-              ))}
-            </List>
-          ) : (
-            <Typography sx={{ mt: 2 }}>
-              {t('faq.itSeemsThereIsNoQuestionInFaq')}
-            </Typography>
-          )}
-        </Paper>
-
-        {entries.length > 0 ? (
-          entries.map((entry) => {
-            const answerParagraphs = entry.answer.split('\n');
-            return (
-              <Box key={entry.name} mb={4}>
-                <Typography id={entry.name} variant="h4" gutterBottom>
-                  {entry.question}
-                </Typography>
-
-                {/* An answer can be composed of several paragraphs. */}
-                {answerParagraphs.map((paragraph, index) => (
-                  <Typography
-                    key={`${entry.name}_p${index}`}
-                    paragraph
-                    textAlign="justify"
-                  >
-                    {paragraph}
-                  </Typography>
-                ))}
-              </Box>
-            );
-          })
-        ) : (
-          <Typography paragraph textAlign="justify">
-            {t('faq.comeAndAskYourQuestionsOnDiscord')}
-          </Typography>
-        )}
+        <FAQTableOfContent entries={entries} />
+        <FAQEntryList entries={entries} />
       </ContentBox>
     </>
   );

--- a/frontend/src/pages/faq/FAQ.tsx
+++ b/frontend/src/pages/faq/FAQ.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import {
+  Box,
   List,
   ListItemButton,
   ListItemText,
@@ -12,6 +14,7 @@ import { ContentBox, ContentHeader } from 'src/components';
 import { FAQEntry, FaqService } from 'src/services/openapi';
 
 const FAQ = () => {
+  const { t } = useTranslation();
   const [entries, setEntries] = useState<Array<FAQEntry>>([]);
 
   useEffect(() => {
@@ -27,7 +30,7 @@ const FAQ = () => {
     }
 
     getFaqEntries();
-  }, []);
+  }, [setEntries]);
 
   console.log(entries);
   return (
@@ -38,40 +41,54 @@ const FAQ = () => {
           square
           sx={{ color: '#fff', p: 2, pb: 2, mb: 2, backgroundColor: '#1282B2' }}
         >
-          <Typography variant="h6">Table of Content</Typography>
-          <List dense={true}>
-            {entries.map((entry) => (
-              <ListItemButton
-                key={entry.name}
-                component="a"
-                href={`#${entry.name}`}
-              >
-                <ListItemText>{entry.question}</ListItemText>
-              </ListItemButton>
-            ))}
-          </List>
-        </Paper>
-        {entries.map((entry) => {
-          const answerParagraphs = entry.answer.split('\n');
-          return (
-            <React.Fragment key={entry.name}>
-              <Typography id={entry.name} variant="h4" gutterBottom>
-                {entry.question}
-              </Typography>
+          <Typography variant="h6">{t('faq.tableOfContent')}</Typography>
 
-              {/* An answer can be composed of several paragraphs. */}
-              {answerParagraphs.map((paragraph, index) => (
-                <Typography
-                  key={`${entry.name}_p${index}`}
-                  paragraph
-                  textAlign="justify"
+          {entries.length > 0 ? (
+            <List dense={true}>
+              {entries.map((entry) => (
+                <ListItemButton
+                  key={entry.name}
+                  component="a"
+                  href={`#${entry.name}`}
                 >
-                  {paragraph}
-                </Typography>
+                  <ListItemText>{entry.question}</ListItemText>
+                </ListItemButton>
               ))}
-            </React.Fragment>
-          );
-        })}
+            </List>
+          ) : (
+            <Typography sx={{ mt: 2 }}>
+              {t('faq.itSeemsThereIsNoQuestionInFaq')}
+            </Typography>
+          )}
+        </Paper>
+
+        {entries.length > 0 ? (
+          entries.map((entry) => {
+            const answerParagraphs = entry.answer.split('\n');
+            return (
+              <Box key={entry.name} mb={4}>
+                <Typography id={entry.name} variant="h4" gutterBottom>
+                  {entry.question}
+                </Typography>
+
+                {/* An answer can be composed of several paragraphs. */}
+                {answerParagraphs.map((paragraph, index) => (
+                  <Typography
+                    key={`${entry.name}_p${index}`}
+                    paragraph
+                    textAlign="justify"
+                  >
+                    {paragraph}
+                  </Typography>
+                ))}
+              </Box>
+            );
+          })
+        ) : (
+          <Typography paragraph textAlign="justify">
+            {t('faq.comeAndAskYourQuestionsOnDiscord')}
+          </Typography>
+        )}
       </ContentBox>
     </>
   );

--- a/frontend/src/pages/faq/FAQ.tsx
+++ b/frontend/src/pages/faq/FAQ.tsx
@@ -41,7 +41,11 @@ const FAQ = () => {
           <Typography variant="h6">Table of Content</Typography>
           <List dense={true}>
             {entries.map((entry) => (
-              <ListItemButton key={entry.name} component="a">
+              <ListItemButton
+                key={entry.name}
+                component="a"
+                href={`#${entry.name}`}
+              >
                 <ListItemText>{entry.question}</ListItemText>
               </ListItemButton>
             ))}
@@ -49,7 +53,7 @@ const FAQ = () => {
         </Paper>
         {entries.map((entry) => (
           <React.Fragment key={entry.name}>
-            <Typography variant="h4" gutterBottom>
+            <Typography id={entry.name} variant="h4" gutterBottom>
               {entry.question}
             </Typography>
             <Typography paragraph textAlign="justify">

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -11,51 +11,57 @@ import { FAQEntry } from 'src/services/openapi';
  *
  * Questions are headings with HTML id, allowing them to be quickly reached
  * using anchors.
+ *
+ * An extra entry is displayed after the provided `entries`, inviting the
+ * users to join Discord if they didn't find the answer to their questions.
  */
 const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
   const { t } = useTranslation();
   return (
     <>
-      {entries.length > 20 ? (
-        entries.map((entry) => {
-          const answerParagraphs = entry.answer.split('\n');
-          return (
-            <Box key={entry.name} mb={4}>
-              <Typography id={entry.name} variant="h4" gutterBottom>
-                {entry.question}
-              </Typography>
+      {entries.map((entry) => {
+        const answerParagraphs = entry.answer.split('\n');
+        return (
+          <Box key={entry.name} mb={4}>
+            <Typography id={entry.name} variant="h4" gutterBottom>
+              {entry.question}
+            </Typography>
 
-              {/* An answer can be composed of several paragraphs. */}
-              {answerParagraphs.map((paragraph, index) => (
-                <Typography
-                  key={`${entry.name}_p${index}`}
-                  paragraph
-                  textAlign="justify"
-                >
-                  {paragraph}
-                </Typography>
-              ))}
-            </Box>
-          );
-        })
-      ) : (
-        <>
-          <Typography paragraph textAlign="justify">
-            {t('faqPage.comeAndAskYourQuestionsOnDiscord')}
-          </Typography>
-          <Box display="flex" justifyContent="flex-end">
-            <Button
-              href="https://discord.gg/TvsFB8RNBV"
-              target="_blank"
-              color="secondary"
-              variant="outlined"
-              endIcon={<PeopleAlt />}
-            >
-              {t('faqPage.joinUsOnDiscord')}
-            </Button>
+            {/* An answer can be composed of several paragraphs. */}
+            {answerParagraphs.map((paragraph, index) => (
+              <Typography
+                key={`${entry.name}_p${index}`}
+                paragraph
+                textAlign="justify"
+              >
+                {paragraph}
+              </Typography>
+            ))}
           </Box>
-        </>
-      )}
+        );
+      })}
+
+      {/* Invite the users to join Discord if needed. */}
+      <Box mb={4}>
+        <Typography id="no_answer_found" variant="h4" gutterBottom>
+          {t('faqPage.iDidFindTheAnswers')}
+        </Typography>
+
+        <Typography paragraph textAlign="justify">
+          {t('faqPage.comeAndAskYourQuestionsOnDiscord')}
+        </Typography>
+      </Box>
+      <Box display="flex" justifyContent="flex-end">
+        <Button
+          href="https://discord.gg/TvsFB8RNBV"
+          target="_blank"
+          color="secondary"
+          variant="outlined"
+          endIcon={<PeopleAlt />}
+        >
+          {t('faqPage.joinUsOnDiscord')}
+        </Button>
+      </Box>
     </>
   );
 };

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -22,7 +22,7 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
       {entries.map((entry) => {
         const answerParagraphs = entry.answer.split('\n');
         return (
-          <Box key={entry.name} mb={4}>
+          <Box key={`q_${entry.name}`} mb={4}>
             <Typography id={entry.name} variant="h4" gutterBottom>
               {entry.question}
             </Typography>
@@ -30,7 +30,7 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
             {/* An answer can be composed of several paragraphs. */}
             {answerParagraphs.map((paragraph, index) => (
               <Typography
-                key={`${entry.name}_p${index}`}
+                key={`$a_{entry.name}_p${index}`}
                 paragraph
                 textAlign="justify"
               >
@@ -41,7 +41,7 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
         );
       })}
 
-      {/* Invite the users to join Discord if needed. */}
+      {/* Always display an extra entry to explain how to ask more questions. */}
       <Box mb={4}>
         <Typography id="no_answer_found" variant="h4" gutterBottom>
           {t('faqPage.iDidFindTheAnswers')}

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
+import { PeopleAlt } from '@mui/icons-material';
 
 import { FAQEntry } from 'src/services/openapi';
 
@@ -15,7 +16,7 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
   const { t } = useTranslation();
   return (
     <>
-      {entries.length > 0 ? (
+      {entries.length > 20 ? (
         entries.map((entry) => {
           const answerParagraphs = entry.answer.split('\n');
           return (
@@ -38,9 +39,22 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
           );
         })
       ) : (
-        <Typography paragraph textAlign="justify">
-          {t('faq.comeAndAskYourQuestionsOnDiscord')}
-        </Typography>
+        <>
+          <Typography paragraph textAlign="justify">
+            {t('faqPage.comeAndAskYourQuestionsOnDiscord')}
+          </Typography>
+          <Box display="flex" justifyContent="flex-end">
+            <Button
+              href="https://discord.gg/TvsFB8RNBV"
+              target="_blank"
+              color="secondary"
+              variant="outlined"
+              endIcon={<PeopleAlt />}
+            >
+              {t('faqPage.joinUsOnDiscord')}
+            </Button>
+          </Box>
+        </>
       )}
     </>
   );

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Box, Typography } from '@mui/material';
+
+import { FAQEntry } from 'src/services/openapi';
+
+/**
+ * The Entry List section of the FAQ page.
+ *
+ * Questions are headings with HTML id, allowing them to be quickly reached
+ * using anchors.
+ */
+const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
+  const { t } = useTranslation();
+  return (
+    <>
+      {entries.length > 0 ? (
+        entries.map((entry) => {
+          const answerParagraphs = entry.answer.split('\n');
+          return (
+            <Box key={entry.name} mb={4}>
+              <Typography id={entry.name} variant="h4" gutterBottom>
+                {entry.question}
+              </Typography>
+
+              {/* An answer can be composed of several paragraphs. */}
+              {answerParagraphs.map((paragraph, index) => (
+                <Typography
+                  key={`${entry.name}_p${index}`}
+                  paragraph
+                  textAlign="justify"
+                >
+                  {paragraph}
+                </Typography>
+              ))}
+            </Box>
+          );
+        })
+      ) : (
+        <Typography paragraph textAlign="justify">
+          {t('faq.comeAndAskYourQuestionsOnDiscord')}
+        </Typography>
+      )}
+    </>
+  );
+};
+
+export default FAQEntryList;

--- a/frontend/src/pages/faq/FAQTableOfContent.tsx
+++ b/frontend/src/pages/faq/FAQTableOfContent.tsx
@@ -29,13 +29,15 @@ const FAQTableOfContent = ({ entries }: { entries: Array<FAQEntry> }) => {
       <List dense={true}>
         {entries.map((entry) => (
           <ListItemButton
-            key={entry.name}
+            key={`$toc_{entry.name}`}
             component="a"
             href={`#${entry.name}`}
           >
             <ListItemText>{entry.question}</ListItemText>
           </ListItemButton>
         ))}
+        {/* Always display an extra entry to explain how to ask more
+            questions. */}
         <ListItemButton component="a" href={`#no_answer_found`}>
           <ListItemText>{t('faqPage.iDidFindTheAnswers')}</ListItemText>
         </ListItemButton>

--- a/frontend/src/pages/faq/FAQTableOfContent.tsx
+++ b/frontend/src/pages/faq/FAQTableOfContent.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Typography,
+} from '@mui/material';
+
+import { FAQEntry } from 'src/services/openapi';
+
+/**
+ * The Table of Content section of the FAQ page.
+ *
+ * Items are anchors allowing to jump directly to the question. The anchor
+ * added to the URL is the `FAQEntry.name`.
+ */
+const FAQTableOfContent = ({ entries }: { entries: Array<FAQEntry> }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Paper
+      square
+      sx={{ color: '#fff', p: 2, pb: 2, mb: 2, backgroundColor: '#1282B2' }}
+    >
+      <Typography variant="h6">{t('faq.tableOfContent')}</Typography>
+
+      {entries.length > 0 ? (
+        <List dense={true}>
+          {entries.map((entry) => (
+            <ListItemButton
+              key={entry.name}
+              component="a"
+              href={`#${entry.name}`}
+            >
+              <ListItemText>{entry.question}</ListItemText>
+            </ListItemButton>
+          ))}
+        </List>
+      ) : (
+        <Typography sx={{ mt: 2 }}>
+          {t('faq.itSeemsThereIsNoQuestionInFaq')}
+        </Typography>
+      )}
+    </Paper>
+  );
+};
+
+export default FAQTableOfContent;

--- a/frontend/src/pages/faq/FAQTableOfContent.tsx
+++ b/frontend/src/pages/faq/FAQTableOfContent.tsx
@@ -25,7 +25,7 @@ const FAQTableOfContent = ({ entries }: { entries: Array<FAQEntry> }) => {
       square
       sx={{ color: '#fff', p: 2, pb: 2, mb: 2, backgroundColor: '#1282B2' }}
     >
-      <Typography variant="h6">{t('faq.tableOfContent')}</Typography>
+      <Typography variant="h6">{t('faqPage.tableOfContent')}</Typography>
 
       {entries.length > 0 ? (
         <List dense={true}>
@@ -41,7 +41,7 @@ const FAQTableOfContent = ({ entries }: { entries: Array<FAQEntry> }) => {
         </List>
       ) : (
         <Typography sx={{ mt: 2 }}>
-          {t('faq.itSeemsThereIsNoQuestionInFaq')}
+          {t('faqPage.itSeemsThereIsNoQuestionInFaq')}
         </Typography>
       )}
     </Paper>

--- a/frontend/src/pages/faq/FAQTableOfContent.tsx
+++ b/frontend/src/pages/faq/FAQTableOfContent.tsx
@@ -26,24 +26,20 @@ const FAQTableOfContent = ({ entries }: { entries: Array<FAQEntry> }) => {
       sx={{ color: '#fff', p: 2, pb: 2, mb: 2, backgroundColor: '#1282B2' }}
     >
       <Typography variant="h6">{t('faqPage.tableOfContent')}</Typography>
-
-      {entries.length > 0 ? (
-        <List dense={true}>
-          {entries.map((entry) => (
-            <ListItemButton
-              key={entry.name}
-              component="a"
-              href={`#${entry.name}`}
-            >
-              <ListItemText>{entry.question}</ListItemText>
-            </ListItemButton>
-          ))}
-        </List>
-      ) : (
-        <Typography sx={{ mt: 2 }}>
-          {t('faqPage.itSeemsThereIsNoQuestionInFaq')}
-        </Typography>
-      )}
+      <List dense={true}>
+        {entries.map((entry) => (
+          <ListItemButton
+            key={entry.name}
+            component="a"
+            href={`#${entry.name}`}
+          >
+            <ListItemText>{entry.question}</ListItemText>
+          </ListItemButton>
+        ))}
+        <ListItemButton component="a" href={`#no_answer_found`}>
+          <ListItemText>{t('faqPage.iDidFindTheAnswers')}</ListItemText>
+        </ListItemButton>
+      </List>
     </Paper>
   );
 };

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -41,6 +41,7 @@ export enum RouteID {
   Home = 'home',
   CollectiveRecommendations = 'collectiveRecommendations',
   EntityAnalysis = 'entityAnalysis',
+  FAQ = 'FAQ',
   About = 'about',
   // public yet personal routes
   PublicPersonalRecommendationsPage = 'publicPersonalRecommendations',


### PR DESCRIPTION
**related to** #1140

---

This PR adds a FAQ and a link to it in the sidebar. If no entries are returned by the back end the page invites the users to ask their questions on Discord.

**to do**
- [x] add a table of content, listing all questions
  - [x] items should be `<a>` tags linking to anchored questions
  - [x] handle empty results from the API 
- [x] list all questions with their answers
  - [x] handle multi-paragraphs answers 
- [x] the FAQ should update when the UI lang changes 
- [x] add a message indicating how to ask questions on Discord
  - [x] add a link to discord
- [x] handle API errors  

### preview

Regardless of the number of FAQ entry, users are always invited to join Discord if they didn't find the answer to their questions.

![capture](https://user-images.githubusercontent.com/39056254/192316181-01b95d61-8a1f-4633-b6d5-966f257cde9b.png)

(On the following capture is old, that is why the Discord button is not displayed)

![screencapture-localhost-3000-faq-2022-09-26-15_55_07](https://user-images.githubusercontent.com/39056254/192294899-fe3c2ead-b9fb-4362-bf2c-afe1b0c082a2.png)
