### PR TITLE
[all] docs: rework CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,38 +14,49 @@ make the project even better.
 - [Got a question or Problem?](#got-a-question-or-problem)
 - [Found a bug?](#found-a-bug)
 - [Missing Feature?](#missing-feature)
-- [The development process / Asking for review](#the-development-process--asking-for-review)
-- [Development guidelines](#development-guidelines)
-  - [Back end](#back-end)
-  - [Front end](#front-end)
-- [Translation](#translation)
+- [Working on the Source Code](#working-on-the-source-code)
+  - [The development process / Asking for review](#the-development-process--asking-for-review)
+  - [Development guidelines](#development-guidelines)
+    - [Back end](#back-end)
+    - [Front end](#front-end)
+  - [Translation](#translation)
 
 ---
 
 ## Code of Conduct
 
+todo
+
 ## Efficient Ways to Contribute
+
+todo
 
 ### Add new comparisons
 
+todo
+
 ### Consider donation
 
+todo
+
 ### Talk about Tournesol to your friends
+
+todo
 
 ## Got a Question or Problem?
 
 Please do not open issues for general support questions as we want to keep
 GitHub issues for bug reports and feature requests.
 
-We collect and answer questions on Discord, in the dedicated channels. This
-way all the community can benefit from your question and also provides
-answers.
+We collect and answer questions on [Discord][tournesol-discord-join], in the
+dedicated channels. This way all the community can benefit from your question
+and also provides answers.
 
 ## Found a Bug?
 
 If you find a bug in the source code, you can help us by submitting an issue
-to our GitHub Repository. Even better, if you are a programmer with spare
-time you can submit a Pull Request with a fix.
+to our [GitHub Repository][tournesol-github-repo]. Even better, if you are a
+programmer with spare time you can submit a Pull Request with a fix.
 
 ## Missing Feature?
 
@@ -54,7 +65,7 @@ Depending on the subject or the complexity, and before planning anything, the
 development team will first discuss the feature to define a clear
 implementation.
 
-## Contributing to the Source code
+## Working on the Source code
 
 ### The development process / Asking for review
 
@@ -129,5 +140,6 @@ On the frontend, translations are handled by `react-i18next`.
   may be useful to learn how to integrate translated content into React components. 
 * To extract the new translation keys, use [`yarn i18n:parse`](./frontend/README.md#yarn-i18nparse)
 
+[tournesol-github-repo]: https://github.com/tournesol-app/tournesol
 [tournesol-discord-join]: https://discord.gg/WvcSG55Bf3
 [tournesol-kanban-board]: https://github.com/tournesol-app/tournesol/projects/9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,9 +84,9 @@ fix.
 ## Missing Feature?
 
 You can request a new feature by submitting an issue to our GitHub Repository.
-Depending on the subject or the complexity, and before planning anything, the
-development team will first discuss the feature to define a clear
-implementation.
+Depending on the subject or the complexity the development team will first
+evaluate the value of the feature for the whole community, then plan how it
+can be implemented and where it fits in the project's priorities.
 
 ## Working on the Source code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,9 @@ make the project even better.
 - [Got a question or Problem?](#got-a-question-or-problem)
 - [Found a bug?](#found-a-bug)
 - [Missing Feature?](#missing-feature)
+
+**Working with the Source Code**
+
 - [Working on the Source Code](#working-on-the-source-code)
   - [The development process / Asking for review](#the-development-process--asking-for-review)
   - [Development guidelines](#development-guidelines)
@@ -33,11 +36,23 @@ todo
 
 ### Add new comparisons
 
-todo
+Everyone can greatly help the project by
+[submitting new comparisons][ts-compare] 🌻
+
+Comparisons are the cornerstones of Tournesol, they are used to provide
+better recommendations, and to create an open database to help the research
+on ethics of algorithms and large scale recommender systems.
 
 ### Consider donation
 
-todo
+The Tournesol team is small, composed mainly by volunteers, that is why every
+donation counts.
+
+With more support we can improve the project, by hiring new developers to
+speed up the development of the application, by creating partnership to
+make Tournesol more visible on the internet, etc.
+
+If you would like to support us, please refer to [the donation page][ts-donate].
 
 ### Talk about Tournesol to your friends
 
@@ -48,14 +63,14 @@ todo
 Please do not open issues for general support questions as we want to keep
 GitHub issues for bug reports and feature requests.
 
-We collect and answer questions on [Discord][tournesol-discord-join], in the
+We collect and answer questions on [Discord][ts-discord-join], in the
 dedicated channels. This way all the community can benefit from your question
 and also provides answers.
 
 ## Found a Bug?
 
 If you find a bug in the source code, you can help us by submitting an issue
-to our [GitHub Repository][tournesol-github-repo]. Even better, if you are a
+to our [GitHub Repository][ts-github-repo]. Even better, if you are a
 programmer with spare time you can submit a Pull Request with a fix.
 
 ## Missing Feature?
@@ -70,7 +85,7 @@ implementation.
 ### The development process / Asking for review
 
 You can track progress of the code development in the dedicated
-[kaban board][tournesol-kanban-board].
+[kaban board][ts-github-kanban].
 
 Anyone can submit ideas that seem relevant, by creating new issues and
 placing them inside the column `Ideas / Backlog`.
@@ -103,7 +118,7 @@ add one, discuss it with the maintainers to debate about the relevance of
 this test.
 
 To keep track of progress, bugs of the project, join the
-[discord][tournesol-discord-join]
+[discord][ts-discord-join]
 
 ### Development guidelines
 
@@ -140,6 +155,10 @@ On the frontend, translations are handled by `react-i18next`.
   may be useful to learn how to integrate translated content into React components. 
 * To extract the new translation keys, use [`yarn i18n:parse`](./frontend/README.md#yarn-i18nparse)
 
-[tournesol-github-repo]: https://github.com/tournesol-app/tournesol
-[tournesol-discord-join]: https://discord.gg/WvcSG55Bf3
-[tournesol-kanban-board]: https://github.com/tournesol-app/tournesol/projects/9
+[ts-donate]: https://tournesol.app/about/donate
+[ts-compare]: https://tournesol.app/comparison
+
+[ts-github-repo]: https://github.com/tournesol-app/tournesol
+[ts-github-kanban]: https://github.com/tournesol-app/tournesol/projects/9
+
+[ts-discord-join]: https://discord.gg/WvcSG55Bf3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ make the project even better.
 - [Found a bug?](#found-a-bug)
 - [Missing Feature?](#missing-feature)
 
-**Working with the Source Code**
+**Working on the Source Code**
 
 - [Working on the Source Code](#working-on-the-source-code)
   - [The development process / Asking for review](#the-development-process--asking-for-review)
@@ -35,35 +35,35 @@ make the project even better.
 ### Add new comparisons
 
 Everyone can greatly help the project by
-[submitting new comparisons][ts-compare] 🌻
+[submitting new comparisons][ts-compare] in the application 🌻
 
-Comparisons are the cornerstones of Tournesol, they are used to provide
-better recommendations, and to create an open database to help the research
+Comparisons are the cornerstones of Tournesol. They are used to provide
+better recommendations and to create an open database to help the research
 on ethics of algorithms and large scale recommender systems.
 
-### Consider donation
+### Consider making a donation
 
-The Tournesol team is small, composed mainly by volunteers, that is why every
-donation counts.
+The Tournesol team is small, mainly composed of volunteers. Every
+donation counts for us.
 
 With more support we can improve the project, by hiring new developers to
-speed up the development of the application, by creating partnership to
-make Tournesol more visible on the internet, etc.
+speed up the development of the application, creating partnership to make
+Tournesol more visible on the internet, etc.
 
 If you would like to support us, please refer to [the donation page][ts-donate].
 
 ### Talk about Tournesol to your friends
 
-With a bigger community Tournesol can improve its recommendations, and the
+With a bigger community Tournesol can improve its recommendations and the
 quality of its open database.
 
 Tournesol behaves as the algorithmic representative of its community. The more
 the community is big and diverse, the more the recommendation and the database
-will be representative or a larger scale of the population.
+will be representative of a larger scale of the population opinion.
 
-Talking about Tournesol to your friends can help the project to snowball from
-a small initiative to a broadly known step in the ethics of algorithms
-research and large scale recommender systems.
+Talking about Tournesol to your friends can help the project to transform from
+a small initiative to a broadly known step in the ethics of algorithms and
+large scale recommender systems research.
 
 ## Got a Question or Problem?
 
@@ -76,9 +76,10 @@ and also provides answers.
 
 ## Found a Bug?
 
-If you find a bug in the source code, you can help us by submitting an issue
-to our [GitHub Repository][ts-github-repo]. Even better, if you are a
-programmer with spare time you can submit a Pull Request with a fix.
+If you find a bug in the application or in the source code, you can help us by
+submitting an issue to our [GitHub Repository][ts-github-repo]. Even better,
+if you are a programmer with spare time you can submit a Pull Request with a
+fix.
 
 ## Missing Feature?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,9 @@ make the project even better.
 
 ## Code of Conduct
 
-todo
+> coming soon
 
 ## Efficient Ways to Contribute
-
-todo
 
 ### Add new comparisons
 
@@ -56,7 +54,16 @@ If you would like to support us, please refer to [the donation page][ts-donate].
 
 ### Talk about Tournesol to your friends
 
-todo
+With a bigger community Tournesol can improve its recommendations, and the
+quality of its open database.
+
+Tournesol behaves as the algorithmic representative of its community. The more
+the community is big and diverse, the more the recommendation and the database
+will be representative or a larger scale of the population.
+
+Talking about Tournesol to your friends can help the project to snowball from
+a small initiative to a broadly known step in the ethics of algorithms
+research and large scale recommender systems.
 
 ## Got a Question or Problem?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,62 @@
 # Contributing to Tournesol
 
- - [The development process / Asking for review](#the-development-process--asking-for-review)
- - [Development guidelines](#development-guidelines)
-   - [Back end](#back-end)
-   - [Front end](#front-end)
- - [Translation](#translation)
+Tournesol is a collective project made possible by the contributions of many
+donors and volunteers. We would love for you to help us in this adventure to
+make the project even better. 
 
-## The development process / Asking for review
+**Table of Content**
+
+- [Code of Conduct](#code-of-conduct)
+- [Efficient Ways to Contribute](#efficient-ways-to-contribute)
+  - [Add new comparisons](#add-new-comparisons)
+  - [Consider donation](#consider-donation)
+  - [Talk about Tournesol to your friends](#talk-about-tournesol-to-your-friends)
+- [Got a question or Problem?](#got-a-question-or-problem)
+- [Found a bug?](#found-a-bug)
+- [Missing Feature?](#missing-feature)
+- [The development process / Asking for review](#the-development-process--asking-for-review)
+- [Development guidelines](#development-guidelines)
+  - [Back end](#back-end)
+  - [Front end](#front-end)
+- [Translation](#translation)
+
+---
+
+## Code of Conduct
+
+## Efficient Ways to Contribute
+
+### Add new comparisons
+
+### Consider donation
+
+### Talk about Tournesol to your friends
+
+## Got a Question or Problem?
+
+Please do not open issues for general support questions as we want to keep
+GitHub issues for bug reports and feature requests.
+
+We collect and answer questions on Discord, in the dedicated channels. This
+way all the community can benefit from your question and also provides
+answers.
+
+## Found a Bug?
+
+If you find a bug in the source code, you can help us by submitting an issue
+to our GitHub Repository. Even better, if you are a programmer with spare
+time you can submit a Pull Request with a fix.
+
+## Missing Feature?
+
+You can request a new feature by submitting an issue to our GitHub Repository.
+Depending on the subject or the complexity, and before planning anything, the
+development team will first discuss the feature to define a clear
+implementation.
+
+## Contributing to the Source code
+
+### The development process / Asking for review
 
 You can track progress of the code development in the dedicated
 [kaban board][tournesol-kanban-board].
@@ -44,9 +94,9 @@ this test.
 To keep track of progress, bugs of the project, join the
 [discord][tournesol-discord-join]
 
-## Development guidelines
+### Development guidelines
 
-### Back end
+#### Back end
 
 When the back end API is updated, the front end must re-generate its local
 client to match the new API schema.
@@ -62,12 +112,12 @@ end representation the back end OpenAPI schema.
 
 If you're using `dev-env` you can update the schema and the service files by running the script `dev-env/update-openapi.sh`.
 
-### Front end
+#### Front end
 
 To correct the lint of frontend files, it is possible to activate plugin
 directly in your IDE. Otherwise the comamnd `yarn lint:fix` enables you to correct lint automatically.
 
-## Translation
+### Translation
 
 Tournesol is currently available in English and French. When submitting
 changes that involve new texts, please ensure that translation keys


### PR DESCRIPTION
### Context

Our current `CONTRIBUTING.md` file is focused on how to help while being a programmer, but Tournesol is not only a programming project. It's also collective research project involving comparing videos and creating an open database of users' judgement.

 This `CONTRIBUTING.md` rework aims to explain how to contribute to Tournesol, by making comparison, by considering giving money, by reporting bugs, making suggestions, etc. It also aims to clearly state where to ask what: bugs should be on GitHub, general purpose questions on Discord.

In this first step I didn't add the code of conduct, to keep the PR small, but I'd like to propose the team to add one. As it implies some governance considerations, we should talk about it separately.

In a future PR I plan to rework the content of the development process section to make it more concise.

See the current rework here:
https://github.com/tournesol-app/tournesol/blob/docs-rework_contributing/CONTRIBUTING.md
