### PR TITLE
[back] fix: file used as default preview image was closed when used in `FileResponse`

### DIFF
--- a/backend/tournesol/tests/test_api_preview.py
+++ b/backend/tournesol/tests/test_api_preview.py
@@ -48,6 +48,8 @@ class DynamicWebsitePreviewDefaultTestCase(TestCase):
             response.headers["Content-Disposition"],
             'inline; filename="tournesol_screenshot_og.png"',
         )
+        content = b''.join(response.streaming_content)
+        self.assertGreater(len(content), 0)
 
     def test_anon_200_get(self):
         """

--- a/backend/tournesol/views/preview.py
+++ b/backend/tournesol/views/preview.py
@@ -48,11 +48,13 @@ class BasePreviewAPIView(APIView):
     """
 
     def default_preview(self):
-        with open(
+        # The file needs to remain open to be streamed and will be closed automatically
+        # by FileResponse. A context-manager should not be used here.
+        # pylint: disable=consider-using-with
+        default_preview = open(
             str(BASE_DIR / "tournesol/resources/tournesol_screenshot_og.png"), "rb"
-        ) as default_preview:
-            response = FileResponse(default_preview, content_type="image/png")
-        return response
+        )
+        return FileResponse(default_preview, content_type="image/png")
 
     def get_entity(self, uid: str) -> Entity:
         try:


### PR DESCRIPTION
A small regression introduced in #1084 about the default preview image.  
It went unnoticed as the response content was not covered by tests.

The documentation about `FileResponse` explains why a context manager should not be used in this case:
https://docs.djangoproject.com/en/4.0/ref/request-response/#fileresponse-objects

So ignoring the pylint warning should be ok here.