### PR TITLE
[back] sec: upgrade django to 4.0.8 (from 4.0.7)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.0.7
+Django==4.0.8
 django-computed-property==0.3.0
 django-cors-headers==3.13.0
 django-countries==7.3.2


### PR DESCRIPTION
Fix:
- CVE-2022-41323

See: https://docs.djangoproject.com/en/4.1/releases/4.0.8/