### PR TITLE
[ext] add tournesol.app link to clickable tournesol logo

### DIFF
--- a/browser-extension/src/browserAction/menu.html
+++ b/browser-extension/src/browserAction/menu.html
@@ -9,8 +9,11 @@
         display: flex;
         flex-direction: column;
       }
-      body > img {
+      body > a {
         margin-bottom: 6px;
+      }
+      body > a > img {
+        width: 120px;
       }
       button {
         background-color: #506ad4;
@@ -50,7 +53,7 @@
     <script type="module" src="menu.js"></script>
   </head>
   <body>
-    <img src="https://tournesol.app/svg/Logo.svg" />
+    <a href="https://tournesol.app/"><img src="https://tournesol.app/svg/Logo.svg" alt="Tournesol Logo" /></a>
     <button id="rate_now">Rate now</button>
     <button id="rate_later">Rate later</button>
     <button id="details">Analysis</button>

--- a/browser-extension/src/browserAction/menu.html
+++ b/browser-extension/src/browserAction/menu.html
@@ -53,9 +53,11 @@
     <script type="module" src="menu.js"></script>
   </head>
   <body>
-    <a href="https://tournesol.app/"><img src="https://tournesol.app/svg/Logo.svg" alt="Tournesol Logo" /></a>
+    <a id="tournesol_home" href="#">
+      <img src="https://tournesol.app/svg/Logo.svg" alt="Tournesol Logo" />
+    </a>
     <button id="rate_now">Rate now</button>
     <button id="rate_later">Rate later</button>
-    <button id="details">Analysis</button>
+    <button id="analysis">Analysis</button>
   </body>
 </html>

--- a/browser-extension/src/browserAction/menu.js
+++ b/browser-extension/src/browserAction/menu.js
@@ -18,6 +18,15 @@ function get_current_tab_video_id() {
 }
 
 /**
+ * Open the Tournesol home page.
+ */
+function openTournesolHome() {
+  chrome.tabs.create({
+    url: `https://tournesol.app`,
+  });
+}
+
+/**
  * Open the Tournesol comparison page in a new tab.
  */
 function rateNowAction(event) {
@@ -96,11 +105,14 @@ function openAnalysisPageAction(event) {
  * Create the action menu.
  */
 document.addEventListener('DOMContentLoaded', function () {
+  document
+    .getElementById('tournesol_home')
+    .addEventListener('click', openTournesolHome);
   document.getElementById('rate_now').addEventListener('click', rateNowAction);
   document
     .getElementById('rate_later')
     .addEventListener('click', addToRateLaterAction);
   document
-    .getElementById('details')
+    .getElementById('analysis')
     .addEventListener('click', openAnalysisPageAction);
 });

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
Extension can now reach tournesol.app website while on (non-)youtube page with now clickable logo to `https://tournesol.app`
as issued in #339

![2022-10-09_11-46-46](https://user-images.githubusercontent.com/23405122/194752708-3a9fc16e-cde2-4692-95d8-6ec9fccb23ac.png)
