### PR TITLE
[front] feat: better contrast between text and bg in the FAQ page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -403,6 +403,9 @@
       "message": "An unexpected error has occured."
     }
   },
+  "faqEntryList": {
+    "urlOfTheQuestionCopied": "URL of the question copied."
+  },
   "faqPage": {
     "iDidFindTheAnswers": "I didn't find the answer to my questions",
     "comeAndAskYourQuestionsOnDiscord": "Join our Discord server to ask directly your questions. Recurring questions will be added to the FAQ.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -404,7 +404,7 @@
     }
   },
   "faqEntryList": {
-    "urlOfTheQuestionCopied": "URL of the question copied."
+    "questionURLCopied": "Question's URL copied."
   },
   "faqPage": {
     "iDidFindTheAnswers": "I didn't find the answer to my questions",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -410,7 +410,7 @@
     }
   },
   "faqEntryList": {
-    "urlOfTheQuestionCopied": "URL de la question copiée."
+    "questionURLCopied": "URL de la question copiée."
   },
   "faqPage": {
     "iDidFindTheAnswers": "Je n'ai pas trouvé la réponse à mes questions",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -409,6 +409,9 @@
       "message": "Une erreur innatendu est survenue."
     }
   },
+  "faqEntryList": {
+    "urlOfTheQuestionCopied": "URL de la question copiée."
+  },
   "faqPage": {
     "iDidFindTheAnswers": "Je n'ai pas trouvé la réponse à mes questions",
     "comeAndAskYourQuestionsOnDiscord": "Venez poser vos questions directement sur notre serveur Discord. Les questions qui reviennent souvent seront ajoutées à la FAQ.",

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -12,6 +12,7 @@ import {
 import { Link, PeopleAlt } from '@mui/icons-material';
 
 import { FAQEntry } from 'src/services/openapi';
+import { useSnackbar } from 'notistack';
 
 /**
  * The Entry List section of the FAQ page.
@@ -24,12 +25,16 @@ import { FAQEntry } from 'src/services/openapi';
  */
 const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
   const { t } = useTranslation();
+  const { enqueueSnackbar } = useSnackbar();
 
   const copyUriToClipboard = (
     event: React.MouseEvent<HTMLElement>,
     anchor: string
   ) => {
     navigator.clipboard.writeText(window.location.toString() + `#${anchor}`);
+    enqueueSnackbar(t('faqEntryList.urlOfTheQuestionCopied'), {
+      variant: 'success',
+    });
   };
 
   return (

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -33,7 +33,7 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
     anchor: string
   ) => {
     navigator.clipboard.writeText(window.location.toString() + `#${anchor}`);
-    enqueueSnackbar(t('faqEntryList.urlOfTheQuestionCopied'), {
+    enqueueSnackbar(t('faqEntryList.questionURLCopied'), {
       variant: 'success',
       autoHideDuration: SNACKBAR_DYNAMIC_FEEDBACK_MS,
     });

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, Paper, Typography } from '@mui/material';
 import { PeopleAlt } from '@mui/icons-material';
 
 import { FAQEntry } from 'src/services/openapi';
@@ -23,20 +23,24 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
         const answerParagraphs = entry.answer.split('\n');
         return (
           <Box key={`q_${entry.name}`} mb={4}>
-            <Typography id={entry.name} variant="h4" gutterBottom>
-              {entry.question}
-            </Typography>
+            <Paper square>
+              <Box p={2} pb="1px">
+                <Typography id={entry.name} variant="h4" gutterBottom>
+                  {entry.question}
+                </Typography>
 
-            {/* An answer can be composed of several paragraphs. */}
-            {answerParagraphs.map((paragraph, index) => (
-              <Typography
-                key={`$a_{entry.name}_p${index}`}
-                paragraph
-                textAlign="justify"
-              >
-                {paragraph}
-              </Typography>
-            ))}
+                {/* An answer can be composed of several paragraphs. */}
+                {answerParagraphs.map((paragraph, index) => (
+                  <Typography
+                    key={`$a_{entry.name}_p${index}`}
+                    paragraph
+                    textAlign="justify"
+                  >
+                    {paragraph}
+                  </Typography>
+                ))}
+              </Box>
+            </Paper>
           </Box>
         );
       })}

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -11,8 +11,9 @@ import {
 } from '@mui/material';
 import { Link, PeopleAlt } from '@mui/icons-material';
 
-import { FAQEntry } from 'src/services/openapi';
 import { useSnackbar } from 'notistack';
+import { FAQEntry } from 'src/services/openapi';
+import { SNACKBAR_DYNAMIC_FEEDBACK_MS } from 'src/utils/notifications';
 
 /**
  * The Entry List section of the FAQ page.
@@ -34,6 +35,7 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
     navigator.clipboard.writeText(window.location.toString() + `#${anchor}`);
     enqueueSnackbar(t('faqEntryList.urlOfTheQuestionCopied'), {
       variant: 'success',
+      autoHideDuration: SNACKBAR_DYNAMIC_FEEDBACK_MS,
     });
   };
 

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Button, Paper, Typography } from '@mui/material';
-import { PeopleAlt } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Grid,
+  IconButton,
+  Paper,
+  Typography,
+} from '@mui/material';
+import { Link, PeopleAlt } from '@mui/icons-material';
 
 import { FAQEntry } from 'src/services/openapi';
 
@@ -17,6 +24,14 @@ import { FAQEntry } from 'src/services/openapi';
  */
 const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
   const { t } = useTranslation();
+
+  const copyUriToClipboard = (
+    event: React.MouseEvent<HTMLElement>,
+    anchor: string
+  ) => {
+    navigator.clipboard.writeText(window.location.toString() + `#${anchor}`);
+  };
+
   return (
     <>
       {entries.map((entry) => {
@@ -25,9 +40,29 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
           <Box key={`q_${entry.name}`} mb={4}>
             <Paper square>
               <Box p={2} pb="1px">
-                <Typography id={entry.name} variant="h4" gutterBottom>
-                  {entry.question}
-                </Typography>
+                <Grid container>
+                  <Grid item xs={11}>
+                    <Typography id={entry.name} variant="h4" gutterBottom>
+                      {entry.question}
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={1}>
+                    <Box
+                      display="flex"
+                      alignItems="center"
+                      justifyContent="flex-end"
+                    >
+                      <IconButton
+                        aria-label="Copy URI to clicboard"
+                        onClick={(event) => {
+                          copyUriToClipboard(event, entry.name);
+                        }}
+                      >
+                        <Link />
+                      </IconButton>
+                    </Box>
+                  </Grid>
+                </Grid>
 
                 {/* An answer can be composed of several paragraphs. */}
                 {answerParagraphs.map((paragraph, index) => (

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -53,7 +53,7 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
                       justifyContent="flex-end"
                     >
                       <IconButton
-                        aria-label="Copy URI to clicboard"
+                        aria-label="Copy URI to clipboard"
                         onClick={(event) => {
                           copyUriToClipboard(event, entry.name);
                         }}

--- a/frontend/src/pages/faq/FAQEntryList.tsx
+++ b/frontend/src/pages/faq/FAQEntryList.tsx
@@ -49,7 +49,14 @@ const FAQEntryList = ({ entries }: { entries: Array<FAQEntry> }) => {
               <Box p={2} pb="1px">
                 <Grid container>
                   <Grid item xs={11}>
-                    <Typography id={entry.name} variant="h4" gutterBottom>
+                    <Typography
+                      id={entry.name}
+                      variant="h4"
+                      gutterBottom
+                      // Match the IconButton padding to align the two items
+                      // nicely, even when the title fits on several lines.
+                      sx={{ pt: 1 }}
+                    >
                       {entry.question}
                     </Typography>
                   </Grid>

--- a/frontend/src/pages/faq/FAQTableOfContent.tsx
+++ b/frontend/src/pages/faq/FAQTableOfContent.tsx
@@ -29,7 +29,7 @@ const FAQTableOfContent = ({ entries }: { entries: Array<FAQEntry> }) => {
       <List dense={true}>
         {entries.map((entry) => (
           <ListItemButton
-            key={`$toc_{entry.name}`}
+            key={`toc_${entry.name}`}
             component="a"
             href={`#${entry.name}`}
           >

--- a/frontend/src/utils/notifications.ts
+++ b/frontend/src/utils/notifications.ts
@@ -1,0 +1,5 @@
+// The default `autoHideDuration` used by the package notistack is 5000 ms.
+// This value is good for form success or error messages, as it gives the
+// users enough time to read. For more simple operations, like clicking on
+// copy button, a quicker feedback appropriate.
+export const SNACKBAR_DYNAMIC_FEEDBACK_MS = 1800;


### PR DESCRIPTION
The look and feel of the FAQ page was a bit raw, and its text not very pleasant to read.

In order to ease the reading I added a white `<Paper>` for each question, increasing the contrast between the text and the brackground.

| before                                                                                                             | after                                                                                                             |
|--------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
| ![capture2](https://user-images.githubusercontent.com/39056254/195390014-6a958e38-2869-470d-ad5e-987016d5db55.png) |![capture](https://user-images.githubusercontent.com/39056254/195395259-b38993cf-1421-405a-8464-ed0fa88df6af.png) |

As suggested I added a copy URL button. A click a this button displays a visual feedback with `notistack`.

https://user-images.githubusercontent.com/39056254/195399542-54d45c66-8bce-4d91-b435-dbd573db2781.mp4

