### PR TITLE
[all] chore: make the `README.md` intro more friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 <p align="center">
   <i>
-    Participants are invited to judge the videos quality, and build together an open database to help the research in AI ethics and recommendation systems.
+    Participants are invited to judge the videos' quality, and build together an open database to help the research in AI ethics and recommendation systems.
   </i>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@
     width="120px"
     height="120px"
   />
-  <br>
-  <i>Tournesol is a free and open source platform which aims to collaboratively identify top videos of public utility
-    <br>by eliciting contributors' judgements on content quality.</i>
-  <br>
+<p>
+<p align="center">
+  <i>
+    Tournesol is free software designed to collaboratively identify public interest videos that should be largely recommended.
+  </i>
+</p>
+<p align="center">
+  <i>
+    Participants are invited to judge the videos quality, and build together an open database to help the research in AI ethics and recommendation systems.
+  </i>
 </p>
 
 <p align="center">
@@ -29,7 +35,7 @@
 
 ---
 
-This repository hosts the free and open source code of the Tournesol platform.
+This repository hosts the source code of the Tournesol platform.
 
 Learn more about the project on our [Wiki][tournesol-wiki], or meet our community
 on [Discord][tournesol-discord-join].


### PR DESCRIPTION
This PR is a proposition to make the introduction in the `README.md` more user friendly and accurate. It's secondary objective is to deprecate the usage of "public utility".

As we have gained some experience in shortening ideas, I tried to be as short as possible while adding some important information. Two paragraphs maximum, one medium sentence each, but full of meaning : )

**(a)** I replaced the usage of "public utility" by "public interest" here, as public utility doesn't seem to have the meaning we expected.

**(b)** I described what we consider to be public interest by simply adding "videos that should be largely recommended". These few words make the connection between the concept of public interest and what kind of judgement the participants will make in the front end.

**(c)** I also explained what the participants are doing, and why: building an open database. Knowing the purpose of the participant can be a source of motivation. It's also the only place in the `README.md` where one of the objectives of Tournesol is explained. Whether we consider the `README.md` a good place or not to explain the project, I think it should contain at least one hint about the project purpose.

**(d)** I removed "free and open source", replaced by "free software". A free software has de facto its source open. Keeping the  open source mention won't make people curious about free software, and can shadow the political meaning of free software as it can be understood as "free of charge" instead of as "protecting the users' freedom".

**(e)** I removed the useless usage of `<br>`

Tell me what do you think : ) You can see the result here: https://github.com/tournesol-app/tournesol/blob/meta-update_readme_intro/README.md