### PR TITLE
[back] fix: enable the previously disabled cache for the entity preview

### DIFF
--- a/backend/tournesol/utils/cache.py
+++ b/backend/tournesol/utils/cache.py
@@ -5,11 +5,15 @@ from django.views.decorators.cache import cache_page
 
 def cache_page_no_i18n(timeout: float):
     """
-    This decorator activates the default language before calling `cache_page`.
+    This decorator activates the default language before calling the Django's
+    decorator `cache_page`.
 
-    By default, `cache_page` includes the request language code in its cache key.
-    Some API responses (e.g public export files) don't depend on the language
-    and can be cached under a single key using this decorator.
+    By default, `cache_page` includes the request language code in its cache
+    key. Some API responses (e.g. public export files) don't depend on the
+    language and can be cached under a single key using this decorator.
+
+    Keyword arguments:
+    timeout -- time to live of the cached page, in seconds.
     """
 
     def decorator(view):

--- a/backend/tournesol/views/preview.py
+++ b/backend/tournesol/views/preview.py
@@ -25,6 +25,9 @@ logger = logging.getLogger(__name__)
 
 BASE_DIR = settings.BASE_DIR
 
+CACHE_DEFAULT_PREVIEW = 3600 * 24  # 24h
+CACHE_ENTITY_PREVIEW = 3600 * 2
+
 FOOTER_FONT_LOCATION = "tournesol/resources/Poppins-Medium.ttf"
 ENTITY_N_CONTRIBUTORS_XY = (60, 98)
 ENTITY_TITLE_XY = (128, 190)
@@ -207,7 +210,7 @@ class DynamicWebsitePreviewDefault(BasePreviewAPIView):
 
     permission_classes = []
 
-    @method_decorator(cache_page_no_i18n(3600 * 24))  # 24h cache
+    @method_decorator(cache_page_no_i18n(CACHE_DEFAULT_PREVIEW))
     @extend_schema(
         description="Default website preview.",
         responses={200: OpenApiTypes.BINARY},
@@ -244,8 +247,7 @@ class DynamicWebsitePreviewEntity(BasePreviewAPIView):
         if score and score > 0:
             image.alpha_composite(self.get_ts_logo(34), dest=(16, 24))
 
-    # TODO: should this cache be enabled?
-    @method_decorator(cache_page_no_i18n(0 * 2))  # 2h cache
+    @method_decorator(cache_page_no_i18n(CACHE_ENTITY_PREVIEW))
     @extend_schema(
         description="Generic preview of an entity.",
         responses={200: OpenApiTypes.BINARY},


### PR DESCRIPTION
This PR enable a 2 hours cache for the entity preview endpoint. 

To be sure we are not merging something we don't want: @lfaucon did we have a good reason to disable the cache in the preview API? Or was it just a leftover of a development configuration?