### PR TITLE
[back] feat: ratings are now order-able by some entity metadata fields

### DIFF
--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Iterable, List, Type
+from typing import Dict, Iterable, List, Optional, Type
 
 from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import F
@@ -19,9 +19,8 @@ class EntityType(ABC):
     Abstract base class for the processing specific to each entity type (mainly about metadata).
     """
 
-    # The 'name' of this entity type corresponds
-    # to the `type` field in Entity,
-    # and to the `entity_type` in Poll.
+    # The name of this entity type corresponds to the `type` field of the
+    # `Entity` model, and to the `entity_type` field of a `Poll`.
     name: str
     metadata_serializer_class: Type[Serializer]
 
@@ -185,6 +184,14 @@ class EntityType(ABC):
     @classmethod
     def filter_date_gte(cls, qs, min_date):
         return qs.filter(add_time__gte=min_date)
+
+    @classmethod
+    def get_allowed_meta_order_fields(cls) -> Optional[List[str]]:
+        """
+        Return a list of metadata fields that can be used to order an entity
+        list.
+        """
+        return None
 
     @classmethod
     @abstractmethod

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Iterable, List, Optional, Type
+from typing import Dict, Iterable, List, Type
 
 from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import F
@@ -186,12 +186,12 @@ class EntityType(ABC):
         return qs.filter(add_time__gte=min_date)
 
     @classmethod
-    def get_allowed_meta_order_fields(cls) -> Optional[List[str]]:
+    def get_allowed_meta_order_fields(cls) -> List[str]:
         """
         Return a list of metadata fields that can be used to order an entity
         list.
         """
-        return None
+        return []
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
**related to** #1174 

---

This PR allows the results of the ratings API to be ordered by `duration` and `publication_date`.

As requested by some users, the default order has changed and is now `-last_compared_at` instead of the video metadata `publication_date`. This change will automatically be visible in the front end when the API will be updated.

Following the "never trust user input" principle, the available metadata fields that can be used to order a entity list through the ratings API are defined in a fixed allow list, per entity type. A `video` can be ordered by `duration`, a candidate no. 