### PR TITLE
[front] feat: add an order by input in the ratings page

### DIFF
--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -25,7 +25,10 @@ ALLOWED_GENERIC_ORDER_BY_VALUES = [
     "-n_comparisons",
 ]
 
-DEFAULT_ORDER_BY = ["-last_compared_at", "-pk"]
+# Appended to the positional arguments of all calls to QuerySet.order_by()
+EXTRA_ORDER_BY = "-pk"
+
+DEFAULT_ORDER_BY = ["-last_compared_at", EXTRA_ORDER_BY]
 
 
 def get_annotated_ratings():
@@ -146,13 +149,13 @@ class ContributorRatingList(PollScopedViewMixin, generics.ListCreateAPIView):
             return qst.order_by(*DEFAULT_ORDER_BY)
 
         if order_by in ALLOWED_GENERIC_ORDER_BY_VALUES:
-            return qst.order_by(order_by)
+            return qst.order_by(order_by, EXTRA_ORDER_BY)
 
         sign = "-" if order_by[0] == "-" else ""
         field = order_by[1:] if order_by[0] == "-" else order_by
 
         if field in poll.entity_cls.get_allowed_meta_order_fields():
-            return qst.order_by(f"{sign}entity__metadata__{field}")
+            return qst.order_by(f"{sign}entity__metadata__{field}", EXTRA_ORDER_BY)
 
         raise ValidationError("The URL parameter 'order_by' is invalid.")
 

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -252,10 +252,10 @@
   "ratingOrderByInput": {
     "orderBy": "Order by",
     "order": "Order",
-    "lastComparisonDate(ASC)": "Last comparison date (ASC)",
-    "lastComparisonDate(DESC)": "Last comparison date (DESC)",
-    "numberOfComparisons(ASC)": "Number of comparisons (ASC)",
-    "numberOfComparisons(DESC)": "Number of comparisons (DESC)"
+    "lastComparisonDate(ASC)": "Last comparison date (asc.)",
+    "lastComparisonDate(DESC)": "Last comparison date (desc.)",
+    "numberOfComparisons(ASC)": "Number of comparisons (asc.)",
+    "numberOfComparisons(DESC)": "Number of comparisons (desc.)"
   },
   "options": "Options",
   "contextualRecommendations": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -253,8 +253,6 @@
     "orderBy": "Order by",
     "order": "Order",
     "lastComparisonDate": "Last comparison date",
-    "(asc)": "(asc.)",
-    "(desc)": "(desc.)",
     "numberOfComparisons": "Number of comparisons"
   },
   "options": "Options",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -250,10 +250,10 @@
     "compareVideosButton": "Compare videos"
   },
   "ratingOrderByInput": {
-    "orderBy": "Order by",
-    "order": "Order",
     "lastComparisonDate": "Last comparison date",
-    "numberOfComparisons": "Number of comparisons"
+    "numberOfComparisons": "Number of comparisons",
+    "orderBy": "Order by",
+    "order": "Order"
   },
   "options": "Options",
   "contextualRecommendations": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -249,6 +249,14 @@
     "noVideoComparedYet": "You haven't compared any video yet",
     "compareVideosButton": "Compare videos"
   },
+  "ratingOrderByInput": {
+    "orderBy": "Order by",
+    "order": "Order",
+    "lastComparisonDate(ASC)": "Last comparison date (ASC)",
+    "lastComparisonDate(DESC)": "Last comparison date (DESC)",
+    "numberOfComparisons(ASC)": "Number of comparisons (ASC)",
+    "numberOfComparisons(DESC)": "Number of comparisons (DESC)"
+  },
   "options": "Options",
   "contextualRecommendations": {
     "channel": "Channel",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -252,10 +252,10 @@
   "ratingOrderByInput": {
     "orderBy": "Order by",
     "order": "Order",
-    "lastComparisonDate(ASC)": "Last comparison date (asc.)",
-    "lastComparisonDate(DESC)": "Last comparison date (desc.)",
-    "numberOfComparisons(ASC)": "Number of comparisons (asc.)",
-    "numberOfComparisons(DESC)": "Number of comparisons (desc.)"
+    "lastComparisonDate": "Last comparison date",
+    "(asc)": "(asc.)",
+    "(desc)": "(desc.)",
+    "numberOfComparisons": "Number of comparisons"
   },
   "options": "Options",
   "contextualRecommendations": {
@@ -572,6 +572,10 @@
     "videos": "videos",
     "entityCandidate": "candidate",
     "entityVideo": "video"
+  },
+  "videoMetadata": {
+    "duration": "Duration",
+    "publication_date": "Publication date"
   },
   "presidentielle2022": {
     "dialogs": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -259,8 +259,6 @@
     "orderBy": "Trier par",
     "order": "Ordre",
     "lastComparisonDate": "Dernière comparaison",
-    "(asc)": "(crois.)",
-    "(desc)": "(décrois.)",
     "numberOfComparisons": "Nombre de comparaisons"
   },
   "options": "Options",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -258,10 +258,10 @@
   "ratingOrderByInput": {
     "orderBy": "Trier par",
     "order": "Ordre",
-    "lastComparisonDate(ASC)": "Dernière comparaison (crois.)",
-    "lastComparisonDate(DESC)": "Dernière comparaison (décrois.)",
-    "numberOfComparisons(ASC)": "Nombre de comparaisons (crois.)",
-    "numberOfComparisons(DESC)": "Nombre de comparaisons (décrois.)"
+    "lastComparisonDate": "Dernière comparaison",
+    "(asc)": "(crois.)",
+    "(desc)": "(décrois.)",
+    "numberOfComparisons": "Nombre de comparaisons"
   },
   "options": "Options",
   "contextualRecommendations": {
@@ -579,6 +579,10 @@
     "videos": "vidéos",
     "entityCandidate": "candidat",
     "entityVideo": "vidéo"
+  },
+  "videoMetadata": {
+    "duration": "Durée",
+    "publication_date": "Date de publication"
   },
   "presidentielle2022": {
     "dialogs": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -256,10 +256,10 @@
     "compareVideosButton": "Comparer des vidéos"
   },
   "ratingOrderByInput": {
-    "orderBy": "Trier par",
-    "order": "Ordre",
     "lastComparisonDate": "Dernière comparaison",
-    "numberOfComparisons": "Nombre de comparaisons"
+    "numberOfComparisons": "Nombre de comparaisons",
+    "orderBy": "Trier par",
+    "order": "Ordre"
   },
   "options": "Options",
   "contextualRecommendations": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -255,6 +255,14 @@
     "noVideoComparedYet": "Vous n'avez pas encore comparé de vidéo",
     "compareVideosButton": "Comparer des vidéos"
   },
+  "ratingOrderByInput": {
+    "orderBy": "Trier par",
+    "order": "Ordre",
+    "lastComparisonDate(ASC)": "Dernière comparaison (ASC)",
+    "lastComparisonDate(DESC)": "Dernière comparaison (DESC)",
+    "numberOfComparisons(ASC)": "Nombre de comparaisons (ASC)",
+    "numberOfComparisons(DESC)": "Nombre de comparaisons (DESC)"
+  },
   "options": "Options",
   "contextualRecommendations": {
     "channel": "Chaîne",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -258,10 +258,10 @@
   "ratingOrderByInput": {
     "orderBy": "Trier par",
     "order": "Ordre",
-    "lastComparisonDate(ASC)": "Dernière comparaison (ASC)",
-    "lastComparisonDate(DESC)": "Dernière comparaison (DESC)",
-    "numberOfComparisons(ASC)": "Nombre de comparaisons (ASC)",
-    "numberOfComparisons(DESC)": "Nombre de comparaisons (DESC)"
+    "lastComparisonDate(ASC)": "Dernière comparaison (crois.)",
+    "lastComparisonDate(DESC)": "Dernière comparaison (décrois.)",
+    "numberOfComparisons(ASC)": "Nombre de comparaisons (crois.)",
+    "numberOfComparisons(DESC)": "Nombre de comparaisons (décrois.)"
   },
   "options": "Options",
   "contextualRecommendations": {

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -411,7 +411,8 @@ paths:
   /exports/all/:
     get:
       operationId: exports_all_retrieve
-      description: Download all the public data in a .zip file
+      description: Download the complete public dataset of the `videos` poll in a
+        .zip file.
       tags:
       - exports
       security:
@@ -429,7 +430,8 @@ paths:
   /exports/comparisons/:
     get:
       operationId: exports_comparisons_retrieve
-      description: Download public data in .csv file
+      description: Download all public comparisons made in the `videos` poll by all
+        users in a CSV file.
       tags:
       - exports
       security:
@@ -1253,7 +1255,7 @@ paths:
         schema:
           type: string
         description: 'Order the results by: last_compared_at, -last_compared_at, n_comparisons,
-          -n_comparisons.'
+          -n_comparisons, or any allowed metadata field.'
       tags:
       - users
       security:
@@ -1521,7 +1523,8 @@ paths:
   /users/me/exports/comparisons/:
     get:
       operationId: users_me_exports_comparisons_retrieve
-      description: Download the current user's comparisons in a .csv file
+      description: Download all comparisons made in all polls by the logged-in user
+        in a CSV file.
       tags:
       - users
       security:

--- a/frontend/src/features/ratings/RatingOrderByInput.tsx
+++ b/frontend/src/features/ratings/RatingOrderByInput.tsx
@@ -42,7 +42,6 @@ function RatingOrderByInput(props: FilterProps) {
           onChange={handleChange}
           inputProps={{ 'data-testid': 'order-by-metadata-input' }}
         >
-          <MenuItem value="">--</MenuItem>
           <MenuItem value="last_compared_at">
             {t('ratingOrderByInput.lastComparisonDate')}&nbsp;
             {t('ratingOrderByInput.(asc)')}

--- a/frontend/src/features/ratings/RatingOrderByInput.tsx
+++ b/frontend/src/features/ratings/RatingOrderByInput.tsx
@@ -35,6 +35,7 @@ function RatingOrderByInput(props: FilterProps) {
           label={t('ratingOrderByInput.order')}
           value={props.value}
           onChange={handleChange}
+          inputProps={{ 'data-testid': 'order-by-metadata-input' }}
         >
           <MenuItem value="">--</MenuItem>
           <MenuItem value="last_compared_at">

--- a/frontend/src/features/ratings/RatingOrderByInput.tsx
+++ b/frontend/src/features/ratings/RatingOrderByInput.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
+  Box,
   FormControl,
   InputLabel,
+  ListItemText,
   MenuItem,
   Select,
   SelectChangeEvent,
@@ -30,6 +32,32 @@ function RatingOrderByInput(props: FilterProps) {
     props.onChange(event.target.value);
   };
 
+  const genericItems = useMemo(
+    () => [
+      {
+        label: t('ratingOrderByInput.lastComparisonDate'),
+        value: 'last_compared_at',
+        icon: CallMadeIcon,
+      },
+      {
+        label: t('ratingOrderByInput.lastComparisonDate'),
+        value: '-last_compared_at',
+        icon: CallReceivedIcon,
+      },
+      {
+        label: t('ratingOrderByInput.lastComparisonDate'),
+        value: 'n_comparisons',
+        icon: CallMadeIcon,
+      },
+      {
+        label: t('ratingOrderByInput.lastComparisonDate'),
+        value: '-n_comparisons',
+        icon: CallReceivedIcon,
+      },
+    ],
+    [t]
+  );
+
   return (
     <TitledSection title={t('ratingOrderByInput.orderBy')}>
       <FormControl fullWidth size="small">
@@ -44,30 +72,36 @@ function RatingOrderByInput(props: FilterProps) {
           onChange={handleChange}
           inputProps={{ 'data-testid': 'order-by-metadata-input' }}
         >
-          <MenuItem value="last_compared_at">
-            {t('ratingOrderByInput.lastComparisonDate')}&nbsp;
-            <CallMadeIcon fontSize="small" />
-          </MenuItem>
-          <MenuItem value="-last_compared_at">
-            {t('ratingOrderByInput.lastComparisonDate')}&nbsp;
-            <CallReceivedIcon fontSize="small" />
-          </MenuItem>
-          <MenuItem value="n_comparisons">
-            {t('ratingOrderByInput.numberOfComparisons')}&nbsp;
-            <CallMadeIcon fontSize="small" />
-          </MenuItem>
-          <MenuItem value="-n_comparisons">
-            {t('ratingOrderByInput.numberOfComparisons')}&nbsp;
-            <CallReceivedIcon fontSize="small" />
-          </MenuItem>
+          {/* Metadata available for any kind of entity type. */}
+          {genericItems.map((item) => (
+            <MenuItem key={item.value} value={item.value}>
+              <Box display="flex" alignItems="center">
+                <ListItemText>{item.label}</ListItemText>
+                &nbsp;
+                <item.icon fontSize="small" />
+              </Box>
+            </MenuItem>
+          ))}
+
+          {/* Metadata specific to the displayed entity type. */}
           {extraMetadataOrderBy.map((metadata) => [
             <MenuItem key={`${metadata}`} value={`${metadata}`}>
-              {getMetadataName(t, pollName, metadata)}&nbsp;
-              <CallMadeIcon fontSize="small" />
+              <Box display="flex" alignItems="center">
+                <ListItemText>
+                  {getMetadataName(t, pollName, metadata)}
+                </ListItemText>
+                &nbsp;
+                <CallMadeIcon fontSize="small" />
+              </Box>
             </MenuItem>,
             <MenuItem key={`-${metadata}`} value={`-${metadata}`}>
-              {getMetadataName(t, pollName, metadata)}&nbsp;
-              <CallReceivedIcon fontSize="small" />
+              <Box display="flex" alignItems="center">
+                <ListItemText>
+                  {getMetadataName(t, pollName, metadata)}
+                </ListItemText>
+                &nbsp;
+                <CallReceivedIcon fontSize="small" />
+              </Box>
             </MenuItem>,
           ])}
         </Select>

--- a/frontend/src/features/ratings/RatingOrderByInput.tsx
+++ b/frontend/src/features/ratings/RatingOrderByInput.tsx
@@ -1,0 +1,61 @@
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from '@mui/material';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { TitledSection } from 'src/components';
+
+export const isPublicChoices = {
+  true: 'Public',
+  false: 'Private',
+};
+
+interface FilterProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function RatingOrderByInput(props: FilterProps) {
+  const { t } = useTranslation();
+
+  const handleChange = (event: SelectChangeEvent) => {
+    props.onChange(event.target.value);
+  };
+
+  return (
+    <TitledSection title={t('ratingOrderByInput.orderBy')}>
+      <FormControl fullWidth size="small">
+        <InputLabel id="order-by-metadata-label">
+          {t('ratingOrderByInput.order')}
+        </InputLabel>
+        <Select
+          id="order-by-metadata"
+          labelId="order-by-metadata-label"
+          label={t('ratingOrderByInput.order')}
+          value={props.value}
+          onChange={handleChange}
+        >
+          <MenuItem value="">--</MenuItem>
+          <MenuItem value="last_compared_at">
+            {t('ratingOrderByInput.lastComparisonDate(ASC)')}
+          </MenuItem>
+          <MenuItem value="-last_compared_at">
+            {t('ratingOrderByInput.lastComparisonDate(DESC)')}
+          </MenuItem>
+          <MenuItem value="n_comparisons">
+            {t('ratingOrderByInput.numberOfComparisons(ASC)')}
+          </MenuItem>
+          <MenuItem value="-n_comparisons">
+            {t('ratingOrderByInput.numberOfComparisons(DESC)')}
+          </MenuItem>
+        </Select>
+      </FormControl>
+    </TitledSection>
+  );
+}
+
+export default RatingOrderByInput;

--- a/frontend/src/features/ratings/RatingOrderByInput.tsx
+++ b/frontend/src/features/ratings/RatingOrderByInput.tsx
@@ -8,6 +8,8 @@ import {
   Select,
   SelectChangeEvent,
 } from '@mui/material';
+import CallMadeIcon from '@mui/icons-material/CallMade';
+import CallReceivedIcon from '@mui/icons-material/CallReceived';
 
 import { TitledSection } from 'src/components';
 import { useCurrentPoll } from 'src/hooks';
@@ -44,28 +46,28 @@ function RatingOrderByInput(props: FilterProps) {
         >
           <MenuItem value="last_compared_at">
             {t('ratingOrderByInput.lastComparisonDate')}&nbsp;
-            {t('ratingOrderByInput.(asc)')}
+            <CallMadeIcon fontSize="small" />
           </MenuItem>
           <MenuItem value="-last_compared_at">
             {t('ratingOrderByInput.lastComparisonDate')}&nbsp;
-            {t('ratingOrderByInput.(desc)')}
+            <CallReceivedIcon fontSize="small" />
           </MenuItem>
           <MenuItem value="n_comparisons">
             {t('ratingOrderByInput.numberOfComparisons')}&nbsp;
-            {t('ratingOrderByInput.(asc)')}
+            <CallMadeIcon fontSize="small" />
           </MenuItem>
           <MenuItem value="-n_comparisons">
             {t('ratingOrderByInput.numberOfComparisons')}&nbsp;
-            {t('ratingOrderByInput.(desc)')}
+            <CallReceivedIcon fontSize="small" />
           </MenuItem>
           {extraMetadataOrderBy.map((metadata) => [
             <MenuItem key={`${metadata}`} value={`${metadata}`}>
               {getMetadataName(t, pollName, metadata)}&nbsp;
-              {t('ratingOrderByInput.(asc)')}
+              <CallMadeIcon fontSize="small" />
             </MenuItem>,
             <MenuItem key={`-${metadata}`} value={`-${metadata}`}>
               {getMetadataName(t, pollName, metadata)}&nbsp;
-              {t('ratingOrderByInput.(desc)')}
+              <CallReceivedIcon fontSize="small" />
             </MenuItem>,
           ])}
         </Select>

--- a/frontend/src/features/ratings/RatingOrderByInput.tsx
+++ b/frontend/src/features/ratings/RatingOrderByInput.tsx
@@ -45,12 +45,12 @@ function RatingOrderByInput(props: FilterProps) {
         icon: CallReceivedIcon,
       },
       {
-        label: t('ratingOrderByInput.lastComparisonDate'),
+        label: t('ratingOrderByInput.numberOfComparisons'),
         value: 'n_comparisons',
         icon: CallMadeIcon,
       },
       {
-        label: t('ratingOrderByInput.lastComparisonDate'),
+        label: t('ratingOrderByInput.numberOfComparisons'),
         value: '-n_comparisons',
         icon: CallReceivedIcon,
       },

--- a/frontend/src/features/ratings/RatingOrderByInput.tsx
+++ b/frontend/src/features/ratings/RatingOrderByInput.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
 import {
   FormControl,
   InputLabel,
@@ -5,14 +8,8 @@ import {
   Select,
   SelectChangeEvent,
 } from '@mui/material';
-import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { TitledSection } from 'src/components';
 
-export const isPublicChoices = {
-  true: 'Public',
-  false: 'Private',
-};
+import { TitledSection } from 'src/components';
 
 interface FilterProps {
   value: string;

--- a/frontend/src/features/ratings/RatingOrderByInput.tsx
+++ b/frontend/src/features/ratings/RatingOrderByInput.tsx
@@ -10,6 +10,8 @@ import {
 } from '@mui/material';
 
 import { TitledSection } from 'src/components';
+import { useCurrentPoll } from 'src/hooks';
+import { getMetadataName } from 'src/utils/constants';
 
 interface FilterProps {
   value: string;
@@ -18,6 +20,9 @@ interface FilterProps {
 
 function RatingOrderByInput(props: FilterProps) {
   const { t } = useTranslation();
+  const { name: pollName, options } = useCurrentPoll();
+
+  const extraMetadataOrderBy = options?.extraMetadataOrderBy ?? [];
 
   const handleChange = (event: SelectChangeEvent) => {
     props.onChange(event.target.value);
@@ -39,17 +44,31 @@ function RatingOrderByInput(props: FilterProps) {
         >
           <MenuItem value="">--</MenuItem>
           <MenuItem value="last_compared_at">
-            {t('ratingOrderByInput.lastComparisonDate(ASC)')}
+            {t('ratingOrderByInput.lastComparisonDate')}&nbsp;
+            {t('ratingOrderByInput.(asc)')}
           </MenuItem>
           <MenuItem value="-last_compared_at">
-            {t('ratingOrderByInput.lastComparisonDate(DESC)')}
+            {t('ratingOrderByInput.lastComparisonDate')}&nbsp;
+            {t('ratingOrderByInput.(desc)')}
           </MenuItem>
           <MenuItem value="n_comparisons">
-            {t('ratingOrderByInput.numberOfComparisons(ASC)')}
+            {t('ratingOrderByInput.numberOfComparisons')}&nbsp;
+            {t('ratingOrderByInput.(asc)')}
           </MenuItem>
           <MenuItem value="-n_comparisons">
-            {t('ratingOrderByInput.numberOfComparisons(DESC)')}
+            {t('ratingOrderByInput.numberOfComparisons')}&nbsp;
+            {t('ratingOrderByInput.(desc)')}
           </MenuItem>
+          {extraMetadataOrderBy.map((metadata) => [
+            <MenuItem key={`${metadata}`} value={`${metadata}`}>
+              {getMetadataName(t, pollName, metadata)}&nbsp;
+              {t('ratingOrderByInput.(asc)')}
+            </MenuItem>,
+            <MenuItem key={`-${metadata}`} value={`-${metadata}`}>
+              {getMetadataName(t, pollName, metadata)}&nbsp;
+              {t('ratingOrderByInput.(desc)')}
+            </MenuItem>,
+          ])}
         </Select>
       </FormControl>
     </TitledSection>

--- a/frontend/src/features/ratings/RatingsFilter.tsx
+++ b/frontend/src/features/ratings/RatingsFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, Collapse, Grid } from '@mui/material';
 
@@ -9,27 +9,23 @@ import IsPublicFilter from './IsPublicFilter';
 import MarkAllRatingsMenu from './MarkAllRatings';
 import RatingOrderByInput from './RatingOrderByInput';
 
-const DEFAULT_FILTER_ORDER_BY = '-last_compared_at';
-
-function RatingsFilter() {
+function RatingsFilter({
+  defaultFilters = [],
+}: {
+  // A list of default values used to initialize the filters.
+  defaultFilters: Array<{ name: string; value: string }>;
+}) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
-  const [filterParams, setFilter] = useListFilter();
+  const [filterParams, setFilter] = useListFilter({ defaults: defaultFilters });
+
+  const defaultFilterOrderBy = defaultFilters
+    .filter((param) => param.name === 'orderBy' && param.value != null)
+    .pop() ?? { value: '' };
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
   };
-
-  // Append default URL parameters if needed.
-  useEffect(() => {
-    const defaults = [{ key: 'orderBy', value: DEFAULT_FILTER_ORDER_BY }];
-
-    defaults.map((param) => {
-      if (!filterParams.get(param.key)) {
-        setFilter(param.key, param.value);
-      }
-    });
-  }, [filterParams, setFilter]);
 
   return (
     <Box color="text.secondary">
@@ -46,7 +42,7 @@ function RatingsFilter() {
           </Grid>
           <Grid item xs={12} sm={6} md={5} lg={4}>
             <RatingOrderByInput
-              value={filterParams.get('orderBy') ?? DEFAULT_FILTER_ORDER_BY}
+              value={filterParams.get('orderBy') ?? defaultFilterOrderBy.value}
               onChange={(value) => setFilter('orderBy', value)}
             />
           </Grid>

--- a/frontend/src/features/ratings/RatingsFilter.tsx
+++ b/frontend/src/features/ratings/RatingsFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, Collapse, Grid } from '@mui/material';
 
@@ -9,6 +9,8 @@ import IsPublicFilter from './IsPublicFilter';
 import MarkAllRatingsMenu from './MarkAllRatings';
 import RatingOrderByInput from './RatingOrderByInput';
 
+const DEFAULT_FILTER_ORDER_BY = '-last_compared_at';
+
 function RatingsFilter() {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
@@ -17,6 +19,17 @@ function RatingsFilter() {
   const handleExpandClick = () => {
     setExpanded(!expanded);
   };
+
+  // Append default URL parameters if needed.
+  useEffect(() => {
+    const defaults = [{ key: 'orderBy', value: DEFAULT_FILTER_ORDER_BY }];
+
+    defaults.map((param) => {
+      if (!filterParams.get(param.key)) {
+        setFilter(param.key, param.value);
+      }
+    });
+  }, [filterParams, setFilter]);
 
   return (
     <Box color="text.secondary">
@@ -33,7 +46,7 @@ function RatingsFilter() {
           </Grid>
           <Grid item xs={12} sm={6} md={5} lg={4}>
             <RatingOrderByInput
-              value={filterParams.get('orderBy') ?? ''}
+              value={filterParams.get('orderBy') ?? DEFAULT_FILTER_ORDER_BY}
               onChange={(value) => setFilter('orderBy', value)}
             />
           </Grid>

--- a/frontend/src/features/ratings/RatingsFilter.tsx
+++ b/frontend/src/features/ratings/RatingsFilter.tsx
@@ -19,10 +19,6 @@ function RatingsFilter({
   const [expanded, setExpanded] = useState(false);
   const [filterParams, setFilter] = useListFilter({ defaults: defaultFilters });
 
-  const defaultFilterOrderBy = defaultFilters
-    .filter((param) => param.name === 'orderBy' && param.value != null)
-    .pop() ?? { value: '' };
-
   const handleExpandClick = () => {
     setExpanded(!expanded);
   };
@@ -42,7 +38,7 @@ function RatingsFilter({
           </Grid>
           <Grid item xs={12} sm={6} md={5} lg={4}>
             <RatingOrderByInput
-              value={filterParams.get('orderBy') ?? defaultFilterOrderBy.value}
+              value={filterParams.get('orderBy') ?? ''}
               onChange={(value) => setFilter('orderBy', value)}
             />
           </Grid>

--- a/frontend/src/features/ratings/RatingsFilter.tsx
+++ b/frontend/src/features/ratings/RatingsFilter.tsx
@@ -4,8 +4,10 @@ import { Box, Collapse, Grid } from '@mui/material';
 
 import { CollapseButton } from 'src/components';
 import { useListFilter } from 'src/hooks';
+
 import IsPublicFilter from './IsPublicFilter';
 import MarkAllRatingsMenu from './MarkAllRatings';
+import RatingOrderByInput from './RatingOrderByInput';
 
 function RatingsFilter() {
   const { t } = useTranslation();
@@ -22,14 +24,20 @@ function RatingsFilter() {
         {t('options')}
       </CollapseButton>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
-        <Grid container spacing={4} sx={{ marginBottom: '8px' }}>
-          <Grid item xs={12} sm={6} md={5}>
+        <Grid container spacing={2} mb={1} justifyContent="space-between">
+          <Grid item xs={12} sm={6} md={3}>
             <IsPublicFilter
               value={filterParams.get('isPublic') ?? ''}
               onChange={(value) => setFilter('isPublic', value)}
             />
           </Grid>
-          <Grid item xs={12} sm={6} md={5}>
+          <Grid item xs={12} sm={6} md={5} lg={4}>
+            <RatingOrderByInput
+              value={filterParams.get('orderBy') ?? ''}
+              onChange={(value) => setFilter('orderBy', value)}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
             <MarkAllRatingsMenu />
           </Grid>
         </Grid>

--- a/frontend/src/hooks/useListFilter.ts
+++ b/frontend/src/hooks/useListFilter.ts
@@ -1,14 +1,22 @@
 import { useLocation, useHistory } from 'react-router';
 
 export const useListFilter = ({
+  defaults = [],
   setEmptyValues = false,
-}: { setEmptyValues?: boolean } = {}): [
-  URLSearchParams,
-  (key: string, value: string) => void
-] => {
+}: {
+  defaults?: Array<{ name: string; value: string }>;
+  setEmptyValues?: boolean;
+} = {}): [URLSearchParams, (key: string, value: string) => void] => {
   const location = useLocation();
   const history = useHistory();
   const searchParams = new URLSearchParams(location.search);
+
+  // Initialize the filters with the default values provided.
+  defaults.map((param) => {
+    if (!searchParams.get(param.name)) {
+      searchParams.set(param.name, param.value);
+    }
+  });
 
   const setFilter = (key: string, value: string) => {
     if (value || setEmptyValues) {

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -19,6 +19,8 @@ import { scrollToTop } from 'src/utils/ui';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import EntityList from 'src/features/entities/EntityList';
 
+const DEFAULT_FILTER_ORDER_BY = '-last_compared_at';
+
 const NoRatingMessage = ({ hasFilter }: { hasFilter: boolean }) => {
   const { t } = useTranslation();
   return (
@@ -69,7 +71,7 @@ const VideoRatingsPage = () => {
     setIsLoading(true);
     const urlParams = new URLSearchParams(location.search);
     const isPublicParam = urlParams.get('isPublic');
-    const orderByParam = urlParams.get('orderBy');
+    const orderByParam = urlParams.get('orderBy') || DEFAULT_FILTER_ORDER_BY;
 
     const isPublic = isPublicParam ? isPublicParam === 'true' : undefined;
     const orderBy = orderByParam ?? undefined;
@@ -130,7 +132,11 @@ const VideoRatingsPage = () => {
       <ContentBox noMinPaddingX maxWidth="lg">
         {options?.comparisonsCanBePublic === true && (
           <Box px={{ xs: 2, sm: 0 }}>
-            <RatingsFilter />
+            <RatingsFilter
+              defaultFilters={[
+                { name: 'orderBy', value: DEFAULT_FILTER_ORDER_BY },
+              ]}
+            />
           </Box>
         )}
         <LoaderWrapper isLoading={isLoading}>

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -69,13 +69,19 @@ const VideoRatingsPage = () => {
     setIsLoading(true);
     const urlParams = new URLSearchParams(location.search);
     const isPublicParam = urlParams.get('isPublic');
+    const orderByParam = urlParams.get('orderBy');
+
     const isPublic = isPublicParam ? isPublicParam === 'true' : undefined;
+    const orderBy = orderByParam ?? undefined;
+
     const response = await UsersService.usersMeContributorRatingsList({
       pollName,
       limit,
       offset,
       isPublic,
+      orderBy,
     });
+
     setRatings(response);
     setIsLoading(false);
   }, [offset, location.search, pollName]);
@@ -121,7 +127,7 @@ const VideoRatingsPage = () => {
       }}
     >
       <ContentHeader title={t('myRatedVideosPage.title')} />
-      <ContentBox noMinPaddingX maxWidth="md">
+      <ContentBox noMinPaddingX maxWidth="lg">
         {options?.comparisonsCanBePublic === true && (
           <Box px={{ xs: 2, sm: 0 }}>
             <RatingsFilter />

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -123,6 +123,32 @@ export const getEntityName = (t: TFunction, pollName: string) => {
   }
 };
 
+/**
+ * Return the translated name of an metadata.
+ */
+export function getMetadataName(
+  t: TFunction,
+  pollName: string,
+  metadata: string
+): string | undefined {
+  let name;
+
+  switch (pollName) {
+    case YOUTUBE_POLL_NAME:
+      switch (metadata) {
+        case 'duration':
+          name = t('videoMetadata.duration');
+          break;
+        case 'publication_date':
+          name = t('videoMetadata.publication_date');
+          break;
+      }
+      break;
+  }
+
+  return name;
+}
+
 export const getRecommendationPageName = (
   t: TFunction,
   pollName: string,
@@ -182,6 +208,7 @@ export const polls: Array<SelectablePoll> = [
     withSearchBar: true,
     topBarBackground: null,
     comparisonsCanBePublic: true,
+    extraMetadataOrderBy: ['duration', 'publication_date'],
     tutorialLength: 4,
     tutorialAlternatives: getTutorialVideos,
     tutorialDialogs: getVideosTutorialDialogs,

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -124,7 +124,7 @@ export const getEntityName = (t: TFunction, pollName: string) => {
 };
 
 /**
- * Return the translated name of an metadata.
+ * Return the translated name of a metadata.
  */
 export function getMetadataName(
   t: TFunction,

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -114,4 +114,7 @@ export type SelectablePoll = {
   tutorialKeepUIDsAfterRedirect?: boolean;
   // whether the 'unsafe' recommendations should be included by default
   unsafeDefault?: boolean;
+  // list of entity type specific metadata that can be used to order a list of
+  // entities
+  extraMetadataOrderBy?: Array<string>;
 };

--- a/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
+++ b/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
@@ -69,16 +69,6 @@ describe('My rated elements page', () => {
       const durationLabel = "Duration";
       const publicationDateLabel = "Publication date";
 
-      it('the default ordering is `-last_compared_at`', () => {
-        cy.visit('/ratings');
-        cy.focused().type("user1");
-        cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
-
-        cy.location().should((loc) => {
-          expect(loc.search).to.eq('?orderBy=-last_compared_at')
-        });
-      });
-
       it('the ratings can be order by `last_compared_at`', () => {
         cy.visit('/ratings');
         cy.focused().type("user1");

--- a/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
+++ b/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
@@ -9,11 +9,14 @@ describe('"My rated videos" page', () => {
 
     // Mark all videos as public.
     cy.contains('button', 'Options', {matchCase: false}).click();
+    cy.contains('Filter by visibility').should('be.visible');
+    cy.contains('Order by').should('be.visible');
     cy.contains('button', 'Mark all as public').click();
 
     // Close options
     cy.contains('button', 'Options').click();
     cy.contains('Filter by visibility').should('not.exist');
+    cy.contains('Order by').should('not.exist');
 
     // Toggle public status of first video
     cy.contains('label', 'Public', {matchCase: false}).click();
@@ -28,7 +31,7 @@ describe('"My rated videos" page', () => {
     cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
   })
 
-  it('visit ratings page with filter in URL', () => {
+  it('visit ratings page with `isPublic` param in URL', () => {
     cy.visit('/ratings?isPublic=false');
     cy.focused().type("user1");
     cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
@@ -36,7 +39,16 @@ describe('"My rated videos" page', () => {
     cy.contains('label', 'Private', {matchCase: false}).within(
       () => cy.get('input[type=checkbox]').should('be.checked')
     );
-  })
+  });
+
+  it('visit ratings page with `orderBy` param in URL', () => {
+    cy.visit('/ratings?orderBy=-last_compared_at');
+    cy.focused().type("user1");
+    cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+    cy.contains('button', 'Options', {matchCase: false}).click();
+    cy.get('input[data-testid=order-by-metadata-input]').should('have.value', '-last_compared_at');
+  });
+
   it('entities\'s thumbnails are clickable', () => {
     cy.visit('/ratings');
     cy.focused().type("user1");

--- a/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
+++ b/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
@@ -61,9 +61,6 @@ describe('My rated elements page', () => {
     });
 
     describe('ratings ordering', () => {
-      const asc = " (asc.)";
-      const desc = " (desc.)";
-
       // Generic parameter available for all entity types.
       const lastComparedAtLabel = "Last comparison date";
       const nComparisonsLabel = "Number of comparisons";
@@ -71,6 +68,16 @@ describe('My rated elements page', () => {
       // Video specific metadata.
       const durationLabel = "Duration";
       const publicationDateLabel = "Publication date";
+
+      it('the default ordering is `-last_compared_at`', () => {
+        cy.visit('/ratings');
+        cy.focused().type("user1");
+        cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=-last_compared_at')
+        });
+      });
 
       it('the ratings can be order by `last_compared_at`', () => {
         cy.visit('/ratings');
@@ -82,14 +89,14 @@ describe('My rated elements page', () => {
 
         // Ascending order.
         cy.get('div[id=order-by-metadata]').click();
-        cy.contains(lastComparedAtLabel + asc, {matchCase: false}).click();
+        cy.get('li[data-value=last_compared_at]').click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=last_compared_at')
         });
 
         // Descending order.
         cy.get('div[id=order-by-metadata]').click();
-        cy.contains(lastComparedAtLabel + desc, {matchCase: false}).click();
+        cy.get('li[data-value=-last_compared_at]').click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=-last_compared_at')
         });
@@ -105,7 +112,7 @@ describe('My rated elements page', () => {
 
         // Ascending order.
         cy.get('div[id=order-by-metadata]').click();
-        cy.contains(nComparisonsLabel + asc, {matchCase: false}).click();
+        cy.get('li[data-value=n_comparisons]').click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=n_comparisons')
         });
@@ -114,7 +121,7 @@ describe('My rated elements page', () => {
 
         // Descending order.
         cy.get('div[id=order-by-metadata]').click();
-        cy.contains(nComparisonsLabel + desc, {matchCase: false}).click();
+        cy.get('li[data-value=-n_comparisons]').click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=-n_comparisons')
         });
@@ -132,51 +139,30 @@ describe('My rated elements page', () => {
 
         // Ascending order.
         cy.get('div[id=order-by-metadata]').click();
-        cy.contains(durationLabel + asc, {matchCase: false}).click();
+        cy.get('li[data-value=duration]').click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=duration')
         });
 
         // Descending order.
         cy.get('div[id=order-by-metadata]').click();
-        cy.contains(durationLabel + desc, {matchCase: false}).click();
+        cy.get('li[data-value=-duration]').click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=-duration')
         });
 
         // Ascending order.
         cy.get('div[id=order-by-metadata]').click();
-        cy.contains(publicationDateLabel + asc, {matchCase: false}).click();
+        cy.get('li[data-value=publication_date]').click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=publication_date')
         });
 
         // Descending order.
         cy.get('div[id=order-by-metadata]').click();
-        cy.contains(publicationDateLabel + desc, {matchCase: false}).click();
+        cy.get('li[data-value=-publication_date]').click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=-publication_date')
-        });
-      });
-
-      it('the default ordering can be reset', () => {
-        cy.visit('/ratings');
-        cy.focused().type("user1");
-        cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
-
-        cy.contains('button', 'Options', {matchCase: false}).click();
-        cy.contains('Order by').should('be.visible');
-
-        cy.get('div[id=order-by-metadata]').click();
-        cy.contains(lastComparedAtLabel + asc, {matchCase: false}).click();
-        cy.location().should((loc) => {
-          expect(loc.search).to.eq('?orderBy=last_compared_at')
-        });
-
-        cy.get('div[id=order-by-metadata]').click();
-        cy.contains("--", {matchCase: false}).click();
-        cy.location().should((loc) => {
-          expect(loc.search).to.eq('')
         });
       });
 

--- a/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
+++ b/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
@@ -10,12 +10,10 @@ describe('"My rated videos" page', () => {
     // Mark all videos as public.
     cy.contains('button', 'Options', {matchCase: false}).click();
     cy.contains('Filter by visibility').should('be.visible');
-    cy.contains('Order by').should('be.visible');
     cy.contains('button', 'Mark all as public').click();
 
     // Close options
     cy.contains('button', 'Options').click();
-    cy.contains('Filter by visibility').should('not.exist');
     cy.contains('Order by').should('not.exist');
 
     // Toggle public status of first video
@@ -29,7 +27,7 @@ describe('"My rated videos" page', () => {
     // Mark all videos as public, the filter is reset and all videos are listed
     cy.contains('button', 'Mark all as public').click();
     cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
-  })
+  });
 
   it('visit ratings page with `isPublic` param in URL', () => {
     cy.visit('/ratings?isPublic=false');
@@ -39,14 +37,6 @@ describe('"My rated videos" page', () => {
     cy.contains('label', 'Private', {matchCase: false}).within(
       () => cy.get('input[type=checkbox]').should('be.checked')
     );
-  });
-
-  it('visit ratings page with `orderBy` param in URL', () => {
-    cy.visit('/ratings?orderBy=-last_compared_at');
-    cy.focused().type("user1");
-    cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
-    cy.contains('button', 'Options', {matchCase: false}).click();
-    cy.get('input[data-testid=order-by-metadata-input]').should('have.value', '-last_compared_at');
   });
 
   it('entities\'s thumbnails are clickable', () => {
@@ -67,5 +57,87 @@ describe('"My rated videos" page', () => {
     const videoCard = cy.get('div[data-testid=video-card-info]').first();
     videoCard.find('h6').click();
     cy.location('pathname').should('match', /^\/entities\//);
+  });
+
+  describe('ratings ordering', () => {
+    const lastComparedAtAscLabel = "Last comparison date (asc.)";
+    const lastComparedAtDescLabel = "Last comparison date (desc.)";
+    const nComparisonsAscLabel = "Number of comparisons (asc.)";
+    const nComparisonsDescLabel = "Number of comparisons (desc.)";
+
+    it('the ratings can be order by `last_compared_at`', () => {
+      cy.visit('/ratings');
+      cy.focused().type("user1");
+      cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+  
+      cy.contains('button', 'Options', {matchCase: false}).click();
+      cy.contains('Order by').should('be.visible');
+  
+      cy.get('div[id=order-by-metadata]').click();
+      cy.contains(lastComparedAtAscLabel, {matchCase: false}).click();
+      cy.location().should((loc) => {
+        expect(loc.search).to.eq('?orderBy=last_compared_at')
+      });
+
+      cy.get('div[id=order-by-metadata]').click();
+      cy.contains(lastComparedAtDescLabel, {matchCase: false}).click();
+      cy.location().should((loc) => {
+        expect(loc.search).to.eq('?orderBy=-last_compared_at')
+      });
+    });
+
+    it('the ratings can be order by `n_comparisons`', () => {
+      cy.visit('/ratings');
+      cy.focused().type("user1");
+      cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+  
+      cy.contains('button', 'Options', {matchCase: false}).click();
+      cy.contains('Order by').should('be.visible');
+  
+      cy.get('div[id=order-by-metadata]').click();
+      cy.contains(nComparisonsAscLabel, {matchCase: false}).click();
+      cy.location().should((loc) => {
+        expect(loc.search).to.eq('?orderBy=n_comparisons')
+      });
+
+      cy.contains('1 comparison by you').should('be.visible');
+
+      cy.get('div[id=order-by-metadata]').click();
+      cy.contains(nComparisonsDescLabel, {matchCase: false}).click();
+      cy.location().should((loc) => {
+        expect(loc.search).to.eq('?orderBy=-n_comparisons')
+      });
+
+      cy.contains('28 comparisons by you').should('be.visible');
+    });
+
+    it('the default ordering can be reset', () => {
+      cy.visit('/ratings');
+      cy.focused().type("user1");
+      cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+
+      cy.contains('button', 'Options', {matchCase: false}).click();
+      cy.contains('Order by').should('be.visible');
+
+      cy.get('div[id=order-by-metadata]').click();
+      cy.contains(lastComparedAtAscLabel, {matchCase: false}).click();
+      cy.location().should((loc) => {
+        expect(loc.search).to.eq('?orderBy=last_compared_at')
+      });
+
+      cy.get('div[id=order-by-metadata]').click();
+      cy.contains("--", {matchCase: false}).click();
+      cy.location().should((loc) => {
+        expect(loc.search).to.eq('')
+      });
+    });
+
+    it('visit ratings page with `orderBy` param in URL', () => {
+      cy.visit('/ratings?orderBy=-last_compared_at');
+      cy.focused().type("user1");
+      cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+      cy.contains('button', 'Options', {matchCase: false}).click();
+      cy.get('input[data-testid=order-by-metadata-input]').should('have.value', '-last_compared_at');
+    });
   });
 });

--- a/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
+++ b/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
@@ -1,143 +1,182 @@
-describe('"My rated videos" page', () => {
-  it('can list and update ratings status', () => {
-    cy.visit('/ratings');
-    cy.focused().type("user1");
-    cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
-
-    // All rated videos are listed.
-    cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
-
-    // Mark all videos as public.
-    cy.contains('button', 'Options', {matchCase: false}).click();
-    cy.contains('Filter by visibility').should('be.visible');
-    cy.contains('button', 'Mark all as public').click();
-
-    // Close options
-    cy.contains('button', 'Options').click();
-    cy.contains('Order by').should('not.exist');
-
-    // Toggle public status of first video
-    cy.contains('label', 'Public', {matchCase: false}).click();
-
-    // Select "Private" filter and check that a single video appears on the list
-    cy.contains('button', 'Options', {matchCase: false}).click();
-    cy.contains('label', 'Private', {matchCase: false}).click();
-    cy.contains('Showing videos 1 to 1 of 1').should('be.visible');
-
-    // Mark all videos as public, the filter is reset and all videos are listed
-    cy.contains('button', 'Mark all as public').click();
-    cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
-  });
-
-  it('visit ratings page with `isPublic` param in URL', () => {
-    cy.visit('/ratings?isPublic=false');
-    cy.focused().type("user1");
-    cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
-    cy.contains('button', 'Options', {matchCase: false}).click();
-    cy.contains('label', 'Private', {matchCase: false}).within(
-      () => cy.get('input[type=checkbox]').should('be.checked')
-    );
-  });
-
-  it('entities\'s thumbnails are clickable', () => {
-    cy.visit('/ratings');
-    cy.focused().type("user1");
-    cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
-
-    const thumbnail = cy.get('img.entity-thumbnail').first();
-    thumbnail.click();
-    cy.location('pathname').should('match', /^\/entities\//);
-  });
-
-  it('entities\'s titles are clickable', () => {
-    cy.visit('/ratings');
-    cy.focused().type("user1");
-    cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
-
-    const videoCard = cy.get('div[data-testid=video-card-info]').first();
-    videoCard.find('h6').click();
-    cy.location('pathname').should('match', /^\/entities\//);
-  });
-
-  describe('ratings ordering', () => {
-    const lastComparedAtAscLabel = "Last comparison date (asc.)";
-    const lastComparedAtDescLabel = "Last comparison date (desc.)";
-    const nComparisonsAscLabel = "Number of comparisons (asc.)";
-    const nComparisonsDescLabel = "Number of comparisons (desc.)";
-
-    it('the ratings can be order by `last_compared_at`', () => {
-      cy.visit('/ratings');
-      cy.focused().type("user1");
-      cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
-  
-      cy.contains('button', 'Options', {matchCase: false}).click();
-      cy.contains('Order by').should('be.visible');
-  
-      cy.get('div[id=order-by-metadata]').click();
-      cy.contains(lastComparedAtAscLabel, {matchCase: false}).click();
-      cy.location().should((loc) => {
-        expect(loc.search).to.eq('?orderBy=last_compared_at')
-      });
-
-      cy.get('div[id=order-by-metadata]').click();
-      cy.contains(lastComparedAtDescLabel, {matchCase: false}).click();
-      cy.location().should((loc) => {
-        expect(loc.search).to.eq('?orderBy=-last_compared_at')
-      });
-    });
-
-    it('the ratings can be order by `n_comparisons`', () => {
-      cy.visit('/ratings');
-      cy.focused().type("user1");
-      cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
-  
-      cy.contains('button', 'Options', {matchCase: false}).click();
-      cy.contains('Order by').should('be.visible');
-  
-      cy.get('div[id=order-by-metadata]').click();
-      cy.contains(nComparisonsAscLabel, {matchCase: false}).click();
-      cy.location().should((loc) => {
-        expect(loc.search).to.eq('?orderBy=n_comparisons')
-      });
-
-      cy.contains('1 comparison by you').should('be.visible');
-
-      cy.get('div[id=order-by-metadata]').click();
-      cy.contains(nComparisonsDescLabel, {matchCase: false}).click();
-      cy.location().should((loc) => {
-        expect(loc.search).to.eq('?orderBy=-n_comparisons')
-      });
-
-      cy.contains('28 comparisons by you').should('be.visible');
-    });
-
-    it('the default ordering can be reset', () => {
+describe('My rated elements page', () => {
+  describe('Poll - videos', () => {
+    it('can list and update ratings status', () => {
       cy.visit('/ratings');
       cy.focused().type("user1");
       cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
 
+      // All rated videos are listed.
+      cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
+
+      // Mark all videos as public.
       cy.contains('button', 'Options', {matchCase: false}).click();
-      cy.contains('Order by').should('be.visible');
+      cy.contains('Filter by visibility').should('be.visible');
+      cy.contains('button', 'Mark all as public').click();
 
-      cy.get('div[id=order-by-metadata]').click();
-      cy.contains(lastComparedAtAscLabel, {matchCase: false}).click();
-      cy.location().should((loc) => {
-        expect(loc.search).to.eq('?orderBy=last_compared_at')
-      });
+      // Close options
+      cy.contains('button', 'Options').click();
+      cy.contains('Order by').should('not.exist');
 
-      cy.get('div[id=order-by-metadata]').click();
-      cy.contains("--", {matchCase: false}).click();
-      cy.location().should((loc) => {
-        expect(loc.search).to.eq('')
-      });
+      // Toggle public status of first video
+      cy.contains('label', 'Public', {matchCase: false}).click();
+
+      // Select "Private" filter and check that a single video appears on the list
+      cy.contains('button', 'Options', {matchCase: false}).click();
+      cy.contains('label', 'Private', {matchCase: false}).click();
+      cy.contains('Showing videos 1 to 1 of 1').should('be.visible');
+
+      // Mark all videos as public, the filter is reset and all videos are listed
+      cy.contains('button', 'Mark all as public').click();
+      cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
     });
 
-    it('visit ratings page with `orderBy` param in URL', () => {
-      cy.visit('/ratings?orderBy=-last_compared_at');
+    it('visit ratings page with `isPublic` param in URL', () => {
+      cy.visit('/ratings?isPublic=false');
       cy.focused().type("user1");
       cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
       cy.contains('button', 'Options', {matchCase: false}).click();
-      cy.get('input[data-testid=order-by-metadata-input]').should('have.value', '-last_compared_at');
+      cy.contains('label', 'Private', {matchCase: false}).within(
+        () => cy.get('input[type=checkbox]').should('be.checked')
+      );
+    });
+
+    it('entities\'s thumbnails are clickable', () => {
+      cy.visit('/ratings');
+      cy.focused().type("user1");
+      cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+
+      const thumbnail = cy.get('img.entity-thumbnail').first();
+      thumbnail.click();
+      cy.location('pathname').should('match', /^\/entities\//);
+    });
+
+    it('entities\'s titles are clickable', () => {
+      cy.visit('/ratings');
+      cy.focused().type("user1");
+      cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+
+      const videoCard = cy.get('div[data-testid=video-card-info]').first();
+      videoCard.find('h6').click();
+      cy.location('pathname').should('match', /^\/entities\//);
+    });
+
+    describe('ratings ordering', () => {
+      const asc = " (asc.)";
+      const desc = " (desc.)";
+      // Generic parameter available for all entity types
+      const lastComparedAtLabel = "Last comparison date";
+      const nComparisonsLabel = "Number of comparisons";
+      // Video specific metadata
+      const durationLabel = "Duration";
+      const publicationDateLabel = "Publication date";
+
+      it('the ratings can be order by `last_compared_at`', () => {
+        cy.visit('/ratings');
+        cy.focused().type("user1");
+        cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+
+        cy.contains('button', 'Options', {matchCase: false}).click();
+        cy.contains('Order by').should('be.visible');
+
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains(lastComparedAtLabel + asc, {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=last_compared_at')
+        });
+
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains(lastComparedAtLabel + desc, {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=-last_compared_at')
+        });
+      });
+
+      it('the ratings can be order by `n_comparisons`', () => {
+        cy.visit('/ratings');
+        cy.focused().type("user1");
+        cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+
+        cy.contains('button', 'Options', {matchCase: false}).click();
+        cy.contains('Order by').should('be.visible');
+
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains(nComparisonsLabel + asc, {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=n_comparisons')
+        });
+
+        cy.contains('1 comparison by you').should('be.visible');
+
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains(nComparisonsLabel + desc, {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=-n_comparisons')
+        });
+
+        cy.contains('28 comparisons by you').should('be.visible');
+      });
+
+      it('the ratings can be order by video specific metadata fields', () => {
+        cy.visit('/ratings');
+        cy.focused().type("user1");
+        cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+    
+        cy.contains('button', 'Options', {matchCase: false}).click();
+        cy.contains('Order by').should('be.visible');
+    
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains(durationLabel + asc, {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=duration')
+        });
+
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains(durationLabel + desc, {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=-duration')
+        });
+
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains(publicationDateLabel + asc, {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=publication_date')
+        });
+
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains(publicationDateLabel + desc, {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=-publication_date')
+        });
+      });
+
+      it('the default ordering can be reset', () => {
+        cy.visit('/ratings');
+        cy.focused().type("user1");
+        cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+
+        cy.contains('button', 'Options', {matchCase: false}).click();
+        cy.contains('Order by').should('be.visible');
+
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains(lastComparedAtLabel + asc, {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('?orderBy=last_compared_at')
+        });
+
+        cy.get('div[id=order-by-metadata]').click();
+        cy.contains("--", {matchCase: false}).click();
+        cy.location().should((loc) => {
+          expect(loc.search).to.eq('')
+        });
+      });
+
+      it('visit ratings page with `orderBy` param in URL', () => {
+        cy.visit('/ratings?orderBy=-last_compared_at');
+        cy.focused().type("user1");
+        cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+        cy.contains('button', 'Options', {matchCase: false}).click();
+        cy.get('input[data-testid=order-by-metadata-input]').should('have.value', '-last_compared_at');
+      });
     });
   });
 });

--- a/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
+++ b/tests/cypress/integration/frontend/myRatedVideosPage.spec.ts
@@ -63,10 +63,12 @@ describe('My rated elements page', () => {
     describe('ratings ordering', () => {
       const asc = " (asc.)";
       const desc = " (desc.)";
-      // Generic parameter available for all entity types
+
+      // Generic parameter available for all entity types.
       const lastComparedAtLabel = "Last comparison date";
       const nComparisonsLabel = "Number of comparisons";
-      // Video specific metadata
+
+      // Video specific metadata.
       const durationLabel = "Duration";
       const publicationDateLabel = "Publication date";
 
@@ -78,12 +80,14 @@ describe('My rated elements page', () => {
         cy.contains('button', 'Options', {matchCase: false}).click();
         cy.contains('Order by').should('be.visible');
 
+        // Ascending order.
         cy.get('div[id=order-by-metadata]').click();
         cy.contains(lastComparedAtLabel + asc, {matchCase: false}).click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=last_compared_at')
         });
 
+        // Descending order.
         cy.get('div[id=order-by-metadata]').click();
         cy.contains(lastComparedAtLabel + desc, {matchCase: false}).click();
         cy.location().should((loc) => {
@@ -99,6 +103,7 @@ describe('My rated elements page', () => {
         cy.contains('button', 'Options', {matchCase: false}).click();
         cy.contains('Order by').should('be.visible');
 
+        // Ascending order.
         cy.get('div[id=order-by-metadata]').click();
         cy.contains(nComparisonsLabel + asc, {matchCase: false}).click();
         cy.location().should((loc) => {
@@ -107,6 +112,7 @@ describe('My rated elements page', () => {
 
         cy.contains('1 comparison by you').should('be.visible');
 
+        // Descending order.
         cy.get('div[id=order-by-metadata]').click();
         cy.contains(nComparisonsLabel + desc, {matchCase: false}).click();
         cy.location().should((loc) => {
@@ -123,25 +129,29 @@ describe('My rated elements page', () => {
     
         cy.contains('button', 'Options', {matchCase: false}).click();
         cy.contains('Order by').should('be.visible');
-    
+
+        // Ascending order.
         cy.get('div[id=order-by-metadata]').click();
         cy.contains(durationLabel + asc, {matchCase: false}).click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=duration')
         });
 
+        // Descending order.
         cy.get('div[id=order-by-metadata]').click();
         cy.contains(durationLabel + desc, {matchCase: false}).click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=-duration')
         });
 
+        // Ascending order.
         cy.get('div[id=order-by-metadata]').click();
         cy.contains(publicationDateLabel + asc, {matchCase: false}).click();
         cy.location().should((loc) => {
           expect(loc.search).to.eq('?orderBy=publication_date')
         });
 
+        // Descending order.
         cy.get('div[id=order-by-metadata]').click();
         cy.contains(publicationDateLabel + desc, {matchCase: false}).click();
         cy.location().should((loc) => {


### PR DESCRIPTION
**follow the work of** #1174 

---

This PR adds an orderBy input in the front end's My rated elements page.

This input contains two generic values available for all entity type: `last_compared_at` and `n_comparisons`. On the poll `videos` two additional parameters are available: `duration` and `publication_date`.

The maximum width of the ratings page has been increased to match the recommendations page width, and to have more space to display the new input.

At first I wanted to create full and exhaustive tests for each ordering parameter. I then realized the front end only displays the results returned by the back end without altering the order. While the back end's tests doesn't 100% ensure the front end will work, the absence of complexity in the front end makes me feel that it might not be worth to add right now and maintain extra e2e tests, and extra CI duration to test the correctness front end's display. My proposition is to rely on the back end for now, and add the needed e2e tests the day this feature will fail.

**to-do**
- [x] add entity type specific parameters
   - [x] `duration` and `publication_date` for video 
- [x] update the e2e tests
- [x] rework the fr translation (asc. vs. crois / desc. vs. décrois.)

### preview

![capture](https://user-images.githubusercontent.com/39056254/197813066-08c42c22-ede1-45a1-aa6b-cd7e4db628fe.png)
