### PR TITLE
[front] refactor: delete the `ContributeSection` from the videos home

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -446,7 +446,7 @@
     "extensionNotAvailableOnYourBrowser": "The extension is not available on your web browser. You may use it on <2>Firefox</2>, <4>Google Chrome</4> or <6>Chromium</6>.",
     "theStatsCouldNotBeDisplayed": "The stats could not be displayed.",
     "collaborativeContentRecommendations": "Collaborative Content Recommendations",
-    "tournesolPlatformDescription": "Tournesol is an <1>free and open source</1> platform which proposes a tool for collaborative decision. The main aim of this tool is to <4>collaboratively</4> identify top videos of public utility by eliciting contributors' judgements on content quality. Currently we are also exploring the possibility of using Tournesol's algorithms to evaluates candidates in an election.<br><br>Thanks to the data collected on Tournesol, we hope to contribute to making today's and tomorrow's large-scale algorithms <7>robustly beneficial</7> for all of humanity."
+    "tournesolPlatformDescription": "Tournesol is a <1>free and open source</1> platform which proposes a tool for collaborative decision. The main aim of this tool is to <4>collaboratively</4> identify top videos of public utility by eliciting contributors' judgements on content quality. Currently we are also exploring the possibility of using Tournesol's algorithms to evaluates candidates in an election.<br><br>Thanks to the data collected on Tournesol, we hope to contribute to making today's and tomorrow's large-scale algorithms <7>robustly beneficial</7> for all of humanity."
   },
   "comparisonSection": {
     "contribute": "Contribute",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -449,6 +449,7 @@
     "tournesolPlatformDescription": "Tournesol is an <1>free and open source</1> platform which proposes a tool for collaborative decision. The main aim of this tool is to <4>collaboratively</4> identify top videos of public utility by eliciting contributors' judgements on content quality. Currently we are also exploring the possibility of using Tournesol's algorithms to evaluates candidates in an election.<br><br>Thanks to the data collected on Tournesol, we hope to contribute to making today's and tomorrow's large-scale algorithms <7>robustly beneficial</7> for all of humanity."
   },
   "comparisonSection": {
+    "contribute": "Contribute",
     "theSimpliestWayToContribute": "The simpliest way to contribute to Tournesol is to compare videos. What content would you like YouTube to recommend to your friends and family?"
   },
   "homeComparison": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -455,6 +455,7 @@
     "tournesolPlatformDescription": "Tournesol est une plateforme <1>libre et open source</1> qui propose un outil de décision collaboratif transparent. Le but principal de cet outil est d'identifier les contenus informationel d'utilité publique de grande qualité en s'appuyant sur le jugement de contributeurs. Une autre application de l'algorithme de Tournesol que nous explorons en ce moment est l'évaluation des candidats à une élection.<br><br>Grâce aux données collectées sur cette plateforme, nous espérons rendre les algorithmes d'aujourd'hui et de demain <7>robustement bénéfique</7> à grande échelle, pour toute l'humanité."
   },
   "comparisonSection": {
+    "contribute": "Contribuer",
     "theSimpliestWayToContribute": "Le moyen le plus simple de contribuer à Tournesol est de comparer des vidéos. Quel contenu voudriez-vous que YouTube recommande à vos proches ?"
   },
   "homeComparison": {

--- a/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
+++ b/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
@@ -56,7 +56,19 @@ const AlternatingBackgroundColorSectionList = ({
   lastItemIsPrimary?: boolean;
 }) => {
   const theme = useTheme();
-  const lastItem = children.at(-1);
+
+  // children.at(-1) didn't work here...
+  const lastItem = children.slice(children.length - 1);
+
+  const nextColor = (idx: number): string => {
+    return idx % 2 == 0 ? secondaryColor : theme.palette.text.primary;
+  };
+
+  const nextBackground = (idx: number): string => {
+    return idx % 2 == 0
+      ? secondaryBackground
+      : theme.palette.background.primary;
+  };
 
   return (
     <Grid container width="100%">
@@ -66,10 +78,8 @@ const AlternatingBackgroundColorSectionList = ({
           key={i}
           child={child}
           verticalPadding={i == 0 ? firstElemVerticalPadding : verticalPadding}
-          color={i % 2 == 0 ? secondaryColor : theme.palette.text.primary}
-          background={
-            i % 2 == 0 ? secondaryBackground : theme.palette.background.primary
-          }
+          color={nextColor(i)}
+          background={nextBackground(i)}
         />
       ))}
 

--- a/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
+++ b/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
@@ -60,11 +60,11 @@ const AlternatingBackgroundColorSectionList = ({
   // children.at(-1) didn't work here...
   const lastItem = children.slice(children.length - 1);
 
-  const nextColor = (idx: number): string => {
+  const colorAtIndex = (idx: number): string => {
     return idx % 2 == 0 ? secondaryColor : theme.palette.text.primary;
   };
 
-  const nextBackground = (idx: number): string => {
+  const backgroundColorAtIndex = (idx: number): string => {
     return idx % 2 == 0
       ? secondaryBackground
       : theme.palette.background.primary;
@@ -78,8 +78,8 @@ const AlternatingBackgroundColorSectionList = ({
           key={i}
           child={child}
           padding={i == 0 ? firstItemPadding : itemPadding}
-          color={nextColor(i)}
-          background={nextBackground(i)}
+          color={colorAtIndex(i)}
+          background={backgroundColorAtIndex(i)}
         />
       ))}
 
@@ -90,16 +90,12 @@ const AlternatingBackgroundColorSectionList = ({
         color={
           lastItemIsPrimary
             ? theme.palette.text.primary
-            : children.length % 2 != 0
-            ? secondaryColor
-            : theme.palette.text.primary
+            : colorAtIndex(children.length - 1)
         }
         background={
           lastItemIsPrimary
             ? theme.palette.background.primary
-            : children.length % 2 != 0
-            ? secondaryBackground
-            : theme.palette.background.primary
+            : backgroundColorAtIndex(children.length - 1)
         }
       />
     </Grid>

--- a/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
+++ b/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
@@ -56,50 +56,42 @@ const AlternatingBackgroundColorSectionList = ({
   lastItemIsPrimary?: boolean;
 }) => {
   const theme = useTheme();
-
-  const isLastItem = (idx: number) => {
-    return idx === children.length - 1;
-  };
+  const lastItem = children.at(-1);
 
   return (
     <Grid container width="100%">
-      {children.map((child: React.ReactNode, i: number) =>
-        isLastItem(i) ? (
-          <SectionGridItem
-            key={i}
-            child={child}
-            verticalPadding={verticalPadding}
-            color={
-              lastItemIsPrimary
-                ? theme.palette.text.primary
-                : i % 2 == 0
-                ? secondaryColor
-                : theme.palette.text.primary
-            }
-            background={
-              lastItemIsPrimary
-                ? theme.palette.background.primary
-                : i % 2 == 0
-                ? secondaryBackground
-                : theme.palette.background.primary
-            }
-          />
-        ) : (
-          <SectionGridItem
-            key={i}
-            child={child}
-            verticalPadding={
-              i == 0 ? firstElemVerticalPadding : verticalPadding
-            }
-            color={i % 2 == 0 ? secondaryColor : theme.palette.text.primary}
-            background={
-              i % 2 == 0
-                ? secondaryBackground
-                : theme.palette.background.primary
-            }
-          />
-        )
-      )}
+      {/* display all items except the last one */}
+      {children.slice(0, -1).map((child: React.ReactNode, i: number) => (
+        <SectionGridItem
+          key={i}
+          child={child}
+          verticalPadding={i == 0 ? firstElemVerticalPadding : verticalPadding}
+          color={i % 2 == 0 ? secondaryColor : theme.palette.text.primary}
+          background={
+            i % 2 == 0 ? secondaryBackground : theme.palette.background.primary
+          }
+        />
+      ))}
+
+      {/* display the last item */}
+      <SectionGridItem
+        child={lastItem}
+        verticalPadding={verticalPadding}
+        color={
+          lastItemIsPrimary
+            ? theme.palette.text.primary
+            : children.length % 2 != 0
+            ? secondaryColor
+            : theme.palette.text.primary
+        }
+        background={
+          lastItemIsPrimary
+            ? theme.palette.background.primary
+            : children.length % 2 != 0
+            ? secondaryBackground
+            : theme.palette.background.primary
+        }
+      />
     </Grid>
   );
 };

--- a/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
+++ b/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
@@ -6,10 +6,12 @@ const SectionGridItem = ({
   child,
   color,
   background,
+  verticalPadding,
 }: {
   child: React.ReactNode;
   color: string;
   background: string;
+  verticalPadding: string;
 }) => {
   const theme = useTheme();
 
@@ -20,9 +22,9 @@ const SectionGridItem = ({
       sx={{
         display: 'flex',
         justifyContent: 'center',
-        padding: '48px',
+        padding: verticalPadding,
         [theme.breakpoints.down('md')]: {
-          padding: '48px 16px 48px 16px',
+          padding: `${verticalPadding} 16px ${verticalPadding} 16px`,
         },
         color: color,
         background: background,
@@ -37,11 +39,18 @@ const AlternatingBackgroundColorSectionList = ({
   children,
   secondaryBackground = '#1282B2',
   secondaryColor = 'white',
+  verticalPadding = '48px',
+  firstElemVerticalPadding = '32px',
   lastItemIsPrimary,
 }: {
   children: React.ReactNode[];
   secondaryBackground?: string;
   secondaryColor?: string;
+  // Allow the first item to have a different padding than the rest of the
+  // items.
+  firstElemVerticalPadding?: string;
+  // Used to wrap every item.
+  verticalPadding?: string;
   // If true the last item will use the primary color regardless of its
   // position in the list.
   lastItemIsPrimary?: boolean;
@@ -59,6 +68,7 @@ const AlternatingBackgroundColorSectionList = ({
           <SectionGridItem
             key={i}
             child={child}
+            verticalPadding={verticalPadding}
             color={
               lastItemIsPrimary
                 ? theme.palette.text.primary
@@ -78,6 +88,9 @@ const AlternatingBackgroundColorSectionList = ({
           <SectionGridItem
             key={i}
             child={child}
+            verticalPadding={
+              i == 0 ? firstElemVerticalPadding : verticalPadding
+            }
             color={i % 2 == 0 ? secondaryColor : theme.palette.text.primary}
             background={
               i % 2 == 0

--- a/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
+++ b/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
@@ -6,12 +6,12 @@ const SectionGridItem = ({
   child,
   color,
   background,
-  verticalPadding,
+  padding,
 }: {
   child: React.ReactNode;
   color: string;
   background: string;
-  verticalPadding: string;
+  padding: string;
 }) => {
   const theme = useTheme();
 
@@ -22,9 +22,10 @@ const SectionGridItem = ({
       sx={{
         display: 'flex',
         justifyContent: 'center',
-        padding: verticalPadding,
+        padding: padding,
         [theme.breakpoints.down('md')]: {
-          padding: `${verticalPadding} 16px ${verticalPadding} 16px`,
+          p: padding,
+          px: { xs: '16px', md: padding },
         },
         color: color,
         background: background,
@@ -37,20 +38,19 @@ const SectionGridItem = ({
 
 const AlternatingBackgroundColorSectionList = ({
   children,
-  secondaryBackground = '#1282B2',
   secondaryColor = 'white',
-  verticalPadding = '48px',
-  firstElemVerticalPadding = '32px',
+  secondaryBackground = '#1282B2',
+  itemPadding = '48px',
+  firstItemPadding = '32px',
   lastItemIsPrimary,
 }: {
   children: React.ReactNode[];
-  secondaryBackground?: string;
   secondaryColor?: string;
-  // Allow the first item to have a different padding than the rest of the
-  // items.
-  firstElemVerticalPadding?: string;
+  secondaryBackground?: string;
   // Used to wrap every item.
-  verticalPadding?: string;
+  itemPadding?: string;
+  // Allow the first item to have a different padding.
+  firstItemPadding?: string;
   // If true the last item will use the primary color regardless of its
   // position in the list.
   lastItemIsPrimary?: boolean;
@@ -77,7 +77,7 @@ const AlternatingBackgroundColorSectionList = ({
         <SectionGridItem
           key={i}
           child={child}
-          verticalPadding={i == 0 ? firstElemVerticalPadding : verticalPadding}
+          padding={i == 0 ? firstItemPadding : itemPadding}
           color={nextColor(i)}
           background={nextBackground(i)}
         />
@@ -86,7 +86,7 @@ const AlternatingBackgroundColorSectionList = ({
       {/* display the last item */}
       <SectionGridItem
         child={lastItem}
-        verticalPadding={verticalPadding}
+        padding={itemPadding}
         color={
           lastItemIsPrimary
             ? theme.palette.text.primary

--- a/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
+++ b/frontend/src/pages/home/AlternatingBackgroundColorSectionList.tsx
@@ -2,45 +2,92 @@ import React from 'react';
 
 import { Grid, useTheme } from '@mui/material';
 
-const AlternatingBackgroundColorSectionList = ({
-  children,
-  secondaryBackground = '#1282B2',
-  secondaryColor = 'white',
+const SectionGridItem = ({
+  child,
+  color,
+  background,
 }: {
-  children: React.ReactNode[];
-  secondaryBackground?: string;
-  secondaryColor?: string;
+  child: React.ReactNode;
+  color: string;
+  background: string;
 }) => {
   const theme = useTheme();
 
   return (
-    <div
-      style={{
-        width: '100%',
+    <Grid
+      item
+      xs={12}
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        padding: '48px',
+        [theme.breakpoints.down('md')]: {
+          padding: '48px 16px 48px 16px',
+        },
+        color: color,
+        background: background,
       }}
     >
-      <Grid container>
-        {children.map((child: React.ReactNode, i: number) => (
-          <Grid
+      {child}
+    </Grid>
+  );
+};
+
+const AlternatingBackgroundColorSectionList = ({
+  children,
+  secondaryBackground = '#1282B2',
+  secondaryColor = 'white',
+  lastItemIsPrimary,
+}: {
+  children: React.ReactNode[];
+  secondaryBackground?: string;
+  secondaryColor?: string;
+  // If true the last item will use the primary color regardless of its
+  // position in the list.
+  lastItemIsPrimary?: boolean;
+}) => {
+  const theme = useTheme();
+
+  const isLastItem = (idx: number) => {
+    return idx === children.length - 1;
+  };
+
+  return (
+    <Grid container width="100%">
+      {children.map((child: React.ReactNode, i: number) =>
+        isLastItem(i) ? (
+          <SectionGridItem
             key={i}
-            item
-            xs={12}
-            sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              padding: '32px',
-              [theme.breakpoints.down('md')]: {
-                padding: '32px 16px 32px 16px',
-              },
-              background: i % 2 == 0 ? secondaryBackground : '#FAF8F3',
-              color: i % 2 == 0 ? secondaryColor : 'black',
-            }}
-          >
-            {child}
-          </Grid>
-        ))}
-      </Grid>
-    </div>
+            child={child}
+            color={
+              lastItemIsPrimary
+                ? theme.palette.text.primary
+                : i % 2 == 0
+                ? secondaryColor
+                : theme.palette.text.primary
+            }
+            background={
+              lastItemIsPrimary
+                ? theme.palette.background.primary
+                : i % 2 == 0
+                ? secondaryBackground
+                : theme.palette.background.primary
+            }
+          />
+        ) : (
+          <SectionGridItem
+            key={i}
+            child={child}
+            color={i % 2 == 0 ? secondaryColor : theme.palette.text.primary}
+            background={
+              i % 2 == 0
+                ? secondaryBackground
+                : theme.palette.background.primary
+            }
+          />
+        )
+      )}
+    </Grid>
   );
 };
 

--- a/frontend/src/pages/home/videos/ComparisonSection.tsx
+++ b/frontend/src/pages/home/videos/ComparisonSection.tsx
@@ -21,42 +21,67 @@ const ComparisonSection = ({ comparisonStats }: Props) => {
   const color = '#fff';
 
   return (
-    <Grid container justifyContent="center" spacing={4}>
-      <Grid item lg={6} xl={6}>
-        <Box display="flex" justifyContent="center">
-          <HomeComparison />
-        </Box>
-      </Grid>
-      <Grid item lg={3} xl={3}>
-        <Box
-          display="flex"
-          flexDirection="column"
-          justifyContent="space-between"
-          gap={2}
+    <Box>
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        mb={6}
+        width="100%"
+      >
+        <Divider
+          component="div"
+          role="presentation"
+          sx={{ width: { xs: '100%', lg: '75%' } }}
         >
-          <Paper square elevation={0}>
-            <Box p={2} bgcolor="#1282B2" color={color}>
-              <Typography paragraph textAlign="justify" fontSize={17}>
-                {t('comparisonSection.theSimpliestWayToContribute')}
-              </Typography>
-              <Box pb={2}>
-                <Divider sx={{ backgroundColor: color }} />
+          <Typography
+            variant="h1"
+            component="h2"
+            textAlign="center"
+            pl={4}
+            pr={4}
+          >
+            Contribute
+          </Typography>
+        </Divider>
+      </Box>
+      <Grid container justifyContent="center" spacing={4}>
+        <Grid item lg={6} xl={6}>
+          <Box display="flex" justifyContent="center">
+            <HomeComparison />
+          </Box>
+        </Grid>
+        <Grid item lg={3} xl={3}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="space-between"
+            gap={2}
+          >
+            <Paper square elevation={0}>
+              <Box p={2} bgcolor="#1282B2" color={color}>
+                <Typography paragraph textAlign="justify" fontSize={17}>
+                  {t('comparisonSection.theSimpliestWayToContribute')}
+                </Typography>
+                <Box pb={2}>
+                  <Divider sx={{ backgroundColor: color }} />
+                </Box>
+                <Box textAlign="center">
+                  <Metrics
+                    text={t('stats.comparisons')}
+                    count={comparisonStats?.comparisonCount || 0}
+                    lastMonthCount={
+                      comparisonStats?.lastMonthComparisonCount || 0
+                    }
+                    lastMonthAsText
+                  />
+                </Box>
               </Box>
-              <Box textAlign="center">
-                <Metrics
-                  text={t('stats.comparisons')}
-                  count={comparisonStats?.comparisonCount || 0}
-                  lastMonthCount={
-                    comparisonStats?.lastMonthComparisonCount || 0
-                  }
-                  lastMonthAsText
-                />
-              </Box>
-            </Box>
-          </Paper>
-        </Box>
+            </Paper>
+          </Box>
+        </Grid>
       </Grid>
-    </Grid>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/home/videos/ComparisonSection.tsx
+++ b/frontend/src/pages/home/videos/ComparisonSection.tsx
@@ -41,7 +41,7 @@ const ComparisonSection = ({ comparisonStats }: Props) => {
             pl={4}
             pr={4}
           >
-            Contribute
+            {t('comparisonSection.contribute')}
           </Typography>
         </Divider>
       </Box>

--- a/frontend/src/pages/home/videos/HomeVideos.tsx
+++ b/frontend/src/pages/home/videos/HomeVideos.tsx
@@ -7,7 +7,6 @@ import { Box, Button, Divider, Stack, Typography } from '@mui/material';
 import UsageStatsSection from 'src/features/statistics/UsageStatsSection';
 import { useCurrentPoll, useLoginState, useNotifications } from 'src/hooks';
 import ExtensionSection from 'src/pages/home/videos/ExtensionSection';
-import ContributeSection from 'src/pages/home/videos/ContributeSection';
 import TitleSection from 'src/pages/home/TitleSection';
 import PollListSection from 'src/pages/home/PollListSection';
 import AlternatingBackgroundColorSectionList from 'src/pages/home/AlternatingBackgroundColorSectionList';
@@ -43,7 +42,7 @@ const HomeVideosPage = () => {
   }, [pollName, showWarningAlert, t]);
 
   return (
-    <AlternatingBackgroundColorSectionList>
+    <AlternatingBackgroundColorSectionList lastItemIsPrimary>
       <TitleSection title={t('home.collaborativeContentRecommendations')}>
         <Typography paragraph>
           <Trans t={t} i18nKey="home.tournesolPlatformDescription">
@@ -117,7 +116,6 @@ const HomeVideosPage = () => {
         }}
       />
       <ExtensionSection />
-      <ContributeSection />
       <UsageStatsSection externalData={stats} />
       <PollListSection />
     </AlternatingBackgroundColorSectionList>

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -11,6 +11,7 @@ declare module '@mui/material/styles/createPalette' {
 
   interface TypeBackground {
     menu: string;
+    primary: string;
   }
 }
 
@@ -33,6 +34,7 @@ export const theme = responsiveFontSizes(
       },
       background: {
         menu: '#FAF8F3',
+        primary: '#FAFAFA',
       },
     },
     typography: {


### PR DESCRIPTION
This section was redundant with the recent `ComparisonSection`.

This PR also:

* Increases the vertical padding of each section of the home page from 32 pixels to 48. This allows the home page to feel less "squashed" and more "modern", especially on mobile. I also tested 64 pixels, which is nice too but I'd prefer to wait for the complete home page refactor before proposing 64. 

* Updates the `AlternatingBackgroundColorSectionList` component to use the app palette instead of defining hard-coded custom colors. Also update this component to be able to choose the color of its last item displayed.

* Adds a title `ComparisonSection` has now a proper title.

### Preview

The important part are the new contribute title, the color of the last sections (stats and polls) and the vertical padding of each section (which is a bit subtle on the image).

![screencapture-localhost-3000-2022-10-26-18_16_32](https://user-images.githubusercontent.com/39056254/198079794-9ce2e864-1159-479b-8151-5cf0d1e22415.png)
