### PR TITLE
[back] fix: update `QrUnc` in ml primitives, as defined in reference paper

### DIFF
--- a/backend/ml/mehestan/primitives.py
+++ b/backend/ml/mehestan/primitives.py
@@ -83,8 +83,9 @@ def QrUnc(
         qr_med = QrMed(W, w, x, delta)
     qr_dev = QrDev(W, default_dev, w, x, delta, qr_med=qr_med)
     delta_2 = delta ** 2
+    bound = np.inf if W <= 0 else 1 / W
     h = W + np.sum(
-        w * np.minimum(1, delta_2 * (delta_2 + (x - qr_med) ** 2) ** (-3 / 2))
+        w * np.minimum(bound, delta_2 * (delta_2 + (x - qr_med) ** 2) ** (-3 / 2))
     )
 
     if h <= W:

--- a/backend/ml/tests/test_mehestan_primitives.py
+++ b/backend/ml/tests/test_mehestan_primitives.py
@@ -1,0 +1,66 @@
+import numpy as np
+from django.test import TestCase
+
+from ml.mehestan.primitives import QrMed, QrUnc
+
+
+class QrMedTest(TestCase):
+    def test_qrmed(self):
+        W = 2
+        weight = 1
+        self.assertAlmostEqual(
+            QrMed(
+                W,
+                w=weight,
+                x=np.array([-10.0, 1.0, 10.0]),
+                delta=np.array([1e-3, 1e-3, 1e-3]),
+            ),
+            0.5, # influence of the median contributor is bounded by weight / W
+            places=3
+        )
+
+    def test_qrmed_with_W_equals_zero(self):
+        W = 0
+        weight = 1
+        self.assertAlmostEqual(
+            QrMed(
+                W,
+                w=weight,
+                x=np.array([-10.0, 1.0, 10.0]),
+                delta=np.array([1e-3, 1e-3, 1e-3]),
+            ),
+            1.0,
+            places=3
+        )
+
+
+class QrUncTest(TestCase):
+    def test_qrunc(self):
+        W = 2
+        weight = 1
+        self.assertAlmostEqual(
+            QrUnc(
+                W,
+                default_dev=0,
+                w=weight,
+                x=np.array([-10.0, 1.0, 10.0]),
+                delta=np.array([1e-3, 1e-3, 1e-3]),
+            ),
+            0.506,
+            places=3,
+        )
+
+    def test_qrunc_with_W_equals_zero(self):
+        W = 0
+        weight = 1
+        self.assertAlmostEqual(
+            QrUnc(
+                W,
+                default_dev=0,
+                w=weight,
+                x=np.array([-10.0, 1.0, 10.0]),
+                delta=np.array([1e-3, 1e-3, 1e-3]),
+            ),
+            0.033,
+            places=3,
+        )

--- a/backend/tournesol/tests/test_ml_run.py
+++ b/backend/tournesol/tests/test_ml_run.py
@@ -84,6 +84,20 @@ class TestMlTrain(TransactionTestCase):
         self.assertEqual(scores_mode_default.filter(poll=Poll.default_poll()).count(), 8)
 
 
+    def test_ml_run_with_video_having_score_zero(self):
+        video = VideoFactory()
+        ComparisonCriteriaScoreFactory(
+            comparison__entity_1=video,
+            score=0,
+            criteria="largely_recommended",
+        )
+
+        self.assertEqual(video.tournesol_score, None)
+        call_command("ml_train")
+        video.refresh_from_db()
+        self.assertAlmostEqual(video.tournesol_score, 0.0)
+
+
     def test_individual_scaling_are_computed(self):
         # User 1 will belong to supertrusted users (as staff member)
         user1 = UserFactory(email="user@verified.test", is_staff=True)


### PR DESCRIPTION
Updates the algorithm computing the quadratically regularized uncertainty `QrUnc`. 

From **Section C.4** in supplementary material, the individual contributions to the second derivative used in the computation should be capped to 1/W, instead of 1.
> 

![image](https://user-images.githubusercontent.com/4726554/198876057-91a2b281-64a0-4432-a5b2-0bee437e1804.png)
