### PR TITLE
[front] refactor: simplify the first home page paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@
 <p>
 <p align="center">
   <i>
-    Tournesol is free software designed to collaboratively identify public interest videos that should be largely recommended.
+    Tournesol is a free software designed to collaboratively identify public
+    interest videos that should be largely recommended.
   </i>
 </p>
 <p align="center">
   <i>
-    Participants are invited to judge the videos' quality, and build together an open database to help the research in AI ethics and recommendation systems.
+    Participants are invited to judge the videos' quality, and build together
+    an open database to help the research in AI ethics and recommendation
+    systems.
   </i>
 </p>
 

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -446,7 +446,8 @@
     "extensionNotAvailableOnYourBrowser": "The extension is not available on your web browser. You may use it on <2>Firefox</2>, <4>Google Chrome</4> or <6>Chromium</6>.",
     "theStatsCouldNotBeDisplayed": "The stats could not be displayed.",
     "collaborativeContentRecommendations": "Collaborative Content Recommendations",
-    "tournesolPlatformDescription": "Tournesol is a <1>free and open source</1> platform which proposes a tool for collaborative decision. The main aim of this tool is to <4>collaboratively</4> identify top videos of public utility by eliciting contributors' judgements on content quality. Currently we are also exploring the possibility of using Tournesol's algorithms to evaluates candidates in an election.<br><br>Thanks to the data collected on Tournesol, we hope to contribute to making today's and tomorrow's large-scale algorithms <7>robustly beneficial</7> for all of humanity."
+    "tournesolIsAParticipatoryResearchProject": "Tournesol is a transparent participatory research project, aiming to identify public interest videos that should be largely recommended.",
+    "helpUsAdvanceResearch": "Help us advance research in the ethics of algorithms and recommendation systems by giving your opinion on the videos you have watched."
   },
   "comparisonSection": {
     "contribute": "Contribute",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -446,8 +446,8 @@
     "extensionNotAvailableOnYourBrowser": "The extension is not available on your web browser. You may use it on <2>Firefox</2>, <4>Google Chrome</4> or <6>Chromium</6>.",
     "theStatsCouldNotBeDisplayed": "The stats could not be displayed.",
     "collaborativeContentRecommendations": "Collaborative Content Recommendations",
-    "tournesolIsAParticipatoryResearchProject": "Tournesol is a transparent participatory research project, aiming to identify public interest videos that should be largely recommended.",
-    "helpUsAdvanceResearch": "Help us advance research in the ethics of algorithms and recommendation systems by giving your opinion on the videos you have watched."
+    "tournesolIsAParticipatoryResearchProject": "Tournesol is a transparent participatory research project about the ethics of algorithms and recommendation systems.",
+    "helpUsAdvanceResearch": "Help us advance research by giving your opinion on the videos you have watched in order to identify public interest contents that should be largely recommended."
   },
   "comparisonSection": {
     "contribute": "Contribute",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -452,8 +452,8 @@
     "extensionNotAvailableOnYourBrowser": "L'extension n'est malheureusement pas disponible pour votre navigateur web. Elle est compatible avec <2>Mozilla Firefox</2>, et <4>Google Chrome</4> ou <6>Chromium</6>.",
     "theStatsCouldNotBeDisplayed": "Les statistiques n'ont pas pu être affichées.",
     "collaborativeContentRecommendations": "Recommandations collaboratives de contenus",
-    "tournesolIsAParticipatoryResearchProject": "Tournesol est un projet de recherche participatif et transparent, qui vise à identifier les vidéos d'utilité publique qui devraient être largement recommandées.",
-    "helpUsAdvanceResearch": "Aidez-nous a faire avancer la recherche dans l'éthique des algorithmes et des systèmes de recommandation en donnant votre avis sur les vidéos que vous avez regardées."
+    "tournesolIsAParticipatoryResearchProject": "Tournesol est un projet de recherche participatif et transparent sur l'éthique des systèmes de recommendations.",
+    "helpUsAdvanceResearch": "Aidez-nous à faire avancer la recherche en donnant votre avis sur les vidéos que vous avez regardées pour identifier les vidéos d'utilité publique qui devraient être largement recommandées."
   },
   "comparisonSection": {
     "contribute": "Contribuer",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -452,7 +452,8 @@
     "extensionNotAvailableOnYourBrowser": "L'extension n'est malheureusement pas disponible pour votre navigateur web. Elle est compatible avec <2>Mozilla Firefox</2>, et <4>Google Chrome</4> ou <6>Chromium</6>.",
     "theStatsCouldNotBeDisplayed": "Les statistiques n'ont pas pu être affichées.",
     "collaborativeContentRecommendations": "Recommandations collaboratives de contenus",
-    "tournesolPlatformDescription": "Tournesol est une plateforme <1>libre et open source</1> qui propose un outil de décision collaboratif transparent. Le but principal de cet outil est d'identifier les contenus informationel d'utilité publique de grande qualité en s'appuyant sur le jugement de contributeurs. Une autre application de l'algorithme de Tournesol que nous explorons en ce moment est l'évaluation des candidats à une élection.<br><br>Grâce aux données collectées sur cette plateforme, nous espérons rendre les algorithmes d'aujourd'hui et de demain <7>robustement bénéfique</7> à grande échelle, pour toute l'humanité."
+    "tournesolIsAParticipatoryResearchProject": "Tournesol est un projet de recherche participatif et transparent, qui vise à identifier les vidéos d'utilité publique qui devraient être largement recommandées.",
+    "helpUsAdvanceResearch": "Aidez-nous a faire avancer la recherche dans l'éthique des algorithmes et des systèmes de recommandation en donnant votre avis sur les vidéos que vous avez regardées."
   },
   "comparisonSection": {
     "contribute": "Contribuer",

--- a/frontend/src/pages/home/videos/HomeVideos.tsx
+++ b/frontend/src/pages/home/videos/HomeVideos.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useTranslation, Trans } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Box, Button, Divider, Stack, Typography } from '@mui/material';
 
@@ -44,15 +44,12 @@ const HomeVideosPage = () => {
   return (
     <AlternatingBackgroundColorSectionList lastItemIsPrimary>
       <TitleSection title={t('home.collaborativeContentRecommendations')}>
-        <Typography paragraph>
-          <Trans t={t} i18nKey="home.tournesolPlatformDescription">
-            Tournesol is an <strong>open source</strong> platform which aims to{' '}
-            <strong>collaboratively</strong> identify top videos of public
-            utility by eliciting contributors&apos; judgements on content
-            quality. We hope to contribute to making today&apos;s and
-            tomorrow&apos;s large-scale algorithms{' '}
-            <strong>robustly beneficial</strong> for all of humanity.
-          </Trans>
+        <Typography paragraph fontSize="1.1em">
+          {t('home.tournesolIsAParticipatoryResearchProject')}
+        </Typography>
+
+        <Typography paragraph fontSize="1.1em">
+          {t('home.helpUsAdvanceResearch')}
         </Typography>
 
         {active ? (


### PR DESCRIPTION
**related to** #1166

---

This PR reworks the first paragraphs of the Tournesol home page. It aims to make them more user friendly by reducing their complexity: less topics ; less words ; more assertive ; slightly bigger font.

The two questions answered by these paragraphs are:
- What is the Tournesol project?
- Why should I contribute?

The answers are of course not exhaustive, as they are discussed with more details in the About and the FAQ pages.

The new French version now contains 48 words instead of 83. The English 40 instead of 78.

**subjective opinion** I didn't explained that the comparisons will improve the recommendations, as this objective has been deferred to the future section "recommendations preview" designed in Miro. In the same way I didn't talk about the public database because we will build a dedicated section later in the home page. I also think all these topics can be visible directly in the first home page section if we add a navigation menu as we designed in Miro.

| lang | before | after |
|---|---|---|
| fr | ![capture](https://user-images.githubusercontent.com/39056254/199028913-d8760f96-ffa4-48cb-be4c-89b47f00695c.png) | ![capture](https://user-images.githubusercontent.com/39056254/199033478-a47e55c1-c2f4-4e36-94b7-82dd661c7293.png) |
| en | ![capture](https://user-images.githubusercontent.com/39056254/199030330-73a366b3-2fa8-4a52-bb22-70783095cfdd.png) | ![capture2](https://user-images.githubusercontent.com/39056254/199030427-d1cf6bf6-bf16-4d85-bfe1-86a98c91a930.png) |

What do you think?