### PR TITLE
[ext] style: use `gap` and `justify-content` in flex containers...

### DIFF
--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -1,15 +1,21 @@
 #tournesol_container {
+  position: relative;
+  box-sizing: border-box;
+
   margin-left: 0;
   margin-right: 0;
   margin-top: 45px;
   margin-bottom: 16px; /* 40px for tournesol container - 24px for margin-top of youtube recommendations */
+  padding: 16px 8px;
+
   display: flex;
-  flex-direction: row;
-  position: relative;
+  flex-flow: row wrap;
+  justify-content: space-between;
+
   border: solid 3px #f3bd00;
+  border-radius: 10px;
   background: #f3bd0011;
-  justify-content: flex-start;
-  flex-wrap: wrap;
+
   width: calc(100% - var(--ytd-rich-grid-item-margin) * 2);
   max-width: calc(
     var(--ytd-rich-grid-items-per-row) *
@@ -114,8 +120,6 @@
   position: relative;
   margin-left: calc(var(--ytd-rich-grid-item-margin) / 2);
   margin-right: calc(var(--ytd-rich-grid-item-margin) / 2);
-  margin-top: 6px;
-  margin-bottom: 6px;
   width: calc(100% / 4 - var(--ytd-rich-grid-item-margin) - 0.01px);
 }
 
@@ -151,12 +155,18 @@
 }
 
 .details_div {
-  position: relative;
   cursor: pointer;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.details_div > h2 {
+  margin: 0;
 }
 
 .video_text {
-  padding-top: 5px;
   color: var(--yt-endpoint-color, var(--yt-spec-text-secondary));
   font-family: 'Roboto', 'Arial', sans-serif;
   word-break: break-word;

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -1,3 +1,7 @@
+:root {
+  --ts-container-padding: 16px;
+}
+
 #tournesol_container {
   position: relative;
   box-sizing: border-box;
@@ -6,7 +10,9 @@
   margin-right: 0;
   margin-top: 45px;
   margin-bottom: 16px; /* 40px for tournesol container - 24px for margin-top of youtube recommendations */
-  padding: 16px 8px;
+
+  padding: var(--ts-container-padding);
+  padding-bottom: 0;
 
   display: flex;
   flex-flow: row wrap;
@@ -118,8 +124,6 @@
 
 .video_box {
   position: relative;
-  margin-left: calc(var(--ytd-rich-grid-item-margin) / 2);
-  margin-right: calc(var(--ytd-rich-grid-item-margin) / 2);
   width: calc(100% / 4 - var(--ytd-rich-grid-item-margin) - 0.01px);
 }
 
@@ -157,9 +161,12 @@
 .details_div {
   cursor: pointer;
   position: relative;
+
   display: flex;
-  flex-direction: column;
   gap: 10px;
+  flex-direction: column;
+
+  padding-bottom: var(--ts-container-padding);
 }
 
 .details_div > h2 {

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -19,7 +19,7 @@
   justify-content: space-between;
 
   border: solid 3px #f3bd00;
-  border-radius: 10px;
+  border-radius: 12px;
   background: #f3bd0011;
 
   width: calc(100% - var(--ytd-rich-grid-item-margin) * 2);
@@ -130,6 +130,7 @@
 .video_thumb {
   width: 100%;
   background: green;
+  border-radius: 12px;
 }
 
 .video_title {

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
...instead of defining a custom `margin` in the flex items.

The PR "fix" a small bit of the extension CSS.

We use a flex container to display the recommended videos, but the spaces between items were managed by a custom `margin` property instead of `gap` and `justify-content`. With the changes made, the spaces between items can be more easily controlled and are aligned the global style of the container.

I also transformed the `.details_div` class in flex container, to gain more control on the display of the videos' title, channel and ratings.

Finally, I proposed to make the yellow borders rounded, to make our design more aligned with the new YT style. I think it looks more polished overall, even if the pale yellow background feels a bit weird on the YT dark theme (personal opinion).

### preview

| before | after |
|---|---|
| ![capture2](https://user-images.githubusercontent.com/39056254/201045777-44379418-a7d2-489f-b177-c0f8e571a632.png) | ![capture](https://user-images.githubusercontent.com/39056254/201045756-d7afa83a-7f30-48d8-964a-1880e1f7cddc.png) |

On a clear theme:

![capture](https://user-images.githubusercontent.com/39056254/201050094-851cd050-93e6-4d77-b1e2-a24722cf381b.png)


### next step

In the title Recommended by Tournesol, add a link on the word Tournesol. It may help people discover the platform behind the recommendations.