### PR TITLE
[front] fix: round the criteria scores to the nearest integer

### DIFF
--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -12,7 +12,7 @@ import {
   Recommendation,
 } from 'src/services/openapi';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { displayScore, criteriaIcon, criterionColor } from 'src/utils/criteria';
+import { criteriaIcon, criterionColor } from 'src/utils/criteria';
 import useCriteriaChartData, {
   CriterionChartScores,
 } from 'src/hooks/useCriteriaChartData';
@@ -184,7 +184,7 @@ const ScoreLabel = ({
       fill={color}
       style={{ fontSize: 14, fontWeight: 'bold' }}
     >
-      {displayScore(score)}
+      {score.toFixed(0)}
     </text>
   );
 };

--- a/frontend/src/components/entity/EntityCardScores.tsx
+++ b/frontend/src/components/entity/EntityCardScores.tsx
@@ -7,7 +7,6 @@ import {
 } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { displayScore } from 'src/utils/criteria';
 import { Recommendation } from 'src/services/openapi';
 import CriteriaIcon from '../CriteriaIcon';
 
@@ -190,9 +189,9 @@ const EntityCardScores = ({
                   criteriaName={max_criteria}
                   emojiSize="26px"
                   imgWidth="32px"
-                  tooltip={`${getCriteriaLabel(max_criteria)}: ${displayScore(
-                    max_score
-                  )}`}
+                  tooltip={`${getCriteriaLabel(
+                    max_criteria
+                  )}: ${max_score.toFixed(0)}`}
                 />
               </>
             )}
@@ -204,9 +203,9 @@ const EntityCardScores = ({
                   criteriaName={min_criteria}
                   emojiSize="26px"
                   imgWidth="32px"
-                  tooltip={`${getCriteriaLabel(min_criteria)}: ${displayScore(
-                    min_score
-                  )}`}
+                  tooltip={`${getCriteriaLabel(
+                    min_criteria
+                  )}: ${min_score.toFixed(0)}`}
                 />
               </>
             )}

--- a/frontend/src/features/charts/CriteriaScoresDistribution.tsx
+++ b/frontend/src/features/charts/CriteriaScoresDistribution.tsx
@@ -18,21 +18,19 @@ import { PollsService, CriteriaDistributionScore } from 'src/services/openapi';
 import useSelectedCriterion from 'src/hooks/useSelectedCriterion';
 import { criterionColor } from 'src/utils/criteria';
 
-const displayScore = (score: number) => score.toFixed(0);
-
 const binLabel = (index: number, bins: number[], t: TFunction) => {
   if (index === 0)
     return t('criteriaScoresDistribution.lessThan', {
-      score: displayScore(bins[1]),
+      score: bins[1].toFixed(0),
     });
   if (index > 0 && index < bins.length - 2)
     return t('criteriaScoresDistribution.fromTo', {
-      from: displayScore(bins[index]),
-      to: displayScore(bins[index + 1]),
+      from: bins[index].toFixed(0),
+      to: bins[index + 1].toFixed(0),
     });
   if (index === bins.length - 2)
     return t('criteriaScoresDistribution.greaterThan', {
-      score: displayScore(bins[bins.length - 2]),
+      score: bins[bins.length - 2].toFixed(0),
     });
 };
 

--- a/frontend/src/features/videos/VideoCardScores.tsx
+++ b/frontend/src/features/videos/VideoCardScores.tsx
@@ -5,7 +5,6 @@ import { Warning as WarningIcon } from '@mui/icons-material';
 import { VideoObject } from 'src/utils/types';
 import { makeStyles } from '@mui/styles';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { displayScore } from 'src/utils/criteria';
 
 interface Props {
   video: VideoObject;
@@ -157,8 +156,8 @@ const VideoCardScores = ({ video }: Props) => {
               <img
                 src={`/svg/${max_criteria}.svg`}
                 alt={max_criteria}
-                title={`${getCriteriaLabel(max_criteria)}: ${displayScore(
-                  max_score
+                title={`${getCriteriaLabel(max_criteria)}: ${max_score.toFixed(
+                  0
                 )}`}
               />
             </>
@@ -170,8 +169,8 @@ const VideoCardScores = ({ video }: Props) => {
               <img
                 src={`/svg/${min_criteria}.svg`}
                 alt={min_criteria}
-                title={`${getCriteriaLabel(min_criteria)}: ${displayScore(
-                  min_score
+                title={`${getCriteriaLabel(min_criteria)}: ${min_score.toFixed(
+                  0
                 )}`}
               />
             </>

--- a/frontend/src/utils/criteria.ts
+++ b/frontend/src/utils/criteria.ts
@@ -1,7 +1,5 @@
 import { criteriaToEmoji } from 'src/utils/constants';
 
-export const displayScore = (score: number) => score.toFixed(1);
-
 export const criteriaIcon = (criteriaName: string) => {
   const emoji =
     criteriaName in criteriaToEmoji ? criteriaToEmoji[criteriaName] : undefined;


### PR DESCRIPTION
**related to** #1157

Changes:
* Scores on CriteriaBarChart and tooltips are rounded to the nearest integer
* Removed the `displayScore`methods as they were duplicated and felt unnecessary