### PR TITLE
[back] test: split tests about `ml_train` and simplify their setup

### DIFF
--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -101,10 +101,13 @@ def run_mehestan_for_criterion(
 
         if update_poll_scaling and mode == ScoreMode.DEFAULT and len(global_scores) > 0:
             quantile_value = np.quantile(global_scores["score"], POLL_SCALING_QUANTILE)
-            scale = (
-                np.tan(POLL_SCALING_SCORE_AT_QUANTILE * TAU / (4 * MAX_SCORE))
-                / quantile_value
-            )
+            if quantile_value == 0.0:
+                scale = 1.0
+            else:
+                scale = (
+                    np.tan(POLL_SCALING_SCORE_AT_QUANTILE * TAU / (4 * MAX_SCORE))
+                    / quantile_value
+                )
             poll.sigmoid_scale = scale
             poll.save(update_fields=["sigmoid_scale"])
 


### PR DESCRIPTION
As discussed in #1200 and on Discord, this PR splits the tests used to validate the behavior of the `ml_train` command.

Instead of using a single complex `setUp()`, each test case will define the relevant comparisons and other data needed to cover of aspect of the algorithms.

The new tests cases are:
* `test_individual_scaling_are_computed`
* `test_tournesol_scores_different_trust`
* `test_tournesol_scores_different_uncertainty`
* `test_tournesol_scores_different_privacy_status`