### PR TITLE
[front] trans: use trust score instead of voting right in vouching page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -511,14 +511,14 @@
       "high": "High",
       "title": "Trust score",
       "description": {
-        "explanation": "Your trust score changes how your comparisons count in Tournesol's recommendations.",
-        "howToChangeIt": "You can increase it by using a certified email and when other users vouch for you.",
+        "explanation": "Your trust score determines how much your comparisons influence the Tournesol's recommendations.",
+        "howToChangeIt": "You can gain more trust by using an email from a trusted domain or when other users vouch of you.",
         "includedInPublicDatabase": "Your trust score is included the public database if you have at least one public comparison."
       },
-      "isTrusted": "Your email address is certified",
-      "isNotTrusted": "Your email address is not certified",
-      "hasReceivedVouchers": "Other users vouch for you",
-      "hasNotReceivedVouchers": "No other users vouch for you"
+      "isTrusted": "Your email address is trusted.",
+      "isNotTrusted": "Your email address is not trusted.",
+      "hasReceivedVouchers": "Other users vouch for you.",
+      "hasNotReceivedVouchers": "No other user vouch for you."
     },
     "aboutVouchingMechanism": "By vouching for other users, you enable them to obtain a higher trust score even if their email address is not considered to be trusted. The list of users for whom you vouch, or who have vouched for you, is a public information."
   },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -236,7 +236,7 @@
         "label": "Trusted only"
       }
     },
-    "scoreModeSection": "Voting rights",
+    "scoreModeSection": "Voting",
     "uploader": "Uploader"
   },
   "ratings": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -520,7 +520,7 @@
       "hasReceivedVouchers": "Other users vouch for you",
       "hasNotReceivedVouchers": "No other users vouch for you"
     },
-    "aboutVouchingMechanism": "By vouching for other users, you enable them to obtain a higher voting right on Tournesol, even if their email address is not considered to be trusted. On Tournesol, the list of users for whom you vouch, or who have vouched for you, is public information."
+    "aboutVouchingMechanism": "By vouching for other users, you enable them to obtain a higher trust score even if their email address is not considered to be trusted. The list of users for whom you vouch, or who have vouched for you, is a public information."
   },
   "myRateLaterListPage": {
     "title": "My rate-later list"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -512,7 +512,7 @@
       "title": "Trust score",
       "description": {
         "explanation": "Your trust score determines how much your comparisons influence the Tournesol's recommendations.",
-        "howToChangeIt": "You can gain more trust by using an email from a trusted domain or when other users vouch of you.",
+        "howToChangeIt": "You can gain more trust by using an email from a trusted domain or when other users vouch for you.",
         "includedInPublicDatabase": "Your trust score is included the public database if you have at least one public comparison."
       },
       "isTrusted": "Your email address is trusted.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -236,7 +236,7 @@
         "label": "Trusted only"
       }
     },
-    "scoreModeSection": "Voting",
+    "scoreModeSection": "Voting rights",
     "uploader": "Uploader"
   },
   "ratings": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -351,8 +351,8 @@
     "publicDatabaseDetailAndLicense": "Contributors on Tournesol can decide to make their data public. We hope this important data will prove useful for researchers on ethics of algorithms and large scale recommender systems. Our public database can be downloaded by clicking the button below and is published under <2>Open Data Commons Attribution License (ODC-By)</2>.",
     "publicDatabaseThanksToContributors": "Finally, we would like to thank all the contributors who compared videos on Tournesol. We count so far about {{userCount}} users who compared {{comparisonCount}} times more than {{comparedEntityCount}} videos.",
     "trustedEmailDomains": "Trusted email domains",
-    "trustedDomainsToProtectTournesol": "In order to protect Tournesol from fake accounts, by default, Tournesol assigns a limited voting right to newly created accounts.",
-    "trustedDomainsGainMoreVotingRights": "You can gain significantly more voting rights by validating <2>an email address from a trusted domain</2>. We are currently working on designing additional means for contributors to gain voting rights.",
+    "trustedDomainsToProtectTournesol": "In order to protect Tournesol from fake accounts, by default, Tournesol assigns a limited trust score to newly created accounts.",
+    "trustedDomainsGainMoreVotingRights": "You can gain significantly more trust by validating <2>an email address from a trusted domain</2>, or by having other users vouch for you.",
     "trustedDomainsValuable": "In any case, your contributions are valuable to us, as they will motivate further research in safe and ethical algorithms.",
     "trustedDomainsCurrentList": "Current list of trusted domains"
   },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -352,7 +352,7 @@
     "publicDatabaseThanksToContributors": "Finally, we would like to thank all the contributors who compared videos on Tournesol. We count so far about {{userCount}} users who compared {{comparisonCount}} times more than {{comparedEntityCount}} videos.",
     "trustedEmailDomains": "Trusted email domains",
     "trustedDomainsToProtectTournesol": "In order to protect Tournesol from fake accounts, by default, Tournesol assigns a limited trust score to newly created accounts.",
-    "trustedDomainsGainMoreVotingRights": "You can gain significantly more trust by validating <2>an email address from a trusted domain</2>, or by having other users vouch for you.",
+    "trustedDomainsGainMoreVotingRights": "You can gain significantly more trust by validating <2>an email address from a trusted domain</2>, or when other users vouch for you.",
     "trustedDomainsValuable": "In any case, your contributions are valuable to us, as they will motivate further research in safe and ethical algorithms.",
     "trustedDomainsCurrentList": "Current list of trusted domains"
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -518,14 +518,14 @@
       "high": "Élevé",
       "title": "Score de confiance",
       "description": {
-        "explanation": "Votre score de confiance change la manière dont vos comparaisons sont prises en compte dans les recommandations de Tournesol.",
-        "howToChangeIt": "Vous pouvez l'augmenter en utilisant une adresse e-mail certifiée ou quand d'autres utilisateurs se portent garant pour vous.",
+        "explanation": "Votre score de confiance détermine à quel point vos comparaisons influencent les recommandations de Tournesol.",
+        "howToChangeIt": "Vous pouvez obtenir plus de confiance en utilisant une adresse e-mail d'un domaine fiable ou lorsque d'autres personnes se portent garant pour vous.",
         "includedInPublicDatabase": "Votre score de confiance est inclus dans la base de données publique si vous avez au moins une comparaison publique."
       },
-      "isTrusted": "Vous utilisez une adresse e-mail certifiée",
-      "isNotTrusted": "Vous n'utilisez pas une adresse e-mail certifiée",
-      "hasReceivedVouchers": "Des utilisateurs se portent garant pour vous",
-      "hasNotReceivedVouchers": "Aucun utilisateur ne se porte garant pour vous"
+      "isTrusted": "Votre adresse e-mail est fiable.",
+      "isNotTrusted": "Votre adresse e-mail n'est pas fiable.",
+      "hasReceivedVouchers": "Vous avez au moins un garant.",
+      "hasNotReceivedVouchers": "Vous n'avez pas encore de garant."
     },
     "aboutVouchingMechanism": "En vous portant garant pour d'autres utilisateurs, vous leur permettez d'augmenter leur score de confiance, y compris si leur adresse e-mail n'est pas considérée comme fiable. La liste des utilisateurs pour lesquels vous vous portez garant ou qui se portent garant pour vous est une information publique."
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -357,8 +357,8 @@
     "publicDatabaseDetailAndLicense": "Les contributeurs de Tournesol peuvent décider de rendre leurs données publiques. Nous espérons que ces données importantes se révéleront utiles pour les chercheurs et chercheuses travaillant sur l'éthique des algorithmes, et les systèmes de recommandation à grande échelle. Notre base de données publique, disponible sous licence <2>Open Data Commons Attribution License (ODC-By)</2>, peut être téléchargée en cliquant sur le bouton ci-dessous.",
     "publicDatabaseThanksToContributors": "Enfin, nous souhaitons vivement remercier tous les contributeurs qui comparent des vidéos sur Tournesol. Nous comptons actuellement environ {{userCount}} utilisateurs qui ont comparé {{comparisonCount}} fois plus de {{comparedEntityCount}} vidéos. ❤️",
     "trustedEmailDomains": "Noms de domaine fiables",
-    "trustedDomainsToProtectTournesol": "Dans le but de protéger Tournesol des faux comptes, la plateforme assigne par défaut un droit de vote limité aux nouveaux comptes créés.",
-    "trustedDomainsGainMoreVotingRights": "Vous pouvez obtenir un droit de vote significativement plus important en validant <2>une adresse e-mail provenant d'un domaine fiable</2>. Nous réfléchissons actuellement à des moyens alternatifs pour que les utilisateurs puissent bénéficier d'un droit de vote plus important.",
+    "trustedDomainsToProtectTournesol": "Dans le but de protéger Tournesol des faux comptes, la plateforme assigne par défaut un score de confiance limité aux nouveaux comptes créés.",
+    "trustedDomainsGainMoreVotingRights": "Vous pouvez augmenter significativement votre score de confiance en validant <2>une adresse e-mail provenant d'un domaine fiable</2>, ou en ayant des personnes qui se portent garant.es pour vous.",
     "trustedDomainsValuable": "Dans tous les cas, vos contributions sont utiles car elles motiveront et aideront la recherche en éthique des algorithmes et de l'intelligence artificielle",
     "trustedDomainsCurrentList": "Liste actuelle des domaines considérés fiables"
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -527,7 +527,7 @@
       "hasReceivedVouchers": "Des utilisateurs se portent garant pour vous",
       "hasNotReceivedVouchers": "Aucun utilisateur ne se porte garant pour vous"
     },
-    "aboutVouchingMechanism": "En vous portant garant pour d'autres utilisateurs, vous leur permettez d'acquérir un droit de vote plus important sur Tournesol, y compris si leur adresse e-mail n'est pas considérée comme fiable. Sur Tournesol, la liste des utilisateurs pour lesquels vous vous portez garant, ou qui se portent garant pour vous, est une information publique."
+    "aboutVouchingMechanism": "En vous portant garant pour d'autres utilisateurs, vous leur permettez d'augmenter leur score de confiance, y compris si leur adresse e-mail n'est pas considérée comme fiable. Sur Tournesol, la liste des utilisateurs pour lesquels vous vous portez garant ou qui se portent garant pour vous est une information publique."
   },
   "myRateLaterListPage": {
     "title": "À comparer plus tard"

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -527,7 +527,7 @@
       "hasReceivedVouchers": "Des utilisateurs se portent garant pour vous",
       "hasNotReceivedVouchers": "Aucun utilisateur ne se porte garant pour vous"
     },
-    "aboutVouchingMechanism": "En vous portant garant pour d'autres utilisateurs, vous leur permettez d'augmenter leur score de confiance, y compris si leur adresse e-mail n'est pas considérée comme fiable. Sur Tournesol, la liste des utilisateurs pour lesquels vous vous portez garant ou qui se portent garant pour vous est une information publique."
+    "aboutVouchingMechanism": "En vous portant garant pour d'autres utilisateurs, vous leur permettez d'augmenter leur score de confiance, y compris si leur adresse e-mail n'est pas considérée comme fiable. La liste des utilisateurs pour lesquels vous vous portez garant ou qui se portent garant pour vous est une information publique."
   },
   "myRateLaterListPage": {
     "title": "À comparer plus tard"

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -242,7 +242,7 @@
         "label": "E-mails fiables seulement"
       }
     },
-    "scoreModeSection": "Droits de vote",
+    "scoreModeSection": "Vote",
     "uploader": "Chaîne"
   },
   "ratings": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -242,7 +242,7 @@
         "label": "E-mails fiables seulement"
       }
     },
-    "scoreModeSection": "Vote",
+    "scoreModeSection": "Droits de vote",
     "uploader": "Chaîne"
   },
   "ratings": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -519,7 +519,7 @@
       "title": "Score de confiance",
       "description": {
         "explanation": "Votre score de confiance détermine à quel point vos comparaisons influencent les recommandations de Tournesol.",
-        "howToChangeIt": "Vous pouvez obtenir plus de confiance en utilisant une adresse e-mail d'un domaine fiable ou lorsque d'autres personnes se portent garant pour vous.",
+        "howToChangeIt": "Vous pouvez obtenir plus de confiance en utilisant une adresse e-mail d'un domaine fiable ou lorsque d'autres personnes se portent garant.es pour vous.",
         "includedInPublicDatabase": "Votre score de confiance est inclus dans la base de données publique si vous avez au moins une comparaison publique."
       },
       "isTrusted": "Votre adresse e-mail est fiable.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -358,7 +358,7 @@
     "publicDatabaseThanksToContributors": "Enfin, nous souhaitons vivement remercier tous les contributeurs qui comparent des vidéos sur Tournesol. Nous comptons actuellement environ {{userCount}} utilisateurs qui ont comparé {{comparisonCount}} fois plus de {{comparedEntityCount}} vidéos. ❤️",
     "trustedEmailDomains": "Noms de domaine fiables",
     "trustedDomainsToProtectTournesol": "Dans le but de protéger Tournesol des faux comptes, la plateforme assigne par défaut un score de confiance limité aux nouveaux comptes créés.",
-    "trustedDomainsGainMoreVotingRights": "Vous pouvez augmenter significativement votre score de confiance en validant <2>une adresse e-mail provenant d'un domaine fiable</2>, ou en ayant des personnes qui se portent garant.es pour vous.",
+    "trustedDomainsGainMoreVotingRights": "Vous pouvez augmenter significativement votre score de confiance en validant <2>une adresse e-mail provenant d'un domaine fiable</2>, ou lorsque d'autres personnes se portent garant.es pour vous.",
     "trustedDomainsValuable": "Dans tous les cas, vos contributions sont utiles car elles motiveront et aideront la recherche en éthique des algorithmes et de l'intelligence artificielle",
     "trustedDomainsCurrentList": "Liste actuelle des domaines considérés fiables"
   },

--- a/frontend/src/pages/about/TrustedDomains.tsx
+++ b/frontend/src/pages/about/TrustedDomains.tsx
@@ -48,10 +48,9 @@ const TrustedDomains = () => {
             <p>{t('about.trustedDomainsToProtectTournesol')}</p>
             <p>
               <Trans t={t} i18nKey="about.trustedDomainsGainMoreVotingRights">
-                You can gain significantly more voting rights by validating{' '}
-                <strong>an email address from a trusted domain</strong>. We are
-                currently working on designing additional means for contributors
-                to gain voting rights.
+                You can gain significantly more trust by validating{' '}
+                <strong>an email address from a trusted domain</strong>, or by
+                having other users vouch for you.
               </Trans>
             </p>
             <p>{t('about.trustedDomainsValuable')}</p>

--- a/frontend/src/pages/personal/vouchers/TrustScore.tsx
+++ b/frontend/src/pages/personal/vouchers/TrustScore.tsx
@@ -20,6 +20,21 @@ import { usePersonalVouchers } from './context';
 
 const TRUST_SCORE_LOW = 0.1;
 const TRUST_SCORE_MEDIUM = 0.5;
+const TRUST_SCORE_LOW_COLOR = 'text.secondary';
+const TRUST_SCORE_MEDIUM_COLOR = '#506AD4';
+const TRUST_SCORE_HIGH_COLOR = '#2e7d32';
+
+const getTrustScoreColor = (trustScore: number | null | undefined) => {
+  if (!trustScore || trustScore < TRUST_SCORE_LOW) {
+    return TRUST_SCORE_LOW_COLOR;
+  }
+
+  if (trustScore < TRUST_SCORE_MEDIUM) {
+    return TRUST_SCORE_MEDIUM_COLOR;
+  }
+
+  return TRUST_SCORE_HIGH_COLOR;
+};
 
 const Thumb = ({
   up,
@@ -132,7 +147,13 @@ const TrustScore = () => {
             justifyContent="center"
             gap={2}
           >
-            <Typography variant="h1" component="span" textTransform="uppercase">
+            <Typography
+              variant="h1"
+              component="span"
+              fontWeight="bold"
+              textTransform="uppercase"
+              color={getTrustScoreColor(userProfile?.trust_score)}
+            >
               {displayedValue}
             </Typography>
             <Stack gap={1}>


### PR DESCRIPTION
As suggested by @sigmike , I propose to use this PR to update the translations in order to use trust score instead of voting right when it's appropriate.

Here are the translations we may want to update:
- **(wont fix, it's the correct terms)** https://github.com/tournesol-app/tournesol/blob/main/frontend/public/locales/en/translation.json#L239

Proposition for the key `howToChangeIt`:

Original
> You can increase it by using a certified email and when other users vouch for you.

Proposition
> You can gain more trust by using an email from a trusted domain or when other users vouch for you.

As discussed with Adrien, trusted domain is more accurate.
 
Additional proposition for the key `explanation`:

Original
> Your trust score changes how your comparisons count in Tournesol's recommendations.

Proposition
> Your trust score determines how much your comparisons influence the Tournesol's recommendations.

I think using the word influence is more explicit than count.