### PR TITLE
[front] fix: reset scroll position on page change

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Switch, Redirect } from 'react-router-dom';
+import { Switch, Redirect, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { i18n as i18nInterface } from 'i18next';
 
@@ -28,6 +28,7 @@ import { polls } from './utils/constants';
 import PollRoutes from './app/PollRoutes';
 import { PollProvider } from './hooks/useCurrentPoll';
 import FAQ from './pages/faq/FAQ';
+import { scrollToTop } from './utils/ui';
 
 // The Analysis Page uses recharts which is a rather big library,
 // thus we choose to load it lazily.
@@ -49,6 +50,16 @@ const initializeOpenAPI = (loginState: LoginState, i18n: i18nInterface) => {
   });
 };
 
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    scrollToTop();
+  }, [pathname]);
+
+  return null;
+};
+
 function App() {
   const { i18n } = useTranslation();
   const { isLoggedIn, loginState } = useLoginState();
@@ -61,6 +72,7 @@ function App() {
 
   return (
     <PollProvider>
+      <ScrollToTop />
       <Frame>
         <Switch>
           {/* About routes */}

--- a/frontend/src/utils/ui.ts
+++ b/frontend/src/utils/ui.ts
@@ -1,5 +1,5 @@
 export const scrollToTop = () => {
-  document.querySelector('main')?.scrollTo({ top: 0 });
+  document.querySelector('main')?.scrollTo?.({ top: 0 });
 };
 
 export const openTwitterPopup = (text: string) => {


### PR DESCRIPTION
When navigating to another page via a React Router link, the scroll position persisted to the previous position. Especially visible when clicking on "see more" in the Recommendations section on the home page.

The implementation is similar to the approach described on https://v5.reactrouter.com/web/guides/scroll-restoration/scroll-to-top
