### PR TITLE
[front] style: move the contribute description text to the left

### DIFF
--- a/frontend/src/pages/home/videos/sections/ComparisonSection.tsx
+++ b/frontend/src/pages/home/videos/sections/ComparisonSection.tsx
@@ -25,11 +25,6 @@ const ComparisonSection = ({ comparisonStats }: Props) => {
     <Box>
       <SectionTitle title={t('comparisonSection.contribute')} />
       <Grid container justifyContent="center" spacing={4}>
-        <Grid item lg={9} xl={6}>
-          <Box display="flex" justifyContent="center">
-            <HomeComparison />
-          </Box>
-        </Grid>
         <Grid item lg={3} xl={3}>
           <Box
             display="flex"
@@ -57,6 +52,11 @@ const ComparisonSection = ({ comparisonStats }: Props) => {
                 </Box>
               </Box>
             </Paper>
+          </Box>
+        </Grid>
+        <Grid item lg={9} xl={6}>
+          <Box display="flex" justifyContent="center">
+            <HomeComparison />
           </Box>
         </Grid>
       </Grid>

--- a/frontend/src/pages/home/videos/sections/SectionTitle.tsx
+++ b/frontend/src/pages/home/videos/sections/SectionTitle.tsx
@@ -12,7 +12,7 @@ interface SectionTitleProps {
  */
 const SectionTitle = ({ title, dividerColor }: SectionTitleProps) => {
   let sx: SxProps = {
-    width: { xs: '100%', lg: '75%' },
+    width: { xs: '100%', xl: '75%' },
   };
 
   if (dividerColor) {


### PR DESCRIPTION
The goal is to display the instructions before the comparison on mobile, which is more coherent.

### preview

(The end of the capture is a bit glitched, sorry)

![screencapture-localhost-3000-2022-11-16-15_25_30](https://user-images.githubusercontent.com/39056254/202206438-8a261a03-c568-4538-b565-1a6a271c66ac.png)
