### PR TITLE
[front] feat: more social links in the footer + add the mailing list

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -132,6 +132,7 @@
     "research": "Research",
     "whitePaper": "White Paper",
     "publicDatabase": "Public database",
+    "tournesolTalksMailingList": "Tournesol Talks - mailing list",
     "more": "More",
     "privacyPolicy": "Privacy policy"
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -137,6 +137,7 @@
     "research": "Recherche",
     "whitePaper": "White Paper",
     "publicDatabase": "Base de données publique",
+    "tournesolTalksMailingList": "Tournesol Talks - liste de diffusion",
     "more": "Plus",
     "privacyPolicy": "Politique de confidentialité"
   },

--- a/frontend/src/features/frame/components/footer/Footer.tsx
+++ b/frontend/src/features/frame/components/footer/Footer.tsx
@@ -8,6 +8,8 @@ import FooterSection from 'src/features/frame/components/footer/FooterSection';
 import { getWebExtensionUrl } from 'src/utils/extension';
 import {
   getWikiBaseUrl,
+  linkedInTournesolUrl,
+  twitchTournesolUrl,
   twitterTournesolBotEnUrl,
   twitterTournesolBotFrUrl,
   twitterTournesolUrl,
@@ -15,6 +17,7 @@ import {
   githubTournesolUrl,
   utipTournesolUrl,
   paypalTournesolUrl,
+  tournesolTalksMailingListUrl,
   whitePaperUrl,
 } from 'src/utils/url';
 import { theme } from 'src/theme';
@@ -47,6 +50,8 @@ const Footer = () => {
       items: [
         { name: 'Twitter', to: twitterTournesolUrl },
         { name: 'Discord', to: discordTournesolInviteUrl },
+        { name: 'Twitch', to: twitchTournesolUrl },
+        { name: 'LinkedIn', to: linkedInTournesolUrl },
         {
           name: 'GitHub',
           to: githubTournesolUrl,
@@ -74,6 +79,10 @@ const Footer = () => {
         {
           name: t('footer.publicDatabase'),
           to: `${apiUrl}/exports/all/`,
+        },
+        {
+          name: t('footer.tournesolTalksMailingList'),
+          to: tournesolTalksMailingListUrl,
         },
       ],
     },

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -6,6 +6,12 @@ export const getWikiBaseUrl = () => {
 };
 
 /**
+ * Mailing list
+ */
+export const tournesolTalksMailingListUrl =
+  'https://framalistes.org/sympa/subscribe/tournesoltalks';
+
+/**
  * Social links
  */
 
@@ -17,6 +23,9 @@ export const discordTournesolInviteUrl =
 export const twitterTournesolUrl = 'https://twitter.com/TournesolApp';
 export const twitterTournesolBotEnUrl = 'https://twitter.com/tournesolbot';
 export const twitterTournesolBotFrUrl = 'https://twitter.com/tournesolbotfr';
+
+// Twitch
+export const twitchTournesolUrl = 'https://twitch.tv/tournesolapp';
 
 // GitHub
 export const githubTournesolUrl = 'https://github.com/tournesol-app/tournesol';


### PR DESCRIPTION
This PR adds more social links in the footer (Tournesol Talks mailing list included).

The Follow Us section order is the following:
- the networks where we are the most active first (Twitter & Discord)
- the networks where we are less active after (Twitch & LinkedIn)
- the less social networks at the end (GitHub)

Note that the Tournesol Talks mailing list will also be included in the home page research section as requested by @lenhoanglnh.

### preview

![capture](https://user-images.githubusercontent.com/39056254/204813102-c9d3afc4-6dce-4da4-aa0f-a09ab7158f21.png)