### PR TITLE
[meta] chore: add a `CODE_OF_CONDUCT`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Tournesol Code of Conduct
 
 **Table of Content**
@@ -70,8 +69,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-`hello@tournesol.app`.
+reported to the community leaders responsible for enforcement using the email
+address `hello -at- tournesol.app`.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,8 +7,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual
-identity and orientation.
+nationality, personal appearance, caste, color, religion, or sexual
+identity and orientation, or any other dimension of human diversity.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -61,7 +61,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+`moderators@tournesol.app`.
+
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,16 @@
 
 # Tournesol Code of Conduct
 
+**Table of Content**
+
+ - [Our Pledge](#our-pledge)
+ - [Our Standards](#our-standards)
+ - [Enforcement Responsibilities](#enforcement-responsibilities)
+ - [Scope](#scope)
+ - [Enforcement](#enforcement)
+ - [Enforcement Guidelines](#enforcement-guidelines)
+ - [Attribution](#attribution)
+
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 
-# Contributor Covenant Code of Conduct
+# Tournesol Code of Conduct
 
 ## Our Pledge
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-`moderators@tournesol.app`.
+`hello@tournesol.app`.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,6 +68,12 @@ All complaints will be reviewed and investigated promptly and fairly.
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
 
+### Discord specificities
+
+In case of need, community leaders can be contacted individually by private
+message on our Discord server. They have the role `@moderator` and are listed
+at the top of the user list of each channel.
+
 ## Enforcement Guidelines
 
 Community leaders will follow these Community Impact Guidelines in determining

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,8 @@ make the project even better.
 
 ## Code of Conduct
 
-> coming soon
+Help us keep Tournesol open and inclusive. Please read and follow our
+[Code of Conduct][ts-github-code-of-conduct].
 
 ## Efficient Ways to Contribute
 
@@ -166,6 +167,7 @@ On the frontend, translations are handled by `react-i18next`.
 [ts-donate]: https://tournesol.app/about/donate
 [ts-compare]: https://tournesol.app/comparison
 
+[ts-github-code-of-conduct]: https://github.com/tournesol-app/tournesol/blob/main/CODE_OF_CONDUCT.md
 [ts-github-repo]: https://github.com/tournesol-app/tournesol
 [ts-github-kanban]: https://github.com/tournesol-app/tournesol/projects/9
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ make the project even better.
 ## Code of Conduct
 
 Help us keep Tournesol open and inclusive. Please read and follow our
-[Code of Conduct][ts-github-code-of-conduct].
+[Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Efficient Ways to Contribute
 
@@ -167,7 +167,6 @@ On the frontend, translations are handled by `react-i18next`.
 [ts-donate]: https://tournesol.app/about/donate
 [ts-compare]: https://tournesol.app/comparison
 
-[ts-github-code-of-conduct]: https://github.com/tournesol-app/tournesol/blob/main/CODE_OF_CONDUCT.md
 [ts-github-repo]: https://github.com/tournesol-app/tournesol
 [ts-github-kanban]: https://github.com/tournesol-app/tournesol/projects/9
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Help us keep Tournesol open and inclusive. Please read and follow our
 
 ### Contributing Guidelines
 
-Read our [contributing guidelines](./CONTRIBUTING.md) to learn how to help the
-project.
+Read through our [contributing guidelines](./CONTRIBUTING.md) to learn about
+the different ways to help the project.
 
 ### Contributors
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,15 @@ Please refer to the `dev-env` directory or the corresponding documents in
 
 ## Contributing
 
-See the [CONTRIBUTING.md](./CONTRIBUTING.md) file.
+### Code of Conduct
+
+Help us keep Tournesol open and inclusive. Please read and follow our
+[Code of Conduct](./CODE_OF_CONDUCT.md).
+
+### Contributing Guidelines
+
+Read our [contributing guidelines](./CONTRIBUTING.md) to learn how to help the
+project.
 
 ### Contributors
 


### PR DESCRIPTION
In order to harmonize the community rules, this PR adds a code of conduct that applies in Discord, GitHub, and other spaces where the Tournesol community is likely to interact.

It contains obligations for both regular users and community leaders. Are considered leaders all moderators, maintainers, members of the association committee and all other person that represent the Tournesol Association or the Tournesol Project.

It's a copy paste of the standard Contributor Covenant v2.1 with three little changes:
- the mention of race has been removed to avoid any kind of confusion, ethnicity seems to be enough 
- the mention of "any other dimension of human diversity" has been added 
- a simplified email address to contact the tournesol team has been added 

See https://github.com/tournesol-app/tournesol/blob/code_of_conduct/CODE_OF_CONDUCT.md

To better document the changes made in the original Contributor Covenant code of conduct, I propose to **not** squash this PR.