### PR TITLE
[front] refactor: add a reusable `<TitledPaper>` component

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -481,6 +481,8 @@
     "weHopeThatOtherProjectsCanBenefitEtc": "We hope that other projects can benefit from the efforts of the Tournesol community. To this end we are making available a database made up of all public contributions that anyone can use.",
     "theseDataArePublishedUnderODCBY": "These data are published under the terms of the Open Data Commons Attribution License <1>(ODC-BY 1.0)</1>.",
     "downloadTheDatabase": "Download the database",
+    "ourAlgorithmsAreFree": "Our algorithms are Free/Libre",
+    "ourAlgorithmsAndAllOurCodeAreFreeSoftware": "In a perspective of transparency and knowledge sharing, the algorithms and all source code we created are Free Software.",
     "accessTheCodeOnGitHub": "Access the code on GitHub"
   },
   "researchSection": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -487,6 +487,8 @@
     "weHopeThatOtherProjectsCanBenefitEtc": "Nous espérons que d'autres projets puissent bénéficier des efforts déployés par la communauté Tournesol. Pour cela nous mettons à disposion une base de données constituée par toutes contributions publiques que tout le monde peut utiliser.",
     "theseDataArePublishedUnderODCBY": "Ces données sont publiées sous la licence Open Data Commons Attribution License <1>(ODC-BY 1.0)</1>.",
     "downloadTheDatabase": "Télécharger la base de données",
+    "ourAlgorithmsAreFree": "Nos algorithmes sont Libres",
+    "ourAlgorithmsAndAllOurCodeAreFreeSoftware": "Dans une optique de transparence et de partage des connaissances, nos algorithmes et tous les codes sources que nous avons créés sont des Logiciels Libres.",
     "accessTheCodeOnGitHub": "Accédez au code sur GitHub"
   },
   "researchSection": {

--- a/frontend/src/components/TitledPaper.tsx
+++ b/frontend/src/components/TitledPaper.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Box, Paper, Typography, SxProps } from '@mui/material';
+
+interface TitledPaperProps {
+  title: string;
+  children: React.ReactNode;
+  sx?: SxProps;
+  contentBoxPadding?: number;
+}
+
+/**
+ * A reusable MUI <Paper> with a customized header and a padded content.
+ */
+const TitledPaper = ({
+  title,
+  children,
+  sx,
+  contentBoxPadding = 2,
+}: TitledPaperProps) => {
+  return (
+    <Paper sx={sx}>
+      <Box
+        p={2}
+        color="#fff"
+        bgcolor="#1282B2"
+        sx={{
+          borderTopLeftRadius: 'inherit',
+          borderTopRightRadius: 'inherit',
+        }}
+      >
+        <Typography variant="h4">{title}</Typography>
+      </Box>
+      <Box p={contentBoxPadding}>{children}</Box>
+    </Paper>
+  );
+};
+
+export default TitledPaper;

--- a/frontend/src/pages/home/videos/sections/research/PublicDataPublicCodeBox.tsx
+++ b/frontend/src/pages/home/videos/sections/research/PublicDataPublicCodeBox.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { Box, Link, Paper, Typography, Button, SxProps } from '@mui/material';
+import { Box, Link, Typography, Button, SxProps } from '@mui/material';
 import { Download, GitHub } from '@mui/icons-material';
+
+import TitledPaper from 'src/components/TitledPaper';
 
 const PublicDataPublicCodeBox = ({ sx }: { sx?: SxProps }) => {
   const apiUrl = process.env.REACT_APP_API_URL;
@@ -10,21 +12,11 @@ const PublicDataPublicCodeBox = ({ sx }: { sx?: SxProps }) => {
 
   return (
     <Box sx={sx}>
-      <Paper sx={{ mb: 2 }}>
-        <Box
-          p={2}
-          color="#fff"
-          bgcolor="#1282B2"
-          sx={{
-            borderTopLeftRadius: 'inherit',
-            borderTopRightRadius: 'inherit',
-          }}
-        >
-          <Typography variant="h4">
-            {t('publicDataPublicCodeBox.ourDataAreOpen')}
-          </Typography>
-        </Box>
-        <Box p={2}>
+      <TitledPaper
+        title={t('publicDataPublicCodeBox.ourDataAreOpen')}
+        sx={{ mb: 2 }}
+      >
+        <>
           <Typography paragraph>
             {t('publicDataPublicCodeBox.weHopeThatOtherProjectsCanBenefitEtc')}
           </Typography>
@@ -40,34 +32,42 @@ const PublicDataPublicCodeBox = ({ sx }: { sx?: SxProps }) => {
               </Link>
             </Trans>
           </Typography>
-        </Box>
-      </Paper>
-      <Paper sx={{ p: 2, mb: 2 }}>
-        <Box display="flex" justifyContent="center">
-          <Button
-            variant="contained"
-            component={Link}
-            href={`${apiUrl}/exports/all/`}
-            endIcon={<Download />}
-          >
-            {t('publicDataPublicCodeBox.downloadTheDatabase')}
-          </Button>
-        </Box>
-      </Paper>
-      <Paper sx={{ p: 2 }}>
-        <Box display="flex" justifyContent="center">
-          <Button
-            variant="contained"
-            component={Link}
-            target="_blank"
-            rel="noopener"
-            href="https://github.com/tournesol-app/tournesol"
-            endIcon={<GitHub />}
-          >
-            {t('publicDataPublicCodeBox.accessTheCodeOnGitHub')}
-          </Button>
-        </Box>
-      </Paper>
+          <Box display="flex" justifyContent="center">
+            <Button
+              variant="contained"
+              component={Link}
+              href={`${apiUrl}/exports/all/`}
+              endIcon={<Download />}
+            >
+              {t('publicDataPublicCodeBox.downloadTheDatabase')}
+            </Button>
+          </Box>
+        </>
+      </TitledPaper>
+      <TitledPaper
+        title={t('publicDataPublicCodeBox.ourAlgorithmsAreFree')}
+        sx={{ mb: 2 }}
+      >
+        <>
+          <Typography paragraph>
+            {t(
+              'publicDataPublicCodeBox.ourAlgorithmsAndAllOurCodeAreFreeSoftware'
+            )}
+          </Typography>
+          <Box display="flex" justifyContent="center">
+            <Button
+              variant="contained"
+              component={Link}
+              target="_blank"
+              rel="noopener"
+              href="https://github.com/tournesol-app/tournesol"
+              endIcon={<GitHub />}
+            >
+              {t('publicDataPublicCodeBox.accessTheCodeOnGitHub')}
+            </Button>
+          </Box>
+        </>
+      </TitledPaper>
     </Box>
   );
 };

--- a/frontend/src/pages/home/videos/sections/research/ScientificLiteratureBox.tsx
+++ b/frontend/src/pages/home/videos/sections/research/ScientificLiteratureBox.tsx
@@ -9,8 +9,6 @@ import {
   ListItemAvatar,
   ListItemText,
   Avatar,
-  Paper,
-  Typography,
   ListItemButton,
   Tabs,
   Tab,
@@ -23,6 +21,7 @@ import {
   VerifiedUser,
   School,
 } from '@mui/icons-material';
+import TitledPaper from 'src/components/TitledPaper';
 
 function a11yProps(index: number) {
   return {
@@ -125,18 +124,11 @@ const ScientificLiteratureBox = () => {
   ];
 
   return (
-    <Paper>
-      <Box
-        p={2}
-        color="#fff"
-        bgcolor="#1282B2"
-        sx={{ borderTopLeftRadius: 'inherit', borderTopRightRadius: 'inherit' }}
-      >
-        <Typography variant="h4">
-          {t('scientificLiteratureBox.ourPublications')}
-        </Typography>
-      </Box>
-      <Box>
+    <TitledPaper
+      title={t('scientificLiteratureBox.ourPublications')}
+      contentBoxPadding={0}
+    >
+      <>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs
             value={selectedTab}
@@ -203,8 +195,8 @@ const ScientificLiteratureBox = () => {
             ))}
           </List>
         </TabPanel>
-      </Box>
-    </Paper>
+      </>
+    </TitledPaper>
   );
 };
 

--- a/frontend/src/pages/home/videos/sections/research/VisualizeDataBox.tsx
+++ b/frontend/src/pages/home/videos/sections/research/VisualizeDataBox.tsx
@@ -1,52 +1,39 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { Box, Link, Paper, Typography } from '@mui/material';
+import { Box, Link, Typography } from '@mui/material';
+
+import TitledPaper from 'src/components/TitledPaper';
 
 const VisualizeDataBox = () => {
   const { t } = useTranslation();
 
   return (
-    <Paper>
-      <Box
-        p={2}
-        color="#fff"
-        bgcolor="#1282B2"
-        sx={{
-          borderTopLeftRadius: 'inherit',
-          borderTopRightRadius: 'inherit',
-        }}
-      >
-        <Typography variant="h4">
-          {t('visualizeDataBox.visualizeTheData')}
+    <TitledPaper title={t('visualizeDataBox.visualizeTheData')}>
+      <Box mb={2} sx={{ '& img': { maxWidth: '100%' } }}>
+        <Typography paragraph>
+          <Trans i18nKey="visualizeDataBox.youCanQuicklyExploreEtc">
+            You can quickly explore our public database with our appplication
+            <Link
+              color="text.primary"
+              href="https://github.com/tournesol-app/tournesol/tree/main/data-visualization"
+            >
+              Tournesol Data Visualization
+            </Link>
+            made with Streamlit.
+          </Trans>
         </Typography>
-      </Box>
-      <Box px={2} sx={{ '& img': { maxWidth: '100%' } }}>
-        <Box p={2}>
-          <Typography paragraph mb={0}>
-            <Trans i18nKey="visualizeDataBox.youCanQuicklyExploreEtc">
-              You can quickly explore our public database with our appplication
-              <Link
-                color="text.primary"
-                href="https://github.com/tournesol-app/tournesol/tree/main/data-visualization"
-              >
-                Tournesol Data Visualization
-              </Link>
-              made with Streamlit.
-            </Trans>
-          </Typography>
-        </Box>
         <img
           src="/images/criteria_pearson_correlation_matrix_2022_10_10.png"
           alt={t('visualizeDataBox.personCorrelationCoefficientMatrix')}
         />
       </Box>
-      <Box p={2} display="flex" justifyContent="center">
+      <Box display="flex" justifyContent="center">
         <Typography variant="caption">
           {t('visualizeDataBox.personCorrelationCoefficientMatrix')}
         </Typography>
       </Box>
-    </Paper>
+    </TitledPaper>
   );
 };
 


### PR DESCRIPTION
**related to** #1219 

---

### Preview

The previously isolated buttons Download the database and Access the source code have been moved into the MUI papers for a better consistency with the rest of the app. A little paragraph has been to introduce the source code.

![capture](https://user-images.githubusercontent.com/39056254/205087695-46f1d178-98e4-452a-9de7-15fad99f131d.png)