### PR TITLE
[back] fix: temporarily downgrade the previews quality

### DIFF
--- a/backend/tournesol/views/preview.py
+++ b/backend/tournesol/views/preview.py
@@ -665,7 +665,11 @@ class DynamicWebsitePreviewComparison(BasePreviewAPIView, APIView):
         if not self.is_video(entity_a) or not self.is_video(entity_b):
             return self.default_preview()
 
-        thumbnail_quality = "maxres"
+        # Not all YT videos have a `maxres` thumbnail available. It could be
+        # good to use `maxres` instead of the `mq` quality when we are sure
+        # that both videos have a `maxres` thumbnail available. In the
+        # meantime, to avoid creating broken preview images we will use `mq`.
+        thumbnail_quality = "mq"
         try:
             thumbnail_a = self.get_yt_thumbnail(entity_a, quality=thumbnail_quality)
             thumbnail_b = self.get_yt_thumbnail(entity_b, quality=thumbnail_quality)

--- a/backend/tournesol/views/preview.py
+++ b/backend/tournesol/views/preview.py
@@ -322,8 +322,13 @@ class DynamicWebsitePreviewEntity(BasePreviewAPIView):
             entity, fnt_config, upscale_ratio=upscale_ratio
         )
 
+        # Not all YT videos have a `maxres` thumbnail available. It could be
+        # good to use `maxres` instead of the `mq` quality when we are sure
+        # that both videos have a `maxres` thumbnail available. In the
+        # meantime, to avoid creating broken preview images we will use `mq`.
+        thumbnail_quality = "mq"
         try:
-            youtube_thumbnail = self.get_yt_thumbnail(entity, quality="maxres")
+            youtube_thumbnail = self.get_yt_thumbnail(entity, quality=thumbnail_quality)
         except ConnectionError:
             return self.default_preview()
 


### PR DESCRIPTION
**related to** #1230

---

The images returned by the preview API could be broken if one of the two videos didn't have a `maxres` thumbnail. For now, only `mq` will be use.

In the future, we could check if both videos have `maxres` thumbnails to determine the preview quality.