### PR TITLE
[infra] fix: update external-urls-monitoring to show error message when failing

### DIFF
--- a/infra/ansible/roles/monitoring/templates/external-urls-monitoring.sh.j2
+++ b/infra/ansible/roles/monitoring/templates/external-urls-monitoring.sh.j2
@@ -5,7 +5,7 @@ URLS='{{monitored_urls | join(' ')}}'
 for u in $URLS
 do
     echo "checking $u"
-    wget -qO /dev/null "$u" && echo "$u OK" || (
+    curl -s --fail --show-error -o /dev/null "$u" && echo "$u OK" || (
         echo "error checking $u"
 {% if discord_infra_alert_webhook is defined and discord_infra_alert_webhook != "" %}
         wget -qO /dev/null \


### PR DESCRIPTION
Instead of `wget`, let's use `curl` with these options:
 * `-s`: Silent or quiet mode. Don't show progress meter .
 * `--show-error`: when used with -s, it makes curl show an error message if it fails.
 * `--fail`: Fail in case of non successful HTTP responses, including server errors.

This should help us to understand the false alerts that have been observed recently.