### PR TITLE
[infra] feat: set up a daily clean-up of expired back end's sessions

### DIFF
--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -49,8 +49,10 @@ all:
           grafana_domain_name: tournesol-grafana
           grafana_scheme: http
 
+          # Daily clean-up of the back end's expired items.
           tournesol_api_cleartokens_schedule: "*-*-* 02:00:00" # daily at 2am
           tournesol_api_deleteinactiveusers_schedule: "*-*-* 02:20:00" # daily at 2:20am
+          tournesol_api_clearsessions_schedule: "*-*-* 02:40:00" # daily at 2:40am
 
           ml_train_schedule: "*-*-* 0,6,12,18:20:00" # every 6 hours
 
@@ -108,8 +110,10 @@ all:
           grafana_domain_name: "grafana.{{domain_name}}"
           grafana_scheme: https
 
+          # Daily clean-up of the back end's expired items.
           tournesol_api_cleartokens_schedule: "*-*-* 02:00:00" # daily at 2am
           tournesol_api_deleteinactiveusers_schedule: "*-*-* 02:20:00" # daily at 2:20am
+          tournesol_api_clearsessions_schedule: "*-*-* 02:40:00" # daily at 2:40am
 
           ml_train_schedule: "*-*-* 0,6,12,18:20:00" # every 6 hours
 
@@ -171,8 +175,10 @@ all:
           grafana_domain_name: "grafana.{{domain_name}}"
           grafana_scheme: https
 
+          # Daily clean-up of the back end's expired items.
           tournesol_api_cleartokens_schedule: "*-*-* 02:00:00" # daily at 2am
           tournesol_api_deleteinactiveusers_schedule: "*-*-* 02:20:00" # daily at 2:20am
+          tournesol_api_clearsessions_schedule: "*-*-* 02:40:00" # daily at 2:40am
 
           # twitterbot: the service script is responsible for running the bot in
           # different languages depending on the day of the week.

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -182,6 +182,25 @@
     enabled: yes
     daemon_reload: yes
 
+# scheduled task: sessions clean-up
+
+- name: Copy Tournesol API clearsessions service
+  template:
+    dest: /etc/systemd/system/tournesol-api-clearsessions.service
+    src: tournesol-api-clearsessions.service.j2
+
+- name: Copy Tournesol API clearsessions timer
+  template:
+    dest: /etc/systemd/system/tournesol-api-clearsessions.timer
+    src: tournesol-api-clearsessions.timer.j2
+
+- name: Enable and start Tournesol API clearsessions timer
+  systemd:
+    name: tournesol-api-clearsessions.timer
+    state: started
+    enabled: yes
+    daemon_reload: yes
+
 # scheduled task: refresh token clean-up
 
 - name: Copy Tournesol API cleartokens service

--- a/infra/ansible/roles/django/templates/tournesol-api-clearsessions.service.j2
+++ b/infra/ansible/roles/django/templates/tournesol-api-clearsessions.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Tournesol API sessions clean-up
+
+[Service]
+Type=oneshot
+User=gunicorn
+Group=gunicorn
+WorkingDirectory=/srv/tournesol-backend
+Environment="SETTINGS_FILE=/etc/tournesol/settings.yaml"
+ExecStart=/usr/bin/bash -c "source venv/bin/activate && python manage.py clearsessions"
+ExecStopPost=/usr/bin/bash -c "if [ "$$EXIT_STATUS" != 0 ]; then /usr/local/bin/post-on-discord.sh -c infra_alert -m 'Tournesol API clearsessions job failed for {{domain_name}}'; fi"

--- a/infra/ansible/roles/django/templates/tournesol-api-clearsessions.timer.j2
+++ b/infra/ansible/roles/django/templates/tournesol-api-clearsessions.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Tournesol API session clean-up
+
+[Timer]
+OnCalendar={{tournesol_api_clearsessions_schedule}}
+Persistent=yes
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
### Context

Our back end's admin interface saves the session data of logged users in the database. Django doesn't automatically clear the expired sessions, thus the `django_session` table slowly grows (very very slowly in fact).

The same way we manually clear the expired API refresh tokens every day, we should manually clear the expired sessions created when users log in the admin interface.

This PR adds a systemd timer that will delete all expired back end's sessions every day at 02:40am. We currently have 224 expired sessions in production.

```sql
SELECT count(1) FROM django_session WHERE expire_date < current_timestamp;
```

See: https://docs.djangoproject.com/en/4.0/topics/http/sessions/#clearing-the-session-store 