### PR TITLE
[front] docs: fix a typo in a CSS comment

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -40,7 +40,7 @@ code {
 }
 html.embedded .SnackbarContainer-root.belowTopBar {
   /* when the site is embedded in the browser extension iframe, we move the
-     snackback into the empty page title bar in order to avoid shadowing any
+     snackbar into the empty page title bar in order to avoid shadowing any
      page content */
   top: 4px;
 }


### PR DESCRIPTION
This PR fix the typo `snackback` -> `snackbar`.

The application was literally u.n.u.s.a.b.l.e.

