### PR TITLE
[back] feat: the proof of vote API is now a more generic proof API

### DIFF
--- a/backend/tournesol/models/poll.py
+++ b/backend/tournesol/models/poll.py
@@ -83,15 +83,12 @@ class Poll(models.Model):
     def __str__(self) -> str:
         return f'Poll "{self.name}"'
 
-    def get_proof_of_vote(self, user_id: int):
+    def get_user_proof(self, user_id: int, keyword: str):
         """
-        Returns the user_id signed with a signature,
-        derived from the Django SECRET_KEY and the current poll name.
-
-        Should only be provided for the user after they submitted
-        at least 1 comparison in the current poll.
+        Return the user_id signed with a signature, derived from the current
+        poll name and the specified keyword.
         """
-        signer = Signer(salt=f"proof_of_vote:{self.name}")
+        signer = Signer(salt=f"{keyword}:{self.name}")
         return signer.sign(f"{user_id:05d}")
 
     @property

--- a/backend/tournesol/models/poll.py
+++ b/backend/tournesol/models/poll.py
@@ -97,7 +97,7 @@ class Poll(models.Model):
         Return False if the proof identified by the provided keyword has
         requirements not satisfied by the provided user, return True instead.
 
-        Random keyword that are not understood by the poll will always return
+        Random keywords that are not understood by the poll will always return
         True.
         """
         from core.models.user import User  # pylint: disable=import-outside-toplevel

--- a/backend/tournesol/models/poll.py
+++ b/backend/tournesol/models/poll.py
@@ -19,6 +19,8 @@ ALGORITHM_CHOICES = (
     (ALGORITHM_MEHESTAN, "Mehestan"),
 )
 
+PROOF_OF_VOTE_KEYWORD = "proof_of_vote"
+
 
 class Poll(models.Model):
     """
@@ -44,6 +46,9 @@ class Poll(models.Model):
         help_text="Scaling factor multiplied by score before the sigmoid function is applied."
         " Updated automatically on each run. (Mehestan only)."
     )
+
+    def __str__(self) -> str:
+        return f'Poll "{self.name}"'
 
     @classmethod
     def default_poll(cls) -> "Poll":
@@ -80,20 +85,44 @@ class Poll(models.Model):
     def entity_cls(self):
         return ENTITY_TYPE_NAME_TO_CLASS[self.entity_type]
 
-    def __str__(self) -> str:
-        return f'Poll "{self.name}"'
-
-    def get_user_proof(self, user_id: int, keyword: str):
-        """
-        Return the user_id signed with a signature, derived from the current
-        poll name and the specified keyword.
-        """
-        signer = Signer(salt=f"{keyword}:{self.name}")
-        return signer.sign(f"{user_id:05d}")
-
     @property
     def scale_function(self):
         if self.algorithm == ALGORITHM_MEHESTAN and self.sigmoid_scale is not None:
             return lambda x: (4 * MEHESTAN_MAX_SCALED_SCORE / TAU) * \
                              np.arctan(self.sigmoid_scale * x)
         return lambda x: x
+
+    def user_meets_proof_requirements(self, user_id: int, keyword: str) -> bool:
+        """
+        Return False if the proof identified by the provided keyword has
+        requirements not satisfied by the provided user, return True instead.
+
+        Random keyword that are not understood by the poll will always return
+        True.
+        """
+        from core.models.user import User  # pylint: disable=import-outside-toplevel
+
+        from ..models import Comparison  # pylint: disable=import-outside-toplevel
+
+        # A proof can be obtained only by activated users.
+        try:
+            User.objects.get(id=user_id, is_active=True)
+        except User.DoesNotExist:
+            return False
+
+        # A proof of vote requires at least one comparison made.
+        if keyword == PROOF_OF_VOTE_KEYWORD:
+            comparisons = Comparison.objects.filter(poll=self, user_id=user_id)
+
+            if not comparisons.exists():
+                return False
+
+        return True
+
+    def get_user_proof(self, user_id: int, keyword: str):
+        """
+        Return the user_id and its signature, derived from the current poll
+        name and the specified keyword.
+        """
+        signer = Signer(salt=f"{keyword}:{self.name}")
+        return signer.sign(f"{user_id:05d}")

--- a/backend/tournesol/tests/test_api_proof.py
+++ b/backend/tournesol/tests/test_api_proof.py
@@ -37,8 +37,8 @@ class ProofViewTestCase(TestCase):
 
     def test_auth_200_can_get_default_proof(self):
         """
-        An authenticated user can get a proof of account, even with no
-        comparison.
+        An authenticated user can get a proof of activated account, even with
+        no comparison.
         """
         self.client.force_authenticate(self.user_with_0_comparison)
 
@@ -48,13 +48,23 @@ class ProofViewTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data["signature"].startswith("00084:"))
 
+        default_signature = response.data["signature"]
+
         # An empty query parameter should be considered as a simple proof of
         # account request.
         response = self.client.get(
             f"/users/me/proof/{self.poll.name}/", data={"keyword": ""}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data["signature"].startswith("00084:"))
+        self.assertTrue(response.data["signature"], default_signature)
+
+        # An empty query parameter should be considered as a simple proof of
+        # account request.
+        response = self.client.get(
+            f"/users/me/proof/{self.poll.name}/", data={"keyword": "activated"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["signature"], default_signature)
 
     def test_auth_403_cant_get_proof_of_vote_without_comparison(self):
         """

--- a/backend/tournesol/tests/test_api_proof.py
+++ b/backend/tournesol/tests/test_api_proof.py
@@ -8,7 +8,7 @@ from .factories.comparison import ComparisonFactory
 from .factories.poll import PollFactory
 
 
-class ProofOfVoteApi(TestCase):
+class ProofViewTestCase(TestCase):
     def setUp(self):
         self.poll = PollFactory()
         self.client = APIClient()

--- a/backend/tournesol/tests/test_proof_of_vote.py
+++ b/backend/tournesol/tests/test_proof_of_vote.py
@@ -8,28 +8,75 @@ from .factories.comparison import ComparisonFactory
 from .factories.poll import PollFactory
 
 
-class PollsApi(TestCase):
+class ProofOfVoteApi(TestCase):
     def setUp(self):
         self.poll = PollFactory()
-        self.user1 = UserFactory(pk=42)
-        self.user2 = UserFactory()
-        ComparisonFactory(
-            poll=self.poll,
-            user=self.user1
-        )
+        self.client = APIClient()
 
-    def test_proof_of_vote_denied(self):
-        """A user without comparison cannot retrieve a proof of vote"""
-        client = APIClient()
-        client.force_authenticate(self.user2)
-        response = client.get(f"/users/me/proof_of_votes/{self.poll.name}/")
+        self.user_with_comparisons = UserFactory(pk=42)
+        self.user_with_0_comparison = UserFactory(pk=84)
+        ComparisonFactory(poll=self.poll, user=self.user_with_comparisons)
+
+    def test_anon_401_cant_get_proof(self):
+        """
+        An anonymous user cannot get any proof.
+        """
+        response = self.client.get(f"/users/me/proof/{self.poll.name}/")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.get(
+            f"/users/me/proof/{self.poll.name}/", data={"keyword": ""}
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.get(
+            f"/users/me/proof/{self.poll.name}/",
+            data={"keyword": "proof_of_vote"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_auth_200_can_get_default_proof(self):
+        """
+        An authenticated user can get a proof of account, even with no
+        comparison.
+        """
+        self.client.force_authenticate(self.user_with_0_comparison)
+
+        # No query parameter should be considered as a simple proof of account
+        # request.
+        response = self.client.get(f"/users/me/proof/{self.poll.name}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["signature"].startswith("00084:"))
+
+        # An empty query parameter should be considered as a simple proof of
+        # account request.
+        response = self.client.get(
+            f"/users/me/proof/{self.poll.name}/", data={"keyword": ""}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["signature"].startswith("00084:"))
+
+    def test_auth_403_cant_get_proof_of_vote_without_comparison(self):
+        """
+        An authenticated user cannot get a proof of vote without comparison.
+        """
+        self.client.force_authenticate(self.user_with_0_comparison)
+        response = self.client.get(
+            f"/users/me/proof/{self.poll.name}/",
+            data={"keyword": "proof_of_vote"},
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_retrieve_proof_of_vote(self):
-        """Retrieve a proof of vote """
-        client = APIClient()
-        client.force_authenticate(self.user1)
-        response = client.get(f"/users/me/proof_of_votes/{self.poll.name}/")
+    def test_auth_200_can_get_proof_of_vote_with_comparisons(self):
+        """
+        An authenticated user with at least one comparison made can get a
+        proof of vote.
+        """
+        self.client.force_authenticate(self.user_with_comparisons)
+        response = self.client.get(
+            f"/users/me/proof/{self.poll.name}/",
+            data={"keyword": "proof_of_vote"},
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["poll_name"], self.poll.name)
         self.assertTrue(response.data["signature"].startswith("00042:"))

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -161,11 +161,11 @@ urlpatterns = [
         ContributorCriteriaCorrelationsView.as_view(),
         name="contributor_criteria_correlations",
     ),
-    # Proof of votes
+    # Contributors' proof API
     path(
-        "users/me/proof_of_votes/<str:poll_name>/",
+        "users/me/proof/<str:poll_name>/",
         ProofOfVoteView.as_view(),
-        name="proof_of_vote",
+        name="usersme-proof",
     ),
     # Email domain API
     path("domains/", EmailDomainsList.as_view(), name="email_domains_list"),

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -5,8 +5,6 @@ The `tournesol` app routes.
 from django.urls import include, path, re_path
 from rest_framework import routers
 
-from tournesol.views.proof_of_vote import ProofOfVoteView
-
 from .views import ComparisonDetailApi, ComparisonListApi, ComparisonListFilteredApi
 from .views.contributor_recommendations import (
     PrivateContributorRecommendationsView,
@@ -35,6 +33,7 @@ from .views.preview import (
     DynamicWebsitePreviewDefault,
     DynamicWebsitePreviewEntity,
 )
+from .views.proof import ProofView
 from .views.rate_later import RateLaterDetail, RateLaterList
 from .views.ratings import (
     ContributorRatingDetail,
@@ -56,7 +55,7 @@ urlpatterns = [
     # User API
     path("users/me/", CurrentUserView.as_view(), name="users_me"),
     # Voucher API
-    path("users/me/", include('vouch.urls')),
+    path("users/me/", include("vouch.urls")),
     # Data exports
     path(
         "users/me/exports/comparisons/",
@@ -164,7 +163,7 @@ urlpatterns = [
     # Contributors' proof API
     path(
         "users/me/proof/<str:poll_name>/",
-        ProofOfVoteView.as_view(),
+        ProofView.as_view(),
         name="usersme-proof",
     ),
     # Email domain API
@@ -200,7 +199,7 @@ urlpatterns = [
         name="website_preview_entity",
     ),
     re_path(
-        r'^preview/.*$',
+        r"^preview/.*$",
         DynamicWebsitePreviewDefault.as_view(),
         name="website_preview_default",
     ),

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -15,6 +15,7 @@ from core.models import User
 from tournesol.entities.base import UID_DELIMITER
 from tournesol.lib.public_dataset import get_dataset, get_users_dataset
 from tournesol.models import Comparison, Poll
+from tournesol.models.poll import PROOF_OF_VOTE_KEYWORD
 from tournesol.serializers.comparison import ComparisonSerializer
 from tournesol.utils.cache import cache_page_no_i18n
 from tournesol.views.mixins.poll import PollScopedViewMixin
@@ -191,7 +192,7 @@ class ExportProofOfVoteView(PollScopedViewMixin, APIView):
         writer = csv.DictWriter(response, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(
-            {**d, "signature": poll.get_proof_of_vote(d["user_id"])}
+            {**d, "signature": poll.get_user_proof(d["user_id"], PROOF_OF_VOTE_KEYWORD)}
             for d in User.objects.filter(comparisons__poll=poll).values(
                 "username", "email", n_comparisons=Count("*"), user_id=F("id")
             )

--- a/backend/tournesol/views/proof.py
+++ b/backend/tournesol/views/proof.py
@@ -1,5 +1,6 @@
 """
-API endpoints to interact with the contributor's proof of work.
+API endpoints to interact with the contributor's proofs of work and other
+kind of proof.
 """
 
 from drf_spectacular.types import OpenApiTypes
@@ -25,7 +26,7 @@ from .mixins.poll import PollScopedViewMixin
         ],
     ),
 )
-class ProofOfVoteView(PollScopedViewMixin, generics.RetrieveAPIView):
+class ProofView(PollScopedViewMixin, generics.RetrieveAPIView):
     """
     Return a cryptographic signature of the user id, associated to the
     selected poll and optionally to the specified keyword.

--- a/backend/tournesol/views/proof_of_vote.py
+++ b/backend/tournesol/views/proof_of_vote.py
@@ -2,6 +2,8 @@
 API endpoints to interact with the contributor's proof of work.
 """
 
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import generics
 from rest_framework.exceptions import PermissionDenied
 
@@ -11,23 +13,74 @@ from ..models import Comparison
 from .mixins.poll import PollScopedViewMixin
 
 
+@extend_schema_view(
+    get=extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "keyword",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Used as an input by the signing algorithm.",
+            ),
+        ],
+    ),
+)
 class ProofOfVoteView(PollScopedViewMixin, generics.RetrieveAPIView):
     """
-    API for retrieving the logged user's proof_of_vote in a given poll.
+    Return a cryptographic signature of the user id, associated to the
+    selected poll and optionally to the specified keyword.
+
+    This signature can act as a proof for the users to guarantee they really
+    have an account, and optionally that they meet specific expectations that
+    can be poll dependant.
+
+    The query parameter `keyword` specifies which set of conditions are
+    expected to be met by the logged-in user. Each set of conditions
+    includes at least having a user account.
+
+    List of accepted keywords and matching conditions:
+
+        "" (empty): Only check if the user has an account.
+
+        "proof_of_vote": Additionally check if the user has participated in
+                         the selected poll.
     """
+
+    _proof_of_vote_keyword = "proof_of_vote"
+
     serializer_class = ProofOfVoteSerializer
 
-    def get_object(self):
-        poll = self.poll_from_url
-        comparisons = Comparison.objects.filter(
-            user=self.request.user,
-            poll=poll,
-        )
+    def user_has_voted(self, poll, user):
+        """
+        Return True if the user has at least one comparison in the given poll,
+        False instead.
 
-        if not comparisons.exists():
-            raise PermissionDenied
+        TODO: This method, and potentially similar future methods should be
+              implemented by the `Poll` model, not by the view, in order to
+              follow the simple view / complex model pattern recommended by
+              the Django community. The view doesn't need to know the
+              strategies used by the model to check if the users meet the
+              expectations. Calling a single Poll's method with the proper
+              arguments should be enough.
+        """
+        comparisons = Comparison.objects.filter(poll=poll, user=user)
+
+        if comparisons.exists():
+            return True
+        return False
+
+    def get_object(self):
+        user = self.request.user
+        poll = self.poll_from_url
+        # Only one keyword at a time is supported for now
+        keyword = self.request.query_params.get("keyword", "")
+
+        if keyword == self._proof_of_vote_keyword:
+            has_voted = self.user_has_voted(poll, user)
+            if not has_voted:
+                raise PermissionDenied
 
         return {
-            "signature": poll.get_proof_of_vote(self.request.user.id),
+            "signature": poll.get_user_proof(self.request.user.id, keyword),
             "poll_name": poll.name,
         }

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1647,16 +1647,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/ScoreInconsistencies'
           description: ''
-  /users/me/proof_of_votes/{poll_name}/:
+  /users/me/proof/{poll_name}/:
     get:
-      operationId: users_me_proof_of_votes_retrieve
-      description: API for retrieving the logged user's proof_of_vote in a given poll.
+      operationId: users_me_proof_retrieve
+      description: |-
+        Return a cryptographic signature of the user id, associated to the
+        selected poll and optionally to the specified keyword.
+
+        This signature can act as a proof for the users to guarantee they really
+        have an account, and optionally that they meet specific expectations that
+        can be poll dependant.
+
+        The query parameter `keyword` specifies which set of conditions are
+        expected to be met by the logged-in user. Each set of conditions
+        includes at least having a user account.
+
+        List of accepted keywords and matching conditions:
+
+            "" (empty): Only check if the user has an account.
+
+            "proof_of_vote": Additionally check if the user has participated in
+                             the selected poll.
       parameters:
       - in: path
         name: poll_name
         schema:
           type: string
         required: true
+      - in: query
+        name: keyword
+        schema:
+          type: string
+        description: Used as an input by the signing algorithm.
       tags:
       - users
       security:

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1654,17 +1654,19 @@ paths:
         Return a cryptographic signature of the user id, associated to the
         selected poll and optionally to the specified keyword.
 
-        This signature can act as a proof for the users to guarantee they really
-        have an account, and optionally that they meet specific expectations that
-        can be poll dependant.
+        This signature can act as a proof for the users to guarantee they have an
+        activated account, and optionally that they meet specific requirements
+        that can be poll dependant.
 
-        The query parameter `keyword` specifies which set of conditions are
-        expected to be met by the logged-in user. Each set of conditions
-        includes at least having a user account.
+        The query parameter `keyword` identifies the requested proof, and its set
+        of requirements that are expected to be met by the logged-in user. Each
+        set of requirements includes at least having an activated user account.
 
         List of accepted keywords and matching conditions:
 
-            "" (empty): Only check if the user has an account.
+            "" (empty): Same as "activated".
+
+            "activated": Only check if the user has an activated account.
 
             "proof_of_vote": Additionally check if the user has participated in
                              the selected poll.
@@ -1678,7 +1680,8 @@ paths:
         name: keyword
         schema:
           type: string
-        description: Used as an input by the signing algorithm.
+        description: A keyword identifying a proof. Used as an input by the signing
+          algorithm.
       tags:
       - users
       security:

--- a/frontend/src/pages/personal/feedback/ProofOfVote.tsx
+++ b/frontend/src/pages/personal/feedback/ProofOfVote.tsx
@@ -11,7 +11,10 @@ const ProofOfVote = () => {
   const [code, setCode] = useState('');
 
   useEffect(() => {
-    UsersService.usersMeProofOfVotesRetrieve({ pollName })
+    UsersService.usersMeProofRetrieve({
+      pollName: pollName,
+      keyword: 'proof_of_vote',
+    })
       .then(({ signature }) => setCode(signature))
       .catch(console.error);
   }, [pollName]);


### PR DESCRIPTION
This PR enhances the previous proof of vote API to make it more generic and able to provide different kind of proof.

This need comes from our future study about the browser extension. Previously a proof was only provided for users having at least one comparison. This behaviour still exists but the API is now also able to provide a proof of "activated account" for users without comparison.

### details

The proof view now accepts a keyword query parameter identifying the requested proof. It is used as an input by the signing algorithm, making the API able to provide a proof per poll per user per keyword. A keyword can be any string.

For instance, the `presidentielle2022` uses the keyword `proof_of_vote` to generate for each user a proof of participation.

The poll `videos` can now give to each user a proof of "activated account" by using an empty keyword, or the standard `activated` string.

We can use any keyword to generate a proof that ensures a user meets a specific set of expectations, as long as those expectations are coded in the back end.

**to-do: back end**

- [x] `ProofOfVote` API is now `Proof`
  - [x] the default behaviour is a proof of user account
  - [x] add the `keyword` query parameter
  - [x] update the API doc
  - [x] add more tests

**to-do: front end**
- [x] update the API schema
- [x] update the the `<ProofOfVote>` component accordingly

### future

I'll rework the export proof API so that it can work with the keyword parameter. 

We may want to use a model to store the allowed keywords in the database. This will help to keep a list of the different kind of proof that have been issued, the administrators won't have to guess or to remind the keywords. We will also be able to activate / deactivate a specific kind of proof, as we may not want to issue a proof of participation to the research study about the browser extension in 2024 if the study ended in 2023. This will also make Tournesol more usable, as some proof of participation are very specific and shouldn't be commited or hard-coded if possible (like `research_study_2023_browser_ext`).

What do you think @amatissart ?