### PR TITLE
[infra] fix: VM provisioning

### DIFF
--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -23,7 +23,6 @@ all:
           django_email_backend: console
           django_enable_api_wikidata_migrations: true
           django_api_throttle_email: "5/min"
-          populate_django_db_from_public_dataset: true
           chrome_extension_id: iahbndmibajbfljmlaaaikgognekamno
 
           loki_version: "v2.2.1"
@@ -81,7 +80,6 @@ all:
           django_email_backend: smtp
           django_enable_api_wikidata_migrations: true
           django_api_throttle_email: "5/min"
-          populate_django_db_from_public_dataset: false
           chrome_extension_id: iahbndmibajbfljmlaaaikgognekamno
 
           loki_version: "v2.2.1"
@@ -146,7 +144,6 @@ all:
           django_email_backend: smtp
           django_enable_api_wikidata_migrations: true
           django_api_throttle_email: "12/min"
-          populate_django_db_from_public_dataset: false
           chrome_extension_id: nidimbejmadpggdgooppinedbggeacla
 
           loki_version: "v2.2.1"

--- a/infra/ansible/roles/django/handlers/main.yml
+++ b/infra/ansible/roles/django/handlers/main.yml
@@ -45,14 +45,6 @@
   become: true
   become_user: gunicorn
 
-- name: Populate Django DB from Public Dataset
-  shell:
-    cmd: cd /tmp && tar xvf /srv/tournesol-backend/scripts/dataset-import/dump-for-migrations-core-0004-tournesol-0007.sql.tgz && psql -1 -d tournesol < dump.sql && rm dump.sql
-    executable: /usr/bin/bash
-  become: yes
-  become_user: postgres
-  when: populate_django_db_from_public_dataset == True
-
 - name: Create Swagger UI OAuth application in Django database
   shell:
     cmd: now=$(date -I) && psql -d tournesol <<< "insert into oauth2_provider_application (client_id, redirect_uris, client_type, authorization_grant_type, client_secret, name, skip_authorization, algorithm, created, updated) values ('{{swagger_ui_oauth2_client_id}}', '{{api_scheme}}://{{api_domain_name}}/docs/', 'confidential', 'password', '{{swagger_ui_oauth2_client_secret}}','Swagger UI', true, 'RS256', '$now', '$now');"

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -45,7 +45,6 @@
     dest: /root/django_oidc_rsa_private_key
     mode: u=rw,g=,o=
   notify:
-    - Populate Django DB from Public Dataset
     - Create Swagger UI OAuth application in Django database
 
 - name: Copy Swagger UI OAuth client ID and secret

--- a/infra/ansible/roles/monitoring/handlers/main.yml
+++ b/infra/ansible/roles/monitoring/handlers/main.yml
@@ -65,3 +65,7 @@
     ds_type: "prometheus"
     ds_url: "http://127.0.0.1:9090"
     is_default: yes
+  register: prometheus_ds
+  retries: 3
+  delay: 10
+  until: prometheus_ds is not failed

--- a/infra/ansible/roles/monitoring/tasks/main.yml
+++ b/infra/ansible/roles/monitoring/tasks/main.yml
@@ -176,9 +176,16 @@
     repo: deb https://packages.grafana.com/oss/deb stable main
     state: present
 
+- name: Gather the package facts
+  package_facts:
+    manager: apt
+
 - name: Install Grafana
   apt:
-    name: grafana
+    # Install older version on provisioning, to workaround bug in
+    # on reset-admin-password in versions 9.3.x.
+    # See https://github.com/grafana/grafana/issues/59915
+    name: "{{ 'grafana' if 'grafana' in ansible_facts.packages else 'grafana=9.2.7' }}"
     install_recommends: no
     update_cache: yes
   notify:

--- a/infra/base-image/fetch-debian-image.sh
+++ b/infra/base-image/fetch-debian-image.sh
@@ -2,7 +2,7 @@
 
 set -Eeuxo pipefail
 
-DEBIAN_VERSION="11.2.0"
+DEBIAN_VERSION="11.6.0"
 CURRENT_DIR="$(realpath -e "$(dirname "$0")")"
 
 cd "$CURRENT_DIR"


### PR DESCRIPTION
* "Populate Django DB" task was broken now that the dev-env uses a public database embedeed in a Docker image, et no dump is available in the repository.  
I think it can be removed. If needed, the database can be populated by either loading a backup (that should be tested regularly anyway) or by using the management command "load_public_dataset".

* Workaround a bug in Granafa when initializing admin password

* Update Debian base image version