### PR TITLE
[infra] feat: keep backup of settings.yaml when it's updated by ansible

### DIFF
--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -37,6 +37,7 @@
   template:
     src: settings.yaml.j2
     dest: /etc/tournesol/settings.yaml
+    backup: true
   notify: Restart Gunicorn
 
 - name: Copy Django OIDC RSA private key


### PR DESCRIPTION
Related to #1239 

With this [`backup`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_module.html#parameter-backup) option, a backup file with timestamp will be writen when the settings file have changed, such as:  
`/etc/tournesol/settings.yaml.77910.2022-12-20@00:19:07~`