### PR TITLE
[infra] sec: do not make secrets readable by all users

### DIFF
--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -32,11 +32,17 @@
   file:
     path: /etc/tournesol
     state: directory
+    mode: 0750
+    owner: root
+    group: gunicorn
 
 - name: Copy Django settings
   template:
     src: settings.yaml.j2
     dest: /etc/tournesol/settings.yaml
+    mode: 0640
+    owner: root
+    group: gunicorn
     backup: true
   notify: Restart Gunicorn
 

--- a/infra/ansible/scripts/get-vm-secrets.sh
+++ b/infra/ansible/scripts/get-vm-secrets.sh
@@ -6,7 +6,7 @@ export VM_USER="${2:-"$USER"}"
 function get_settings_value() {
     local jq_filter=$1;
     ssh "$VM_USER@$VM_ADDR" -- \
-    'python3 -c '\''import yaml,json; print(json.dumps(yaml.safe_load(open("/etc/tournesol/settings.yaml"))))'\'' \
+    'sudo python3 -c '\''import yaml,json; print(json.dumps(yaml.safe_load(open("/etc/tournesol/settings.yaml"))))'\'' \
     | jq -r' "'$jq_filter | values'"
 }
 


### PR DESCRIPTION
The back end's secrets are currently readable by all regular users on the server, no admin privilege is required.

This includes sensitive secrets like the database password, the Django secret key, the OpenID Connect private key and more. It should be a good idea to restrict the access to these secrets only to `root` and `gunicorn` user. All other users don't need to have this knowledge.