### PR TITLE
[back] fix: disable the individual criteria scores in the export

### DIFF
--- a/backend/tournesol/tests/test_exports.py
+++ b/backend/tournesol/tests/test_exports.py
@@ -217,7 +217,7 @@ class ExportTest(TestCase):
                 root + "/README.txt",
                 root + "/comparisons.csv",
                 root + "/users.csv",
-                root + "/individual_criteria_scores.csv",
+                # root + "/individual_criteria_scores.csv",
             ]
             self.assertEqual(zip_file.namelist(), expected_files)
 
@@ -248,7 +248,7 @@ class ExportTest(TestCase):
                 user_row = user_rows[0]
                 self.assertEqual(user_row["trust_score"], "0.5844")
 
-    def test_all_exports_voting_rights(self):
+    def disabled_test_all_exports_voting_rights(self):
         self.assertEqual(ContributorRatingCriteriaScore.objects.count(), 0)
 
         last_user = UserFactory(username="z")

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -273,8 +273,10 @@ class ExportPublicAllView(APIView):
                 write_public_users_file(Poll.default_poll().name, output)
                 zip_file.writestr(f"{zip_root}/users.csv", output.getvalue())
 
-            with StringIO() as output:
-                write_individual_criteria_scores_file(Poll.default_poll().name, output)
-                zip_file.writestr(f"{zip_root}/individual_criteria_scores.csv", output.getvalue())
+        # Temporarily disable the construction of this file, as the underlying
+        # SQL query is too slow.
+        # with StringIO() as output:
+        #     write_individual_criteria_scores_file(Poll.default_poll().name, output)
+        #     zip_file.writestr(f"{zip_root}/individual_criteria_scores.csv", output.getvalue())
 
         return response


### PR DESCRIPTION
The SQL query takes too much time to run, leading to HTTP timeout when downloading the full dataset from the front end.