### PR TITLE
[back] feat: restore the individual scores export

### DIFF
--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -144,7 +144,7 @@ def get_individual_criteria_scores_data(poll_name: str) -> QuerySet:
 
         FROM core_user
 
-        LEFT OUTER JOIN tournesol_contributorrating
+        JOIN tournesol_contributorrating
           ON tournesol_contributorrating.user_id = core_user.id
 
         JOIN tournesol_poll
@@ -157,8 +157,7 @@ def get_individual_criteria_scores_data(poll_name: str) -> QuerySet:
           ON tournesol_contributorrating.id
            = tournesol_contributorratingcriteriascore.contributor_rating_id
 
-        WHERE core_user.is_active = true
-          AND tournesol_poll.name = %(poll_name)s
+        WHERE tournesol_poll.name = %(poll_name)s
           AND tournesol_contributorrating.is_public
 
         -- this query can be significantly faster by keeping only the username

--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -124,7 +124,7 @@ def get_individual_criteria_scores_data(poll_name: str) -> QuerySet:
     and return a non-evaluated Django `RawQuerySet`.
 
     An individual criteria score is a score computed by the algorithm for
-    a specific criterion, a specific entity and specific user:
+    a specific criterion, previously rated by a user for a specific entity.
 
         User X Entity X Computed criteria score
     """
@@ -132,18 +132,42 @@ def get_individual_criteria_scores_data(poll_name: str) -> QuerySet:
         ContributorRatingCriteriaScore,
     )
 
-    return (
-        ContributorRatingCriteriaScore
-        .objects
-        .select_related("contributor_rating")
-        .select_related("contributor_rating__poll")
-        .select_related("contributor_rating__user")
-        .select_related("contributor_rating__entity")
-        .filter(contributor_rating__poll__name=poll_name)
-        .filter(contributor_rating__is_public=True)
-        .order_by(
-            "contributor_rating__user__username",
-            "contributor_rating__entity__uid",
-            "criteria",
-        )
+    return ContributorRatingCriteriaScore.objects.raw(
+        """
+        SELECT
+            tournesol_contributorratingcriteriascore.id,
+            core_user.username,
+            tournesol_entity.uid,
+            tournesol_contributorratingcriteriascore.criteria,
+            tournesol_contributorratingcriteriascore.score,
+            tournesol_contributorratingcriteriascore.voting_right
+
+        FROM core_user
+
+        LEFT OUTER JOIN tournesol_contributorrating
+          ON tournesol_contributorrating.user_id = core_user.id
+
+        JOIN tournesol_poll
+          ON tournesol_poll.id = tournesol_contributorrating.poll_id
+
+        JOIN tournesol_entity
+          ON tournesol_entity.id = tournesol_contributorrating.entity_id
+
+        JOIN tournesol_contributorratingcriteriascore
+          ON tournesol_contributorrating.id
+           = tournesol_contributorratingcriteriascore.contributor_rating_id
+
+        WHERE core_user.is_active = true
+          AND tournesol_poll.name = %(poll_name)s
+          AND tournesol_contributorrating.is_public
+
+        -- this query can be significantly faster by keeping only the username
+        -- in the ORDER BY clause
+
+        ORDER BY
+            core_user.username ASC,
+            tournesol_entity.uid ASC,
+            tournesol_contributorratingcriteriascore.criteria ASC
+        """,
+        {"poll_name": poll_name},
     )

--- a/backend/tournesol/resources/export_readme.txt
+++ b/backend/tournesol/resources/export_readme.txt
@@ -20,21 +20,21 @@ comparisons.csv
 
 Type: algorithm input.
 
-This file contains all the public comparisons made users. A comparison is
-represented by a rating given by a user for a specific criteria and a couple
-of videos.
+This file contains all the public comparisons made by users. A comparison is
+represented by a rating given by a user for a specific criteria and a pair of
+videos.
 
 users.csv
 ---------
 
 Type: algorithm input.
 
-This file contains the list of the users who appear in comparisons.csv.
+This file contains the list of users who appear in the comparisons.csv file.
 
     trust score:
 
-    The trust score represents how much the algorithm trust the user is a
-    human with an authentic behavior, using a single account on the platform.
+    The trust score represents how confident the algorithm is that the user is
+    a human with an authentic behavior, using a single account on the platform.
 
     This score is calculated from the user's email address (trusted domain or
     not) and from the others users who vouched for them.

--- a/backend/tournesol/tests/test_exports.py
+++ b/backend/tournesol/tests/test_exports.py
@@ -217,7 +217,7 @@ class ExportTest(TestCase):
                 root + "/README.txt",
                 root + "/comparisons.csv",
                 root + "/users.csv",
-                # root + "/individual_criteria_scores.csv",
+                root + "/individual_criteria_scores.csv",
             ]
             self.assertEqual(zip_file.namelist(), expected_files)
 
@@ -248,7 +248,7 @@ class ExportTest(TestCase):
                 user_row = user_rows[0]
                 self.assertEqual(user_row["trust_score"], "0.5844")
 
-    def disabled_test_all_exports_voting_rights(self):
+    def test_all_exports_voting_rights(self):
         self.assertEqual(ContributorRatingCriteriaScore.objects.count(), 0)
 
         last_user = UserFactory(username="z")

--- a/backend/tournesol/views/exports.py
+++ b/backend/tournesol/views/exports.py
@@ -116,21 +116,17 @@ def write_individual_criteria_scores_file(poll_name: str, write_target) -> None:
         "voting_right",
     ]
 
-    contributor_rating_criteria_scores = (
-        get_individual_criteria_scores_data(poll_name).iterator()
-    )
+    criteria_scores = get_individual_criteria_scores_data(poll_name).iterator()
 
     rows = (
         {
-            "public_username": contributor_rating_criteria_score.contributor_rating.user.username,
-            "video": (
-                contributor_rating_criteria_score.contributor_rating.entity.metadata["video_id"]
-            ),
-            "criteria": contributor_rating_criteria_score.criteria,
-            "score": contributor_rating_criteria_score.score,
-            "voting_right": contributor_rating_criteria_score.voting_right,
+            "public_username": criteria_score.username,
+            "video": criteria_score.uid.split(UID_DELIMITER)[1],
+            "criteria": criteria_score.criteria,
+            "score": criteria_score.score,
+            "voting_right": criteria_score.voting_right,
         }
-        for contributor_rating_criteria_score in contributor_rating_criteria_scores
+        for criteria_score in criteria_scores
     )
 
     writer = csv.DictWriter(write_target, fieldnames=fieldnames)
@@ -273,10 +269,8 @@ class ExportPublicAllView(APIView):
                 write_public_users_file(Poll.default_poll().name, output)
                 zip_file.writestr(f"{zip_root}/users.csv", output.getvalue())
 
-        # Temporarily disable the construction of this file, as the underlying
-        # SQL query is too slow.
-        # with StringIO() as output:
-        #     write_individual_criteria_scores_file(Poll.default_poll().name, output)
-        #     zip_file.writestr(f"{zip_root}/individual_criteria_scores.csv", output.getvalue())
+            with StringIO() as output:
+                write_individual_criteria_scores_file(Poll.default_poll().name, output)
+                zip_file.writestr(f"{zip_root}/individual_criteria_scores.csv", output.getvalue())
 
         return response


### PR DESCRIPTION
I manually re-wrote the SQL query to have more control on it.

Now only the required columns are fetched from the database, which significantly reduce the amount of data read from the disk. The previous query used to fetch all columns of all involved tables (including hashed passwords) even if there were not used by the view.

The cost of this new query (in PostgreSQL arbitrary unit) is `48,233.24` contrary to the previous one which was `111,985.19`. The execution time is more than three time faster and could be even further reduced by sorting the results only by usernames (which can greatly increase the sorting effort required by people using our dataset).

Finally the view doesn't go from one table to another using the ORM, preventing any unexpected additional database queries.