### PR TITLE
[infra] fix: exclude requests to grafana to compute 95th percentile in alert definition

### DIFF
--- a/infra/ansible/roles/logging/templates/alerting-dashboard.json.j2
+++ b/infra/ansible/roles/logging/templates/alerting-dashboard.json.j2
@@ -153,7 +153,7 @@
       "pluginVersion": "8.1.2",
       "targets": [
         {
-          "expr": "quantile_over_time(0.95,{filename=\"/var/log/nginx/json_access.log\", host=\"localhost\"} | json | unwrap request_time |  __error__=\"\"  [30s]) by (host)",
+          "expr": "quantile_over_time(0.95,{filename=\"/var/log/nginx/json_access.log\", host=\"localhost\"} | json | unwrap request_time |  __error__=\"\" | http_host!=\"{{ grafana_domain_name }}\"  [30s]) by (host)",
           "legendFormat": "95th percentile",
           "refId": "A"
         }


### PR DESCRIPTION
False alerts could be triggered about the server latency, due to Grafana using long pending requests to fetch live data in some dashboards.

This is especially unfortunate to see these alerts when we are debugging unrelated errors on Grafana. So this change should reduce the noise and confusion.

