### PR TITLE
[infra] fix: ensure that discord alert script runs with necessary permissions in Systemd services

### DIFF
--- a/infra/ansible/roles/postgresql/templates/pg-backups.service.j2
+++ b/infra/ansible/roles/postgresql/templates/pg-backups.service.j2
@@ -6,4 +6,6 @@ Type=oneshot
 User=postgres
 Group=postgres
 ExecStart=/usr/local/bin/pg_backup_rotated.sh -c /etc/postgresql/pg_backup.config
-ExecStopPost=/usr/bin/bash -c "if [ "$$EXIT_STATUS" != 0 ]; then /usr/local/bin/post-on-discord.sh -c infra_alert -m 'Postgres backup failed for {{domain_name}}'; fi"
+# The user "postgres" doesn't have permissions to run "post-on-discord" (relying on Django).
+# Hence the "!" prefix to run the command with elevated privileges.
+ExecStopPost=!/usr/bin/bash -c "if [ "$$EXIT_STATUS" != 0 ]; then /usr/local/bin/post-on-discord.sh -c infra_alert -m 'Postgres backup failed for {{domain_name}}'; fi"


### PR DESCRIPTION
When introducing `post-on-discord.sh`  in #979, the script permissions have been restricted as it requires to be run in the Django virtualenv. 

One of the services relying on this script does not use the user "root" or "gunicorn" and needs extra permissions to trigger the alert (when the service fails).