### PR TITLE
[back] feat: enable non-strict option in unconnected entities API route

### DIFF
--- a/backend/tournesol/views/unconnected_entities.py
+++ b/backend/tournesol/views/unconnected_entities.py
@@ -92,6 +92,7 @@ class UnconnectedEntitiesView(PollScopedViewMixin, generics.ListAPIView):
         sorted_entity_ids = sorted(
             entity_ids,
             # Sorting first by distance and secondly by number of comparisons
-            key=lambda x: (-distances.get(x, math.inf), len(neighbors.get(x, [])))
+            # and thirdly by entity_id such that we avoid non-determinism
+            key=lambda x: (-distances.get(x, math.inf), len(neighbors.get(x, [])), x)
         )
         return sorted_entity_ids

--- a/backend/tournesol/views/unconnected_entities.py
+++ b/backend/tournesol/views/unconnected_entities.py
@@ -91,7 +91,9 @@ class UnconnectedEntitiesView(PollScopedViewMixin, generics.ListAPIView):
         # True (the default). Otherwise all the entities except the source are
         # selected.
         strict = self.request.query_params.get("strict") != "false"
-        entity_ids = set(neighbors) - (set(distances) if strict else {source_node.id})
+        entity_ids = set(e_id for e_id in neighbors if (
+            (e_id not in distances) if strict else (distances.get(e_id, 2) > 1)
+        ))
         sorted_entity_ids = sorted(
             entity_ids,
             # Sorting first by distance and secondly by number of comparisons

--- a/backend/tournesol/views/unconnected_entities.py
+++ b/backend/tournesol/views/unconnected_entities.py
@@ -19,7 +19,7 @@ from tournesol.views.mixins.poll import PollScopedViewMixin
 # We override the pagination filtering for our queryset for performance reasons. We decided to
 # already filter and sort the queryset in python directly because the annotation and sorting
 # operations were inneficient when done on the database.
-class AlreadyFilteredQuerySetLimitOffsetPagination(LimitOffsetPagination):
+class SortedEntityIdLimitOffsetPagination(LimitOffsetPagination):
 
     hacked_count_updated_by_view = -1
 
@@ -63,7 +63,7 @@ class UnconnectedEntitiesView(PollScopedViewMixin, generics.ListAPIView):
 
     serializer_class = EntityNoExtraFieldSerializer
     permission_classes = [IsAuthenticated]
-    pagination_class = AlreadyFilteredQuerySetLimitOffsetPagination
+    pagination_class = SortedEntityIdLimitOffsetPagination
 
     def get_queryset(self):
         # Get related entities from source entity

--- a/backend/tournesol/views/unconnected_entities.py
+++ b/backend/tournesol/views/unconnected_entities.py
@@ -21,8 +21,6 @@ from tournesol.views.mixins.poll import PollScopedViewMixin
 # operations were inneficient when done on the database.
 class SortedEntityIdLimitOffsetPagination(LimitOffsetPagination):
 
-    hacked_count_updated_by_view = -1
-
     def paginate_queryset(self, queryset, request, view=None):
         # Here the parameter queryset is instead the list of ids returned by
         # UnconnectedEntitiesView.get_queryset. This is done this way for performance.
@@ -30,9 +28,6 @@ class SortedEntityIdLimitOffsetPagination(LimitOffsetPagination):
         entity_by_id = {e.id: e for e in Entity.objects.filter(id__in=paginated_entity_ids)}
         entities = [entity_by_id[e_id] for e_id in queryset if e_id in entity_by_id]
         return entities
-
-    def get_count(self, queryset):
-        return self.hacked_count_updated_by_view
 
 
 @extend_schema_view(
@@ -99,5 +94,4 @@ class UnconnectedEntitiesView(PollScopedViewMixin, generics.ListAPIView):
             # Sorting first by distance and secondly by number of comparisons
             key=lambda x: (-distances.get(x, math.inf), len(neighbors.get(x, [])))
         )
-        self.paginator.hacked_count_updated_by_view = len(sorted_entity_ids)
         return sorted_entity_ids


### PR DESCRIPTION
This is a first step for #1247. Next step would be to use this option in the frontend entity selector, but I prefer making this change once the backend route is approved. 