### PR TITLE
[back] fix: support january in get_top_public_contributors_last_month

### DIFF
--- a/backend/tournesol/utils/contributors.py
+++ b/backend/tournesol/utils/contributors.py
@@ -1,6 +1,7 @@
 """
 Shortcut functions related to the contributors.
 """
+from datetime import timedelta
 
 from django.db.models.query import RawQuerySet
 from django.utils import timezone
@@ -16,13 +17,9 @@ def get_top_public_contributors_last_month(
 
     See: `get_top_public_contributors`.
     """
-    now = timezone.now()
-
-    last_month = now.month - 1
-    year = now.year
-
-    if last_month == 12:
-        year -= 1
+    last_month_dt = timezone.now().replace(day=1) - timedelta(days=1)
+    last_month = last_month_dt.month
+    year = last_month_dt.year
 
     return get_top_public_contributors(poll_name, year, last_month, top)
 


### PR DESCRIPTION
Months and years were not correctly handled and failed now that we are in January :) Tests luckily caught it.