### PR TITLE
[front] fix: disable pointer events on slider rails on touchscreens

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,6 +55,10 @@ html.embedded .SnackbarContainer-root.belowTopBar {
   }
   .MuiSlider-root .MuiSlider-thumb {
     pointer-events: auto;
+    /* `touch-action: none` is used internally by MUI on Slider to disable
+    scrolling and zooming on touch events. But it conflicts with
+    `pointer-events: none` on Firefox. So it's required here too. */
+    touch-action: none;
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -45,4 +45,17 @@ html.embedded .SnackbarContainer-root.belowTopBar {
   top: 4px;
 }
 
+
+/* pkg: @mui/material */
+@media (pointer: coarse) {
+  /* On touch screens, disable touch events on the slider rail.
+     Only the slider "thumb" will remain interactive. */
+  .MuiSlider-root {
+    pointer-events: none;
+  }
+  .MuiSlider-root .MuiSlider-thumb {
+    pointer-events: auto;
+  }
+}
+
 /* -- end: third-party packages customization -- */


### PR DESCRIPTION
Following the discussion in #1240, I realized this could be a quick fix, before the future comparison redesign on mobile (#1274)

This change would make the slider handle the only interactive part on sliders when using a touch screen (or any pointing device of limited accuracy covered by `pointer: coarse`).

Note that you need to emulate a mobile device to test this change on a desktop browser.

[Capture vidéo du 2023-01-07 11-42-52.webm](https://user-images.githubusercontent.com/4726554/211146921-7d9335d5-91d5-4043-b234-3111e34ed484.webm)



