### PR TITLE
[dev-env] fix: postgres container could be healthy before the database is ready

### DIFF
--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     healthcheck:
-      test: pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB
+      test: pg_isready -U $$POSTGRES_USER && psql -U $$POSTGRES_USER -d $$POSTGRES_DB -c "select 1"
       interval: 10s
       timeout: 5s
       retries: 5

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     healthcheck:
-      test: pg_isready -U $$POSTGRES_USER && psql -U $$POSTGRES_USER -d $$POSTGRES_DB -c "select 1"
+      test: psql -h localhost -U $$POSTGRES_USER -d $$POSTGRES_DB -c "select 1"
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
`pg_isready` is not enough to check that the "database" itself has been created and is ready:
https://dba.stackexchange.com/a/298647