### PR TITLE
[infra] fix: update the grafana rapository URL

### DIFF
--- a/infra/ansible/roles/monitoring/tasks/main.yml
+++ b/infra/ansible/roles/monitoring/tasks/main.yml
@@ -168,12 +168,12 @@
 
 - name: Add Grafana repository signing key
   apt_key:
-    url: https://packages.grafana.com/gpg.key
+    url: https://apt.grafana.com/gpg.key
     state: present
 
 - name: Add Grafana repository
   apt_repository:
-    repo: deb https://packages.grafana.com/oss/deb stable main
+    repo: deb https://apt.grafana.com stable main
     state: present
 
 - name: Gather the package facts


### PR DESCRIPTION
The Grafana packages are served from a different apt repository and our Ansible configuration must be updated. See the note in the [grafana documentation](https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/#repository-migration-november-8th-2022).

After this change is merged, and before deploying on your local VM,  the previous Grafana apt repository configuration must be manually removed from `/etc/apt/sources.list.d/`. The staging and production servers are already updated.