### PR TITLE
[front] fix: use Playlist YouTube instead of YT Playlist in french

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -125,6 +125,8 @@
     "getRecommendations": "Get Recommendations",
     "chromeExtension": "Chrome Extension",
     "firefoxExtension": "Firefox Extension",
+    "youtubePlaylistEn": "YouTube Playlist EN",
+    "youtubePlaylistFr": "YouTube Playlist FR",
     "followUs": "Follow Us",
     "supportUs": "Support Us",
     "directTransfer": "Direct transfer",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -130,6 +130,8 @@
     "getRecommendations": "Recommandations",
     "chromeExtension": "Extension Chrome",
     "firefoxExtension": "Extension Firefox",
+    "youtubePlaylistEn": "Playlist YouTube EN",
+    "youtubePlaylistFr": "Playlist YouTube FR",
     "followUs": "Suivez-nous",
     "supportUs": "Nous soutenir",
     "directTransfer": "Virement direct",

--- a/frontend/src/features/frame/components/footer/Footer.tsx
+++ b/frontend/src/features/frame/components/footer/Footer.tsx
@@ -44,8 +44,8 @@ const Footer = () => {
         },
         { name: 'Twitter Bot EN', to: twitterTournesolBotEnUrl },
         { name: 'Twitter Bot FR', to: twitterTournesolBotFrUrl },
-        { name: 'YouTube Playlist EN', to: youtubePlaylistEnUrl },
-        { name: 'YouTube Playlist FR', to: youtubePlaylistFrUrl },
+        { name: t('footer.youtubePlaylistEn'), to: youtubePlaylistEnUrl },
+        { name: t('footer.youtubePlaylistFr'), to: youtubePlaylistFrUrl },
       ],
     },
     {


### PR DESCRIPTION
This PR changes `YouTube Playlist` for `Playlist YouTube` in the french translation. It sounds more natural to have the main noun first in a mot-valise.

We can also think about the `Twitter Bot`. Should we use `Bot Twitter` in french? In my personal opinion yes, to be coherent with the YouTube Playlist. The contraction `Bot` (from the French and English robot) being more common than `agent` or `robogiciel` I think `Bot Twitter` is an acceptable translation.