### PR TITLE
[front] feat: add a funding section on the home page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -469,6 +469,14 @@
     "contribute": "Contribute",
     "theSimpliestWayToContribute": "The simplest way to contribute to Tournesol is to compare videos. What content would you like YouTube to recommend to your friends and family?"
   },
+  "fundingSection": {
+    "supportUs": "Support Us!",
+    "tournesolExistsThanksToYourInvolvment": "Tournesol exists thanks to your involvment. By financing Tournesol you...",
+    "guaranteeTheProjectsIndependence": "<0>guarantee</0> the project's independance",
+    "participateInTheCreationOfCommons": "<0>participate</0> in the creation of commons",
+    "actForTheEthicsOfInformation": "<0>act</0> for the ethics of information",
+    "iSupport": "I support"
+  },
   "homeComparison": {
     "sorryTheComparisonIsTemporarilyUnavailable": "Sorry, the comparison of video is temporarily unavailable. Please try again later.",
     "compareTheVideos": "Compare the videos"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -471,7 +471,7 @@
   },
   "fundingSection": {
     "supportUs": "Support Us!",
-    "tournesolExistsThanksToYourInvolvment": "Tournesol exists thanks to your involvment. By financing Tournesol you...",
+    "tournesolExistsThanksToYourInvolvement": "Tournesol exists thanks to your involvement. By financing Tournesol you...",
     "guaranteeTheProjectsIndependence": "<0>guarantee</0> the project's independance",
     "participateInTheCreationOfCommons": "<0>participate</0> in the creation of commons",
     "actForTheEthicsOfInformation": "<0>act</0> for the ethics of information",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -475,6 +475,14 @@
     "contribute": "Contribuer",
     "theSimpliestWayToContribute": "Le moyen le plus simple de contribuer à Tournesol est de comparer des vidéos. Quel contenu voudriez-vous que YouTube recommande à vos proches ?"
   },
+  "fundingSection": {
+    "supportUs": "Soutenez-nous !",
+    "tournesolExistsThanksToYourInvolvment": "Tournesol existe grâce à votre implication. En finançant Tournesol vous...",
+    "guaranteeTheProjectsIndependence": "<0>garantissez</0> l'indépendance du projet",
+    "participateInTheCreationOfCommons": "<0>participez</0> à la création de biens communs",
+    "actForTheEthicsOfInformation": "<0>agissez</0> pour l'éthique de l'information",
+    "iSupport": "Je soutiens"
+  },
   "homeComparison": {
     "sorryTheComparisonIsTemporarilyUnavailable": "Désolé, la comparaison de vidéo est momentanément indisponible. Veuillez réessayer plus tard.",
     "compareTheVideos": "Comparer les vidéos"

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -477,7 +477,7 @@
   },
   "fundingSection": {
     "supportUs": "Soutenez-nous !",
-    "tournesolExistsThanksToYourInvolvment": "Tournesol existe grâce à votre implication. En finançant Tournesol vous...",
+    "tournesolExistsThanksToYourInvolvement": "Tournesol existe grâce à votre implication. En finançant Tournesol vous...",
     "guaranteeTheProjectsIndependence": "<0>garantissez</0> l'indépendance du projet",
     "participateInTheCreationOfCommons": "<0>participez</0> à la création de biens communs",
     "actForTheEthicsOfInformation": "<0>agissez</0> pour l'éthique de l'information",

--- a/frontend/src/pages/home/videos/HomeVideos.tsx
+++ b/frontend/src/pages/home/videos/HomeVideos.tsx
@@ -10,6 +10,7 @@ import { useCurrentPoll, useLoginState, useNotifications } from 'src/hooks';
 import TitleSection from 'src/pages/home/TitleSection';
 import PollListSection from 'src/pages/home/PollListSection';
 import ComparisonSection from 'src/pages/home/videos/sections/ComparisonSection';
+import FundingSection from 'src/pages/home/videos/sections/FundingSection';
 import RecommendationsSection from 'src/pages/home/videos/sections/recommendations/RecommendationsSection';
 import ResearchSection from 'src/pages/home/videos/sections/research/ResearchSection';
 import { DEFAULT_POLL_STATS, getPollStats } from 'src/utils/api/stats';
@@ -135,6 +136,9 @@ const HomeVideosPage = () => {
               lastMonthComparedEntityCount: stats.lastMonthComparedEntityCount,
             }}
           />
+        </Grid2>
+        <Grid2 sx={homeSectionSx}>
+          <FundingSection />
         </Grid2>
         <Grid2 sx={homeSectionSx}>
           <ResearchSection />

--- a/frontend/src/pages/home/videos/sections/FundingSection.tsx
+++ b/frontend/src/pages/home/videos/sections/FundingSection.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+import { Box, Button, Paper, Typography, useTheme } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
+import { VolunteerActivism } from '@mui/icons-material';
+
+import SectionTitle from './SectionTitle';
+
+const FundingSection = () => {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  const motivationSx = {
+    '& span': {
+      color: theme.palette.primary.main,
+      textTransform: 'uppercase',
+    },
+  };
+
+  return (
+    <>
+      <SectionTitle title={t('fundingSection.supportUs')} />
+      <Box display="flex" justifyContent="center" mb={6}>
+        <Box sx={{ width: { lg: '44%', xl: '44%' } }}>
+          <Typography variant="h3" textAlign="center" letterSpacing="0.8px">
+            {t('fundingSection.tournesolExistsThanksToYourInvolvment')}
+          </Typography>
+        </Box>
+      </Box>
+      <Grid2 container spacing={4} justifyContent="center">
+        <Grid2 sm={12} md={4} lg={4} xl={3}>
+          <Paper elevation={0}>
+            <Box
+              p={2}
+              height="110px"
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              color="#fff"
+              bgcolor="#1282B2"
+              borderRadius={1}
+            >
+              <Typography
+                m={0}
+                variant="h4"
+                textAlign="center"
+                sx={motivationSx}
+              >
+                <Trans i18nKey="fundingSection.guaranteeTheProjectsIndependence">
+                  <span>guarantee</span> the project&apos;s independance
+                </Trans>
+              </Typography>
+            </Box>
+          </Paper>
+        </Grid2>
+        <Grid2 sm={12} md={4} lg={4} xl={3}>
+          <Paper elevation={0}>
+            <Box
+              p={2}
+              height="110px"
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              color="#fff"
+              bgcolor="#1282B2"
+              borderRadius={1}
+            >
+              <Typography
+                m={0}
+                variant="h4"
+                textAlign="center"
+                sx={motivationSx}
+              >
+                <Trans i18nKey="fundingSection.participateInTheCreationOfCommons">
+                  <span>participate</span> in the creation of commons
+                </Trans>
+              </Typography>
+            </Box>
+          </Paper>
+        </Grid2>
+        <Grid2 sm={12} md={4} lg={4} xl={3}>
+          <Paper elevation={0}>
+            <Box
+              p={2}
+              height="110px"
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              color="#fff"
+              bgcolor="#1282B2"
+              borderRadius={1}
+            >
+              <Typography
+                m={0}
+                variant="h4"
+                textAlign="center"
+                sx={motivationSx}
+              >
+                <Trans i18nKey="fundingSection.actForTheEthicsOfInformation">
+                  <span>act</span> for the ethics of information
+                </Trans>
+              </Typography>
+            </Box>
+          </Paper>
+        </Grid2>
+        <Grid2 xs={9} display="flex" justifyContent="center">
+          <Button
+            variant="contained"
+            size="large"
+            component={Link}
+            to="/donate"
+            endIcon={<VolunteerActivism />}
+          >
+            {t('fundingSection.iSupport')}
+          </Button>
+        </Grid2>
+      </Grid2>
+    </>
+  );
+};
+
+export default FundingSection;

--- a/frontend/src/pages/home/videos/sections/FundingSection.tsx
+++ b/frontend/src/pages/home/videos/sections/FundingSection.tsx
@@ -25,7 +25,7 @@ const FundingSection = () => {
       <Box display="flex" justifyContent="center" mb={6}>
         <Box sx={{ width: { lg: '44%', xl: '44%' } }}>
           <Typography variant="h3" textAlign="center" letterSpacing="0.8px">
-            {t('fundingSection.tournesolExistsThanksToYourInvolvment')}
+            {t('fundingSection.tournesolExistsThanksToYourInvolvement')}
           </Typography>
         </Box>
       </Box>


### PR DESCRIPTION
**related to** https://github.com/tournesol-app/tournesol/issues/1168

**based on the PR** https://github.com/tournesol-app/tournesol/pull/1287

---

This PR adds a funding section on the home page.

This funding section has been designed to be straightforward: it doesn't explain what we do with the funds (could be the responsibility of the donate page), but it explain why people should give.

**Questions**

**(a)** I'm not sure if `commons` is an acceptable translation for the french `biens communs`. In this PR I use `commons` in it's economical definition, not philosophical, even if both seem to work.

**to-do**

- [x] factorize the CSS code applied to <span>
- [x] increase the font size of the yellow verb 
- [x] make the I support button bigger

### details

fr

![cap](https://user-images.githubusercontent.com/39056254/213674855-907db0d1-c115-4480-9164-653b3aa5ff15.png)

en

![capture](https://user-images.githubusercontent.com/39056254/213674873-238765a2-2186-4738-8bdf-d4ce54251550.png)

### preview

![screencapture-localhost-3000-2023-01-20-11_35_09](https://user-images.githubusercontent.com/39056254/213675075-a75f8f99-3b82-4ca8-9d08-2a6f22fdb9b9.png)
