### PR TITLE
ml: update alpha and poll scaling to smoothen individual scores distribution

### DIFF
--- a/backend/ml/mehestan/global_scores.py
+++ b/backend/ml/mehestan/global_scores.py
@@ -312,7 +312,9 @@ def compute_scaled_scores(
 
 def get_global_scores(scaled_scores: pd.DataFrame):
     if len(scaled_scores) == 0:
-        return pd.DataFrame(columns=["entity_id", "score", "uncertainty", "deviation"])
+        return pd.DataFrame(
+            columns=["entity_id", "score", "uncertainty", "deviation", "n_contributors"]
+        )
 
     global_scores = {}
     for (entity_id, scores) in scaled_scores.groupby("entity_id"):
@@ -326,10 +328,8 @@ def get_global_scores(scaled_scores: pd.DataFrame):
             "score": rho,
             "uncertainty": rho_uncertainty,
             "deviation": rho_deviation,
+            "n_contributors": len(scores),
         }
-
-    if len(global_scores) == 0:
-        return pd.DataFrame(columns=["entity_id", "score", "uncertainty", "deviation"])
 
     result = pd.DataFrame.from_dict(global_scores, orient="index")
     result.index.name = "entity_id"

--- a/backend/ml/mehestan/individual.py
+++ b/backend/ml/mehestan/individual.py
@@ -4,7 +4,7 @@ import pandas as pd
 from tournesol.utils.constants import COMPARISON_MAX
 
 R_MAX = COMPARISON_MAX  # Maximum score for a comparison in the input
-ALPHA = 0.01  # Signal-to-noise hyperparameter
+ALPHA = 1.0  # Signal-to-noise hyperparameter
 
 
 def compute_individual_score(scores: pd.DataFrame):

--- a/backend/tournesol/management/commands/sync_yt_playlists.py
+++ b/backend/tournesol/management/commands/sync_yt_playlists.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
             metadata__publication_date__gte=time_ago(days=60).isoformat(),
             metadata__language=language,
             tournesol_score__gt=20,
-            rating_n_contributors__gte=2,
+            rating_n_contributors__gte=3,
         ).order_by("tournesol_score")
 
     def get_existing_items(self, yt_client, playlist_id):

--- a/backend/tournesol/management/commands/sync_yt_playlists.py
+++ b/backend/tournesol/management/commands/sync_yt_playlists.py
@@ -30,6 +30,7 @@ class Command(BaseCommand):
             metadata__publication_date__gte=time_ago(days=60).isoformat(),
             metadata__language=language,
             tournesol_score__gt=20,
+            rating_n_contributors__gte=2,
         ).order_by("tournesol_score")
 
     def get_existing_items(self, yt_client, playlist_id):

--- a/backend/tournesol/tests/test_ml_run.py
+++ b/backend/tournesol/tests/test_ml_run.py
@@ -173,8 +173,8 @@ class TestMlTrain(TransactionTestCase):
         call_command("ml_train")
         video1.refresh_from_db()
         video2.refresh_from_db()
-        self.assertAlmostEqual(video1.tournesol_score, -50.6, places=1)
-        self.assertAlmostEqual(video2.tournesol_score, 50.6, places=1)
+        self.assertAlmostEqual(video1.tournesol_score, -44.0, places=1)
+        self.assertAlmostEqual(video2.tournesol_score, 44.0, places=1)
         # Asserts that voting rights have been given the correct values based on the number of
         # contributors and their verified status
         # 0.4 = 0.8 [verified] * 0.5 [privacy penalty]
@@ -209,12 +209,15 @@ class TestMlTrain(TransactionTestCase):
         )
 
         # Reduce uncertainty on user1 scores by creating additional comparisons
-        ComparisonCriteriaScoreFactory.create_batch(
-            10,
-            comparison__user=user1,
-            score=0,
-            criteria="largely_recommended",
-        )
+        additional_videos = VideoFactory.create_batch(6)
+        for (vid_a, vid_b) in zip(additional_videos, additional_videos[1:]):
+            ComparisonCriteriaScoreFactory(
+                comparison__entity_1=vid_a,
+                comparison__entity_2=vid_b,
+                comparison__user=user1,
+                score=1,
+                criteria="largely_recommended",
+            )
 
         self.assertEqual(video1.tournesol_score, None)
         self.assertEqual(video2.tournesol_score, None)
@@ -222,8 +225,8 @@ class TestMlTrain(TransactionTestCase):
         video1.refresh_from_db()
         video2.refresh_from_db()
 
-        self.assertAlmostEqual(video1.tournesol_score, 57.4, places=1)
-        self.assertAlmostEqual(video2.tournesol_score, -57.4, places=1)
+        self.assertAlmostEqual(video1.tournesol_score, 8.8, places=1)
+        self.assertAlmostEqual(video2.tournesol_score, -8.8, places=1)
 
 
     def test_tournesol_scores_different_privacy_status(self):
@@ -260,5 +263,5 @@ class TestMlTrain(TransactionTestCase):
         video1.refresh_from_db()
         video2.refresh_from_db()
 
-        self.assertAlmostEqual(video1.tournesol_score, 50.6, places=1)
-        self.assertAlmostEqual(video2.tournesol_score, -50.6, places=1)
+        self.assertAlmostEqual(video1.tournesol_score, 44.0, places=1)
+        self.assertAlmostEqual(video2.tournesol_score, -44.0, places=1)

--- a/backend/tournesol/tests/test_sync_yt_playlists.py
+++ b/backend/tournesol/tests/test_sync_yt_playlists.py
@@ -38,6 +38,7 @@ class SyncYtPlaylistsCommandTest(TestCase):
         video = VideoFactory.create_batch(
             3,
             tournesol_score=100,
+            rating_n_contributors=3,
             metadata__language="en",
             metadata__publication_date=date.today().isoformat(),
         )
@@ -45,6 +46,7 @@ class SyncYtPlaylistsCommandTest(TestCase):
         # Set up 1 video that should NOT be inserted into the playlist
         VideoFactory(
             tournesol_score=-10,
+            rating_n_contributors=3,
             metadata__language="en",
             metadata__publication_date=date.today().isoformat(),
         )


### PR DESCRIPTION
## Modifications

* Alpha: 0.01 --> 1.0
* New poll scaling: (the sigmoid shape is unchanged)
  **Before** : Tournesol score 50 is the top 1% of rated videos
 **After** : Tournesol score 25 is the top 25% of videos rated by at least 4 contributors


## Impact on scaled individual scores

### Before
![ref_0 01_indiv](https://user-images.githubusercontent.com/4726554/214384068-899ac219-5665-468f-90f2-6742cb3018e7.png)

### After
![1 0_indiv](https://user-images.githubusercontent.com/4726554/214384145-a732ed66-cc9f-460c-87ed-58a26985f6ca.png)


## Impact on Tournesol scores

`sum_overall_contrib_comparisons` is the total number comparisons made by all users who contributed to a given video

### Before
![ref_0 01_global](https://user-images.githubusercontent.com/4726554/214384253-132120bf-a58d-474e-b265-fddbc5685c53.png)

### After
![1 0_global](https://user-images.githubusercontent.com/4726554/214385975-fff74746-0ccd-4a2c-ac0a-88293beb0475.png)

This PR should close #1065 
