### PR TITLE
Improve "email considered trusted" wording

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -227,7 +227,7 @@
     "language": "Language",
     "scoreMode": {
       "default": {
-        "description": "More importance is given to accounts associated with a trusted email address",
+        "description": "More importance is given to accounts associated with an email address considered trusted",
         "label": "Default"
       },
       "allEqual": {
@@ -235,7 +235,7 @@
         "label": "All equal"
       },
       "trustedOnly": {
-        "description": "Only accounts associated with <2>a trusted email address</2> are considered",
+        "description": "Only accounts associated with <2>an email address considered trusted</2> are taken into account",
         "label": "Trusted only"
       }
     },
@@ -276,7 +276,7 @@
     "emailStatus": "Email status",
     "emailTrusted": "Trusted",
     "emailNonTrusted": "Non-trusted",
-    "learnMoreAboutTrustedDomains": "Learn more about trusted domains",
+    "learnMoreAboutTrustedDomains": "Learn more about domains which are considered trusted",
     "verificationEmailSentNewEmail": "A verification email has been sent to confirm your new email address.",
     "currentEmailAddressIs": "Your current email address is",
     "newEmailAddress": "New email address",
@@ -360,11 +360,11 @@
     "publicDatabase": "Public Database",
     "publicDatabaseDetailAndLicense": "Contributors on Tournesol can decide to make their data public. We hope this important data will prove useful for researchers on ethics of algorithms and large scale recommender systems. Our public database can be downloaded by clicking the button below and is published under <2>Open Data Commons Attribution License (ODC-By)</2>.",
     "publicDatabaseThanksToContributors": "Finally, we would like to thank all the contributors who compared videos on Tournesol. We count so far about {{userCount}} users who compared {{comparisonCount}} times more than {{comparedEntityCount}} videos.",
-    "trustedEmailDomains": "Trusted email domains",
+    "trustedEmailDomains": "Email domains considered trusted",
     "trustedDomainsToProtectTournesol": "In order to protect Tournesol from fake accounts, by default, Tournesol assigns a limited trust score to newly created accounts.",
-    "trustedDomainsGainMoreVotingRights": "You can gain significantly more trust by validating <2>an email address from a trusted domain</2>, or when other users vouch for you.",
+    "trustedDomainsGainMoreVotingRights": "You can gain significantly more trust by validating <2>an email address from a domain considered trusted</2>, or when other users vouch for you.",
     "trustedDomainsValuable": "In any case, your contributions are valuable to us, as they will motivate further research in safe and ethical algorithms.",
-    "trustedDomainsCurrentList": "Current list of trusted domains"
+    "trustedDomainsCurrentList": "Current list of domains considered trusted"
   },
   "privacyPolicy": {
     "privacyPolicy": "Privacy Policy",
@@ -546,15 +546,15 @@
       "title": "Trust score",
       "description": {
         "explanation": "Your trust score determines how much your comparisons influence the Tournesol's recommendations.",
-        "howToChangeIt": "You can gain more trust by using an email from a trusted domain or when other users vouch for you.",
+        "howToChangeIt": "You can gain more trust by using an email from a domain considered trusted or when other users vouch for you.",
         "includedInPublicDatabase": "Your trust score is included the public database if you have at least one public comparison."
       },
       "nullValue": "Unknown",
       "low": "Low",
       "medium": "Medium",
       "high": "High",
-      "isTrusted": "Your email address is trusted.",
-      "isNotTrusted": "Your email address is not trusted.",
+      "isTrusted": "Your email address is considered trusted.",
+      "isNotTrusted": "Your email address is not considered trusted.",
       "hasReceivedVouchers": "Other users vouch for you.",
       "hasNotReceivedVouchers": "No other user vouch for you."
     },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -227,7 +227,7 @@
     "language": "Language",
     "scoreMode": {
       "default": {
-        "description": "More importance is given to accounts associated with an email address considered trusted",
+        "description": "More importance is given to accounts associated with an email address considered trustworthy",
         "label": "Default"
       },
       "allEqual": {
@@ -235,7 +235,7 @@
         "label": "All equal"
       },
       "trustedOnly": {
-        "description": "Only accounts associated with <2>an email address considered trusted</2> are taken into account",
+        "description": "Only accounts associated with <2>an email address considered trustworthy</2> are taken into account",
         "label": "Trusted only"
       }
     },
@@ -276,7 +276,7 @@
     "emailStatus": "Email status",
     "emailTrusted": "Trusted",
     "emailNonTrusted": "Non-trusted",
-    "learnMoreAboutTrustedDomains": "Learn more about domains which are considered trusted",
+    "learnMoreAboutTrustedDomains": "Learn more about domains which are considered trustworthy",
     "verificationEmailSentNewEmail": "A verification email has been sent to confirm your new email address.",
     "currentEmailAddressIs": "Your current email address is",
     "newEmailAddress": "New email address",
@@ -360,11 +360,11 @@
     "publicDatabase": "Public Database",
     "publicDatabaseDetailAndLicense": "Contributors on Tournesol can decide to make their data public. We hope this important data will prove useful for researchers on ethics of algorithms and large scale recommender systems. Our public database can be downloaded by clicking the button below and is published under <2>Open Data Commons Attribution License (ODC-By)</2>.",
     "publicDatabaseThanksToContributors": "Finally, we would like to thank all the contributors who compared videos on Tournesol. We count so far about {{userCount}} users who compared {{comparisonCount}} times more than {{comparedEntityCount}} videos.",
-    "trustedEmailDomains": "Email domains considered trusted",
+    "trustedEmailDomains": "Email domains considered trustworthy",
     "trustedDomainsToProtectTournesol": "In order to protect Tournesol from fake accounts, by default, Tournesol assigns a limited trust score to newly created accounts.",
-    "trustedDomainsGainMoreVotingRights": "You can gain significantly more trust by validating <2>an email address from a domain considered trusted</2>, or when other users vouch for you.",
+    "trustedDomainsGainMoreVotingRights": "You can gain significantly more trust by validating <2>an email address from a domain considered trustworthy</2>, or when other users vouch for you.",
     "trustedDomainsValuable": "In any case, your contributions are valuable to us, as they will motivate further research in safe and ethical algorithms.",
-    "trustedDomainsCurrentList": "Current list of domains considered trusted"
+    "trustedDomainsCurrentList": "Current list of domains considered trustworthy"
   },
   "privacyPolicy": {
     "privacyPolicy": "Privacy Policy",
@@ -546,19 +546,19 @@
       "title": "Trust score",
       "description": {
         "explanation": "Your trust score determines how much your comparisons influence the Tournesol's recommendations.",
-        "howToChangeIt": "You can gain more trust by using an email from a domain considered trusted or when other users vouch for you.",
+        "howToChangeIt": "You can gain more trust by using an email from a domain considered trustworthy or when other users vouch for you.",
         "includedInPublicDatabase": "Your trust score is included the public database if you have at least one public comparison."
       },
       "nullValue": "Unknown",
       "low": "Low",
       "medium": "Medium",
       "high": "High",
-      "isTrusted": "Your email address is considered trusted.",
-      "isNotTrusted": "Your email address is not considered trusted.",
+      "isTrusted": "Your email address is considered trustworthy.",
+      "isNotTrusted": "Your email address is not considered trustworthy.",
       "hasReceivedVouchers": "Other users vouch for you.",
       "hasNotReceivedVouchers": "No other user vouch for you."
     },
-    "aboutVouchingMechanism": "By vouching for other users, you enable them to obtain a higher trust score even if their email address is not considered to be trusted. The list of users for whom you vouch, or who have vouched for you, is a public information."
+    "aboutVouchingMechanism": "By vouching for other users, you enable them to obtain a higher trust score even if their email address is not considered trustworthy. The list of users for whom you vouch, or who have vouched for you, is a public information."
   },
   "myRateLaterListPage": {
     "title": "My rate-later list"

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -233,7 +233,7 @@
     "language": "Langues",
     "scoreMode": {
       "default": {
-        "description": "Davantage d'importance est donnée aux comptes associés à une adresse e-mail fiable",
+        "description": "Davantage d'importance est donnée aux comptes associés à une adresse e-mail considérée comme fiable",
         "label": "Par défaut"
       },
       "allEqual": {
@@ -241,8 +241,8 @@
         "label": "À égalité"
       },
       "trustedOnly": {
-        "description": "Seuls les comptes associés à <2>une adresse e-mail fiable</2> sont inclus",
-        "label": "E-mails fiables seulement"
+        "description": "Seuls les comptes associés à <2>une adresse e-mail considérée comme fiable</2> sont inclus",
+        "label": "E-mails considérés comme fiable seulement"
       }
     },
     "scoreModeSection": "Droits de vote",
@@ -282,7 +282,7 @@
     "emailStatus": "Statut de l'adresse",
     "emailTrusted": "Fiable",
     "emailNonTrusted": "Non-fiable",
-    "learnMoreAboutTrustedDomains": "À propos des domaines fiables",
+    "learnMoreAboutTrustedDomains": "À propos des domaines considérés comme fiables",
     "verificationEmailSentNewEmail": "Un courriel de vérification a été envoyé pour confirmer votre nouvelle adresse.",
     "currentEmailAddressIs": "Votre adresse actuelle est",
     "newEmailAddress": "Nouvelle adresse e-mail",
@@ -366,9 +366,9 @@
     "publicDatabase": "Base de données publique",
     "publicDatabaseDetailAndLicense": "Les contributeurs de Tournesol peuvent décider de rendre leurs données publiques. Nous espérons que ces données importantes se révéleront utiles pour les chercheurs et chercheuses travaillant sur l'éthique des algorithmes, et les systèmes de recommandation à grande échelle. Notre base de données publique, disponible sous licence <2>Open Data Commons Attribution License (ODC-By)</2>, peut être téléchargée en cliquant sur le bouton ci-dessous.",
     "publicDatabaseThanksToContributors": "Enfin, nous souhaitons vivement remercier tous les contributeurs qui comparent des vidéos sur Tournesol. Nous comptons actuellement environ {{userCount}} utilisateurs qui ont comparé {{comparisonCount}} fois plus de {{comparedEntityCount}} vidéos. ❤️",
-    "trustedEmailDomains": "Noms de domaine fiables",
+    "trustedEmailDomains": "Noms de domaine considérés comme fiables",
     "trustedDomainsToProtectTournesol": "Dans le but de protéger Tournesol des faux comptes, la plateforme assigne par défaut un score de confiance limité aux nouveaux comptes créés.",
-    "trustedDomainsGainMoreVotingRights": "Vous pouvez augmenter significativement votre score de confiance en validant <2>une adresse e-mail provenant d'un domaine fiable</2>, ou lorsque d'autres personnes se portent garant.es pour vous.",
+    "trustedDomainsGainMoreVotingRights": "Vous pouvez augmenter significativement votre score de confiance en validant <2>une adresse e-mail provenant d'un domaine considéré comme fiable</2>, ou lorsque d'autres personnes se portent garant.es pour vous.",
     "trustedDomainsValuable": "Dans tous les cas, vos contributions sont utiles car elles motiveront et aideront la recherche en éthique des algorithmes et de l'intelligence artificielle",
     "trustedDomainsCurrentList": "Liste actuelle des domaines considérés fiables"
   },
@@ -553,15 +553,15 @@
       "title": "Score de confiance",
       "description": {
         "explanation": "Votre score de confiance détermine à quel point vos comparaisons influencent les recommandations de Tournesol.",
-        "howToChangeIt": "Vous pouvez obtenir plus de confiance en utilisant une adresse e-mail d'un domaine fiable ou lorsque d'autres personnes se portent garant.es pour vous.",
+        "howToChangeIt": "Vous pouvez obtenir plus de confiance en utilisant une adresse e-mail d'un domaine considéré comme fiable ou lorsque d'autres personnes se portent garant.es pour vous.",
         "includedInPublicDatabase": "Votre score de confiance est inclus dans la base de données publique si vous avez au moins une comparaison publique."
       },
       "nullValue": "Indéterminé",
       "low": "Faible",
       "medium": "Moyen",
       "high": "Élevé",
-      "isTrusted": "Votre adresse e-mail est fiable.",
-      "isNotTrusted": "Votre adresse e-mail n'est pas fiable.",
+      "isTrusted": "Votre adresse e-mail est considérée comme fiable.",
+      "isNotTrusted": "Votre adresse e-mail n'est pas considérée comme fiable.",
       "hasReceivedVouchers": "Vous avez au moins un garant.",
       "hasNotReceivedVouchers": "Vous n'avez pas encore de garant."
     },


### PR DESCRIPTION
 #1255

Maybe in english we could use: "considered trustworthy"...