### PR TITLE
[back] fix: server error on search where total criteria weights is zero

### DIFF
--- a/backend/tournesol/tests/test_text_search.py
+++ b/backend/tournesol/tests/test_text_search.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -730,3 +732,13 @@ class TextSearchTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], self.setup_results_count + 1)
+
+    def test_search_with_total_criteria_weights_zero(self):
+        criteria_weights_dict = {
+            f"weights[{c}]": 0
+            for c in self.poll.criterias_list
+        }
+        url = f"{self.url_with_params}&{urlencode(criteria_weights_dict)}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], self.setup_results_count)

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -171,9 +171,12 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
         """
         if filters["search"] and self.poll_from_url.algorithm == ALGORITHM_MEHESTAN:
             max_absolute_score = MEHESTAN_MAX_SCALED_SCORE * self._weights_sum
-            normalized_total_score = (
-                (F("total_score") + max_absolute_score) / (2 * max_absolute_score)
-            )
+            if max_absolute_score > 0:
+                normalized_total_score = (
+                    (F("total_score") + max_absolute_score) / (2 * max_absolute_score)
+                )
+            else:
+                normalized_total_score = 0
             queryset = queryset.alias(
                 search_score=F("relevance")
                 * (F("relevance") + self.search_score_coef * normalized_total_score)


### PR DESCRIPTION
This would cause an error on the frontend when setting all criteria weights to zero in the advanced filters