### PR TITLE
[front] feat: set 'autocomplete' attr on login and signup forms

### DIFF
--- a/frontend/src/features/login/Login.tsx
+++ b/frontend/src/features/login/Login.tsx
@@ -81,6 +81,7 @@ const Login = () => {
                 size="small"
                 variant="outlined"
                 autoFocus={true}
+                autoComplete="username"
                 onChange={(event) => setUsername(event.target.value)}
               />
             </Grid>
@@ -94,6 +95,7 @@ const Login = () => {
                 size="small"
                 type="password"
                 variant="outlined"
+                autoComplete="current-password"
                 onChange={(event) => setPassword(event.target.value)}
               />
             </Grid>

--- a/frontend/src/features/settings/account/PasswordForm.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.tsx
@@ -83,6 +83,7 @@ const PasswordForm = () => {
             value={password}
             onChange={(event) => setPassword(event.target.value)}
             inputProps={{ 'data-testid': 'password' }}
+            autoComplete="new-password"
           />
         </Grid>
         <Grid item>
@@ -104,6 +105,7 @@ const PasswordForm = () => {
             error={passwordConfirm !== '' && !passwordConfirmMatches}
             onChange={(event) => setPasswordConfirm(event.target.value)}
             inputProps={{ 'data-testid': 'password_confirm' }}
+            autoComplete="new-password"
           />
         </Grid>
         <Grid item>

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -83,6 +83,7 @@ const Signup = () => {
                 <FormTextField
                   name="email"
                   label={t('emailAddress')}
+                  autoComplete="email"
                   formError={formError}
                 />
               </Grid>
@@ -101,6 +102,7 @@ const Signup = () => {
                   name="password"
                   label={t('password')}
                   type="password"
+                  autoComplete="new-password"
                   formError={formError}
                 />
               </Grid>
@@ -109,6 +111,7 @@ const Signup = () => {
                   name="password_confirm"
                   label={t('confirmYourPassword')}
                   type="password"
+                  autoComplete="new-password"
                   formError={formError}
                 />
               </Grid>


### PR DESCRIPTION
I am not sure about how to test this properly. On my environment, it seems that browsers suggest auto-completion options automatically. The browsers may also behave differently on "localhost". 

@lfaucon Could you have a look with your browser?