### PR TITLE
[back] feat: the rate-later auto remove is now connected to the user settings

### DIFF
--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -200,10 +200,10 @@ class Entity(models.Model):
         )
         self.save(update_fields=["rating_n_ratings", "rating_n_contributors"])
 
-    def auto_remove_from_rate_later(self, poll, user) -> None:
+    def auto_remove_from_rate_later(self, poll, user, max_) -> None:
         """
         When called, the entity is removed from the user's rate-later list if
-        it has been compared at least 4 times.
+        it has been compared at least `max_` times.
         """
         from .comparisons import Comparison  # pylint: disable=import-outside-toplevel
 
@@ -213,7 +213,7 @@ class Entity(models.Model):
             Q(entity_1=self) | Q(entity_2=self)
         ).count()
 
-        if n_comparisons >= 4:
+        if n_comparisons >= max_:
             RateLater.objects.filter(poll=poll, user=user, entity=self).delete()
 
     @property

--- a/backend/tournesol/models/rate_later.py
+++ b/backend/tournesol/models/rate_later.py
@@ -7,6 +7,9 @@ from django.db import models
 from core.models import User
 from tournesol.models.poll import Poll
 
+# The default minimum number of comparisons required to remove an entity from
+# a user's rate-later list. This default value should be overriden by the
+# user's settings.
 RATE_LATER_AUTO_REMOVE_DEFAULT = 4
 
 

--- a/backend/tournesol/models/rate_later.py
+++ b/backend/tournesol/models/rate_later.py
@@ -7,6 +7,8 @@ from django.db import models
 from core.models import User
 from tournesol.models.poll import Poll
 
+RATE_LATER_AUTO_REMOVE_DEFAULT = 4
+
 
 class RateLater(models.Model):
     """An `Entity` a user wants to rate later in a poll."""

--- a/backend/tournesol/models/rate_later.py
+++ b/backend/tournesol/models/rate_later.py
@@ -8,8 +8,8 @@ from core.models import User
 from tournesol.models.poll import Poll
 
 # The default minimum number of comparisons required to remove an entity from
-# a user's rate-later list. This default value should be overriden by the
-# user's settings.
+# a user's rate-later list. When this constant is imported and used, the
+# user's settings should take precedence over this default value.
 RATE_LATER_AUTO_REMOVE_DEFAULT = 4
 
 

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -985,43 +985,6 @@ class ComparisonApiTestCase(TestCase):
             self._compare(video_main.uid, video.uid)
         self.assertEqual(RateLater.objects.filter(entity=video_main).count(), 0)
 
-    def test_comparing_removes_from_rate_later_with_settings(self):
-        """
-        A video compared several times should be removed from the user's
-        rate-later list.
-
-        If the user has configured `rate_later__auto_remove`, the video
-        should be removed according to the value of this setting.
-        """
-
-        # [GIVEN] a user with the setting `rate_later__auto_remove` set to 8.
-        self.user.settings[self.poll_videos.name] = {"rate_later__auto_remove": 8}
-        self.user.save(update_fields=["settings"])
-
-        self.client.force_authenticate(user=self.user)
-        video_main, *videos = (VideoFactory() for _ in range(9))
-
-        data = {"entity": {"uid": video_main.uid}}
-        self.client.post(
-            f"/users/me/rate_later/{self.poll_videos.name}/",
-            data,
-            format="json",
-        )
-
-        # The main video should be in the rate later list after 1 comparison.
-        self._compare(video_main.uid, videos[0].uid)
-        self.assertEqual(RateLater.objects.filter(entity=video_main).count(), 1)
-
-        # The main video should be in the rate later list after 5 comparison.
-        for video in videos[1:5]:
-            self._compare(video_main.uid, video.uid)
-        self.assertEqual(RateLater.objects.filter(entity=video_main).count(), 1)
-
-        # The main video should not be in the rate later list after 8 comparison.
-        for video in videos[5:]:
-            self._compare(video_main.uid, video.uid)
-        self.assertEqual(RateLater.objects.filter(entity=video_main).count(), 0)
-
 
 class ComparisonWithMehestanTest(TransactionTestCase):
     def setUp(self):

--- a/backend/tournesol/tests/test_api_rate_later.py
+++ b/backend/tournesol/tests/test_api_rate_later.py
@@ -454,7 +454,7 @@ class RateLaterFeaturesTestCase(RateLaterCommonMixinTestCase, TestCase):
             0,
         )
 
-    def test_auto_remove_is_setting(self) -> None:
+    def test_auto_remove_is_setting_specific(self) -> None:
         """
         Test of the `auto_remove_from_rate_later` method of the Entity model.
 

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -13,7 +13,6 @@ from rest_framework import exceptions, generics, mixins
 from ml.mehestan.run import update_user_scores
 from tournesol.models import Comparison
 from tournesol.models.poll import ALGORITHM_MEHESTAN
-from tournesol.models.rate_later import RATE_LATER_AUTO_REMOVE_DEFAULT
 from tournesol.serializers.comparison import ComparisonSerializer, ComparisonUpdateSerializer
 from tournesol.views.mixins.poll import PollScopedViewMixin
 
@@ -113,16 +112,12 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
             )
         comparison: Comparison = serializer.save()
 
-        auto_remove = self.request.user.settings.get(poll.name, {}).get(
-            "rate_later__auto_remove", RATE_LATER_AUTO_REMOVE_DEFAULT
-        )
-
         # TODO To be removed, replaced by update_n_poll_ratings
         comparison.entity_1.update_n_ratings()
 
         comparison.entity_1.inner.refresh_metadata()
         comparison.entity_1.auto_remove_from_rate_later(
-            poll=poll, user=self.request.user, max_=auto_remove
+            poll=poll, user=self.request.user
         )
 
         # TODO To be removed, replaced by update_n_poll_ratings
@@ -130,7 +125,7 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
 
         comparison.entity_2.inner.refresh_metadata()
         comparison.entity_2.auto_remove_from_rate_later(
-            poll=poll, user=self.request.user, max_=auto_remove
+            poll=poll, user=self.request.user
         )
 
         if settings.UPDATE_MEHESTAN_SCORES_ON_COMPARISON and poll.algorithm == ALGORITHM_MEHESTAN:

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -13,6 +13,7 @@ from rest_framework import exceptions, generics, mixins
 from ml.mehestan.run import update_user_scores
 from tournesol.models import Comparison
 from tournesol.models.poll import ALGORITHM_MEHESTAN
+from tournesol.models.rate_later import RATE_LATER_AUTO_REMOVE_DEFAULT
 from tournesol.serializers.comparison import ComparisonSerializer, ComparisonUpdateSerializer
 from tournesol.views.mixins.poll import PollScopedViewMixin
 
@@ -112,12 +113,16 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
             )
         comparison: Comparison = serializer.save()
 
+        auto_remove = self.request.user.settings.get(poll.name, {}).get(
+            "rate_later__auto_remove", RATE_LATER_AUTO_REMOVE_DEFAULT
+        )
+
         # TODO To be removed, replaced by update_n_poll_ratings
         comparison.entity_1.update_n_ratings()
 
         comparison.entity_1.inner.refresh_metadata()
         comparison.entity_1.auto_remove_from_rate_later(
-            poll=poll, user=self.request.user
+            poll=poll, user=self.request.user, max_=auto_remove
         )
 
         # TODO To be removed, replaced by update_n_poll_ratings
@@ -125,7 +130,7 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
 
         comparison.entity_2.inner.refresh_metadata()
         comparison.entity_2.auto_remove_from_rate_later(
-            poll=poll, user=self.request.user
+            poll=poll, user=self.request.user, max_=auto_remove
         )
 
         if settings.UPDATE_MEHESTAN_SCORES_ON_COMPARISON and poll.algorithm == ALGORITHM_MEHESTAN:


### PR DESCRIPTION
**related to** #1294 

---

This PR makes the comparisons API use the `rate_later__auto_remove` setting.

If the setting is not defined in the requested poll, the default value defined in the `RateLater` model is used, currently `4`. If the setting is defined, its value is used instead.

The new tests of the comparisons API ensure the API call `auto_remove_from_rate_later` with the user setting or the default value in case of need.

The new tests of the rate-later API ensure the `Entity.auto_remove_from_rate_later` behaves as expected (note: in the future these tests could be moved in the entity unit tests, as they test a behaviour of the `Entity` model, not a behaviour of the rate-later API).

**to-do**
- [x] connect the auto remove feature to the user settings
- [x] define the default auto remove setting as a constant
- [x] update the tests
- [x] add the missing tests

**next steps**

- check if the settings are returned after an authentication
- ensure they are saved in the front end's redux store
- create the update form in the front end