### PR TITLE
[back] Fix deadlock between comparison and ml

### DIFF
--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -3,7 +3,6 @@ API endpoints to interact with the contributor's comparisons.
 """
 
 from django.conf import settings
-from django.db import transaction
 from django.db.models import ObjectDoesNotExist, Q
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
@@ -101,7 +100,6 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
             raise InactivePollError
         return self.create(request, *args, **kwargs)
 
-    @transaction.atomic
     def perform_create(self, serializer):
         poll = serializer.context["poll"]
 


### PR DESCRIPTION
## Problem

A deadlock was recently observed at the end of the "ml_train" job. It's similar to the issue addressed in #1227 
And I think I have now realized what exactly is the root cause for this situation. When creating a comparison at the moment when tournesol scores are being updated, there may exist 2 concurrent transactions which try to update the same Entity objects in a different order:

### Deadlock scenario

```
      TRANSACTION 1 (ml)                   TRANSACTION 2 (api)
    save_tournesol_scores()                 perform_create()
        ----------------                    ---------------


+-------------------------------+                  |
|    Update tournesol_score     |                  |
|         Entity 1000           |                  |
|   (Locked by Transaction 1)   |                  |
|                               |                  |
+-------------+-----------------+                  v
              |
              |                    +-------------------------------+
              |                    |      Update n_ratings         |
              |                    |          Entity 2000          |
              |                    |    (Locked by Transaction 2)  |
              .                    |                               |
              .                    +-------------------------------+
              .                                   |
              .                                   |
              .                                   v
              .                    +-------------------------------+
              |                    |      Update n_ratings         |
              |                    |       Entity 1000             |
              |                    |                               |
              |                    |   (waiting for Transaction 1  |
              |                    |       to complete...)         |
              v                    |                               |
                                   +-------------------------------+
+--------------------------------+
|   Update tournesol_score       |                |
|     Entity 2000                |                |
|                                |                |
|    (waiting for Transaction 2  |                |
|     to complete ....)          |                |
+--------------------------------+                |
              |                                   |
              |                                   |
              |
+-------------------------------------------------------------------+
|                             DEADLOCK                              |
+-------------------------------------------------------------------+
```

## Suggested changes

1. Tournesol scores should not be updated from a single long-running transaction.  
Even when using `batch_size`, the whole `bulk_update()` runs [inside a single transaction](https://github.com/django/django/blob/ca891ef44b27eb93890846615e0121037e6c8a35/django/db/models/query.py#L640-L642). Let's use manual batches to run smaller distinct transactions, to avoid locking too many entities at the same time.

2. When POSTing a new comparison the transaction on `perform_create()` is redundant and can be removed.  
It was motivated in #315 to ensure that related ContributorRatings are created in the same transaction. Ratings are now created beforehand (and checked by "ml-train"), and the `ComparisonSerializer` also creates its own transaction to save all criteria scores safely. So the top transaction can be removed, in order to execute `update_n_ratings()` for both entities in distinct transactions.
