### PR TITLE
Fix extension's iframe event listener not removed

### DIFF
--- a/browser-extension/src/addModal.js
+++ b/browser-extension/src/addModal.js
@@ -117,7 +117,7 @@ function displayModal({ src, height } = {}) {
 
   const display = function display() {
     modal.style.display = EXT_MODAL_VISIBLE_STATE;
-    iframe.removeEventListener('load', displayModal);
+    iframe.removeEventListener('load', display);
   };
 
   // prevent visual blink while refreshing the iframe

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
I think it was a typo made when the the code was initially introduced in 4185735c06269a5ae6f3aafef022f91a604d75f7.