### PR TITLE
[extension] Show the release date and number of views #1315

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Tournesol is a collective project made possible by the contributions of many
 donors and volunteers. We would love for you to help us in this adventure to
-make the project even better. 
+make the project even better.
 
 **Table of Content**
 
@@ -94,7 +94,7 @@ can be implemented and where it fits in the project's priorities.
 ### The development process / Asking for review
 
 You can track progress of the code development in the dedicated
-[kaban board][ts-github-kanban].
+[kanban board][ts-github-kanban].
 
 Anyone can submit ideas that seem relevant, by creating new issues and
 placing them inside the column `Ideas / Backlog`.
@@ -160,14 +160,13 @@ are defined and localized messages are updated, for English at least.
 Reviewers can help with the translation to French if necessary.
 
 On the frontend, translations are handled by `react-i18next`.
-* [This guide](https://react.i18next.com/guides/quick-start#translate-your-content)
-  may be useful to learn how to integrate translated content into React components. 
-* To extract the new translation keys, use [`yarn i18n:parse`](./frontend/README.md#yarn-i18nparse)
+
+- [This guide](https://react.i18next.com/guides/quick-start#translate-your-content)
+  may be useful to learn how to integrate translated content into React components.
+- To extract the new translation keys, use [`yarn i18n:parse`](./frontend/README.md#yarn-i18nparse)
 
 [ts-donate]: https://tournesol.app/about/donate
 [ts-compare]: https://tournesol.app/comparison
-
 [ts-github-repo]: https://github.com/tournesol-app/tournesol
 [ts-github-kanban]: https://github.com/tournesol-app/tournesol/projects/9
-
 [ts-discord-join]: https://discord.gg/WvcSG55Bf3

--- a/browser-extension/src/addTournesolRecommendations.js
+++ b/browser-extension/src/addTournesolRecommendations.js
@@ -1,5 +1,7 @@
 // Youtube doesnt completely load a video page, so content script doesn't lauch correctly without these events
 
+import { millifyViews } from './utils';
+
 // This part is called on connection for the first time on youtube.com/*
 /* ********************************************************************* */
 
@@ -158,7 +160,9 @@ const getTournesolComponent = () => {
 
     const video_views_publication = document.createElement('p');
     video_views_publication.className = 'video_text';
-    video_views_publication.innerHTML = `<strong>${video.metadata.views} &nbsp·&nbsp ${video.metadata.publication_date}</strong>`;
+    video_views_publication.innerHTML = `<strong>${millifyViews(
+      video.metadata.views
+    )} &nbsp·&nbsp ${video.metadata.publication_date}</strong>`;
     details_div.append(video_views_publication);
 
     const video_score = document.createElement('p');

--- a/browser-extension/src/addTournesolRecommendations.js
+++ b/browser-extension/src/addTournesolRecommendations.js
@@ -156,6 +156,11 @@ const getTournesolComponent = () => {
     video_uploader.append(video.metadata.uploader);
     details_div.append(video_uploader);
 
+    const video_views_publication = document.createElement('p');
+    video_views_publication.className = 'video_text';
+    video_views_publication.innerHTML = `<strong>${video.metadata.views} &nbsp·&nbsp ${video.metadata.publication_date}</strong>`;
+    details_div.append(video_views_publication);
+
     const video_score = document.createElement('p');
     video_score.className = 'video_text';
     video_score.innerHTML = `🌻 <strong>${video.tournesol_score.toFixed(

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -103,3 +103,104 @@ export const getRandomSubarray = (arr, size) => {
 export const getVideoStatistics = (videoId) => {
   return fetchTournesolApi(`videos/?video_id=${videoId}`, 'GET', {});
 };
+
+export const millifyViews = (videoViews) => {
+  videoViews = videoViews.toString().replace(/[^0-9.]/g, '');
+  if (videoViews < 1000) {
+    return videoViews;
+  }
+  let si = [
+    { v: 1e3, s: 'K' },
+    { v: 1e6, s: 'M' },
+    { v: 1e9, s: 'B' },
+  ];
+  let index;
+  for (index = si.length - 1; index > 0; index--) {
+    if (videoViews >= si[index].v) {
+      break;
+    }
+  }
+  return (
+    (videoViews / si[index].v)
+      .toFixed(1)
+      .replace(/\.0+$|(\.[0-9]*[1-9])0+$/, '$1') + si[index].s
+  );
+};
+
+// Code for TimeAgo
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+function getFormattedDate(date, prefomattedDate = false, hideYear = false) {
+  const day = date.getDate();
+  const month = MONTH_NAMES[date.getMonth()];
+  const year = date.getFullYear();
+  const hours = date.getHours();
+  let minutes = date.getMinutes();
+
+  if (minutes < 10) {
+    // Adding leading zero to minutes
+    minutes = `0${minutes}`;
+  }
+
+  if (prefomattedDate) {
+    // Today at 10:20
+    // Yesterday at 10:20
+    return `${prefomattedDate} at ${hours}:${minutes}`;
+  }
+
+  if (hideYear) {
+    // 10. January at 10:20
+    return `${day}. ${month} at ${hours}:${minutes}`;
+  }
+
+  // 10. January 2017. at 10:20
+  return `${day}. ${month} ${year}. at ${hours}:${minutes}`;
+}
+
+// --- Main function
+function timeAgo(dateParam) {
+  if (!dateParam) {
+    return null;
+  }
+
+  const date = typeof dateParam === 'object' ? dateParam : new Date(dateParam);
+  const DAY_IN_MS = 86400000; // 24 * 60 * 60 * 1000
+  const today = new Date();
+  const yesterday = new Date(today - DAY_IN_MS);
+  const seconds = Math.round((today - date) / 1000);
+  const minutes = Math.round(seconds / 60);
+  const isToday = today.toDateString() === date.toDateString();
+  const isYesterday = yesterday.toDateString() === date.toDateString();
+  const isThisYear = today.getFullYear() === date.getFullYear();
+
+  if (seconds < 5) {
+    return 'now';
+  } else if (seconds < 60) {
+    return `${seconds} seconds ago`;
+  } else if (seconds < 90) {
+    return 'about a minute ago';
+  } else if (minutes < 60) {
+    return `${minutes} minutes ago`;
+  } else if (isToday) {
+    return getFormattedDate(date, 'Today'); // Today at 10:20
+  } else if (isYesterday) {
+    return getFormattedDate(date, 'Yesterday'); // Yesterday at 10:20
+  } else if (isThisYear) {
+    return getFormattedDate(date, false, true); // 10. January at 10:20
+  }
+
+  return getFormattedDate(date); // 10. January 2017. at 10:20
+}


### PR DESCRIPTION
Hi,

This PR is opened for issue #1315 , I have added the code for the required metadata (views and publication/release date) in raw format, e.g. `513496 views, publication date : 10-02-2023`. Would you like the formatting to be done by ourselves?

Otherwise, I have a request to install two libraries to show the data in a cleaner format:
1. Views (1K, 1M, etc.): [Millify](https://www.npmjs.com/package/millify)
2. Publication Date (Just Now, 4 Minutes ago, Today, Yesterday, etc.): [timeago.js](https://timeago.org/), or directly use [Unpackaged code snippet using just the `Date()`](https://muffinman.io/blog/javascript-time-ago-function/)


**P.S. I am new to open-source contribution, I am all ears to feedback and guidance.**