### PR TITLE
[back] ml: rename 'supertrusted' into 'scaling-calibration' users, sync definition with latest paper

### DIFF
--- a/backend/core/models/user.py
+++ b/backend/core/models/user.py
@@ -21,9 +21,9 @@ logger = logging.getLogger(__name__)
 class User(AbstractUser):
     """
     Administrative, social and profile information about users.
-    (most of these fields are actually still unused)
 
-    Contains methods for retrieving trusted and supertrusted users.
+    This model also contains application settings for each user,
+    and methods related to email validation.
     """
 
     # Fields used by django-rest-registation to find a user.
@@ -73,10 +73,6 @@ class User(AbstractUser):
             .alias(is_trusted=Exists(accepted_domain))
             .filter(is_trusted=True)
         )
-
-    @classmethod
-    def supertrusted_seed_users(cls) -> QuerySet["User"]:
-        return cls.with_trusted_email().filter(is_staff=True)
 
     @classmethod
     def validate_email_unique_with_plus(cls, email: str, username="") -> str:

--- a/backend/ml/inputs.py
+++ b/backend/ml/inputs.py
@@ -57,7 +57,7 @@ class MlInputFromPublicDataset(MlInput):
         if isinstance(dataset_zip, str) and (
             dataset_zip.startswith("http://") or dataset_zip.startswith("https://")
         ):
-            dataset_zip, _headers = urlretrieve(dataset_zip)
+            dataset_zip, _headers = urlretrieve(dataset_zip)  # nosec B310
 
         with zipfile.ZipFile(dataset_zip) as zip_file:
             zip_root_dir = next(path for path in zipfile.Path(zip_file).iterdir() if path.is_dir())

--- a/backend/ml/inputs.py
+++ b/backend/ml/inputs.py
@@ -1,7 +1,7 @@
 import zipfile
 from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import Optional
+from typing import BinaryIO, Optional, Union
 from urllib.request import urlretrieve
 
 import pandas as pd
@@ -53,11 +53,13 @@ class MlInput(ABC):
 
 
 class MlInputFromPublicDataset(MlInput):
-    def __init__(self, zip_path: str):
-        if zip_path.startswith("http://") or zip_path.startswith("https://"):
-            zip_path, _headers = urlretrieve(zip_path)
+    def __init__(self, dataset_zip: Union[str, BinaryIO]):
+        if isinstance(dataset_zip, str) and (
+            dataset_zip.startswith("http://") or dataset_zip.startswith("https://")
+        ):
+            dataset_zip, _headers = urlretrieve(dataset_zip)
 
-        with zipfile.ZipFile(zip_path) as zip_file:
+        with zipfile.ZipFile(dataset_zip) as zip_file:
             zip_root_dir = next(path for path in zipfile.Path(zip_file).iterdir() if path.is_dir())
 
             with (zip_root_dir / "comparisons.csv").open() as comparison_file:

--- a/backend/ml/inputs.py
+++ b/backend/ml/inputs.py
@@ -100,7 +100,6 @@ class MlInputFromPublicDataset(MlInput):
         scaling_calibration_user_ids = (
             dtf[dtf.trust_score > self.SCALING_CALIBRATION_MIN_TRUST_SCORE]["user_id"]
             .value_counts(sort=True)[: self.MAX_SCALING_CALIBRATION_USERS]
-            .loc[lambda count: count >= self.SCALING_CALIBRATION_MIN_ENTITIES_TO_COMPARE]
             .index
         )
         dtf["is_scaling_calibration_user"] = dtf["user_id"].isin(scaling_calibration_user_ids)

--- a/backend/ml/inputs.py
+++ b/backend/ml/inputs.py
@@ -62,13 +62,13 @@ class MlInputFromPublicDataset(MlInput):
         with zipfile.ZipFile(dataset_zip) as zip_file:
             zip_root_dir = next(path for path in zipfile.Path(zip_file).iterdir() if path.is_dir())
 
-            with (zip_root_dir / "comparisons.csv").open() as comparison_file:
+            with (zip_root_dir / "comparisons.csv").open(mode="rb") as comparison_file:
                 self.comparisons = pd.read_csv(comparison_file)
                 self.comparisons.rename(
                     {"video_a": "entity_a", "video_b": "entity_b"}, axis=1, inplace=True
                 )
 
-            with (zip_root_dir / "users.csv").open() as users_file:
+            with (zip_root_dir / "users.csv").open(mode="rb") as users_file:
                 self.users = pd.read_csv(users_file)
                 self.users.index.name = "user_id"
 

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -92,7 +92,7 @@ def add_voting_rights(ratings_properties_df: pd.DataFrame, score_mode=ScoreMode.
         False: VOTE_WEIGHT_PRIVATE_RATINGS,
     })
     if score_mode == ScoreMode.TRUSTED_ONLY:
-        ratings_df = ratings_df[ratings_df["is_trusted"]]
+        ratings_df = ratings_df[ratings_df["trust_score"] >= 0.8]
         ratings_df["voting_right"] = 1
     if score_mode == ScoreMode.ALL_EQUAL:
         ratings_df["voting_right"] = 1

--- a/backend/tournesol/suggestions/suggestionprovider.py
+++ b/backend/tournesol/suggestions/suggestionprovider.py
@@ -70,10 +70,9 @@ class SuggestionProvider:
         uncertainties of the user are not high enough
         """
         # I want all entities from the current poll compared by supertrusted user
-        # todo create alias to properly detect supertrusted ?
         supertrusted_comparisons = Comparison.objects.filter(
             poll=self.poll,
-            user__in=User.supertrusted_seed_users()
+            user__in=User.with_trusted_email().filter(is_staff=True),
         ).values_list("entity_1__uid", "entity_2__uid")
 
         supertursted_compared_entities = set(

--- a/backend/tournesol/tests/test_exports.py
+++ b/backend/tournesol/tests/test_exports.py
@@ -62,7 +62,9 @@ class ExportTest(TestCase):
         )
         self.user_without_comparisons = UserFactory(username="user_without_comparisons")
 
-        self.public_comparisons = UserFactory(username="public_comparisons", trust_score=0.5844)
+        self.user_with_public_comparisons = UserFactory(
+            username="public_comparisons", trust_score=0.5844
+        )
         self.video_public_1 = VideoFactory()
         self.video_public_2 = VideoFactory()
         self.video_private_3 = VideoFactory()

--- a/backend/tournesol/tests/test_ml_run.py
+++ b/backend/tournesol/tests/test_ml_run.py
@@ -99,8 +99,8 @@ class TestMlTrain(TransactionTestCase):
 
 
     def test_individual_scaling_are_computed(self):
-        # User 1 will belong to supertrusted users (as staff member)
-        user1 = UserFactory(email="user@verified.test", is_staff=True)
+        # User 1 will belong to calibration users (as the most active trusted user)
+        user1 = UserFactory(email="user@verified.test")
         user2 = UserFactory()
 
         for user in [user1, user2]:
@@ -120,12 +120,12 @@ class TestMlTrain(TransactionTestCase):
         self.assertEqual(ContributorScaling.objects.count(), 2)
 
         # Check scaling values for user1
-        supertrusted_scaling = ContributorScaling.objects.get(user=user1)
-        self.assertAlmostEqual(supertrusted_scaling.scale, 1.0)
-        self.assertAlmostEqual(supertrusted_scaling.translation, 0.0)
-        # Scaling uncertainties are not defined for supertrusted users
-        self.assertIsNone(supertrusted_scaling.scale_uncertainty)
-        self.assertIsNone(supertrusted_scaling.translation_uncertainty)
+        calibration_scaling = ContributorScaling.objects.get(user=user1)
+        self.assertAlmostEqual(calibration_scaling.scale, 1.0)
+        self.assertAlmostEqual(calibration_scaling.translation, 0.0)
+        # Scaling uncertainties are not defined for scaling calibration users
+        self.assertIsNone(calibration_scaling.scale_uncertainty)
+        self.assertIsNone(calibration_scaling.translation_uncertainty)
 
         # Check scaling values for user2
         scaling = ContributorScaling.objects.get(user=user2)


### PR DESCRIPTION
Fixes #1351 

Note: a few references to "supertrusted" users are still present in the suggestion provider, which uses a subset of comparisons from the staff team to initialize its algorithm. (Not related to Mehestan)

