### PR TITLE
[ext] feat: display videos' views and publication date

### DIFF
--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -164,7 +164,7 @@
   position: relative;
 
   display: flex;
-  gap: 10px;
+  gap: 6px;
   flex-direction: column;
 
   padding-bottom: var(--ts-container-padding);

--- a/browser-extension/src/addTournesolRecommendations.js
+++ b/browser-extension/src/addTournesolRecommendations.js
@@ -156,6 +156,14 @@ const getTournesolComponent = () => {
     video_uploader.append(video.metadata.uploader);
     details_div.append(video_uploader);
 
+        const video_views_publication = document.createElement('p');
+    video_views_publication.className = 'video_text';
+    video_views_publication.innerHTML = `${millifyViews(
+      video.metadata.views
+    )} views &nbsp·&nbsp ${viewPublishedDate(video.metadata.publication_date)}`;
+    details_div.append(video_views_publication);
+
+
     const video_score = document.createElement('p');
     video_score.className = 'video_text';
     video_score.innerHTML = `🌻 <strong>${video.tournesol_score.toFixed(
@@ -256,4 +264,41 @@ function loadRecommandations() {
     },
     handleResponse
   );
+}
+
+function millifyViews(videoViews) {
+  // Intl.NumberFormat object is in-built and enables language-sensitive number formatting
+  return Intl.NumberFormat('en', { notation: 'compact' }).format(videoViews);
+}
+
+function viewPublishedDate(publishedDate) {
+  const date1 = new Date(publishedDate);
+  const date2 = new Date();
+  // we will find the difference in time of today's date and the published date, and will convert it into Days
+  // after calculating no. of days, we classify it into days, weeks, months, years, etc.
+  const diffTime = date2.getTime() - date1.getTime();
+  const diffDays = Math.floor(Math.abs(diffTime / (1000 * 3600 * 24)));
+
+
+  if (diffDays == 0) {
+    return `Today`;
+  } else if (diffDays < 31) {
+    if (diffDays < 14) {
+      return `${diffDays} days ago`;
+    } else {
+      return `${Math.floor(diffDays / 7)} weeks ago`;
+    }
+  } else if (diffDays >= 31 && diffDays < 365) {
+    if (diffDays < 61) {
+      return '1 month ago';
+    } else {
+      return `${Math.floor(diffDays / 30)} months ago`;
+    }
+  } else {
+    if (diffDays < 730) {
+      return '1 year ago';
+    } else {
+      return `${Math.floor(diffDays / 365)} years ago`;
+    }
+  }
 }

--- a/browser-extension/src/addTournesolRecommendations.js
+++ b/browser-extension/src/addTournesolRecommendations.js
@@ -156,13 +156,12 @@ const getTournesolComponent = () => {
     video_uploader.append(video.metadata.uploader);
     details_div.append(video_uploader);
 
-        const video_views_publication = document.createElement('p');
+    const video_views_publication = document.createElement('p');
     video_views_publication.className = 'video_text';
     video_views_publication.innerHTML = `${millifyViews(
       video.metadata.views
-    )} views &nbsp·&nbsp ${viewPublishedDate(video.metadata.publication_date)}`;
+    )} views &nbsp•&nbsp ${viewPublishedDate(video.metadata.publication_date)}`;
     details_div.append(video_views_publication);
-
 
     const video_score = document.createElement('p');
     video_score.className = 'video_text';
@@ -279,16 +278,22 @@ function viewPublishedDate(publishedDate) {
   const diffTime = date2.getTime() - date1.getTime();
   const diffDays = Math.floor(Math.abs(diffTime / (1000 * 3600 * 24)));
 
+  if (diffDays < 0) {
+    //in case the local machine UTC time is less than the published date
+    return '';
+  }
 
   if (diffDays == 0) {
-    return `Today`;
+    return 'Today';
+  } else if (diffDays == 1) {
+    return 'Yesterday';
   } else if (diffDays < 31) {
     if (diffDays < 14) {
       return `${diffDays} days ago`;
     } else {
       return `${Math.floor(diffDays / 7)} weeks ago`;
     }
-  } else if (diffDays >= 31 && diffDays < 365) {
+  } else if (diffDays < 365) {
     if (diffDays < 61) {
       return '1 month ago';
     } else {

--- a/browser-extension/src/addTournesolRecommendations.js
+++ b/browser-extension/src/addTournesolRecommendations.js
@@ -276,12 +276,12 @@ function viewPublishedDate(publishedDate) {
   // we will find the difference in time of today's date and the published date, and will convert it into Days
   // after calculating no. of days, we classify it into days, weeks, months, years, etc.
   const diffTime = date2.getTime() - date1.getTime();
-  const diffDays = Math.floor(Math.abs(diffTime / (1000 * 3600 * 24)));
 
-  if (diffDays < 0) {
+  if (diffTime < 0) {
     //in case the local machine UTC time is less than the published date
     return '';
   }
+  const diffDays = Math.floor(Math.abs(diffTime / (1000 * 3600 * 24)));
 
   if (diffDays == 0) {
     return 'Today';

--- a/browser-extension/src/addTournesolRecommendations.js
+++ b/browser-extension/src/addTournesolRecommendations.js
@@ -281,7 +281,7 @@ function viewPublishedDate(publishedDate) {
     //in case the local machine UTC time is less than the published date
     return '';
   }
-  const diffDays = Math.floor(Math.abs(diffTime / (1000 * 3600 * 24)));
+  const diffDays = Math.floor(diffTime / (1000 * 3600 * 24));
 
   if (diffDays == 0) {
     return 'Today';

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
Hi,

This is a new PR for issue #1315.
1. I have changed the view count logic from using regex and unnecessary string conversion to directly using the in-built `Intl` object. This is what the `millifyViews` function does.

2. The `viewPublishedDate` function takes the publish date from the metadata and converts it into a human-friendly format. According to my observation, Youtube's UI displays `days` until 13 days, then shifts to weeks, months, and years. I have upgraded the logic to match the same. I have also added comments in the code where necessary.

Let me know if it looks good to you, and/or if there are any changes to be made.

**P.S. While developing and debugging, I found out that my `console logs` in the `addTournesolRecommendations.js` were being called twice.** It might just be on my end during debugging and stuff, but if this is something to look into then you can let me know!

Here is a preview of how it looks on the extension:
![Tournesol Demo 4](https://user-images.githubusercontent.com/20269286/218310215-4459e35d-17ca-4c75-bf85-5e9b77d11cad.JPG)


