### PR TITLE
[back] feat: add a command able to monitor trusted accounts created

### DIFF
--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -43,8 +43,9 @@ class Command(BaseCommand):
 
         for domain in email_domains_alert_qs:
 
-            msg = (f"{domain.cnt} accounts created an account with '{domain.domain}' "
-                   f"email domain in the last {options['since-n-hours']} hour(s)")
+            msg = (f"{domain.cnt} accounts were created during the last "
+                   f"{options['since-n-hours']} hour(s) with the domain '{domain.domain}'")
+           
             self.stdout.write(msg)
 
             # Post the alert on Discord

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -4,6 +4,7 @@ Watch and alert when a certain number of accounts are created with the same trus
 from django.core.management.base import BaseCommand
 
 from core.lib.discord.api import write_in_channel
+from core.models.user import EmailDomain
 from core.utils.email_domain import get_email_domain_with_recent_new_users
 from core.utils.time import time_ago
 
@@ -35,7 +36,7 @@ class Command(BaseCommand):
         created_after = time_ago(hours=options["since_n_hours"])
 
         email_domains_alert_qs = get_email_domain_with_recent_new_users(
-            created_after, "ACK", options["n_account"]
+            created_after, EmailDomain.STATUS_ACCEPTED, options["n_account"]
         )
 
         for domain in email_domains_alert_qs:

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
 
             msg = (f"{domain.cnt} accounts were created during the last "
                    f"{options['since-n-hours']} hour(s) with the domain '{domain.domain}'")
-           
+            
             self.stdout.write(msg)
 
             # Post the alert on Discord

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -1,0 +1,50 @@
+"""
+Watch and alert when a certain number of accounts are created with the same trusted domaine.
+"""
+from django.core.management.base import BaseCommand
+
+from core.lib.discord.api import write_in_channel
+from core.utils.email_domain import get_user_cnt_per_email_domain
+from core.utils.time import time_ago
+
+class Command(BaseCommand):
+    help = "Alert when a certain of accounts are created with the same trusted mail domain."
+
+    def add_arguments(self, parser):
+
+        parser.add_argument(
+            "-s",
+            "--since_n_hours",
+            type=int,
+            help="Number of hours ago to watch",
+        )
+
+        # Optional
+        parser.add_argument(
+            "-n",
+            "--n_account",
+            type=int,
+            default=1,
+            help="Number of account to raise alerting (default 1)",
+        )
+
+    def handle(self, *args, **options):
+        self.stdout.write(f"start command: {__name__}")
+
+        created_after = time_ago(hours=options["since_n_hours"])
+
+        email_domains_alert_qs = get_user_cnt_per_email_domain(
+            created_after, "ACK", options["n_account"]
+        )
+
+        for d in email_domains_alert_qs:
+
+            msg = (f"{d.cnt} accounts created an account with '{d.domain}' email domain"
+                   f" in the last {options['since_n_hours']} hour(s)")
+            self.stdout.write(msg)
+
+            # Post the alert on Discord
+            write_in_channel("infra_alert_private", msg)
+
+        self.stdout.write(self.style.SUCCESS("success"))
+        self.stdout.write("end")

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -7,6 +7,7 @@ from core.lib.discord.api import write_in_channel
 from core.utils.email_domain import get_user_cnt_per_email_domain
 from core.utils.time import time_ago
 
+
 class Command(BaseCommand):
     help = "Alert when a certain of accounts are created with the same trusted mail domain."
 
@@ -37,10 +38,10 @@ class Command(BaseCommand):
             created_after, "ACK", options["n_account"]
         )
 
-        for d in email_domains_alert_qs:
+        for domain in email_domains_alert_qs:
 
-            msg = (f"{d.cnt} accounts created an account with '{d.domain}' email domain"
-                   f" in the last {options['since_n_hours']} hour(s)")
+            msg = (f"{domain.cnt} accounts created an account with '{domain.domain}' "
+                   f"email domain in the last {options['since_n_hours']} hour(s)")
             self.stdout.write(msg)
 
             # Post the alert on Discord

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
         parser.add_argument(
             "-s",
-            "--since_n_hours",
+            "--since-n-hours",
             type=int,
             help="Number of hours ago to watch",
         )
@@ -26,7 +26,7 @@ class Command(BaseCommand):
         # Optional
         parser.add_argument(
             "-n",
-            "--n_account",
+            "--n-accounts",
             type=int,
             default=1,
             help="Number of account to raise alerting (default 1)",
@@ -35,16 +35,16 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.stdout.write(f"start command: {__name__}")
 
-        created_after = time_ago(hours=options["since_n_hours"])
+        created_after = time_ago(hours=options["since-n-hours"])
 
         email_domains_alert_qs = get_email_domain_with_recent_new_users(
-            created_after, EmailDomain.STATUS_ACCEPTED, options["n_account"]
+            created_after, EmailDomain.STATUS_ACCEPTED, options["n-accounts"]
         )
 
         for domain in email_domains_alert_qs:
 
             msg = (f"{domain.cnt} accounts created an account with '{domain.domain}' "
-                   f"email domain in the last {options['since_n_hours']} hour(s)")
+                   f"email domain in the last {options['since-n-hours']} hour(s)")
             self.stdout.write(msg)
 
             # Post the alert on Discord

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -35,16 +35,16 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.stdout.write(f"start command: {__name__}")
 
-        created_after = time_ago(hours=options["since-n-hours"])
+        created_after = time_ago(hours=options["since_n_hours"])
 
         email_domains_alert_qs = get_email_domain_with_recent_new_users(
-            created_after, EmailDomain.STATUS_ACCEPTED, options["n-accounts"]
+            created_after, EmailDomain.STATUS_ACCEPTED, options["n_accounts"]
         )
 
         for domain in email_domains_alert_qs:
 
             msg = (f"{domain.cnt} accounts were created during the last "
-                   f"{options['since-n-hours']} hour(s) with the domain '{domain.domain}'")
+                   f"{options['since_n_hours']} hour(s) with the domain '{domain.domain}'")
 
             self.stdout.write(msg)
 

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -4,7 +4,7 @@ Watch and alert when a certain number of accounts are created with the same trus
 from django.core.management.base import BaseCommand
 
 from core.lib.discord.api import write_in_channel
-from core.utils.email_domain import get_user_cnt_per_email_domain
+from core.utils.email_domain import get_email_domain_with_recent_new_users
 from core.utils.time import time_ago
 
 
@@ -34,7 +34,7 @@ class Command(BaseCommand):
 
         created_after = time_ago(hours=options["since_n_hours"])
 
-        email_domains_alert_qs = get_user_cnt_per_email_domain(
+        email_domains_alert_qs = get_email_domain_with_recent_new_users(
             created_after, "ACK", options["n_account"]
         )
 

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -11,7 +11,8 @@ from core.utils.time import time_ago
 
 
 class Command(BaseCommand):
-    help = "Alert when a certain of accounts are created with the same trusted mail domain."
+    help = "Send an alert on Discord when X users have created accounts using" \
+           " email addresses considered trusted during the last Y hours."
 
     def add_arguments(self, parser):
 

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -1,5 +1,6 @@
 """
-Watch and alert when a certain number of accounts are created with the same trusted domaine.
+Send an alert on Discord when too many users have created accounts using email
+addresses considered trusted during the last hours.
 """
 from django.core.management.base import BaseCommand
 

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
 
             msg = (f"{domain.cnt} accounts were created during the last "
                    f"{options['since-n-hours']} hour(s) with the domain '{domain.domain}'")
-            
+
             self.stdout.write(msg)
 
             # Post the alert on Discord

--- a/backend/core/management/commands/watch_account_creation.py
+++ b/backend/core/management/commands/watch_account_creation.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             "--n-accounts",
             type=int,
             default=1,
-            help="Number of account to raise alerting (default 1)",
+            help="Minimum number of created accounts required to raise an alert.",
         )
 
     def handle(self, *args, **options):

--- a/backend/core/tests/management/test_watch_account_creation.py
+++ b/backend/core/tests/management/test_watch_account_creation.py
@@ -16,6 +16,7 @@ class WatchAccountCreationTestCase(TestCase):
         
         out = StringIO()
 
+        # Test which must trigger the alert
         EmailDomain.objects.create(domain="@verified.test", status=EmailDomain.STATUS_ACCEPTED)
         UserFactory(email="user1@verified.test", date_joined=time_ago(minutes=5))
 
@@ -24,8 +25,16 @@ class WatchAccountCreationTestCase(TestCase):
         
         self.assertIn("1 accounts were created during the last 1 hour(s) "
                       "with the domain '@verified.test'", output)
-        
         self.assertIn("success", output)
-
         self.assertEqual(write_in_channel_mock.call_count, 1)
+
+        # Test which must not trigger the alert
+        UserFactory(email="user2@verified.test", date_joined=time_ago(minutes=65))
+        UserFactory(email="user3@verified.test", date_joined=time_ago(minutes=65))
+
+        call_command("watch_account_creation", since-n-hours=1, n-accounts=2, stdout=out)
+        output = out.getvalue()
+
+        self.assertIn("success", output)
+        self.assertEqual(write_in_channel_mock.call_count, 0)
   

--- a/backend/core/tests/management/test_watch_account_creation.py
+++ b/backend/core/tests/management/test_watch_account_creation.py
@@ -1,0 +1,30 @@
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from core.models.user import EmailDomain
+from core.tests.factories.user import UserFactory
+from core.utils.time import time_ago
+
+
+class WatchAccountCreationTestCase(TestCase):
+
+    @mock.patch("core.lib.discord.api.write_in_channel")
+    def test_cmd_watch_account_creation(self, write_in_channel_mock):
+        
+        out = StringIO()
+
+        EmailDomain.objects.create(domain="@verified.test", status=EmailDomain.STATUS_ACCEPTED)
+        UserFactory(email="user1@verified.test", date_joined=time_ago(minutes=5))
+
+        call_command("watch_account_creation", since_n_hours=1, n_account=1, stdout=out)
+        output = out.getvalue()
+        
+        self.assertIn("1 accounts created an account with '@verified.test' "
+                      "email domain in the last 1 hour(s)", output)
+        self.assertIn("success", output)
+
+        self.assertEqual(write_in_channel_mock.call_count, 1)
+  

--- a/backend/core/tests/management/test_watch_account_creation.py
+++ b/backend/core/tests/management/test_watch_account_creation.py
@@ -19,7 +19,7 @@ class WatchAccountCreationTestCase(TestCase):
         EmailDomain.objects.create(domain="@verified.test", status=EmailDomain.STATUS_ACCEPTED)
         UserFactory(email="user1@verified.test", date_joined=time_ago(minutes=5))
 
-        call_command("watch_account_creation", since_n_hours=1, n_account=1, stdout=out)
+        call_command("watch_account_creation", since-n-hours=1, n-accounts=1, stdout=out)
         output = out.getvalue()
         
         self.assertIn("1 accounts created an account with '@verified.test' "

--- a/backend/core/tests/management/test_watch_account_creation.py
+++ b/backend/core/tests/management/test_watch_account_creation.py
@@ -22,8 +22,9 @@ class WatchAccountCreationTestCase(TestCase):
         call_command("watch_account_creation", since-n-hours=1, n-accounts=1, stdout=out)
         output = out.getvalue()
         
-        self.assertIn("1 accounts created an account with '@verified.test' "
-                      "email domain in the last 1 hour(s)", output)
+        self.assertIn("1 accounts were created during the last 1 hour(s) "
+                      "with the domain '@verified.test'", output)
+        
         self.assertIn("success", output)
 
         self.assertEqual(write_in_channel_mock.call_count, 1)

--- a/backend/core/tests/management/test_watch_account_creation.py
+++ b/backend/core/tests/management/test_watch_account_creation.py
@@ -20,7 +20,7 @@ class WatchAccountCreationTestCase(TestCase):
         EmailDomain.objects.create(domain="@verified.test", status=EmailDomain.STATUS_ACCEPTED)
         UserFactory(email="user1@verified.test", date_joined=time_ago(minutes=5))
 
-        call_command("watch_account_creation", since-n-hours=1, n-accounts=1, stdout=out)
+        call_command("watch_account_creation", since_n_hours=1, n_accounts=1, stdout=out)
         output = out.getvalue()
         
         self.assertIn("1 accounts were created during the last 1 hour(s) "
@@ -32,9 +32,9 @@ class WatchAccountCreationTestCase(TestCase):
         UserFactory(email="user2@verified.test", date_joined=time_ago(minutes=65))
         UserFactory(email="user3@verified.test", date_joined=time_ago(minutes=65))
 
-        call_command("watch_account_creation", since-n-hours=1, n-accounts=2, stdout=out)
+        call_command("watch_account_creation", since_n_hours=1, n_accounts=2, stdout=out)
         output = out.getvalue()
 
         self.assertIn("success", output)
-        self.assertEqual(write_in_channel_mock.call_count, 0)
+        self.assertEqual(write_in_channel_mock.call_count, 1)
   

--- a/backend/core/utils/email_domain.py
+++ b/backend/core/utils/email_domain.py
@@ -12,7 +12,8 @@ def get_user_cnt_per_email_domain(
     since: datetime.datetime, status: str = "ACK", n_account: int = 1
 ) -> RawQuerySet:
     """
-    Return the email domain with the number of account created `since` date with at least `n_account`.
+    Return the email domain with the number of account created `since` date with atleast
+    `n_account`.
 
     Keyword arguments:
 
@@ -31,7 +32,7 @@ def get_user_cnt_per_email_domain(
             e.domain,
             count(*) as cnt
         FROM core_emaildomain AS e
-        INNER JOIN (SELECT *, regexp_replace("email", '(.*)(@.*$)', '\\2') 
+        INNER JOIN (SELECT *, regexp_replace("email", '(.*)(@.*$)', '\\2')
         AS user_domain FROM core_user) AS u
         ON e.domain=u.user_domain
         WHERE u.date_joined >= %(since)s

--- a/backend/core/utils/email_domain.py
+++ b/backend/core/utils/email_domain.py
@@ -1,0 +1,48 @@
+"""
+Shortcut functions related to the email domain.
+"""
+import datetime
+
+from django.db.models.query import RawQuerySet
+
+from core.models.user import EmailDomain
+
+
+def get_user_cnt_per_email_domain(
+    since: datetime.datetime, status: str = "ACK", n_account: int = 1
+) -> RawQuerySet:
+    """
+    Return the email domain with the number of account created `since` date with at least `n_account`.
+
+    Keyword arguments:
+
+    since -- date from which the count start
+    status -- email domain status: "ACK": accepted, "PD": pending, "RJ": rejected (default "ACK")
+    n_account -- minimum number of account to be consider (default 1)
+
+    Ex:
+        get_user_cnt_per_email_domain(datetime.datetime(2022,3,4), 10)
+        Return all the domain name with 10 or more users created since the 4th of March 2022
+    """
+    return EmailDomain.objects.raw(
+        """
+        SELECT
+            e.id,
+            e.domain,
+            count(*) as cnt
+        FROM core_emaildomain AS e
+        INNER JOIN (SELECT *, regexp_replace("email", '(.*)(@.*$)', '\\2') 
+        AS user_domain FROM core_user) AS u
+        ON e.domain=u.user_domain
+        WHERE u.date_joined >= %(since)s
+        AND e.status = %(status)s
+        GROUP BY e.domain, e.id
+        HAVING count(*) >= %(n_account)s
+        ORDER BY cnt DESC;
+        """,
+        {
+            "since": since.strftime("%Y-%m-%d %H:%M:%S"),
+            "status": status,
+            "n_account": n_account,
+        },
+    )

--- a/backend/core/utils/email_domain.py
+++ b/backend/core/utils/email_domain.py
@@ -35,7 +35,7 @@ def get_email_domain_with_recent_new_users(
         FROM core_emaildomain AS e
 
         JOIN (
-            SELECT *, regexp_replace("email", '(.*)(@.*$)', '\\2') AS user_domain 
+            SELECT *, regexp_replace("email", '(.*)(@.*$)', '\\2') AS user_domain
             FROM core_user
         ) AS u ON e.domain=u.user_domain
 

--- a/backend/core/utils/email_domain.py
+++ b/backend/core/utils/email_domain.py
@@ -9,7 +9,7 @@ from core.models.user import EmailDomain
 
 
 def get_email_domain_with_recent_new_users(
-    since: datetime.datetime, status: str = "ACK", n_account: int = 1
+    since: datetime.datetime, status: str = EmailDomain.STATUS_ACCEPTED, n_account: int = 1
 ) -> RawQuerySet:
     """
     Return the email domain with the number of account created `since` date with atleast

--- a/backend/core/utils/email_domain.py
+++ b/backend/core/utils/email_domain.py
@@ -8,7 +8,7 @@ from django.db.models.query import RawQuerySet
 from core.models.user import EmailDomain
 
 
-def get_user_cnt_per_email_domain(
+def get_email_domain_with_recent_new_users(
     since: datetime.datetime, status: str = "ACK", n_account: int = 1
 ) -> RawQuerySet:
     """
@@ -22,7 +22,7 @@ def get_user_cnt_per_email_domain(
     n_account -- minimum number of account to be consider (default 1)
 
     Ex:
-        get_user_cnt_per_email_domain(datetime.datetime(2022,3,4), 10)
+        get_email_domain_with_recent_new_users(datetime.datetime(2022,3,4), 10)
         Return all the domain name with 10 or more users created since the 4th of March 2022
     """
     return EmailDomain.objects.raw(

--- a/backend/core/utils/email_domain.py
+++ b/backend/core/utils/email_domain.py
@@ -31,12 +31,17 @@ def get_email_domain_with_recent_new_users(
             e.id,
             e.domain,
             count(*) as cnt
+
         FROM core_emaildomain AS e
-        INNER JOIN (SELECT *, regexp_replace("email", '(.*)(@.*$)', '\\2')
-        AS user_domain FROM core_user) AS u
-        ON e.domain=u.user_domain
+
+        JOIN (
+            SELECT *, regexp_replace("email", '(.*)(@.*$)', '\\2') AS user_domain 
+            FROM core_user
+        ) AS u ON e.domain=u.user_domain
+
         WHERE u.date_joined >= %(since)s
-        AND e.status = %(status)s
+          AND e.status = %(status)s
+
         GROUP BY e.domain, e.id
         HAVING count(*) >= %(n_account)s
         ORDER BY cnt DESC;

--- a/backend/core/utils/tests/test_email_domain.py
+++ b/backend/core/utils/tests/test_email_domain.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from core.models.user import EmailDomain
 from core.tests.factories.user import UserFactory
-from core.utils.email_domain import get_user_cnt_per_email_domain
+from core.utils.email_domain import get_email_domain_with_recent_new_users
 from core.utils.time import time_ago
 
 
@@ -33,26 +33,26 @@ class UtilsEmailDomainTestCase(TestCase):
         UserFactory(email="user13@rejected.test", date_joined=time_ago(hours=10))
         UserFactory(email="user14@rejected.test", date_joined=time_ago(days=2))
 
-    def test_get_user_cnt_per_email_domain(self):
+    def test_get_email_domain_with_recent_new_users(self):
         """Test get user count per email domain at different time"""
 
-        self.assertEqual(len(get_user_cnt_per_email_domain(time_ago(minutes=1), "ACK", 1)), 0)
+        self.assertEqual(len(get_email_domain_with_recent_new_users(time_ago(minutes=1), "ACK", 1)), 0)
 
-        email_accepted_10min = get_user_cnt_per_email_domain(time_ago(minutes=10), "ACK", 1)
+        email_accepted_10min = get_email_domain_with_recent_new_users(time_ago(minutes=10), "ACK", 1)
         self.assertEqual(len(email_accepted_10min), 2)
         self.assertEqual(email_accepted_10min[0].domain, "@verified2.test")
         self.assertEqual(email_accepted_10min[0].cnt, 2)
         self.assertEqual(email_accepted_10min[1].domain, "@verified.test")
         self.assertEqual(email_accepted_10min[1].cnt, 1)
 
-        email_accepted_2h = get_user_cnt_per_email_domain(time_ago(hours=2), "ACK", 2)
+        email_accepted_2h = get_email_domain_with_recent_new_users(time_ago(hours=2), "ACK", 2)
         self.assertEqual(email_accepted_2h[0].domain, "@verified.test")
         self.assertEqual(email_accepted_2h[0].cnt, 2)
 
-        email_pending_2h = get_user_cnt_per_email_domain(time_ago(hours=2), "PD", 3)
+        email_pending_2h = get_email_domain_with_recent_new_users(time_ago(hours=2), "PD", 3)
         self.assertEqual(email_pending_2h[0].domain, "@pending.test")
         self.assertEqual(email_pending_2h[0].cnt, 4)
 
-        email_rejected_1day = get_user_cnt_per_email_domain(time_ago(days=1), "RJ", 3)
+        email_rejected_1day = get_email_domain_with_recent_new_users(time_ago(days=1), "RJ", 3)
         self.assertEqual(email_rejected_1day[0].domain, "@rejected.test")
         self.assertEqual(email_rejected_1day[0].cnt, 3)

--- a/backend/core/utils/tests/test_email_domain.py
+++ b/backend/core/utils/tests/test_email_domain.py
@@ -1,0 +1,58 @@
+from django.test import TestCase
+
+from core.models.user import EmailDomain
+from core.tests.factories.user import UserFactory
+from core.utils.email_domain import get_user_cnt_per_email_domain
+from core.utils.time import time_ago
+
+
+class UtilsEmailDomainTestCase(TestCase):
+    """TestCase of the utils.email_domain module."""
+
+    def setUp(self):
+
+        EmailDomain.objects.create(domain="@verified.test", status=EmailDomain.STATUS_ACCEPTED)
+        EmailDomain.objects.create(domain="@verified2.test", status=EmailDomain.STATUS_ACCEPTED)
+        EmailDomain.objects.create(domain="@pending.test", status=EmailDomain.STATUS_PENDING)
+        EmailDomain.objects.create(domain="@rejected.test", status=EmailDomain.STATUS_REJECTED)
+
+        UserFactory(email="user1@verified.test", date_joined=time_ago(minutes=5))
+        UserFactory(email="user2@verified2.test", date_joined=time_ago(minutes=5))
+        UserFactory(email="user3@verified2.test", date_joined=time_ago(minutes=5))
+        UserFactory(email="user4@pending.test", date_joined=time_ago(minutes=5))
+        UserFactory(email="user5@rejected.test", date_joined=time_ago(minutes=5))
+
+        UserFactory(email="user6@verified.test", date_joined=time_ago(minutes=75))
+        UserFactory(email="user7@pending.test", date_joined=time_ago(minutes=75))
+        UserFactory(email="user8@pending.test", date_joined=time_ago(minutes=75))
+        UserFactory(email="user9@pending.test", date_joined=time_ago(minutes=75))
+        UserFactory(email="user10@rejected.test", date_joined=time_ago(minutes=75))
+
+        UserFactory(email="user11@verified.test", date_joined=time_ago(hours=10))
+        UserFactory(email="user12@pending.test", date_joined=time_ago(hours=10))
+        UserFactory(email="user13@rejected.test", date_joined=time_ago(hours=10))
+        UserFactory(email="user14@rejected.test", date_joined=time_ago(days=2))
+
+    def test_get_user_cnt_per_email_domain(self):
+        """Test get user count per email domain at different time"""
+
+        self.assertEqual(len(get_user_cnt_per_email_domain(time_ago(minutes=1), "ACK", 1)), 0)
+
+        email_accepted_10min = get_user_cnt_per_email_domain(time_ago(minutes=10), "ACK", 1)
+        self.assertEqual(len(email_accepted_10min), 2)
+        self.assertEqual(email_accepted_10min[0].domain, "@verified2.test")
+        self.assertEqual(email_accepted_10min[0].cnt, 2)
+        self.assertEqual(email_accepted_10min[1].domain, "@verified.test")
+        self.assertEqual(email_accepted_10min[1].cnt, 1)
+
+        email_accepted_2h = get_user_cnt_per_email_domain(time_ago(hours=2), "ACK", 2)
+        self.assertEqual(email_accepted_2h[0].domain, "@verified.test")
+        self.assertEqual(email_accepted_2h[0].cnt, 2)
+
+        email_pending_2h = get_user_cnt_per_email_domain(time_ago(hours=2), "PD", 3)
+        self.assertEqual(email_pending_2h[0].domain, "@pending.test")
+        self.assertEqual(email_pending_2h[0].cnt, 4)
+
+        email_rejected_1day = get_user_cnt_per_email_domain(time_ago(days=1), "RJ", 3)
+        self.assertEqual(email_rejected_1day[0].domain, "@rejected.test")
+        self.assertEqual(email_rejected_1day[0].cnt, 3)


### PR DESCRIPTION
To solve #823

Things to do:

- [x] Create a function to get the number of account create with the same email domain
- [x] Add a test for this function
- [x] Add the management command to run this function
- [x] Add a test for the management command

The next point will be adressed in a next PR:
- Add timers to run it every 1 hour and every day
- Create a private Discord channel for these alert
- Add the webhook to the secrets