### PR TITLE
[back] sec: upgrade Django to 4.0.10 (from 4.0.9)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.0.9
+Django==4.0.10
 django-computed-property==0.3.0
 django-cors-headers==3.13.0
 django-countries==7.3.2


### PR DESCRIPTION
Fix:
- CVE-2023-24580

See: https://docs.djangoproject.com/en/4.0/releases/4.0.10/