### PR TITLE
[back] refactor: Add `time_ahead` function and harmonize

### DIFF
--- a/backend/core/tests/management/test_delete_inactive_users.py
+++ b/backend/core/tests/management/test_delete_inactive_users.py
@@ -2,10 +2,10 @@ from io import StringIO
 
 from django.core.management import call_command
 from django.test import TestCase
-from core.utils.time import time_ago
 
 from core.models.user import User
 from core.tests.factories.user import UserFactory
+from core.utils.time import time_ago
 
 
 class DeleteInactiveUsersTestCase(TestCase):

--- a/backend/core/tests/management/test_delete_inactive_users.py
+++ b/backend/core/tests/management/test_delete_inactive_users.py
@@ -1,9 +1,8 @@
-import datetime
 from io import StringIO
 
 from django.core.management import call_command
 from django.test import TestCase
-from django.utils import timezone
+from core.utils.time import time_ago
 
 from core.models.user import User
 from core.tests.factories.user import UserFactory
@@ -15,8 +14,8 @@ class DeleteInactiveUsersTestCase(TestCase):
     def test_cmd_delete_old_inactive_users(self):
         out = StringIO()
 
-        old_date = timezone.now() - datetime.timedelta(days=self.default_period + 1)
-        recent_date = timezone.now() - datetime.timedelta(days=self.default_period - 1)
+        old_date = time_ago(days=self.default_period + 1)
+        recent_date = time_ago(days=self.default_period - 1)
 
         # active users must not be deleted
         UserFactory(username="still_there_1", is_active=True, date_joined=old_date)
@@ -31,8 +30,7 @@ class DeleteInactiveUsersTestCase(TestCase):
         n_users_before = User.objects.count()
         n_users_to_delete = User.objects.filter(
             is_active=False,
-            date_joined__lt=timezone.now()
-            - datetime.timedelta(days=self.default_period),
+            date_joined__lt=time_ago(days=self.default_period),
         ).count()
 
         call_command("delete_inactive_users", stdout=out)

--- a/backend/core/utils/tests/test_time.py
+++ b/backend/core/utils/tests/test_time.py
@@ -1,4 +1,4 @@
-from core.utils.time import time_ago
+from core.utils.time import time_ago, time_ahead
 
 
 def test_time_ago():
@@ -8,3 +8,12 @@ def test_time_ago():
     assert time_ago(hours=10) > time_ago(days=1)
     assert time_ago(days=1) > time_ago(days=1, hours= 3)
     assert time_ago(days=6, hours=23) > time_ago(weeks=1)
+
+
+def test_time_ahead():
+    """Test method time_ahead."""
+    
+    assert time_ahead(hours=1) < time_ahead(hours=10)
+    assert time_ahead(hours=10) < time_ahead(days=1)
+    assert time_ahead(days=1) < time_ahead(days=1, hours= 3)
+    assert time_ahead(days=6, hours=23) < time_ahead(weeks=1)

--- a/backend/core/utils/time.py
+++ b/backend/core/utils/time.py
@@ -11,7 +11,7 @@ def time_ago(**kwargs):
     return timezone.now() - timedelta(**kwargs)
 
 
-def time_ahead(**kwargs):
+def time_ahead(**kwargs) -> datetime:
     """
     Return a `datetime` in the future relative to now.
 

--- a/backend/core/utils/time.py
+++ b/backend/core/utils/time.py
@@ -6,7 +6,11 @@ from django.utils import timezone
 
 
 def time_ago(**kwargs):
-    """Return a time in the past as specified as keyword arguments."""
+    """
+    Return a `datetime` in the past relative to now.
+
+    The keyword arguments are directly passed to `datetime.timedelta`.
+    """
 
     return timezone.now() - timedelta(**kwargs)
 

--- a/backend/core/utils/time.py
+++ b/backend/core/utils/time.py
@@ -9,3 +9,8 @@ def time_ago(**kwargs):
     """Return a time in the past as specified as keyword arguments."""
 
     return timezone.now() - timedelta(**kwargs)
+
+def time_ahead(**kwargs):
+    """Return a time in the future as specified as keyword arguments."""
+
+    return timezone.now() + timedelta(**kwargs)

--- a/backend/core/utils/time.py
+++ b/backend/core/utils/time.py
@@ -12,6 +12,10 @@ def time_ago(**kwargs):
 
 
 def time_ahead(**kwargs):
-    """Return a time in the future as specified as keyword arguments."""
+    """
+    Return a `datetime` in the future relative to now.
+
+    The keyword arguments are directly passed to `datetime.timedelta`.
+    """
 
     return timezone.now() + timedelta(**kwargs)

--- a/backend/core/utils/time.py
+++ b/backend/core/utils/time.py
@@ -1,6 +1,6 @@
 """Utils methods related to time."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.utils import timezone
 

--- a/backend/core/utils/time.py
+++ b/backend/core/utils/time.py
@@ -10,6 +10,7 @@ def time_ago(**kwargs):
 
     return timezone.now() - timedelta(**kwargs)
 
+
 def time_ahead(**kwargs):
     """Return a time in the future as specified as keyword arguments."""
 

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -10,7 +10,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from core.tests.factories.user import UserFactory
-from core.utils.time import time_ago
+from core.utils.time import time_ago, time_ahead
 from tournesol.models import (
     Comparison,
     ContributorRatingCriteriaScore,
@@ -96,7 +96,7 @@ class ComparisonApiTestCase(TestCase):
                 entity_1=self.videos[0],
                 entity_2=self.videos[3],
                 duration_ms=104,
-                datetime_lastedit=now + datetime.timedelta(minutes=1),
+                datetime_lastedit=time_ahead(minutes=1),
             ),
             # "other" will have the comparisons: 03 / 02 and 03 / 04
             ComparisonFactory(
@@ -104,14 +104,14 @@ class ComparisonApiTestCase(TestCase):
                 entity_1=self.videos[2],
                 entity_2=self.videos[1],
                 duration_ms=302,
-                datetime_lastedit=now + datetime.timedelta(minutes=3),
+                datetime_lastedit=time_ahead(minutes=3),
             ),
             ComparisonFactory(
                 user=self.other,
                 entity_1=self.videos[2],
                 entity_2=self.videos[3],
                 duration_ms=304,
-                datetime_lastedit=now + datetime.timedelta(minutes=2),
+                datetime_lastedit=time_ahead(minutes=2),
             ),
         ]
 

--- a/backend/tournesol/tests/test_api_inconsistencies.py
+++ b/backend/tournesol/tests/test_api_inconsistencies.py
@@ -1,18 +1,12 @@
 from math import sqrt
 
 from django.test import TestCase
-from core.utils.time import time_ago, time_ahead
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from core.tests.factories.user import UserFactory
-from tournesol.models import (
-    Comparison,
-    ComparisonCriteriaScore,
-    ContributorRating,
-    ContributorRatingCriteriaScore,
-    Poll,
-)
+from core.utils.time import time_ago, time_ahead
+from tournesol.models import Poll
 from tournesol.tests.factories.comparison import ComparisonCriteriaScoreFactory, ComparisonFactory
 from tournesol.tests.factories.entity import EntityFactory
 from tournesol.tests.factories.poll import PollWithCriteriasFactory

--- a/backend/tournesol/tests/test_api_inconsistencies.py
+++ b/backend/tournesol/tests/test_api_inconsistencies.py
@@ -1,7 +1,7 @@
-import datetime
 from math import sqrt
 
 from django.test import TestCase
+from core.utils.time import time_ago, time_ahead
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -238,8 +238,8 @@ class Length3CyclesApiTestCase(TestCase):
         """Can use the date filter to ignore old comparisons"""
         self.client.force_authenticate(self.user)
 
-        tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
-        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+        tomorrow = time_ahead(days=1)
+        yesterday = time_ago(days=1)
 
         response = self.client.get(
             self.url + f"?date_gte={yesterday.isoformat()}",
@@ -429,8 +429,8 @@ class ScoreInconsistenciesApiTestCase(TestCase):
 
         self._create_comparison_and_rating()
 
-        tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
-        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+        tomorrow = time_ahead(days=1)
+        yesterday = time_ago(days=1)
 
         response = self.client.get(
             self.url + f"?date_gte={yesterday.isoformat()}",

--- a/backend/tournesol/tests/test_api_inconsistencies.py
+++ b/backend/tournesol/tests/test_api_inconsistencies.py
@@ -238,18 +238,18 @@ class Length3CyclesApiTestCase(TestCase):
         """Can use the date filter to ignore old comparisons"""
         self.client.force_authenticate(self.user)
 
-        tomorrow = time_ahead(days=1)
-        yesterday = time_ago(days=1)
-
+        tomorrow = time_ahead(days=1).isoformat().split('+')[0]
+        yesterday = time_ago(days=1).isoformat().split('+')[0]
+ 
         response = self.client.get(
-            self.url + f"?date_gte={yesterday.isoformat()}",
+            self.url + f"?date_gte={yesterday}",
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], self.setup_cycles_count)
 
         response = self.client.get(
-            self.url + f"?date_gte={tomorrow.isoformat()}",
+            self.url + f"?date_gte={tomorrow}",
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -429,18 +429,18 @@ class ScoreInconsistenciesApiTestCase(TestCase):
 
         self._create_comparison_and_rating()
 
-        tomorrow = time_ahead(days=1)
-        yesterday = time_ago(days=1)
+        tomorrow = time_ahead(days=1).isoformat().split('+')[0]
+        yesterday = time_ago(days=1).isoformat().split('+')[0]
 
         response = self.client.get(
-            self.url + f"?date_gte={yesterday.isoformat()}",
+            self.url + f"?date_gte={yesterday}",
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
         response = self.client.get(
-            self.url + f"?date_gte={tomorrow.isoformat()}",
+            self.url + f"?date_gte={tomorrow}",
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from core.tests.factories.user import UserFactory
+from core.utils.time import time_ago, time_ahead
 from tournesol.models import Comparison, ContributorRating, Poll
 from tournesol.tests.factories.comparison import ComparisonFactory
 from tournesol.tests.factories.entity import VideoFactory
@@ -330,13 +331,9 @@ class RatingApi(TestCase):
             entity_2=video_recent2,
         )
 
-        ten_days_ago = self.comparison_user2.datetime_lastedit - timedelta(days=10)
-        ten_days_ahead = self.comparison_user2.datetime_lastedit + timedelta(days=10)
         # update() allows to bypass the auto_now=True of the `datetime_lastedit` field.
-        Comparison.objects.filter(pk=comp_old.pk).update(datetime_lastedit=ten_days_ago)
-        Comparison.objects.filter(pk=comp_recent.pk).update(
-            datetime_lastedit=ten_days_ahead
-        )
+        Comparison.objects.filter(pk=comp_old.pk).update(datetime_lastedit=time_ago(days=10))
+        Comparison.objects.filter(pk=comp_recent.pk).update(datetime_lastedit=time_ahead(days=10))
 
         self.client.force_authenticate(user=self.user2)
 

--- a/backend/tournesol/tests/test_api_statistics.py
+++ b/backend/tournesol/tests/test_api_statistics.py
@@ -1,8 +1,5 @@
-from datetime import timedelta
-
 from django.test import TestCase
 from django.urls import reverse
-from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 


### PR DESCRIPTION
- I created a `time_ahead` function which is the opposite of the existing `time_ago` function.
- I used those two function when it was possible
