### PR TITLE
[front] feat: `<TitledPaper>` can now be scrolled into

### DIFF
--- a/frontend/src/components/TitledPaper.tsx
+++ b/frontend/src/components/TitledPaper.tsx
@@ -21,7 +21,7 @@ const TitledPaper = ({
   contentBoxPadding = 2,
 }: TitledPaperProps) => {
   return (
-    <Paper sx={sx} id={titleId}>
+    <Paper sx={sx}>
       <Box
         p={2}
         color="#fff"
@@ -31,7 +31,9 @@ const TitledPaper = ({
           borderTopRightRadius: 'inherit',
         }}
       >
-        <Typography variant="h4">{title}</Typography>
+        <Typography variant="h4" id={titleId}>
+          {title}
+        </Typography>
       </Box>
       <Box p={contentBoxPadding}>{children}</Box>
     </Paper>

--- a/frontend/src/components/TitledPaper.tsx
+++ b/frontend/src/components/TitledPaper.tsx
@@ -4,6 +4,7 @@ import { Box, Paper, Typography, SxProps } from '@mui/material';
 
 interface TitledPaperProps {
   title: string;
+  titleId?: string;
   children: React.ReactNode;
   sx?: SxProps;
   contentBoxPadding?: number;
@@ -14,12 +15,13 @@ interface TitledPaperProps {
  */
 const TitledPaper = ({
   title,
+  titleId,
   children,
   sx,
   contentBoxPadding = 2,
 }: TitledPaperProps) => {
   return (
-    <Paper sx={sx}>
+    <Paper sx={sx} id={titleId}>
       <Box
         p={2}
         color="#fff"

--- a/frontend/src/components/TitledPaper.tsx
+++ b/frontend/src/components/TitledPaper.tsx
@@ -31,7 +31,7 @@ const TitledPaper = ({
           borderTopRightRadius: 'inherit',
         }}
       >
-        <Typography variant="h4" id={titleId}>
+        <Typography id={titleId} variant="h4">
           {title}
         </Typography>
       </Box>

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -12,3 +12,4 @@ export { default as SettingsSection } from './SettingsSection';
 export { default as MenuButton } from './MenuButton';
 export { default as LanguageSelector } from './LanguageSelector';
 export { default as CriteriaIcon } from './CriteriaIcon';
+export { default as TitledPaper } from './TitledPaper';

--- a/frontend/src/features/frame/components/footer/Footer.tsx
+++ b/frontend/src/features/frame/components/footer/Footer.tsx
@@ -63,7 +63,10 @@ const Footer = () => {
       id: 'support-us',
       title: t('footer.supportUs'),
       items: [
-        { name: t('footer.directTransfer'), to: '/about/donate' },
+        {
+          name: t('footer.directTransfer'),
+          to: '/about/donate#direct_transfer',
+        },
         { name: 'uTip', to: utipTournesolUrl },
         { name: 'PayPal', to: paypalTournesolUrl },
         { name: t('footer.compareVideos'), to: '/comparison' },

--- a/frontend/src/pages/about/Donate.tsx
+++ b/frontend/src/pages/about/Donate.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 import {
   Alert,
@@ -13,8 +14,7 @@ import {
 import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
 import makeStyles from '@mui/styles/makeStyles';
 
-import { ContentHeader, ContentBox } from 'src/components';
-import TitledPaper from 'src/components/TitledPaper';
+import { ContentHeader, ContentBox, TitledPaper } from 'src/components';
 import FundingSection from 'src/pages/home/videos/sections/FundingSection';
 import { utipTournesolUrl, paypalDonateTournesolUrl } from 'src/utils/url';
 
@@ -25,12 +25,29 @@ const useStyles = makeStyles(() => ({
 }));
 
 const DonatePage = () => {
+  const { hash } = useLocation();
+  const alreadyScrolled = React.useRef(false);
+
   const classes = useStyles();
   const { t } = useTranslation();
 
   const donateSectionSx = {
     width: '100%',
   };
+
+  useEffect(() => {
+    // Do not scroll when it's not required.
+    if (hash) {
+      // Scroll only one time.
+      if (!alreadyScrolled.current) {
+        const element = document.getElementById(hash.substring(1));
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth' });
+          alreadyScrolled.current = true;
+        }
+      }
+    }
+  }, [hash]);
 
   return (
     <>
@@ -119,7 +136,10 @@ const DonatePage = () => {
             </TitledPaper>
           </Grid2>
           <Grid2 sx={donateSectionSx}>
-            <TitledPaper title={t('donate.doYouPreferDirectTransfer')}>
+            <TitledPaper
+              title={t('donate.doYouPreferDirectTransfer')}
+              titleId="direct_transfer"
+            >
               <Box>
                 <Typography variant="h5" sx={{ marginBottom: 1 }}>
                   {t('about.donateByDirectTransferEUR')}


### PR DESCRIPTION
… into direct transfer section of donate page

TitledPaper now has a titledId props.
Footer direct transfer link now point to the direct_transfer anchor.
DonatePage component now scroll to the pointed anchor once.