### PR TITLE
[back] refactor: round floating point numbers of the dataset

### DIFF
--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -13,16 +13,16 @@ from django.utils import timezone
 
 from tournesol.entities.base import UID_DELIMITER
 
-# The maximal decimal precision of floating point numbers appearing in the
-# dataset.
+# The standard decimal precision of floating point numbers appearing in the
+# dataset. Very small numbers can use a higher precision.
 FLOAT_PRECISION = 2
 
 
-def _round_or_none(value: float):
+def _round_or_none(value: float, precision: int = FLOAT_PRECISION):
     if value is None:
         return None
 
-    return round(value, FLOAT_PRECISION)
+    return round(value, precision)
 
 
 def get_comparisons_data(poll_name: str, until_: datetime) -> QuerySet:
@@ -300,7 +300,9 @@ def write_individual_criteria_scores_file(poll_name: str, write_target) -> None:
             "video": criteria_score.uid.split(UID_DELIMITER)[1],
             "criteria": criteria_score.criteria,
             "score": round(criteria_score.score, FLOAT_PRECISION),
-            "voting_right": criteria_score.voting_right,
+            # The voting rights can be very small and reach numbers like 10e-3
+            # or even 10e-4. Thus, we round them with more precision.
+            "voting_right": round(criteria_score.voting_right, 3),
         }
         for criteria_score in criteria_scores
     )

--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -13,6 +13,17 @@ from django.utils import timezone
 
 from tournesol.entities.base import UID_DELIMITER
 
+# The maximal decimal precision of floating point numbers appearing in the
+# dataset.
+FLOAT_PRECISION = 2
+
+
+def _round_or_none(value: float):
+    if value is None:
+        return None
+
+    return round(value, FLOAT_PRECISION)
+
 
 def get_comparisons_data(poll_name: str, until_: datetime) -> QuerySet:
     """
@@ -259,7 +270,7 @@ def write_users_file(poll_name: str, write_target) -> None:
     writer.writerows(
         {
             "public_username": user.username,
-            "trust_score": user.trust_score,
+            "trust_score": _round_or_none(user.trust_score),
         }
         for user in get_users_data(poll_name).iterator()
     )
@@ -288,7 +299,7 @@ def write_individual_criteria_scores_file(poll_name: str, write_target) -> None:
             "public_username": criteria_score.username,
             "video": criteria_score.uid.split(UID_DELIMITER)[1],
             "criteria": criteria_score.criteria,
-            "score": criteria_score.score,
+            "score": round(criteria_score.score, FLOAT_PRECISION),
             "voting_right": criteria_score.voting_right,
         }
         for criteria_score in criteria_scores
@@ -319,7 +330,7 @@ def write_collective_criteria_scores_file(poll_name: str, write_target) -> None:
         {
             "video": score["entity__metadata__video_id"],
             "criteria": score["criteria"],
-            "score": score["score"],
+            "score": round(score["score"], FLOAT_PRECISION),
         }
         for score in criteria_scores
     )

--- a/backend/tournesol/tests/test_exports.py
+++ b/backend/tournesol/tests/test_exports.py
@@ -425,7 +425,7 @@ class ExportTest(TestCase):
             )
             self.assertEqual(row["criteria"], expected_export.criteria)
             self.assertEqual(row["score"], str(round(expected_export.score, 2)))
-            self.assertEqual(row["voting_right"], str(expected_export.voting_right))
+            self.assertEqual(row["voting_right"], str(round(expected_export.voting_right, 3)))
 
     def test_all_export_sorts_by_username(self):
         last_user = UserFactory(username="z")

--- a/backend/tournesol/tests/test_exports.py
+++ b/backend/tournesol/tests/test_exports.py
@@ -312,7 +312,7 @@ class ExportTest(TestCase):
         user_rows = [row for row in rows if row["public_username"] == username]
         self.assertEqual(len(user_rows), 1)
         user_row = user_rows[0]
-        self.assertEqual(user_row["trust_score"], "0.5844")
+        self.assertEqual(user_row["trust_score"], "0.58")
 
     def test_user_with_only_private_comparisons_not_in_users(self):
         user_with_only_private_comparisons = UserFactory(username="privacy_conscious")
@@ -424,7 +424,7 @@ class ExportTest(TestCase):
                 expected_export.contributor_rating.entity.metadata["video_id"],
             )
             self.assertEqual(row["criteria"], expected_export.criteria)
-            self.assertEqual(row["score"], str(expected_export.score))
+            self.assertEqual(row["score"], str(round(expected_export.score, 2)))
             self.assertEqual(row["voting_right"], str(expected_export.voting_right))
 
     def test_all_export_sorts_by_username(self):

--- a/backend/tournesol/tests/test_utils_contributors.py
+++ b/backend/tournesol/tests/test_utils_contributors.py
@@ -98,5 +98,8 @@ class UtilsContributorsTestCase(TestCase):
         self.assertEqual(top_contributors[0], (self.users[2].username, 5))
         self.assertEqual(top_contributors[1], (self.users[0].username, 3))
         self.assertEqual(top_contributors[2], (self.users[3].username, 2))
-        self.assertEqual(top_contributors[3], (self.users[1].username, 1))
-        self.assertEqual(top_contributors[4], (self.users[4].username, 1))
+        # The remaining users have both 1 comparison. The order is not deterministic.
+        self.assertEqual(
+            {top_contributors[3], top_contributors[4]},
+            {(self.users[1].username, 1), (self.users[4].username, 1)},
+        )


### PR DESCRIPTION
As previously discussed, this PR rounds the computed individual and collective scores in the dataset.

I chose a two digits precision after the decimal point.