### PR TITLE
[front] multi-page lists navigation (#1001)

### DIFF
--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -65,7 +65,7 @@ function wait_for() {
       return 0
     fi
     echo "Waiting for $service_name to be ready..."
-    sleep 3
+    sleep 4
   done
   echo "$service_name is unreachable."
   exit 1

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -39,12 +39,6 @@
   "score": {
     "totalScoreBasedOnRankingChoice": "Score based on selected ranking parameters"
   },
-  "pagination": {
-    "videos": "videos",
-    "previousButton": "Previous {{limit}}",
-    "nextButton": "Next {{limit}}",
-    "page": "Page :"
-  },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {
       "notLoggedIn": "You must be logged in to display personal scores.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -42,9 +42,8 @@
   "pagination": {
     "videos": "videos",
     "previousButton": "Previous {{limit}}",
-    "showingCounts": "Showing {{itemTypeText}} {{firstShowing}} to {{lastShowing}} of {{total}}",
     "nextButton": "Next {{limit}}",
-    "comparisons": "comparisons"
+    "page": "Page :"
   },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -42,12 +42,6 @@
   "score": {
     "totalScoreBasedOnRankingChoice": "Score basé sur les critères de classement selectionnés"
   },
-  "pagination": {
-    "videos": "vidéos",
-    "previousButton": "{{limit}} prec.",
-    "nextButton": "{{limit}} suiv.",
-    "page": "Page :"
-  },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {
       "notLoggedIn": "Vous devez être connecté.e pour afficher les scores personnels.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -45,9 +45,8 @@
   "pagination": {
     "videos": "vidéos",
     "previousButton": "{{limit}} prec.",
-    "showingCounts": "de {{firstShowing}} à {{lastShowing}} sur un total de {{total}} {{itemTypeText}}",
     "nextButton": "{{limit}} suiv.",
-    "comparisons": "comparaisons"
+    "page": "Page :"
   },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+
 import {
-  Typography,
   Button,
   Paper,
   Pagination as PaginationComponent,
@@ -9,7 +9,6 @@ import {
   useTheme,
 } from '@mui/material';
 
-import { useTranslation, Trans } from 'react-i18next';
 import { scrollToTop } from 'src/utils/ui';
 
 interface PaginationProps {
@@ -25,15 +24,14 @@ const Pagination = ({
   onOffsetChange,
   count,
 }: PaginationProps) => {
-  const { t } = useTranslation();
   const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'), {
+
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'), {
     noSsr: true,
   });
   const [currentPage, setCurrentPage] = React.useState(
     (offset + limit) / limit
   );
-  const [pageSearch, setPageSearch] = React.useState('');
   const totalPages = Math.floor(count / limit) + (count % limit === 0 ? 0 : 1);
 
   const handleChangePage = (
@@ -43,19 +41,6 @@ const Pagination = ({
     scrollToTop();
     setCurrentPage(page);
     onOffsetChange(Math.max(0, (page - 1) * limit));
-  };
-  const handlePageSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setPageSearch(event.target.value);
-  };
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter' && /^\d+$/.test(pageSearch)) {
-      const page = parseInt(pageSearch, 10);
-      if (page > 0 && page <= totalPages) {
-        scrollToTop();
-        onOffsetChange(Math.max(page * limit - limit, 0));
-        setCurrentPage(page);
-      }
-    }
   };
 
   const previousPageStep = (step: number) => {
@@ -81,7 +66,8 @@ const Pagination = ({
       square
       variant="outlined"
       sx={{
-        padding: '10px',
+        padding: 2,
+        gap: 1,
         display: 'flex',
         alignItems: 'center',
         flexDirection: 'row',
@@ -89,136 +75,91 @@ const Pagination = ({
         flexWrap: 'wrap',
       }}
     >
-      {isSmallScreen && (
-        <PaginationComponent
-          count={totalPages}
-          page={currentPage}
-          onChange={handleChangePage}
-          hidePrevButton
-          hideNextButton
-          sx={{
-            flexBasis: {
-              xs: '100%',
-              sm: 'auto',
-            },
-            display: 'flex',
-            justifyContent: 'center',
-            '& ul': {
-              justifyContent: 'center',
-            },
-          }}
-        />
-      )}
+      <PaginationComponent
+        count={totalPages}
+        page={currentPage}
+        siblingCount={isSmallScreen ? 1 : 3}
+        boundaryCount={isSmallScreen ? 1 : 2}
+        onChange={handleChangePage}
+        hidePrevButton
+        hideNextButton
+      />
       <Box
-        sx={{
-          width: '100%',
-          display: 'flex',
-          justifyContent: isSmallScreen ? 'space-around' : 'center',
-          alignItems: 'center',
-          marginTop: isSmallScreen ? '8px' : '0px',
-          '& button': {
-            whiteSpace: 'nowrap',
-          },
-        }}
+        width="100%"
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        flexWrap="wrap"
+        gap={1}
       >
         <Button
-          variant="contained"
-          color="primary"
+          id="pagination_1_prev"
           size="small"
-          id="id_rate_later_100_prev"
-          sx={{ marginRight: !isSmallScreen ? '8px' : '0px' }}
-          onClick={() => previousPageStep(100)}
+          variant="contained"
+          onClick={() => previousPageStep(1)}
         >
-          {'< '}
-          {isSmallScreen ? (
-            '-100'
-          ) : (
-            <Trans t={t} i18nKey="pagination.previousButton">
-              Previous {{ limit: 100 }}
-            </Trans>
-          )}
+          {'< -1'}
         </Button>
         <Button
-          variant="contained"
-          color="primary"
+          id="pagination_10_prev"
           size="small"
-          id="id_rate_later_10_prev"
+          variant="outlined"
+          sx={{
+            color: theme.palette.text.primary,
+            borderColor: theme.palette.text.primary,
+          }}
           onClick={() => previousPageStep(10)}
         >
-          {'< '}
-          {isSmallScreen ? (
-            '-10'
-          ) : (
-            <Trans t={t} i18nKey="pagination.previousButton">
-              Previous {{ limit: 10 }}
-            </Trans>
-          )}
+          {'< -10'}
         </Button>
-        {!isSmallScreen && (
-          <PaginationComponent
-            count={totalPages}
-            page={currentPage}
-            siblingCount={3}
-            boundaryCount={2}
-            onChange={handleChangePage}
-            hidePrevButton
-            hideNextButton
-            sx={{
-              '& .MuiPagination-ul': {
-                flexWrap: 'nowrap',
-              },
-            }}
-          />
+        {totalPages > 100 && (
+          <>
+            <Button
+              id="pagination_100_prev"
+              size="small"
+              variant="outlined"
+              sx={{
+                color: theme.palette.text.primary,
+                borderColor: theme.palette.text.primary,
+              }}
+              onClick={() => previousPageStep(100)}
+            >
+              {'< -100'}
+            </Button>
+            <Button
+              id="pagination_100_next"
+              size="small"
+              variant="outlined"
+              sx={{
+                color: theme.palette.text.primary,
+                borderColor: theme.palette.text.primary,
+              }}
+              onClick={() => nextPageStep(100)}
+            >
+              {'+100 >'}
+            </Button>
+          </>
         )}
         <Button
-          variant="contained"
-          color="primary"
+          id="pagination_10_next"
           size="small"
-          id="id_rate_later_10_next"
-          sx={{ marginRight: !isSmallScreen ? '8px' : '0px' }}
+          variant="outlined"
+          sx={{
+            color: theme.palette.text.primary,
+            borderColor: theme.palette.text.primary,
+          }}
           onClick={() => nextPageStep(10)}
         >
-          {isSmallScreen ? (
-            '+10'
-          ) : (
-            <Trans t={t} i18nKey="pagination.nextButton">
-              Next {{ limit: 10 }}
-            </Trans>
-          )}
-          {' >'}
+          {'+10 >'}
         </Button>
         <Button
-          variant="contained"
-          color="primary"
+          id="pagination_1_next"
           size="small"
-          id="id_rate_later_100_next"
-          onClick={() => nextPageStep(100)}
+          variant="contained"
+          onClick={() => nextPageStep(1)}
         >
-          {isSmallScreen ? (
-            '+100'
-          ) : (
-            <Trans t={t} i18nKey="pagination.nextButton">
-              Next {{ limit: 100 }}
-            </Trans>
-          )}
-          {' >'}
+          {'+1 >'}
         </Button>
-        {!isSmallScreen && (
-          <Box display="flex" alignItems="center" style={{ height: '100%' }}>
-            <Typography variant="body2" mx={2} style={{ whiteSpace: 'nowrap' }}>
-              <Trans t={t} i18nKey="pagination.page">
-                Page :
-              </Trans>
-            </Typography>
-            <input
-              type="text"
-              id="searchPageInput"
-              size={3}
-              onChange={handlePageSearch}
-              onKeyDown={handleKeyDown}
-            ></input>
-          </Box>
-        )}
       </Box>
     </Paper>
   );

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -29,9 +29,7 @@ const Pagination = ({
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'), {
     noSsr: true,
   });
-  const [currentPage, setCurrentPage] = React.useState(
-    (offset + limit) / limit
-  );
+  const currentPage = (offset + limit) / limit;
   const totalPages = Math.floor(count / limit) + (count % limit === 0 ? 0 : 1);
 
   const handleChangePage = (
@@ -39,7 +37,6 @@ const Pagination = ({
     page: number
   ) => {
     scrollToTop();
-    setCurrentPage(page);
     onOffsetChange(Math.max(0, (page - 1) * limit));
   };
 
@@ -47,7 +44,6 @@ const Pagination = ({
     if (currentPage > 1) {
       scrollToTop();
       const page = Math.max(1, currentPage - step);
-      setCurrentPage(page);
       onOffsetChange(Math.max(page * limit - limit, 0));
     }
   };
@@ -56,7 +52,6 @@ const Pagination = ({
     if (currentPage < Math.ceil(count / limit)) {
       scrollToTop();
       const page = Math.min(totalPages, currentPage + step);
-      setCurrentPage(page);
       onOffsetChange(page * limit - limit);
     }
   };
@@ -96,6 +91,7 @@ const Pagination = ({
           id="pagination_1_prev"
           size="small"
           variant="contained"
+          disabled={currentPage <= 1}
           onClick={() => previousPageStep(1)}
         >
           {'< -1'}
@@ -104,6 +100,7 @@ const Pagination = ({
           id="pagination_10_prev"
           size="small"
           variant="outlined"
+          disabled={currentPage <= 1}
           sx={{
             color: theme.palette.text.primary,
             borderColor: theme.palette.text.primary,
@@ -118,6 +115,7 @@ const Pagination = ({
               id="pagination_100_prev"
               size="small"
               variant="outlined"
+              disabled={currentPage <= 1}
               sx={{
                 color: theme.palette.text.primary,
                 borderColor: theme.palette.text.primary,
@@ -130,6 +128,7 @@ const Pagination = ({
               id="pagination_100_next"
               size="small"
               variant="outlined"
+              disabled={currentPage >= totalPages}
               sx={{
                 color: theme.palette.text.primary,
                 borderColor: theme.palette.text.primary,
@@ -144,6 +143,7 @@ const Pagination = ({
           id="pagination_10_next"
           size="small"
           variant="outlined"
+          disabled={currentPage >= totalPages}
           sx={{
             color: theme.palette.text.primary,
             borderColor: theme.palette.text.primary,
@@ -156,6 +156,7 @@ const Pagination = ({
           id="pagination_1_next"
           size="small"
           variant="contained"
+          disabled={currentPage >= totalPages}
           onClick={() => nextPageStep(1)}
         >
           {'+1 >'}

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Button, Paper, Typography } from '@mui/material';
+import {
+  Typography,
+  Button,
+  Paper,
+  Pagination as PaginationComponent,
+  Box,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+
 import { useTranslation, Trans } from 'react-i18next';
 import { scrollToTop } from 'src/utils/ui';
 
@@ -8,7 +17,6 @@ interface PaginationProps {
   offset: number;
   count: number;
   onOffsetChange: (n: number) => void;
-  itemType?: string;
 }
 
 const Pagination = ({
@@ -16,13 +24,57 @@ const Pagination = ({
   limit,
   onOffsetChange,
   count,
-  itemType,
 }: PaginationProps) => {
   const { t } = useTranslation();
+  const theme = useTheme();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'), {
+    noSsr: true,
+  });
+  const [currentPage, setCurrentPage] = React.useState(
+    (offset + limit) / limit
+  );
+  const [pageSearch, setPageSearch] = React.useState('');
+  const totalPages = Math.floor(count / limit) + (count % limit === 0 ? 0 : 1);
 
-  const firstShowing = offset + 1;
-  const lastShowing = Math.min(count, offset + limit);
-  const itemTypeText = itemType ?? t('pagination.videos');
+  const handleChangePage = (
+    _event: React.ChangeEvent<unknown>,
+    page: number
+  ) => {
+    scrollToTop();
+    setCurrentPage(page);
+    onOffsetChange(Math.max(0, (page - 1) * limit));
+  };
+  const handlePageSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPageSearch(event.target.value);
+  };
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && /^\d+$/.test(pageSearch)) {
+      const page = parseInt(pageSearch, 10);
+      if (page > 0 && page <= totalPages) {
+        scrollToTop();
+        onOffsetChange(Math.max(page * limit - limit, 0));
+        setCurrentPage(page);
+      }
+    }
+  };
+
+  const previousPageStep = (step: number) => {
+    if (currentPage > 1) {
+      scrollToTop();
+      const page = Math.max(1, currentPage - step);
+      setCurrentPage(page);
+      onOffsetChange(Math.max(page * limit - limit, 0));
+    }
+  };
+
+  const nextPageStep = (step: number) => {
+    if (currentPage < Math.ceil(count / limit)) {
+      scrollToTop();
+      const page = Math.min(totalPages, currentPage + step);
+      setCurrentPage(page);
+      onOffsetChange(page * limit - limit);
+    }
+  };
 
   return (
     <Paper
@@ -34,46 +86,140 @@ const Pagination = ({
         alignItems: 'center',
         flexDirection: 'row',
         justifyContent: 'center',
+        flexWrap: 'wrap',
       }}
     >
-      <Button
-        disabled={offset <= 0}
-        variant="contained"
-        color="primary"
-        size="small"
-        id="id_rate_later_prev"
-        onClick={() => {
-          scrollToTop();
-          onOffsetChange(Math.max(offset - limit, 0));
+      {isSmallScreen && (
+        <PaginationComponent
+          count={totalPages}
+          page={currentPage}
+          onChange={handleChangePage}
+          hidePrevButton
+          hideNextButton
+          sx={{
+            flexBasis: {
+              xs: '100%',
+              sm: 'auto',
+            },
+            display: 'flex',
+            justifyContent: 'center',
+            '& ul': {
+              justifyContent: 'center',
+            },
+          }}
+        />
+      )}
+      <Box
+        sx={{
+          width: '100%',
+          display: 'flex',
+          justifyContent: isSmallScreen ? 'space-around' : 'center',
+          alignItems: 'center',
+          marginTop: isSmallScreen ? '8px' : '0px',
+          '& button': {
+            whiteSpace: 'nowrap',
+          },
         }}
       >
-        {'< '}
-        <Trans t={t} i18nKey="pagination.previousButton">
-          Previous {{ limit }}
-        </Trans>
-      </Button>
-      <Typography variant="body2" mx={2}>
-        <Trans t={t} i18nKey="pagination.showingCounts">
-          Showing {{ itemTypeText }} {{ firstShowing }} to {{ lastShowing }} of{' '}
-          {{ total: count }}
-        </Trans>
-      </Typography>
-      <Button
-        disabled={offset + limit >= count}
-        variant="contained"
-        color="primary"
-        size="small"
-        id="id_rate_later_next"
-        onClick={() => {
-          scrollToTop();
-          onOffsetChange(Math.min(count, offset + limit));
-        }}
-      >
-        <Trans t={t} i18nKey="pagination.nextButton">
-          Next {{ limit }}
-        </Trans>
-        {' >'}
-      </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          id="id_rate_later_100_prev"
+          sx={{ marginRight: !isSmallScreen ? '8px' : '0px' }}
+          onClick={() => previousPageStep(100)}
+        >
+          {'< '}
+          {isSmallScreen ? (
+            '-100'
+          ) : (
+            <Trans t={t} i18nKey="pagination.previousButton">
+              Previous {{ limit: 100 }}
+            </Trans>
+          )}
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          id="id_rate_later_10_prev"
+          onClick={() => previousPageStep(10)}
+        >
+          {'< '}
+          {isSmallScreen ? (
+            '-10'
+          ) : (
+            <Trans t={t} i18nKey="pagination.previousButton">
+              Previous {{ limit: 10 }}
+            </Trans>
+          )}
+        </Button>
+        {!isSmallScreen && (
+          <PaginationComponent
+            count={totalPages}
+            page={currentPage}
+            siblingCount={3}
+            boundaryCount={2}
+            onChange={handleChangePage}
+            hidePrevButton
+            hideNextButton
+            sx={{
+              '& .MuiPagination-ul': {
+                flexWrap: 'nowrap',
+              },
+            }}
+          />
+        )}
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          id="id_rate_later_10_next"
+          sx={{ marginRight: !isSmallScreen ? '8px' : '0px' }}
+          onClick={() => nextPageStep(10)}
+        >
+          {isSmallScreen ? (
+            '+10'
+          ) : (
+            <Trans t={t} i18nKey="pagination.nextButton">
+              Next {{ limit: 10 }}
+            </Trans>
+          )}
+          {' >'}
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          id="id_rate_later_100_next"
+          onClick={() => nextPageStep(100)}
+        >
+          {isSmallScreen ? (
+            '+100'
+          ) : (
+            <Trans t={t} i18nKey="pagination.nextButton">
+              Next {{ limit: 100 }}
+            </Trans>
+          )}
+          {' >'}
+        </Button>
+        {!isSmallScreen && (
+          <Box display="flex" alignItems="center" style={{ height: '100%' }}>
+            <Typography variant="body2" mx={2} style={{ whiteSpace: 'nowrap' }}>
+              <Trans t={t} i18nKey="pagination.page">
+                Page :
+              </Trans>
+            </Typography>
+            <input
+              type="text"
+              id="searchPageInput"
+              size={3}
+              onChange={handlePageSearch}
+              onKeyDown={handleKeyDown}
+            ></input>
+          </Box>
+        )}
+      </Box>
     </Paper>
   );
 };

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -26,9 +26,13 @@ const Pagination = ({
 }: PaginationProps) => {
   const theme = useTheme();
 
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'), {
+  const lessThanSm = useMediaQuery(theme.breakpoints.down('sm'), {
     noSsr: true,
   });
+  const lessThanLg = useMediaQuery(theme.breakpoints.down('lg'), {
+    noSsr: true,
+  });
+
   const currentPage = (offset + limit) / limit;
   const totalPages = Math.floor(count / limit) + (count % limit === 0 ? 0 : 1);
 
@@ -73,8 +77,8 @@ const Pagination = ({
       <PaginationComponent
         count={totalPages}
         page={currentPage}
-        siblingCount={isSmallScreen ? 1 : 3}
-        boundaryCount={isSmallScreen ? 1 : 2}
+        siblingCount={lessThanLg ? 1 : 3}
+        boundaryCount={lessThanLg ? 1 : 2}
         onChange={handleChangePage}
         hidePrevButton
         hideNextButton
@@ -109,7 +113,7 @@ const Pagination = ({
         >
           {'< -10'}
         </Button>
-        {totalPages > 100 && (
+        {totalPages > 100 && !lessThanSm && (
           <>
             <Button
               id="pagination_100_prev"

--- a/frontend/src/pages/comparisons/ComparisonList.tsx
+++ b/frontend/src/pages/comparisons/ComparisonList.tsx
@@ -100,13 +100,14 @@ function ComparisonsPage() {
             <>
               {nbComparisonsMessage}
               <ComparisonList comparisons={comparisons} />
-              <Pagination
-                offset={offset}
-                count={comparisonCount}
-                onOffsetChange={handleOffsetChange}
-                limit={limit}
-                itemType={t('pagination.comparisons')}
-              />
+              {comparisonCount > limit && (
+                <Pagination
+                  offset={offset}
+                  count={comparisonCount}
+                  onOffsetChange={handleOffsetChange}
+                  limit={limit}
+                />
+              )}
             </>
           )}
         </LoaderWrapper>

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -185,7 +185,7 @@ const RateLaterPage = () => {
               />
             </LoaderWrapper>
           </Box>
-          {!!entityCount && (
+          {!!entityCount && entityCount > limit && (
             <div className={classes.stickyPagination}>
               <Pagination
                 offset={offset}

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -146,7 +146,7 @@ const VideoRatingsPage = () => {
             emptyMessage={<NoRatingMessage hasFilter={hasFilter} />}
           />
         </LoaderWrapper>
-        {!isLoading && videoCount > 0 && (
+        {!isLoading && videoCount > 0 && videoCount > limit && (
           <Pagination
             offset={offset}
             count={videoCount}

--- a/tests/cypress/e2e/frontend/myRatedVideosPage.cy.ts
+++ b/tests/cypress/e2e/frontend/myRatedVideosPage.cy.ts
@@ -8,8 +8,12 @@ describe('My rated elements page', () => {
       cy.focused().type(TEST_USERNAME);
       cy.get('input[name="password"]').click().type(TEST_PASSWORD).type('{enter}');
 
-      // All rated videos are listed.
-      cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
+      // Pagination is display.
+      cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
+      cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
+      cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
+      cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
+      cy.contains('Page :', {matchCase: false}).should('exist');;
 
       // Mark all videos as public.
       cy.contains('button', 'Options', {matchCase: false}).click();
@@ -26,11 +30,19 @@ describe('My rated elements page', () => {
       // Select "Private" filter and check that a single video appears on the list
       cy.contains('button', 'Options', {matchCase: false}).click();
       cy.contains('label', 'Private', {matchCase: false}).click();
-      cy.contains('Showing videos 1 to 1 of 1').should('be.visible');
+      cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
+      cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
+      cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
+      cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
+      cy.contains('Page :', {matchCase: false}).should('exist');;
 
       // Mark all videos as public, the filter is reset and all videos are listed
       cy.contains('button', 'Mark all as public').click();
-      cy.contains(/Showing videos 1 to 20 of \d+/).should('be.visible');
+      cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
+      cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
+      cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
+      cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
+      cy.contains('Page :', {matchCase: false}).should('exist');;
     });
 
     it('visit ratings page with `isPublic` param in URL', () => {

--- a/tests/cypress/e2e/frontend/myRatedVideosPage.cy.ts
+++ b/tests/cypress/e2e/frontend/myRatedVideosPage.cy.ts
@@ -3,17 +3,21 @@ describe('My rated elements page', () => {
     const TEST_USERNAME = "aidjango";
     const TEST_PASSWORD = "tournesol";
 
-    it('can list and update ratings status', () => {
+    it('display the pagination', () => {
       cy.visit('/ratings');
       cy.focused().type(TEST_USERNAME);
       cy.get('input[name="password"]').click().type(TEST_PASSWORD).type('{enter}');
 
-      // Pagination is display.
-      cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
-      cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
-      cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
-      cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
-      cy.contains('Page :', {matchCase: false}).should('exist');;
+      cy.contains('button', '< -10', {matchCase: false}).should('exist');
+      cy.contains('button', '< -1', {matchCase: false}).should('exist');
+      cy.contains('button', '+1 >', {matchCase: false}).should('exist');
+      cy.contains('button', '+10 >', {matchCase: false}).should('exist');
+    });
+
+    it('can list and update ratings status', () => {
+      cy.visit('/ratings');
+      cy.focused().type(TEST_USERNAME);
+      cy.get('input[name="password"]').click().type(TEST_PASSWORD).type('{enter}');
 
       // Mark all videos as public.
       cy.contains('button', 'Options', {matchCase: false}).click();
@@ -30,19 +34,9 @@ describe('My rated elements page', () => {
       // Select "Private" filter and check that a single video appears on the list
       cy.contains('button', 'Options', {matchCase: false}).click();
       cy.contains('label', 'Private', {matchCase: false}).click();
-      cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
-      cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
-      cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
-      cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
-      cy.contains('Page :', {matchCase: false}).should('exist');;
 
       // Mark all videos as public, the filter is reset and all videos are listed
       cy.contains('button', 'Mark all as public').click();
-      cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
-      cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
-      cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
-      cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
-      cy.contains('Page :', {matchCase: false}).should('exist');;
     });
 
     it('visit ratings page with `isPublic` param in URL', () => {

--- a/tests/cypress/e2e/frontend/recommendationsPage.cy.ts
+++ b/tests/cypress/e2e/frontend/recommendationsPage.cy.ts
@@ -58,8 +58,14 @@ describe('Recommendations page', () => {
           cy.get('input[type=checkbox][name=Month]').should('not.be.checked');
 
           cy.location('search').should('contain', 'date=Year');
-          cy.contains('Showing videos 1 to', {matchCase: false}).should('be.visible');
           cy.contains('No video corresponds to your search criterias.', {matchCase: false}).should('not.exist');
+
+          // Pagination is display.
+          cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
+          cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
+          cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
+          cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
+          cy.contains('Page :', {matchCase: false}).should('exist');;
         });
 
         it('shows no videos for 1 day ago', () => {
@@ -79,9 +85,14 @@ describe('Recommendations page', () => {
           cy.contains('All time', {matchCase: false}).click();
           cy.get('input[type=checkbox][name=""]').should('be.checked');
           cy.get('input[type=checkbox][name=Month]').should('not.be.checked');
-
-          cy.contains('Showing videos 1 to 20 of', {matchCase: false}).should('be.visible');
           cy.contains('No video corresponds to your search criterias.', {matchCase: false}).should('not.exist');
+          
+          // Pagination is display.
+          cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
+          cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
+          cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
+          cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
+          cy.contains('Page :', {matchCase: false}).should('exist');
         })
       });
     });

--- a/tests/cypress/e2e/frontend/recommendationsPage.cy.ts
+++ b/tests/cypress/e2e/frontend/recommendationsPage.cy.ts
@@ -1,5 +1,16 @@
 describe('Recommendations page', () => {
   describe('Poll - videos', () => {
+
+    describe('Pagination', () => {
+      it('displays the pagination', () => {
+        cy.visit('/recommendations');
+        cy.contains('button', '< -10', {matchCase: false}).should('exist');
+        cy.contains('button', '< -1', {matchCase: false}).should('exist');
+        cy.contains('button', '+1 >', {matchCase: false}).should('exist');
+        cy.contains('button', '+10 >', {matchCase: false}).should('exist');
+      });
+    });
+
     describe('Search filters', () => {
       it('sets default languages properly and backward navigation works', () => {
         cy.visit('/');
@@ -59,13 +70,6 @@ describe('Recommendations page', () => {
 
           cy.location('search').should('contain', 'date=Year');
           cy.contains('No video corresponds to your search criterias.', {matchCase: false}).should('not.exist');
-
-          // Pagination is display.
-          cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
-          cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
-          cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
-          cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
-          cy.contains('Page :', {matchCase: false}).should('exist');;
         });
 
         it('shows no videos for 1 day ago', () => {
@@ -86,13 +90,6 @@ describe('Recommendations page', () => {
           cy.get('input[type=checkbox][name=""]').should('be.checked');
           cy.get('input[type=checkbox][name=Month]').should('not.be.checked');
           cy.contains('No video corresponds to your search criterias.', {matchCase: false}).should('not.exist');
-          
-          // Pagination is display.
-          cy.contains('button', '< Previous 100', {matchCase: false}).should('exist');
-          cy.contains('button', '< Previous 10', {matchCase: false}).should('exist');
-          cy.contains('button', 'Next 10 >', {matchCase: false}).should('exist');
-          cy.contains('button', 'Next 100 >', {matchCase: false}).should('exist');
-          cy.contains('Page :', {matchCase: false}).should('exist');
         })
       });
     });


### PR DESCRIPTION
Refactoring of the Pagination component to present the list of pages.
Allow quick navigation to 3 pages before or 3 pages after.
Ability to go to -100 -10 +10 +100 pages
Added a field to enter the page number.

Pagination on large screens: 
![image](https://user-images.githubusercontent.com/11448109/222376012-499fb26e-da9d-4e06-bf13-344d0771133d.png)

Pagination on small screens: 
![image](https://user-images.githubusercontent.com/11448109/222376303-7b1f1a3c-2c04-43d2-bb48-8df5aff70eed.png)

Requested change in issue #1001