### PR TITLE
[front] fix redirection from legacy params on comparison page with autofill

### DIFF
--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Redirect, useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Location } from 'history';
 
 import { CircularProgress, Grid, Typography, Card } from '@mui/material';
 
@@ -27,32 +28,26 @@ const LEGACY_PARAMS: { vidA: string; vidB: string } = {
   vidB: 'videoB',
 };
 
-/**
- * Return an URLSearchParams without legacy parameters.
- */
-const rewriteLegacyParameters = (
-  uidA: string,
-  uidB: string,
-  legacyA: string | null,
-  legacyB: string | null,
-  paramVidA: string,
-  paramVidB: string
-) => {
-  const searchParams = new URLSearchParams();
-  searchParams.append(paramVidA, uidA);
-  searchParams.append(paramVidB, uidB);
-
-  if (legacyA && uidA === '') {
-    searchParams.delete(paramVidA);
-    searchParams.append(paramVidA, UID_YT_NAMESPACE + legacyA);
+const getUidsFromLocation = (location: Location) => {
+  const searchParams = new URLSearchParams(location.search);
+  let uidA = searchParams.get(UID_PARAMS.vidA);
+  if (uidA === null) {
+    const legacyA = searchParams.get(LEGACY_PARAMS.vidA);
+    if (legacyA) {
+      uidA = UID_YT_NAMESPACE + legacyA;
+    }
   }
-
-  if (legacyB && uidB === '') {
-    searchParams.delete(paramVidB);
-    searchParams.append(paramVidB, UID_YT_NAMESPACE + legacyB);
+  let uidB = searchParams.get(UID_PARAMS.vidB);
+  if (uidB === null) {
+    const legacyB = searchParams.get(LEGACY_PARAMS.vidB);
+    if (legacyB) {
+      uidB = UID_YT_NAMESPACE + legacyB;
+    }
   }
-
-  return searchParams;
+  return {
+    uidA,
+    uidB,
+  };
 };
 
 interface Props {
@@ -80,22 +75,7 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
   const [initialComparison, setInitialComparison] =
     useState<ComparisonRequest | null>(null);
 
-  const searchParams = new URLSearchParams(location.search);
-  const uidA: string | null = searchParams.get(UID_PARAMS.vidA);
-  const uidB: string | null = searchParams.get(UID_PARAMS.vidB);
-
-  // clean the URL by replacing legacy parameters by UIDs
-  const legacyA = searchParams.get(LEGACY_PARAMS.vidA);
-  const legacyB = searchParams.get(LEGACY_PARAMS.vidB);
-  const newSearchParams = rewriteLegacyParameters(
-    uidA || '',
-    uidB || '',
-    legacyA,
-    legacyB,
-    UID_PARAMS.vidA,
-    UID_PARAMS.vidB
-  );
-
+  const { uidA, uidB } = getUidsFromLocation(location);
   const [selectorA, setSelectorA] = useState<SelectorValue>({
     uid: uidA,
     rating: null,
@@ -106,28 +86,30 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
   });
 
   const onChange = useCallback(
-    (uidKey: string) => (newValue: SelectorValue) => {
+    (vidKey: 'vidA' | 'vidB') => (newValue: SelectorValue) => {
       // `window.location` is used here, to avoid memoizing the location
       // defined in component state, which could be obsolete and cause a
       // race condition when the 2 selectors are updated concurrently.
       const searchParams = new URLSearchParams(window.location.search);
       const uid = newValue.uid;
 
+      const uidKey = UID_PARAMS[vidKey];
       if ((searchParams.get(uidKey) || '') !== uid) {
         searchParams.set(uidKey, uid || '');
+        searchParams.delete(LEGACY_PARAMS[vidKey]);
         history.replace({ search: searchParams.toString() });
       }
-      if (uidKey === UID_PARAMS.vidA) {
+      if (vidKey === 'vidA') {
         setSelectorA(newValue);
-      } else if (uidKey === UID_PARAMS.vidB) {
+      } else if (vidKey === 'vidB') {
         setSelectorB(newValue);
       }
     },
     [history]
   );
 
-  const onChangeA = useMemo(() => onChange(UID_PARAMS.vidA), [onChange]);
-  const onChangeB = useMemo(() => onChange(UID_PARAMS.vidB), [onChange]);
+  const onChangeA = useMemo(() => onChange('vidA'), [onChange]);
+  const onChangeB = useMemo(() => onChange('vidB'), [onChange]);
 
   useEffect(() => {
     setIsLoading(true);
@@ -201,16 +183,6 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
 
     showSuccessAlert(t('comparison.successfullySubmitted'));
   };
-
-  // redirect the user if at least one legacy parameters has been used
-  // existing UIDs always prevail
-  if (legacyA != null || legacyB != null) {
-    return (
-      <Redirect
-        to={{ pathname: location.pathname, search: newSearchParams.toString() }}
-      />
-    );
-  }
 
   const entityName = getEntityName(t, pollName);
 

--- a/tests/cypress/integration/frontend/comparisonPage.ts
+++ b/tests/cypress/integration/frontend/comparisonPage.ts
@@ -265,5 +265,24 @@ describe('Comparison page', () => {
       cy.get('input[placeholder="Paste URL or Video ID"]').last()
         .should('have.value', `yt:${videoBId}`);
     });
+
+    it('auto-fills selector correctly when one of the video uses a legacy param', () => {
+      const videoAId = 'u83A7DUNMHs';
+      const videoBId = '6jK9bFWE--g';
+
+      cy.visit(`/comparison/?videoA=${videoAId}&uidB=yt:${videoBId}`);
+      cy.focused().type('user1');
+      cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
+
+      cy.wait(1000);
+
+      cy.location('search').should('contain', `uidA=yt%3A${videoAId}`)
+      cy.location('search').should('contain', `uidB=yt%3A${videoBId}`)
+
+      cy.get('input[placeholder="Paste URL or Video ID"]').first()
+        .should('have.value', `yt:${videoAId}`);
+      cy.get('input[placeholder="Paste URL or Video ID"]').last()
+        .should('have.value', `yt:${videoBId}`);
+    });
   })
 });


### PR DESCRIPTION
When redirecting from legacy params videoA and videoB, the state `selectorA` and `selectorB` was already initialized with empty uids. That breaks assumptions made by the video selectors when using the autofill feature.