### PR TITLE
[front] feat: hide unavailable videos in list

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -14,6 +14,7 @@
     "continue": "continue"
   },
   "video": {
+    "notAvailableAnymore": "This video is not available anymore",
     "labelShowSettings": "Show settings related to this video",
     "unsafeNotEnoughContributor": "The relevance of this score is uncertain, due to too few contributors.",
     "unsafeNegativeRating": "This video score is below the average of the other videos added to Tournesol.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -14,7 +14,7 @@
     "continue": "continue"
   },
   "video": {
-    "notAvailableAnymore": "This video is not available anymore",
+    "notAvailableAnymore": "This video is not available anymore.",
     "labelShowSettings": "Show settings related to this video",
     "unsafeNotEnoughContributor": "The relevance of this score is uncertain, due to too few contributors.",
     "unsafeNegativeRating": "This video score is below the average of the other videos added to Tournesol.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -33,6 +33,9 @@
     "contributionsArePrivateMessage": "Your contributions about this item are currently private. The details of your personal ratings are not published, but they may still be used to compute public aggregated scores.",
     "personalScore": "Personal score: {{score}}"
   },
+  "entityCard": {
+    "notAvailableAnymore": "This entity is not available anymore."
+  },
   "score": {
     "totalScoreBasedOnRankingChoice": "Score based on selected ranking parameters"
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -14,6 +14,7 @@
     "continue": "continuer"
   },
   "video": {
+    "notAvailableAnymore": "Cette vidéo n'est plus disponible",
     "labelShowSettings": "Voir les paramètres de cette video",
     "unsafeNotEnoughContributor": "La pertinence de ce score est incertaine, en raison d'un trop faible nombre de contributeurs.",
     "unsafeNegativeRating": "Cette vidéo a un score inférieur à la moyenne des autres vidéos ajoutées à Tournesol.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -36,6 +36,9 @@
     "contributionsArePrivateMessage": "Vos contributions impliquant cet élément sont actuellement privées. Les détails de vos jugements ne sont pas publiés, mais ils sont tout de même pris en compte pour calculer des scores agrégés publics.",
     "personalScore": "Score personnel\u00a0: {{score}}"
   },
+  "entityCard": {
+    "notAvailableAnymore": "Cette entité n'est plus disponible."
+  },
   "score": {
     "totalScoreBasedOnRankingChoice": "Score basé sur les critères de classement selectionnés"
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -14,7 +14,7 @@
     "continue": "continuer"
   },
   "video": {
-    "notAvailableAnymore": "Cette vidéo n'est plus disponible",
+    "notAvailableAnymore": "Cette vidéo n'est plus disponible.",
     "labelShowSettings": "Voir les paramètres de cette video",
     "unsafeNotEnoughContributor": "La pertinence de ce score est incertaine, en raison d'un trop faible nombre de contributeurs.",
     "unsafeNegativeRating": "Cette vidéo a un score inférieur à la moyenne des autres vidéos ajoutées à Tournesol.",

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -1,20 +1,52 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Grid } from '@mui/material';
+import { Box, Grid, Typography } from '@mui/material';
 import { idFromUid } from '../../utils/video';
 import { entityCardMainSx } from './style';
+import { ActionList } from 'src/utils/types';
+import { TypeEnum } from 'src/services/openapi';
 
-export const EntityNotAvailable = ({ type }: { type: string }) => {
+/*
+ * return a different error element related to the type of the entity and actions
+ */
+export const EntityNotAvailable = ({
+  type,
+  unavailableActions,
+  uid,
+}: {
+  type: string;
+  unavailableActions?: ActionList;
+  uid: string;
+}) => {
   const { t } = useTranslation();
 
-  if (type == 'video') {
+  if (type == TypeEnum.VIDEO) {
     return (
       <Box mx={1} my={2}>
-        <Grid container sx={entityCardMainSx}>
-          <Box mx={1} my={2}>
-            {t('video.notAvailableAnymore')}
-          </Box>
+        <Grid
+          mx={1}
+          my={2}
+          container
+          sx={entityCardMainSx}
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Grid ml={1} my={2}>
+            <Typography >
+              {t('video.notAvailableAnymore')}
+            </Typography>
+          </Grid>
+          <Grid justifyContent="center" alignItems="flex-end">
+            {unavailableActions &&
+              unavailableActions.map((Action, index) =>
+                typeof Action === 'function' ? (
+                  <Action key={index} uid={uid} />
+                ) : (
+                  Action
+                )
+              )}
+          </Grid>
         </Grid>
       </Box>
     );
@@ -23,14 +55,20 @@ export const EntityNotAvailable = ({ type }: { type: string }) => {
   return null;
 };
 
+/*
+ * Check if an entity is available
+ * It returns children if it is available either it returns an error element
+ */
 const AvailableEntity = ({
   children,
   uid,
   type,
+  unavailableActions,
 }: {
   children: React.ReactNode;
   uid: string;
   type: string;
+  unavailableActions?: ActionList;
 }) => {
   const [isAvailable, setIsAvailable] = useState(false);
 
@@ -46,7 +84,15 @@ const AvailableEntity = ({
     }
   }, [uid, type]);
 
-  return isAvailable ? <>{children}</> : <EntityNotAvailable type={type} />;
+  return isAvailable ? (
+    <>{children}</>
+  ) : (
+    <EntityNotAvailable
+      type={type}
+      unavailableActions={unavailableActions}
+      uid={uid}
+    />
+  );
 };
 
 export default AvailableEntity;

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -1,58 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-
-import { Box, Grid, Typography } from '@mui/material';
 
 import LoaderWrapper from 'src/components/LoaderWrapper';
 import { TypeEnum } from 'src/services/openapi';
 import { ActionList } from 'src/utils/types';
 import { idFromUid } from 'src/utils/video';
-import { entityCardMainSx } from './style';
-
-/*
- * This component can be returned instead of <EntityCard> when the entity
- * doesn't seem to be available online at its original location.
- */
-export const EntityNotAvailable = ({
-  uid,
-  type,
-  actionsIfUnavailable,
-}: {
-  uid: string;
-  type: string;
-  actionsIfUnavailable?: ActionList;
-}) => {
-  const { t } = useTranslation();
-
-  if (type === TypeEnum.VIDEO) {
-    return (
-      <Box mx={1} my={2}>
-        <Grid
-          container
-          justifyContent="space-between"
-          alignItems="center"
-          sx={entityCardMainSx}
-        >
-          <Grid item pl={1} py={2}>
-            <Typography>{t('video.notAvailableAnymore')}</Typography>
-          </Grid>
-          <Grid item>
-            {actionsIfUnavailable &&
-              actionsIfUnavailable.map((Action, index) =>
-                typeof Action === 'function' ? (
-                  <Action key={index} uid={uid} />
-                ) : (
-                  Action
-                )
-              )}
-          </Grid>
-        </Grid>
-      </Box>
-    );
-  }
-
-  return null;
-};
 
 /**
  * Return an <EntityNotAvailable> if the entity doesn't seem to be available
@@ -67,7 +18,7 @@ const AvailableEntity = ({
 }: {
   uid: string;
   type: string;
-  children: React.ReactNode;
+  children: React.ReactElement;
   actionsIfUnavailable?: ActionList;
 }) => {
   const [isLoading, setIsLoading] = useState(true);
@@ -97,11 +48,12 @@ const AvailableEntity = ({
       {isAvailable ? (
         <>{children}</>
       ) : (
-        <EntityNotAvailable
-          uid={uid}
-          type={type}
-          actionsIfUnavailable={actionsIfUnavailable}
-        />
+        <>
+          {React.cloneElement(children, {
+            isAvailable: isAvailable,
+            actions: actionsIfUnavailable,
+          })}
+        </>
       )}
     </LoaderWrapper>
   );

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -15,11 +15,11 @@ import { entityCardMainSx } from './style';
 export const EntityNotAvailable = ({
   uid,
   type,
-  unavailableActions,
+  actionsIfUnavailable,
 }: {
   uid: string;
   type: string;
-  unavailableActions?: ActionList;
+  actionsIfUnavailable?: ActionList;
 }) => {
   const { t } = useTranslation();
 
@@ -36,8 +36,8 @@ export const EntityNotAvailable = ({
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
           <Grid item>
-            {unavailableActions &&
-              unavailableActions.map((Action, index) =>
+            {actionsIfUnavailable &&
+              actionsIfUnavailable.map((Action, index) =>
                 typeof Action === 'function' ? (
                   <Action key={index} uid={uid} />
                 ) : (
@@ -62,12 +62,12 @@ const AvailableEntity = ({
   uid,
   type,
   children,
-  unavailableActions,
+  actionsIfUnavailable,
 }: {
   uid: string;
   type: string;
   children: React.ReactNode;
-  unavailableActions?: ActionList;
+  actionsIfUnavailable?: ActionList;
 }) => {
   const [isAvailable, setIsAvailable] = useState(false);
 
@@ -94,7 +94,7 @@ const AvailableEntity = ({
     <EntityNotAvailable
       uid={uid}
       type={type}
-      unavailableActions={unavailableActions}
+      actionsIfUnavailable={actionsIfUnavailable}
     />
   );
 };

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -33,7 +33,7 @@ export const EntityNotAvailable = ({
           alignItems="center"
           sx={entityCardMainSx}
         >
-          <Grid item px={1} py={2}>
+          <Grid item pl={1} py={2}>
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
           <Grid item>

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -22,7 +22,7 @@ export const EntityNotAvailable = ({
 }) => {
   const { t } = useTranslation();
 
-  if (type == TypeEnum.VIDEO) {
+  if (type === TypeEnum.VIDEO) {
     return (
       <Box mx={1} my={2}>
         <Grid
@@ -52,25 +52,31 @@ export const EntityNotAvailable = ({
   return null;
 };
 
-/*
- * Check if an entity is available
- * It returns children if it is available either it returns an error element
+/**
+ * Return an <EntityNotAvailable> if the entity doesn't seem to be available
+ * online at its original location, return the given children component
+ * instead.
  */
 const AvailableEntity = ({
-  children,
   uid,
   type,
+  children,
   unavailableActions,
 }: {
-  children: React.ReactNode;
   uid: string;
   type: string;
+  children: React.ReactNode;
   unavailableActions?: ActionList;
 }) => {
   const [isAvailable, setIsAvailable] = useState(false);
 
+  /**
+   * Check if the entity is available.
+   *
+   * The behaviour "is available" could be factorized in a custom hook.
+   */
   useEffect(() => {
-    if (type != 'video') {
+    if (type !== TypeEnum.VIDEO) {
       setIsAvailable(true);
     } else {
       const img = new Image();
@@ -85,9 +91,9 @@ const AvailableEntity = ({
     <>{children}</>
   ) : (
     <EntityNotAvailable
+      uid={uid}
       type={type}
       unavailableActions={unavailableActions}
-      uid={uid}
     />
   );
 };

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -35,7 +35,7 @@ export const EntityNotAvailable = ({
           <Grid ml={1} my={2}>
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
-          <Grid >
+          <Grid>
             {unavailableActions &&
               unavailableActions.map((Action, index) =>
                 typeof Action === 'function' ? (

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -35,7 +35,7 @@ export const EntityNotAvailable = ({
           <Grid ml={1} my={2}>
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
-          <Grid justifyContent="center" alignItems="flex-end">
+          <Grid >
             {unavailableActions &&
               unavailableActions.map((Action, index) =>
                 typeof Action === 'function' ? (

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Box, Grid } from '@mui/material';
+import { idFromUid } from '../../utils/video';
+import { entityCardMainSx } from './style';
+
+export const EntityNotAvailable = ({ type }: { type: string }) => {
+  const { t } = useTranslation();
+
+  if (type == 'video') {
+    return (
+      <Box mx={1} my={2}>
+        <Grid container sx={entityCardMainSx}>
+          <Box mx={1} my={2}>
+            {t('video.notAvailableAnymore')}
+          </Box>
+        </Grid>
+      </Box>
+    );
+  }
+
+  return null;
+};
+
+const AvailableEntity = ({
+  children,
+  uid,
+  type,
+}: {
+  children: React.ReactNode;
+  uid: string;
+  type: string;
+}) => {
+  const [isAvailable, setIsAvailable] = useState(false);
+
+  useEffect(() => {
+    if (type != 'video') {
+      setIsAvailable(true);
+    } else {
+      const img = new Image();
+      img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
+      img.onload = function () {
+        setIsAvailable(img.width !== 120);
+      };
+    }
+  }, [uid, type]);
+
+  return isAvailable ? <>{children}</> : <EntityNotAvailable type={type} />;
+};
+
+export default AvailableEntity;

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -33,9 +33,7 @@ export const EntityNotAvailable = ({
           alignItems="center"
         >
           <Grid ml={1} my={2}>
-            <Typography >
-              {t('video.notAvailableAnymore')}
-            </Typography>
+            <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
           <Grid justifyContent="center" alignItems="flex-end">
             {unavailableActions &&

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Box, Grid, Typography } from '@mui/material';
 
+import LoaderWrapper from 'src/components/LoaderWrapper';
 import { TypeEnum } from 'src/services/openapi';
 import { ActionList } from 'src/utils/types';
 import { idFromUid } from 'src/utils/video';
@@ -69,6 +70,7 @@ const AvailableEntity = ({
   children: React.ReactNode;
   actionsIfUnavailable?: ActionList;
 }) => {
+  const [isLoading, setIsLoading] = useState(true);
   const [isAvailable, setIsAvailable] = useState(false);
 
   /**
@@ -78,24 +80,30 @@ const AvailableEntity = ({
    */
   useEffect(() => {
     if (type !== TypeEnum.VIDEO) {
+      setIsLoading(false);
       setIsAvailable(true);
     } else {
       const img = new Image();
       img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
       img.onload = function () {
+        setIsLoading(false);
         setIsAvailable(img.width !== 120);
       };
     }
   }, [uid, type]);
 
-  return isAvailable ? (
-    <>{children}</>
-  ) : (
-    <EntityNotAvailable
-      uid={uid}
-      type={type}
-      actionsIfUnavailable={actionsIfUnavailable}
-    />
+  return (
+    <LoaderWrapper isLoading={isLoading}>
+      {isAvailable ? (
+        <>{children}</>
+      ) : (
+        <EntityNotAvailable
+          uid={uid}
+          type={type}
+          actionsIfUnavailable={actionsIfUnavailable}
+        />
+      )}
+    </LoaderWrapper>
   );
 };
 

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -8,16 +8,17 @@ import { ActionList } from 'src/utils/types';
 import { TypeEnum } from 'src/services/openapi';
 
 /*
- * return a different error element related to the type of the entity and actions
+ * This component can be returned instead of <EntityCard> when the entity
+ * doesn't seem to be available online at its original location.
  */
 export const EntityNotAvailable = ({
+  uid,
   type,
   unavailableActions,
-  uid,
 }: {
+  uid: string;
   type: string;
   unavailableActions?: ActionList;
-  uid: string;
 }) => {
   const { t } = useTranslation();
 
@@ -25,17 +26,15 @@ export const EntityNotAvailable = ({
     return (
       <Box mx={1} my={2}>
         <Grid
-          mx={1}
-          my={2}
           container
-          sx={entityCardMainSx}
           justifyContent="space-between"
           alignItems="center"
+          sx={entityCardMainSx}
         >
-          <Grid ml={1} my={2}>
+          <Grid item px={1} py={2}>
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
-          <Grid>
+          <Grid item>
             {unavailableActions &&
               unavailableActions.map((Action, index) =>
                 typeof Action === 'function' ? (

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, Grid, Typography } from '@mui/material';
-import { idFromUid } from '../../utils/video';
-import { entityCardMainSx } from './style';
-import { ActionList } from 'src/utils/types';
+
 import { TypeEnum } from 'src/services/openapi';
+import { ActionList } from 'src/utils/types';
+import { idFromUid } from 'src/utils/video';
+import { entityCardMainSx } from './style';
 
 /*
  * This component can be returned instead of <EntityCard> when the entity

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -6,9 +6,9 @@ import { ActionList } from 'src/utils/types';
 import { idFromUid } from 'src/utils/video';
 
 /**
- * Return an <EntityNotAvailable> if the entity doesn't seem to be available
- * online at its original location, return the given children component
- * instead.
+ * Return an <EntityCard> with isAvailable=false if the entity doesn't seem to
+ * be available online at its original location, return the given children
+ * components as-is instead.
  */
 const AvailableEntity = ({
   uid,

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
@@ -22,6 +22,7 @@ import EntityCardScores from './EntityCardScores';
 import EntityImagery from './EntityImagery';
 import EntityMetadata, { VideoMetadata } from './EntityMetadata';
 import { entityCardMainSx } from './style';
+import { idFromUid } from 'src/utils/video';
 
 const EntityCard = ({
   entity,
@@ -44,6 +45,7 @@ const EntityCard = ({
     noSsr: true,
   });
   const [settingsVisible, setSettingsVisible] = useState(!isSmallScreen);
+  const [isAvailable, setIsAvailable] = useState(true);
 
   const displayEntityCardScores = () => {
     if ('tournesol_score' in entity && !compact) {
@@ -57,6 +59,18 @@ const EntityCard = ({
     }
     return null;
   };
+
+  useEffect(() => {
+    if (entity.uid) {
+      const img = new Image();
+      img.src = `https://i.ytimg.com/vi/${idFromUid(entity.uid)}/mqdefault.jpg`;
+      img.onload = function () {
+        setIsAvailable(img.width !== 120);
+      };
+    }
+
+    console.log('change');
+  }, [entity]);
 
   return (
     <Grid container sx={entityCardMainSx}>
@@ -89,7 +103,9 @@ const EntityCard = ({
       >
         <EntityCardTitle
           uid={entity.uid}
-          title={entity.metadata.name}
+          title={
+            isAvailable ? entity.metadata.name : t('video.notAvailableAnymore')
+          }
           compact={compact}
         />
         <EntityMetadata entity={entity} />

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
@@ -22,7 +22,6 @@ import EntityCardScores from './EntityCardScores';
 import EntityImagery from './EntityImagery';
 import EntityMetadata, { VideoMetadata } from './EntityMetadata';
 import { entityCardMainSx } from './style';
-import { idFromUid } from 'src/utils/video';
 
 const EntityCard = ({
   entity,
@@ -45,7 +44,6 @@ const EntityCard = ({
     noSsr: true,
   });
   const [settingsVisible, setSettingsVisible] = useState(!isSmallScreen);
-  const [isAvailable, setIsAvailable] = useState(true);
 
   const displayEntityCardScores = () => {
     if ('tournesol_score' in entity && !compact) {
@@ -59,18 +57,6 @@ const EntityCard = ({
     }
     return null;
   };
-
-  useEffect(() => {
-    if (entity.uid) {
-      const img = new Image();
-      img.src = `https://i.ytimg.com/vi/${idFromUid(entity.uid)}/mqdefault.jpg`;
-      img.onload = function () {
-        setIsAvailable(img.width !== 120);
-      };
-    }
-
-    console.log('change');
-  }, [entity]);
 
   return (
     <Grid container sx={entityCardMainSx}>
@@ -103,9 +89,7 @@ const EntityCard = ({
       >
         <EntityCardTitle
           uid={entity.uid}
-          title={
-            isAvailable ? entity.metadata.name : t('video.notAvailableAnymore')
-          }
+          title={entity.metadata.name}
           compact={compact}
         />
         <EntityMetadata entity={entity} />

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
@@ -8,10 +8,13 @@ import {
   useTheme,
   useMediaQuery,
   Stack,
+  Typography,
 } from '@mui/material';
 import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
+  ArrowDropDown,
+  ArrowDropUp,
 } from '@mui/icons-material';
 
 import { TypeEnum } from 'src/services/openapi';
@@ -29,11 +32,13 @@ const EntityCard = ({
   settings = [],
   compact = false,
   entityTypeConfig,
+  isAvailable = true,
 }: {
   entity: RelatedEntityObject;
   actions?: ActionList;
   settings?: ActionList;
   compact?: boolean;
+  isAvailable?: boolean;
   // Configuration specific to the entity type.
   entityTypeConfig?: { [k in TypeEnum]?: { [k: string]: JSONValue } };
 }) => {
@@ -44,6 +49,11 @@ const EntityCard = ({
     noSsr: true,
   });
   const [settingsVisible, setSettingsVisible] = useState(!isSmallScreen);
+  const [entityVisible, setEntityVisible] = useState(true);
+
+  useEffect(() => {
+    setEntityVisible(isAvailable);
+  }, [isAvailable]);
 
   const displayEntityCardScores = () => {
     if ('tournesol_score' in entity && !compact) {
@@ -58,97 +68,127 @@ const EntityCard = ({
     return null;
   };
 
+  const toggleEntityVisibility = () => {
+    setEntityVisible((prevEntityVisibility) => !prevEntityVisibility);
+  };
+
   return (
     <Grid container sx={entityCardMainSx}>
-      <Grid
-        item
-        xs={12}
-        sm={compact ? 12 : 'auto'}
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          ...(compact ? {} : { minWidth: '240px', maxWidth: { sm: '240px' } }),
-        }}
-      >
-        <EntityImagery
-          entity={entity}
-          compact={compact}
-          config={entityTypeConfig}
-        />
-      </Grid>
-      <Grid
-        item
-        xs={12}
-        sm={compact ? 12 : true}
-        sx={{
-          padding: 1,
-        }}
-        data-testid="video-card-info"
-        container
-        direction="column"
-      >
-        <EntityCardTitle
-          uid={entity.uid}
-          title={entity.metadata.name}
-          compact={compact}
-        />
-        <EntityMetadata entity={entity} />
-        {displayEntityCardScores()}
-      </Grid>
-      <Grid
-        item
-        xs={12}
-        sm={compact ? 12 : 1}
-        sx={{
-          display: 'flex',
-          alignItems: 'end',
-          justifyContent: 'space-between',
-          flexDirection: 'column',
-          [theme.breakpoints.down('sm')]: {
-            flexDirection: 'row',
-          },
-        }}
-      >
-        {actions.map((Action, index) =>
-          typeof Action === 'function' ? (
-            <Action key={index} uid={entity.uid} />
-          ) : (
-            Action
-          )
-        )}
-        {isSmallScreen && settings.length > 0 && (
-          <>
-            <Box flexGrow={1} />
-            <IconButton
-              size="small"
-              aria-label={t('video.labelShowSettings')}
-              onClick={() => setSettingsVisible(!settingsVisible)}
-            >
-              {settingsVisible ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-            </IconButton>
-          </>
-        )}
-      </Grid>
-      {settings.length > 0 && (
-        <Grid item xs={12}>
-          <Collapse in={settingsVisible || !isSmallScreen}>
-            <Box
-              paddingY={1}
-              borderTop="1px solid rgba(0, 0, 0, 0.12)"
-              display="flex"
-              gap="16px"
-              color="text.secondary"
-            >
-              {settings.map((Action, index) =>
-                typeof Action === 'function' ? (
-                  <Action key={index} uid={entity.uid} />
-                ) : (
-                  Action
-                )
+      {!isAvailable && (
+        <Grid container justifyContent="space-between" alignItems="center">
+          <Grid item pl={1} py={2}>
+            <Typography>
+              {entity.type == TypeEnum.VIDEO
+                ? t('video.notAvailableAnymore')
+                : t('entityCard.notAvailableAnymore')}
+            </Typography>
+          </Grid>
+          <Grid item>
+            <IconButton size="small" onClick={toggleEntityVisibility}>
+              {entityVisible ? (
+                <ArrowDropUp sx={{ color: 'rgba(0, 0, 0, 0.42)' }} />
+              ) : (
+                <ArrowDropDown sx={{ color: 'rgba(0, 0, 0, 0.42)' }} />
               )}
-            </Box>
-          </Collapse>
+            </IconButton>
+          </Grid>
         </Grid>
+      )}
+      {entityVisible && (
+        <>
+          <Grid
+            item
+            xs={12}
+            sm={compact ? 12 : 'auto'}
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              ...(compact
+                ? {}
+                : { minWidth: '240px', maxWidth: { sm: '240px' } }),
+            }}
+          >
+            <EntityImagery
+              entity={entity}
+              compact={compact}
+              config={entityTypeConfig}
+            />
+          </Grid>
+          <Grid
+            item
+            xs={12}
+            sm={compact ? 12 : true}
+            sx={{
+              padding: 1,
+            }}
+            data-testid="video-card-info"
+            container
+            direction="column"
+          >
+            <EntityCardTitle
+              uid={entity.uid}
+              title={entity.metadata.name}
+              compact={compact}
+            />
+            <EntityMetadata entity={entity} />
+            {displayEntityCardScores()}
+          </Grid>
+          <Grid
+            item
+            xs={12}
+            sm={compact ? 12 : 1}
+            sx={{
+              display: 'flex',
+              alignItems: 'end',
+              justifyContent: 'space-between',
+              flexDirection: 'column',
+              [theme.breakpoints.down('sm')]: {
+                flexDirection: 'row',
+              },
+            }}
+          >
+            {actions.map((Action, index) =>
+              typeof Action === 'function' ? (
+                <Action key={index} uid={entity.uid} />
+              ) : (
+                Action
+              )
+            )}
+            {isSmallScreen && settings.length > 0 && (
+              <>
+                <Box flexGrow={1} />
+                <IconButton
+                  size="small"
+                  aria-label={t('video.labelShowSettings')}
+                  onClick={() => setSettingsVisible(!settingsVisible)}
+                >
+                  {settingsVisible ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                </IconButton>
+              </>
+            )}
+          </Grid>
+          {settings.length > 0 && (
+            <Grid item xs={12}>
+              <Collapse in={settingsVisible || !isSmallScreen}>
+                <Box
+                  paddingY={1}
+                  borderTop="1px solid rgba(0, 0, 0, 0.12)"
+                  display="flex"
+                  gap="16px"
+                  color="text.secondary"
+                >
+                  {settings.map((Action, index) =>
+                    typeof Action === 'function' ? (
+                      <Action key={index} uid={entity.uid} />
+                    ) : (
+                      Action
+                    )
+                  )}
+                </Box>
+              </Collapse>
+            </Grid>
+          )}
+        </>
       )}
     </Grid>
   );

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -48,11 +48,12 @@ const EntityCard = ({
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'), {
     noSsr: true,
   });
+
+  const [contentDisplayed, setContentDisplayed] = useState(true);
   const [settingsVisible, setSettingsVisible] = useState(!isSmallScreen);
-  const [entityVisible, setEntityVisible] = useState(true);
 
   useEffect(() => {
-    setEntityVisible(isAvailable);
+    setContentDisplayed(isAvailable);
   }, [isAvailable]);
 
   const displayEntityCardScores = () => {
@@ -69,7 +70,7 @@ const EntityCard = ({
   };
 
   const toggleEntityVisibility = () => {
-    setEntityVisible((prevEntityVisibility) => !prevEntityVisibility);
+    setContentDisplayed(!contentDisplayed);
   };
 
   return (
@@ -84,8 +85,8 @@ const EntityCard = ({
             </Typography>
           </Grid>
           <Grid item>
-            <IconButton size="small" onClick={toggleEntityVisibility}>
-              {entityVisible ? (
+            <IconButton onClick={toggleEntityVisibility}>
+              {contentDisplayed ? (
                 <ArrowDropUp sx={{ color: 'rgba(0, 0, 0, 0.42)' }} />
               ) : (
                 <ArrowDropDown sx={{ color: 'rgba(0, 0, 0, 0.42)' }} />
@@ -94,7 +95,7 @@ const EntityCard = ({
           </Grid>
         </Grid>
       )}
-      {entityVisible && (
+      {contentDisplayed && (
         <>
           <Grid
             item

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+import { Box, Typography, Grid } from '@mui/material';
 
 import EntityCard from 'src/components/entity/EntityCard';
 import { useCurrentPoll, useLoginState } from 'src/hooks';
 import { Recommendation } from 'src/services/openapi/models/Recommendation';
 import { ActionList, RelatedEntityObject } from 'src/utils/types';
 import { idFromUid } from 'src/utils/video';
+import { entityCardMainSx } from '../../components/entity/style';
 
 interface Props {
   entities: RelatedEntityObject[] | Recommendation[] | undefined;
@@ -18,21 +21,40 @@ interface Props {
 const AvailableEntity = ({
   children,
   uid,
+  errorElement,
+  type,
 }: {
   children: React.ReactNode;
   uid: string;
+  errorElement?: React.ReactNode;
+  type: string;
 }) => {
-  const [isAvailableOnYoutube, setIsAvailableOnYoutube] = useState(false);
+  const { t } = useTranslation();
+  const [isAvailable, setIsAvailable] = useState(false);
+
+  const errorElementDisplay = errorElement ?? (
+    <Box mx={1} my={2}>
+      <Grid container sx={entityCardMainSx}>
+        <Box mx={1} my={2}>
+          {t('video.notAvailableAnymore')}
+        </Box>
+      </Grid>
+    </Box>
+  );
 
   useEffect(() => {
-    const img = new Image();
-    img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
-    img.onload = function () {
-      setIsAvailableOnYoutube(img.width !== 120);
-    };
-  }, [uid]);
+    if (type != 'video') {
+      setIsAvailable(true);
+    } else {
+      const img = new Image();
+      img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
+      img.onload = function () {
+        setIsAvailable(img.width !== 120);
+      };
+    }
+  }, [uid,type]);
 
-  return isAvailableOnYoutube ? <>{children}</> : null;
+  return isAvailable ? <>{children}</> : <>{errorElementDisplay}</>;
 };
 
 /**
@@ -63,7 +85,7 @@ function EntityList({
     <>
       {entities && entities.length ? (
         entities.map((entity: Recommendation | RelatedEntityObject) => (
-          <AvailableEntity key={entity.uid} uid={entity.uid}>
+          <AvailableEntity key={entity.uid} uid={entity.uid} type={entity.type}>
             <Box mx={1} my={2}>
               <EntityCard
                 entity={entity}

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Typography } from '@mui/material';
 
 import EntityCard from 'src/components/entity/EntityCard';
 import { useCurrentPoll, useLoginState } from 'src/hooks';
 import { Recommendation } from 'src/services/openapi/models/Recommendation';
 import { ActionList, RelatedEntityObject } from 'src/utils/types';
+import { idFromUid } from 'src/utils/video';
 
 interface Props {
   entities: RelatedEntityObject[] | Recommendation[] | undefined;
@@ -13,6 +14,26 @@ interface Props {
   emptyMessage?: React.ReactNode;
   personalScores?: { [uid: string]: number };
 }
+
+const AvailableEntity = ({
+  children,
+  uid,
+}: {
+  children: React.ReactNode;
+  uid: string;
+}) => {
+  const [isAvailableOnYoutube, setIsAvailableOnYoutube] = useState(false);
+
+  useEffect(() => {
+    const img = new Image();
+    img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
+    img.onload = function () {
+      setIsAvailableOnYoutube(img.width !== 120);
+    };
+  }, [uid]);
+
+  return isAvailableOnYoutube ? <>{children}</> : null;
+};
 
 /**
  * Display a list of entities.
@@ -42,15 +63,17 @@ function EntityList({
     <>
       {entities && entities.length ? (
         entities.map((entity: Recommendation | RelatedEntityObject) => (
-          <Box key={entity.uid} mx={1} my={2}>
-            <EntityCard
-              entity={entity}
-              actions={actions ?? defaultEntityActions}
-              settings={settings}
-              compact={false}
-              entityTypeConfig={{ video: { displayPlayer: false } }}
-            />
-          </Box>
+          <AvailableEntity key={entity.uid} uid={entity.uid}>
+            <Box mx={1} my={2}>
+              <EntityCard
+                entity={entity}
+                actions={actions ?? defaultEntityActions}
+                settings={settings}
+                compact={false}
+                entityTypeConfig={{ video: { displayPlayer: false } }}
+              />
+            </Box>
+          </AvailableEntity>
         ))
       ) : (
         <Box m={2}>

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -42,7 +42,6 @@ function EntityList({
   const defaultEntityActions = isLoggedIn
     ? options?.defaultAuthEntityActions
     : options?.defaultAnonEntityActions;
-  console.log(entities);
 
   return (
     <>

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -15,7 +15,7 @@ interface Props {
   settings?: ActionList;
   emptyMessage?: React.ReactNode;
   personalScores?: { [uid: string]: number };
-  unavailableActions?: ActionList;
+  actionsIfUnavailable?: ActionList;
 }
 
 /**
@@ -34,7 +34,7 @@ function EntityList({
   settings = [],
   // personalScores,
   emptyMessage,
-  unavailableActions,
+  actionsIfUnavailable,
 }: Props) {
   const { isLoggedIn } = useLoginState();
   const { options } = useCurrentPoll();
@@ -51,7 +51,7 @@ function EntityList({
             key={entity.uid}
             uid={entity.uid}
             type={entity.type}
-            unavailableActions={unavailableActions}
+            actionsIfUnavailable={actionsIfUnavailable}
           >
             <Box mx={1} my={2}>
               <EntityCard

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -1,14 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import React from 'react';
 
-import { Box, Typography, Grid } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 import EntityCard from 'src/components/entity/EntityCard';
+import AvailableEntity from '../../components/entity/AvailableEntity';
+
 import { useCurrentPoll, useLoginState } from 'src/hooks';
 import { Recommendation } from 'src/services/openapi/models/Recommendation';
 import { ActionList, RelatedEntityObject } from 'src/utils/types';
-import { idFromUid } from 'src/utils/video';
-import { entityCardMainSx } from '../../components/entity/style';
 
 interface Props {
   entities: RelatedEntityObject[] | Recommendation[] | undefined;
@@ -17,45 +16,6 @@ interface Props {
   emptyMessage?: React.ReactNode;
   personalScores?: { [uid: string]: number };
 }
-
-const AvailableEntity = ({
-  children,
-  uid,
-  errorElement,
-  type,
-}: {
-  children: React.ReactNode;
-  uid: string;
-  errorElement?: React.ReactNode;
-  type: string;
-}) => {
-  const { t } = useTranslation();
-  const [isAvailable, setIsAvailable] = useState(false);
-
-  const errorElementDisplay = errorElement ?? (
-    <Box mx={1} my={2}>
-      <Grid container sx={entityCardMainSx}>
-        <Box mx={1} my={2}>
-          {t('video.notAvailableAnymore')}
-        </Box>
-      </Grid>
-    </Box>
-  );
-
-  useEffect(() => {
-    if (type != 'video') {
-      setIsAvailable(true);
-    } else {
-      const img = new Image();
-      img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
-      img.onload = function () {
-        setIsAvailable(img.width !== 120);
-      };
-    }
-  }, [uid,type]);
-
-  return isAvailable ? <>{children}</> : <>{errorElementDisplay}</>;
-};
 
 /**
  * Display a list of entities.

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -47,13 +47,12 @@ function EntityList({
     <>
       {entities && entities.length ? (
         entities.map((entity: Recommendation | RelatedEntityObject) => (
-          <AvailableEntity
-            key={entity.uid}
-            uid={entity.uid}
-            type={entity.type}
-            actionsIfUnavailable={actionsIfUnavailable}
-          >
-            <Box mx={1} my={2}>
+          <Box key={entity.uid} mx={1} my={2}>
+            <AvailableEntity
+              uid={entity.uid}
+              type={entity.type}
+              actionsIfUnavailable={actionsIfUnavailable}
+            >
               <EntityCard
                 entity={entity}
                 actions={actions ?? defaultEntityActions}
@@ -61,8 +60,8 @@ function EntityList({
                 compact={false}
                 entityTypeConfig={{ video: { displayPlayer: false } }}
               />
-            </Box>
-          </AvailableEntity>
+            </AvailableEntity>
+          </Box>
         ))
       ) : (
         <Box m={2}>

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -15,6 +15,7 @@ interface Props {
   settings?: ActionList;
   emptyMessage?: React.ReactNode;
   personalScores?: { [uid: string]: number };
+  unavailableActions?: ActionList;
 }
 
 /**
@@ -33,6 +34,7 @@ function EntityList({
   settings = [],
   // personalScores,
   emptyMessage,
+  unavailableActions,
 }: Props) {
   const { isLoggedIn } = useLoginState();
   const { options } = useCurrentPoll();
@@ -40,12 +42,18 @@ function EntityList({
   const defaultEntityActions = isLoggedIn
     ? options?.defaultAuthEntityActions
     : options?.defaultAnonEntityActions;
+  console.log(entities);
 
   return (
     <>
       {entities && entities.length ? (
         entities.map((entity: Recommendation | RelatedEntityObject) => (
-          <AvailableEntity key={entity.uid} uid={entity.uid} type={entity.type}>
+          <AvailableEntity
+            key={entity.uid}
+            uid={entity.uid}
+            type={entity.type}
+            unavailableActions={unavailableActions}
+          >
             <Box mx={1} my={2}>
               <EntityCard
                 entity={entity}

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -181,7 +181,7 @@ const RateLaterPage = () => {
               <EntityList
                 entities={entities}
                 actions={rateLaterPageActions}
-                unavailableActions={[RemoveFromRateLater(loadList)]}
+                actionsIfUnavailable={[RemoveFromRateLater(loadList)]}
               />
             </LoaderWrapper>
           </Box>

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -178,7 +178,11 @@ const RateLaterPage = () => {
 
           <Box width="100%" textAlign="center">
             <LoaderWrapper isLoading={isLoading}>
-              <EntityList entities={entities} actions={rateLaterPageActions} />
+              <EntityList
+                entities={entities}
+                actions={rateLaterPageActions}
+                unavailableActions={[RemoveFromRateLater(loadList)]}
+              />
             </LoaderWrapper>
           </Box>
           {!!entityCount && (


### PR DESCRIPTION
**related to** #1070

---

This PR has for goal to find and apply a better way to display a video in `<EntityList>` when it is not available anymore. For the moment I focused on the display of unavailable videos on the list of recommendations, video ratings and rate later pages.

On the recommendation and video ratings page a  "video unavailable" message is displayed with the possibility to see the unavailable entity by toggling a button. The rate later page display a delete button in addition of the message so we can still delete the video from the rate later list.

- [x] Make AvailableEntity work for more types than just videos (only check availability of video for the moment)
- [x] Add actionsIfUnavailable props to the  EntityList and  AvailableEntity component
- [x] Pass the actionsIfUnavailable from EntityList to AvailableEntity
- [x] Pass the actionsIfUnavailable props from AvailableEntity into  EntityCard actions  props when the entity is unavailable

### preview

In the rate-later list, actions are displayed.

![unavailable](https://user-images.githubusercontent.com/50485333/223094861-81defbd2-31e4-4149-9a1c-5926c7c4cf06.PNG)

![unavailable2](https://user-images.githubusercontent.com/50485333/223094887-6489895d-5f78-48f9-ad32-bbcffff133a2.PNG)

On other lists, no action is displayed.


![unavailable3](https://user-images.githubusercontent.com/50485333/223094921-49af5043-e68d-4df5-b669-e6216f2b1da4.PNG)

![unavailable4](https://user-images.githubusercontent.com/50485333/223094942-8112407c-de06-4994-8bb8-4560080a8736.PNG)


