### PR TITLE
[browser-extension] Video link edited to correct a bug reported on discord

### DIFF
--- a/browser-extension/src/browserAction/menu.js
+++ b/browser-extension/src/browserAction/menu.js
@@ -34,7 +34,7 @@ function rateNowAction(event) {
   get_current_tab_video_id().then(
     (videoId) => {
       chrome.tabs.create({
-        url: `https://tournesol.app/comparison/?videoA=${videoId}`,
+        url: `https://tournesol.app/comparison/?uidA=yt:${videoId}`,
       });
     },
     () => {

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
Browser-extension patch: Correct the bug reported on discord informing that the videos loaded by the rate now button of the browser extension are sometimes replaced by another random video on the tournesol.app comparison page.