### PR TITLE
[extension] fix: removes the text of rate buttons on some screen sizes

### DIFF
--- a/browser-extension/src/addRateButtons.css
+++ b/browser-extension/src/addRateButtons.css
@@ -27,18 +27,6 @@ button.tournesol-rate-button:disabled {
   background: #ffc800;
 }
 
-@media (min-width: 656px) and (max-width: 990px) {
-  button.tournesol-rate-button {
-    font-size: 0;
-  }
-}
-
-@media (min-width: 1017px) and (max-width: 1366px) {
-  button.tournesol-rate-button {
-    font-size: 0;
-  }
-}
-
 img.tournesol-button-image {
   margin-left: -6px;
   margin-right: 6px;
@@ -48,4 +36,32 @@ img.tournesol-button-image.tournesol-rate-later {
   /* Compensate the extra margins inside the Material UI "Add" icon */
   margin-left: -10px;
   margin-right: 2px;
+}
+
+@media (min-width: 656px) and (max-width: 990px) {
+  button.tournesol-rate-button {
+    font-size: 0;
+  }
+
+  img.tournesol-button-image {
+    margin: 0;
+  }
+
+  img.tournesol-button-image.tournesol-rate-later {
+    margin: 0;
+  }
+}
+
+@media (min-width: 1017px) and (max-width: 1366px) {
+  button.tournesol-rate-button {
+    font-size: 0;
+  }
+
+  img.tournesol-button-image {
+    margin: 0;
+  }
+
+  img.tournesol-button-image.tournesol-rate-later {
+    margin: 0;
+  }
 }

--- a/browser-extension/src/addRateButtons.css
+++ b/browser-extension/src/addRateButtons.css
@@ -27,6 +27,18 @@ button.tournesol-rate-button:disabled {
   background: #ffc800;
 }
 
+@media (min-width: 656px) and (max-width: 990px) {
+  button.tournesol-rate-button {
+    font-size: 0;
+  }
+}
+
+@media (min-width: 1017px) and (max-width: 1366px) {
+  button.tournesol-rate-button {
+    font-size: 0;
+  }
+}
+
 img.tournesol-button-image {
   margin-left: -6px;
   margin-right: 6px;

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
This PR tries to be a temporary fix to #1319. 

There are too many factors that decide the width at which we should remove the text from the `Rate Later` and `Rate Now` Buttons. They are:
1. If you are subscribed or not. If you are, their button takes more size and has dropdown for Notification settings (All, Personalized, None)
2. If they have a Membership feature set up, this adds another `Join` button to the UI
3. If their channel name is too long.

![tournesol Rate](https://user-images.githubusercontent.com/20269286/221716757-c8848bb1-5098-4807-8908-75a193252336.JPG)



We can add UI customization based on the three factors mentioned above or just go with the pixel numbers decided in this commit that may work well for the general use case. We can at least keep `1017px` value since it is a break point of Youtube UI change as well.



**Please Note:** I found out that during inspect in browser and toggling to Mobile view/Responsive view, the buttons do not show up at all for sizes ~`1420px` and console shows this error:
```
Refused to frame 'https://tournesol.app/' because an ancestor violates the following Content Security Policy directive: "frame-ancestors https://www.youtube.com moz-extension: chrome-extension:".
```