### PR TITLE
[front] fix: expanding filters should not push entries in history

### DIFF
--- a/frontend/src/hooks/useListFilter.ts
+++ b/frontend/src/hooks/useListFilter.ts
@@ -19,16 +19,24 @@ export const useListFilter = ({
   });
 
   const setFilter = (key: string, value: string | null) => {
+    const oldValue = searchParams.get(key);
+    let modified = false;
     if (value || (setEmptyValues && value === '')) {
-      searchParams.set(key, value);
-    } else {
+      if (value !== oldValue) {
+        searchParams.set(key, value);
+        modified = true;
+      }
+    } else if (oldValue !== null) {
       searchParams.delete(key);
+      modified = true;
     }
-    // Reset pagination if filters change
-    if (key !== 'offset') {
-      searchParams.delete('offset');
+    if (modified) {
+      // Reset pagination if any filter has changed
+      if (key !== 'offset') {
+        searchParams.delete('offset');
+      }
+      history.push({ search: searchParams.toString() });
     }
-    history.push({ search: searchParams.toString() });
   };
 
   return [searchParams, setFilter];

--- a/tests/cypress/integration/frontend/recommendationsPage.ts
+++ b/tests/cypress/integration/frontend/recommendationsPage.ts
@@ -15,7 +15,7 @@ describe('Recommendations page', () => {
         cy.visit('/');
         cy.location('pathname').should('equal', '/');
         cy.contains('Recommendations').click();
-        cy.contains('Filters').click();
+        cy.contains('Filters', {matchCase: false}).click();
         cy.contains('Duration (minutes)', {matchCase: false}).should('be.visible');
         cy.go('back');
         cy.location('pathname').should('equal', '/');

--- a/tests/cypress/integration/frontend/recommendationsPage.ts
+++ b/tests/cypress/integration/frontend/recommendationsPage.ts
@@ -11,6 +11,16 @@ describe('Recommendations page', () => {
         cy.location('pathname').should('equal', '/');
       });
 
+      it('expand filters and backward navigation works', () => {
+        cy.visit('/');
+        cy.location('pathname').should('equal', '/');
+        cy.contains('Recommendations').click();
+        cy.contains('Filters').click();
+        cy.contains('Duration (minutes)', {matchCase: false}).should('be.visible');
+        cy.go('back');
+        cy.location('pathname').should('equal', '/');
+      });
+
       describe('Filter - upload date', () => {
         it('must propose 5 timedelta', () => {
           cy.visit('/');


### PR DESCRIPTION
This should also avoid counting duplicated pageviews when accessing the recommendation pages.

A new history entry (and pageview) is still created when one of the filter changes.