### PR TITLE
[front][ext] fix: disable Plausible in login iframe, add url tags in pageviews from extension

### DIFF
--- a/browser-extension/src/addRateButtons.js
+++ b/browser-extension/src/addRateButtons.js
@@ -102,7 +102,7 @@ function addRateButtons() {
         chrome.runtime.sendMessage({
           message: 'displayModal',
           modalOptions: {
-            src: `https://tournesol.app/comparison?embed=1&uidA=yt%3A${videoId}`,
+            src: `https://tournesol.app/comparison?embed=1&utm_source=extension&utm_medium=frame&uidA=yt%3A${videoId}`,
             height: '90vh',
           },
         });

--- a/browser-extension/src/browserAction/menu.js
+++ b/browser-extension/src/browserAction/menu.js
@@ -34,7 +34,7 @@ function rateNowAction(event) {
   get_current_tab_video_id().then(
     (videoId) => {
       chrome.tabs.create({
-        url: `https://tournesol.app/comparison/?uidA=yt:${videoId}`,
+        url: `https://tournesol.app/comparison?uidA=yt:${videoId}&utm_source=extension&utm_medium=menu`,
       });
     },
     () => {
@@ -91,7 +91,7 @@ function openAnalysisPageAction(event) {
   get_current_tab_video_id().then(
     (videoId) => {
       chrome.tabs.create({
-        url: `https://tournesol.app/entities/yt:${videoId}`,
+        url: `https://tournesol.app/entities/yt:${videoId}?utm_source=extension&utm_medium=menu`,
       });
     },
     () => {

--- a/browser-extension/src/html/tournesol-iframe.html
+++ b/browser-extension/src/html/tournesol-iframe.html
@@ -11,7 +11,7 @@
 
       <iframe
         id="x-tournesol-iframe-inner"
-        src="https://tournesol.app/login?embed=1"
+        src="https://tournesol.app/login?embed=1&dnt=1"
       >
       </iframe>
     </div>

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -12,9 +12,11 @@ export const TRACKED_EVENTS = {
   accountDeleted: 'account deleted',
 };
 
-const analyticsClient = process.env.REACT_APP_WEBSITE_ANALYTICS_URL
-  ? Plausible({ apiHost: process.env.REACT_APP_WEBSITE_ANALYTICS_URL })
-  : null;
+const doNotTrack = new URLSearchParams(location.search).get('dnt') === '1';
+const analyticsClient =
+  process.env.REACT_APP_WEBSITE_ANALYTICS_URL && !doNotTrack
+    ? Plausible({ apiHost: process.env.REACT_APP_WEBSITE_ANALYTICS_URL })
+    : null;
 
 if (analyticsClient) {
   analyticsClient.enableAutoPageviews();


### PR DESCRIPTION
The browser extension uses an invisible iframe "/login" to fetch or refresh the access token used for authentication.

This PR adds a parameter "?dnt=1" in the URL of this iframe, to disable tracking of this invisible page.

["UTM tags" ](https://plausible.io/docs/manual-link-tagging )are also used on the comparison iframe and links used in the extension menu.