### PR TITLE
[ext] chore: add missing `utm_source` query parameter

### DIFF
--- a/browser-extension/src/addTournesolRecommendations.js
+++ b/browser-extension/src/addTournesolRecommendations.js
@@ -71,7 +71,7 @@ const getTournesolComponent = () => {
   // Add title
   const tournesol_link = document.createElement('a');
   tournesol_link.id = 'tournesol_link';
-  tournesol_link.href = 'https://tournesol.app';
+  tournesol_link.href = 'https://tournesol.app?utm_source=extension';
   tournesol_link.append('learn more');
   inline_div.append(tournesol_link);
 

--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -87,7 +87,9 @@ function process() {
 
           // On click
           statisticsButton.onclick = () => {
-            open(`https://tournesol.app/entities/yt:${videoId}?utm_source=extension`);
+            open(
+              `https://tournesol.app/entities/yt:${videoId}?utm_source=extension`
+            );
           };
 
           var div =

--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -87,7 +87,7 @@ function process() {
 
           // On click
           statisticsButton.onclick = () => {
-            open(`https://tournesol.app/entities/yt:${videoId}`);
+            open(`https://tournesol.app/entities/yt:${videoId}?utm_source=extension`);
           };
 
           var div =

--- a/browser-extension/src/browserAction/menu.js
+++ b/browser-extension/src/browserAction/menu.js
@@ -22,7 +22,7 @@ function get_current_tab_video_id() {
  */
 function openTournesolHome() {
   chrome.tabs.create({
-    url: `https://tournesol.app`,
+    url: `https://tournesol.app?utm_source=extension&utm_medium=menu`,
   });
 }
 

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
This PR continues #1400 

If I'm not mistaken all links to the website should now include `utm_source=extension`.