### PR TITLE
[tests] fix: close youtube promotional banner when testing browser extension

### DIFF
--- a/tests/cypress/e2e/browser-extension/extension.cy.ts
+++ b/tests/cypress/e2e/browser-extension/extension.cy.ts
@@ -7,12 +7,16 @@ onlyOn('headed', () => {
       defaultCommandTimeout: 16000,
     },
     () => {
-      const consent = () => {
+      const closeBanners = () => {
         cy.get('body')
           .then(($body) => {
             // Agree to cookies dialog if it's present
             if ($body.find('#dialog').length) {
-              cy.get('#dialog [role="button"]').last().click();
+              cy.get('#dialog button').last().click();
+            }
+            // Close Youtube promotional banner
+            if ($body.find('ytd-banner-promo-renderer').length) {
+              cy.get("ytd-banner-promo-renderer #dismiss-button").click()
             }
           })
       }
@@ -27,13 +31,13 @@ onlyOn('headed', () => {
 
       it('shows Tournesol recommendations on youtube.com', () => {
         cy.visit('https://www.youtube.com');
-        consent();
+        closeBanners();
         cy.contains('Recommended by Tournesol').should('be.visible');
       });
 
       it('shows "Rate later" button on video page', () => {
         cy.visit('https://www.youtube.com/watch?v=6jK9bFWE--g');
-        consent();
+        closeBanners();
         cy.get('body').then($body => {
           if ($body.find("button:contains('Dismiss')").length > 0) {
             // Dismiss Youtube Ad if present


### PR DESCRIPTION
Should fix broken e2e tests, observed in #1419