### PR TITLE
Refactoring /video/ to /polls/videos/recommendations on clicking auto button

### DIFF
--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -1,4 +1,4 @@
-import { VideoService, UsersService, TypeEnum } from 'src/services/openapi';
+import { UsersService, TypeEnum, PollsService } from 'src/services/openapi';
 import { YOUTUBE_POLL_NAME } from './constants';
 import { RelatedEntityObject, VideoObject } from './types';
 
@@ -167,8 +167,15 @@ export async function getVideoForComparison(
     );
     if (videoFromComparisons) return videoFromComparisons;
   }
-  const videoResult = await VideoService.videoList({ limit: 100, offset: 0 });
-  const videoList = (videoResult?.results || []).map((v) => v.video_id);
+  const videoResult = await PollsService.pollsRecommendationsList({
+    name: 'videos',
+    limit: 100,
+    offset: 0,
+  });
+  // console.log(videoResult);
+  const videoList = (videoResult?.results || []).map((v) =>
+    v.uid.slice(3, v.uid.length)
+  );
   const videoId = await retryRandomPick(5, otherVideo, currentVideo, videoList);
   if (videoId) return videoId;
   return videoList ? pick(videoList) : null;

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -172,9 +172,7 @@ export async function getVideoForComparison(
     limit: 100,
     offset: 0,
   });
-  const videoList = (videoResult?.results || []).map((v) =>
-    v.uid.slice(3, v.uid.length)
-  );
+  const videoList = (videoResult?.results || []).map((v) => idFromUid(v.uid));
   const videoId = await retryRandomPick(5, otherVideo, currentVideo, videoList);
   if (videoId) return videoId;
   return videoList ? pick(videoList) : null;

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -172,7 +172,6 @@ export async function getVideoForComparison(
     limit: 100,
     offset: 0,
   });
-  // console.log(videoResult);
   const videoList = (videoResult?.results || []).map((v) =>
     v.uid.slice(3, v.uid.length)
   );


### PR DESCRIPTION
This PR tries to solve issue #1263 where the obsolete `/video/` API call is replaced by `/polls/{name = videos}/recommendations` API when the `Auto` button is clicked on the _comparison_ page.

While I believe this PR is opened way before a merge, I wanted to open the discussion with some code that we could inspect.