### PR TITLE
Front reload unavailable video in comparisons page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -26,6 +26,7 @@
     "criteriaRatedLow": "Rated low:",
     "nbViews": "{{nbViews}} views",
     "seeRecommendedVideosSameUploader": "See recommended videos of the same uploader",
+    "loadAnother": "Youtube video not available. Please load another to compare.",
     "nComparisonsByYou_one": "{{count}} comparison by you",
     "nComparisonsByYou_other": "{{count}} comparisons by you",
     "notYetComparedByYou": "Not yet compared by you",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -14,6 +14,7 @@
     "continue": "continue"
   },
   "video": {
+    "notAvailableAnymore": "This video is not available anymore",
     "labelShowSettings": "Show settings related to this video",
     "unsafeNotEnoughContributor": "The relevance of this score is uncertain, due to too few contributors.",
     "unsafeNegativeRating": "This video score is below the average of the other videos added to Tournesol.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -14,7 +14,7 @@
     "continue": "continue"
   },
   "video": {
-    "notAvailableAnymore": "This video is not available anymore",
+    "notAvailableAnymore": "This video is not available anymore.",
     "labelShowSettings": "Show settings related to this video",
     "unsafeNotEnoughContributor": "The relevance of this score is uncertain, due to too few contributors.",
     "unsafeNegativeRating": "This video score is below the average of the other videos added to Tournesol.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -14,6 +14,7 @@
     "continue": "continuer"
   },
   "video": {
+    "notAvailableAnymore": "Cette vidéo n'est plus disponible",
     "labelShowSettings": "Voir les paramètres de cette video",
     "unsafeNotEnoughContributor": "La pertinence de ce score est incertaine, en raison d'un trop faible nombre de contributeurs.",
     "unsafeNegativeRating": "Cette vidéo a un score inférieur à la moyenne des autres vidéos ajoutées à Tournesol.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -28,6 +28,7 @@
     "criteriaRatedLow": "Noté faiblement :",
     "nbViews": "{{nbViews}} vues",
     "seeRecommendedVideosSameUploader": "Voir les vidéos recommandées de cette chaîne",
+    "loadAnother": "Vidéo youtube indisponible. Veuillez charger une vidéo différente.",
     "nComparisonsByYou_one": "{{count}} comparaison par vous",
     "nComparisonsByYou_many": "{{count}} comparaisons par vous",
     "nComparisonsByYou_other": "{{count}} comparaisons par vous",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -14,7 +14,7 @@
     "continue": "continuer"
   },
   "video": {
-    "notAvailableAnymore": "Cette vidéo n'est plus disponible",
+    "notAvailableAnymore": "Cette vidéo n'est plus disponible.",
     "labelShowSettings": "Voir les paramètres de cette video",
     "unsafeNotEnoughContributor": "La pertinence de ce score est incertaine, en raison d'un trop faible nombre de contributeurs.",
     "unsafeNegativeRating": "Cette vidéo a un score inférieur à la moyenne des autres vidéos ajoutées à Tournesol.",

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -1,20 +1,52 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Grid } from '@mui/material';
+import { Box, Grid, Typography } from '@mui/material';
 import { idFromUid } from '../../utils/video';
 import { entityCardMainSx } from './style';
+import { ActionList } from 'src/utils/types';
+import { TypeEnum } from 'src/services/openapi';
 
-export const EntityNotAvailable = ({ type }: { type: string }) => {
+/*
+ * return a different error element related to the type of the entity and actions
+ */
+export const EntityNotAvailable = ({
+  type,
+  unavailableActions,
+  uid,
+}: {
+  type: string;
+  unavailableActions?: ActionList;
+  uid: string;
+}) => {
   const { t } = useTranslation();
 
-  if (type == 'video') {
+  if (type == TypeEnum.VIDEO) {
     return (
       <Box mx={1} my={2}>
-        <Grid container sx={entityCardMainSx}>
-          <Box mx={1} my={2}>
-            {t('video.notAvailableAnymore')}
-          </Box>
+        <Grid
+          mx={1}
+          my={2}
+          container
+          sx={entityCardMainSx}
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Grid ml={1} my={2}>
+            <Typography >
+              {t('video.notAvailableAnymore')}
+            </Typography>
+          </Grid>
+          <Grid justifyContent="center" alignItems="flex-end">
+            {unavailableActions &&
+              unavailableActions.map((Action, index) =>
+                typeof Action === 'function' ? (
+                  <Action key={index} uid={uid} />
+                ) : (
+                  Action
+                )
+              )}
+          </Grid>
         </Grid>
       </Box>
     );
@@ -23,14 +55,20 @@ export const EntityNotAvailable = ({ type }: { type: string }) => {
   return null;
 };
 
+/*
+ * Check if an entity is available
+ * It returns children if it is available either it returns an error element
+ */
 const AvailableEntity = ({
   children,
   uid,
   type,
+  unavailableActions,
 }: {
   children: React.ReactNode;
   uid: string;
   type: string;
+  unavailableActions?: ActionList;
 }) => {
   const [isAvailable, setIsAvailable] = useState(false);
 
@@ -46,7 +84,15 @@ const AvailableEntity = ({
     }
   }, [uid, type]);
 
-  return isAvailable ? <>{children}</> : <EntityNotAvailable type={type} />;
+  return isAvailable ? (
+    <>{children}</>
+  ) : (
+    <EntityNotAvailable
+      type={type}
+      unavailableActions={unavailableActions}
+      uid={uid}
+    />
+  );
 };
 
 export default AvailableEntity;

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -1,13 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, Grid, Typography } from '@mui/material';
 
 import LoaderWrapper from 'src/components/LoaderWrapper';
-import { TypeEnum } from 'src/services/openapi';
 import { ActionList } from 'src/utils/types';
-import { idFromUid } from 'src/utils/video';
 import { entityCardMainSx } from './style';
+import useIsAvailable from '../../hooks/useIsAvailable';
 
 /*
  * This component can be returned instead of <EntityCard> when the entity
@@ -15,16 +14,14 @@ import { entityCardMainSx } from './style';
  */
 export const EntityNotAvailable = ({
   uid,
-  type,
   actionsIfUnavailable,
 }: {
   uid: string;
-  type: string;
   actionsIfUnavailable?: ActionList;
 }) => {
   const { t } = useTranslation();
 
-  if (type === TypeEnum.VIDEO) {
+  if (uid.indexOf('yt:') !== -1) {
     return (
       <Box mx={1} my={2}>
         <Grid
@@ -61,45 +58,22 @@ export const EntityNotAvailable = ({
  */
 const AvailableEntity = ({
   uid,
-  type,
   children,
   actionsIfUnavailable,
 }: {
   uid: string;
-  type: string;
   children: React.ReactNode;
   actionsIfUnavailable?: ActionList;
 }) => {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isAvailable, setIsAvailable] = useState(false);
-
-  /**
-   * Check if the entity is available.
-   *
-   * The behaviour "is available" could be factorized in a custom hook.
-   */
-  useEffect(() => {
-    if (type !== TypeEnum.VIDEO) {
-      setIsLoading(false);
-      setIsAvailable(true);
-    } else {
-      const img = new Image();
-      img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
-      img.onload = function () {
-        setIsLoading(false);
-        setIsAvailable(img.width !== 120);
-      };
-    }
-  }, [uid, type]);
+  const { entityIsChecking, entityIsAvailable } = useIsAvailable(uid);
 
   return (
-    <LoaderWrapper isLoading={isLoading}>
-      {isAvailable ? (
+    <LoaderWrapper isLoading={entityIsChecking}>
+      {entityIsAvailable ? (
         <>{children}</>
       ) : (
         <EntityNotAvailable
           uid={uid}
-          type={type}
           actionsIfUnavailable={actionsIfUnavailable}
         />
       )}

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -15,11 +15,11 @@ import { entityCardMainSx } from './style';
 export const EntityNotAvailable = ({
   uid,
   type,
-  unavailableActions,
+  actionsIfUnavailable,
 }: {
   uid: string;
   type: string;
-  unavailableActions?: ActionList;
+  actionsIfUnavailable?: ActionList;
 }) => {
   const { t } = useTranslation();
 
@@ -36,8 +36,8 @@ export const EntityNotAvailable = ({
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
           <Grid item>
-            {unavailableActions &&
-              unavailableActions.map((Action, index) =>
+            {actionsIfUnavailable &&
+              actionsIfUnavailable.map((Action, index) =>
                 typeof Action === 'function' ? (
                   <Action key={index} uid={uid} />
                 ) : (
@@ -62,12 +62,12 @@ const AvailableEntity = ({
   uid,
   type,
   children,
-  unavailableActions,
+  actionsIfUnavailable,
 }: {
   uid: string;
   type: string;
   children: React.ReactNode;
-  unavailableActions?: ActionList;
+  actionsIfUnavailable?: ActionList;
 }) => {
   const [isAvailable, setIsAvailable] = useState(false);
 
@@ -94,7 +94,7 @@ const AvailableEntity = ({
     <EntityNotAvailable
       uid={uid}
       type={type}
-      unavailableActions={unavailableActions}
+      actionsIfUnavailable={actionsIfUnavailable}
     />
   );
 };

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -33,7 +33,7 @@ export const EntityNotAvailable = ({
           alignItems="center"
           sx={entityCardMainSx}
         >
-          <Grid item px={1} py={2}>
+          <Grid item pl={1} py={2}>
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
           <Grid item>

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -22,7 +22,7 @@ export const EntityNotAvailable = ({
 }) => {
   const { t } = useTranslation();
 
-  if (type == TypeEnum.VIDEO) {
+  if (type === TypeEnum.VIDEO) {
     return (
       <Box mx={1} my={2}>
         <Grid
@@ -52,25 +52,31 @@ export const EntityNotAvailable = ({
   return null;
 };
 
-/*
- * Check if an entity is available
- * It returns children if it is available either it returns an error element
+/**
+ * Return an <EntityNotAvailable> if the entity doesn't seem to be available
+ * online at its original location, return the given children component
+ * instead.
  */
 const AvailableEntity = ({
-  children,
   uid,
   type,
+  children,
   unavailableActions,
 }: {
-  children: React.ReactNode;
   uid: string;
   type: string;
+  children: React.ReactNode;
   unavailableActions?: ActionList;
 }) => {
   const [isAvailable, setIsAvailable] = useState(false);
 
+  /**
+   * Check if the entity is available.
+   *
+   * The behaviour "is available" could be factorized in a custom hook.
+   */
   useEffect(() => {
-    if (type != 'video') {
+    if (type !== TypeEnum.VIDEO) {
       setIsAvailable(true);
     } else {
       const img = new Image();
@@ -85,9 +91,9 @@ const AvailableEntity = ({
     <>{children}</>
   ) : (
     <EntityNotAvailable
+      uid={uid}
       type={type}
       unavailableActions={unavailableActions}
-      uid={uid}
     />
   );
 };

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -35,7 +35,7 @@ export const EntityNotAvailable = ({
           <Grid ml={1} my={2}>
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
-          <Grid >
+          <Grid>
             {unavailableActions &&
               unavailableActions.map((Action, index) =>
                 typeof Action === 'function' ? (

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -35,7 +35,7 @@ export const EntityNotAvailable = ({
           <Grid ml={1} my={2}>
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
-          <Grid justifyContent="center" alignItems="flex-end">
+          <Grid >
             {unavailableActions &&
               unavailableActions.map((Action, index) =>
                 typeof Action === 'function' ? (

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Box, Grid } from '@mui/material';
+import { idFromUid } from '../../utils/video';
+import { entityCardMainSx } from './style';
+
+export const EntityNotAvailable = ({ type }: { type: string }) => {
+  const { t } = useTranslation();
+
+  if (type == 'video') {
+    return (
+      <Box mx={1} my={2}>
+        <Grid container sx={entityCardMainSx}>
+          <Box mx={1} my={2}>
+            {t('video.notAvailableAnymore')}
+          </Box>
+        </Grid>
+      </Box>
+    );
+  }
+
+  return null;
+};
+
+const AvailableEntity = ({
+  children,
+  uid,
+  type,
+}: {
+  children: React.ReactNode;
+  uid: string;
+  type: string;
+}) => {
+  const [isAvailable, setIsAvailable] = useState(false);
+
+  useEffect(() => {
+    if (type != 'video') {
+      setIsAvailable(true);
+    } else {
+      const img = new Image();
+      img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
+      img.onload = function () {
+        setIsAvailable(img.width !== 120);
+      };
+    }
+  }, [uid, type]);
+
+  return isAvailable ? <>{children}</> : <EntityNotAvailable type={type} />;
+};
+
+export default AvailableEntity;

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -33,9 +33,7 @@ export const EntityNotAvailable = ({
           alignItems="center"
         >
           <Grid ml={1} my={2}>
-            <Typography >
-              {t('video.notAvailableAnymore')}
-            </Typography>
+            <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
           <Grid justifyContent="center" alignItems="flex-end">
             {unavailableActions &&

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Box, Grid, Typography } from '@mui/material';
 
+import LoaderWrapper from 'src/components/LoaderWrapper';
 import { TypeEnum } from 'src/services/openapi';
 import { ActionList } from 'src/utils/types';
 import { idFromUid } from 'src/utils/video';
@@ -69,6 +70,7 @@ const AvailableEntity = ({
   children: React.ReactNode;
   actionsIfUnavailable?: ActionList;
 }) => {
+  const [isLoading, setIsLoading] = useState(true);
   const [isAvailable, setIsAvailable] = useState(false);
 
   /**
@@ -78,24 +80,30 @@ const AvailableEntity = ({
    */
   useEffect(() => {
     if (type !== TypeEnum.VIDEO) {
+      setIsLoading(false);
       setIsAvailable(true);
     } else {
       const img = new Image();
       img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
       img.onload = function () {
+        setIsLoading(false);
         setIsAvailable(img.width !== 120);
       };
     }
   }, [uid, type]);
 
-  return isAvailable ? (
-    <>{children}</>
-  ) : (
-    <EntityNotAvailable
-      uid={uid}
-      type={type}
-      actionsIfUnavailable={actionsIfUnavailable}
-    />
+  return (
+    <LoaderWrapper isLoading={isLoading}>
+      {isAvailable ? (
+        <>{children}</>
+      ) : (
+        <EntityNotAvailable
+          uid={uid}
+          type={type}
+          actionsIfUnavailable={actionsIfUnavailable}
+        />
+      )}
+    </LoaderWrapper>
   );
 };
 

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -8,16 +8,17 @@ import { ActionList } from 'src/utils/types';
 import { TypeEnum } from 'src/services/openapi';
 
 /*
- * return a different error element related to the type of the entity and actions
+ * This component can be returned instead of <EntityCard> when the entity
+ * doesn't seem to be available online at its original location.
  */
 export const EntityNotAvailable = ({
+  uid,
   type,
   unavailableActions,
-  uid,
 }: {
+  uid: string;
   type: string;
   unavailableActions?: ActionList;
-  uid: string;
 }) => {
   const { t } = useTranslation();
 
@@ -25,17 +26,15 @@ export const EntityNotAvailable = ({
     return (
       <Box mx={1} my={2}>
         <Grid
-          mx={1}
-          my={2}
           container
-          sx={entityCardMainSx}
           justifyContent="space-between"
           alignItems="center"
+          sx={entityCardMainSx}
         >
-          <Grid ml={1} my={2}>
+          <Grid item px={1} py={2}>
             <Typography>{t('video.notAvailableAnymore')}</Typography>
           </Grid>
-          <Grid>
+          <Grid item>
             {unavailableActions &&
               unavailableActions.map((Action, index) =>
                 typeof Action === 'function' ? (

--- a/frontend/src/components/entity/AvailableEntity.tsx
+++ b/frontend/src/components/entity/AvailableEntity.tsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, Grid, Typography } from '@mui/material';
-import { idFromUid } from '../../utils/video';
-import { entityCardMainSx } from './style';
-import { ActionList } from 'src/utils/types';
+
 import { TypeEnum } from 'src/services/openapi';
+import { ActionList } from 'src/utils/types';
+import { idFromUid } from 'src/utils/video';
+import { entityCardMainSx } from './style';
 
 /*
  * This component can be returned instead of <EntityCard> when the entity

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
@@ -22,6 +22,7 @@ import EntityCardScores from './EntityCardScores';
 import EntityImagery from './EntityImagery';
 import EntityMetadata, { VideoMetadata } from './EntityMetadata';
 import { entityCardMainSx } from './style';
+import { idFromUid } from 'src/utils/video';
 
 const EntityCard = ({
   entity,
@@ -44,6 +45,7 @@ const EntityCard = ({
     noSsr: true,
   });
   const [settingsVisible, setSettingsVisible] = useState(!isSmallScreen);
+  const [isAvailable, setIsAvailable] = useState(true);
 
   const displayEntityCardScores = () => {
     if ('tournesol_score' in entity && !compact) {
@@ -57,6 +59,18 @@ const EntityCard = ({
     }
     return null;
   };
+
+  useEffect(() => {
+    if (entity.uid) {
+      const img = new Image();
+      img.src = `https://i.ytimg.com/vi/${idFromUid(entity.uid)}/mqdefault.jpg`;
+      img.onload = function () {
+        setIsAvailable(img.width !== 120);
+      };
+    }
+
+    console.log('change');
+  }, [entity]);
 
   return (
     <Grid container sx={entityCardMainSx}>
@@ -89,7 +103,9 @@ const EntityCard = ({
       >
         <EntityCardTitle
           uid={entity.uid}
-          title={entity.metadata.name}
+          title={
+            isAvailable ? entity.metadata.name : t('video.notAvailableAnymore')
+          }
           compact={compact}
         />
         <EntityMetadata entity={entity} />

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
@@ -22,7 +22,6 @@ import EntityCardScores from './EntityCardScores';
 import EntityImagery from './EntityImagery';
 import EntityMetadata, { VideoMetadata } from './EntityMetadata';
 import { entityCardMainSx } from './style';
-import { idFromUid } from 'src/utils/video';
 
 const EntityCard = ({
   entity,
@@ -45,7 +44,6 @@ const EntityCard = ({
     noSsr: true,
   });
   const [settingsVisible, setSettingsVisible] = useState(!isSmallScreen);
-  const [isAvailable, setIsAvailable] = useState(true);
 
   const displayEntityCardScores = () => {
     if ('tournesol_score' in entity && !compact) {
@@ -59,18 +57,6 @@ const EntityCard = ({
     }
     return null;
   };
-
-  useEffect(() => {
-    if (entity.uid) {
-      const img = new Image();
-      img.src = `https://i.ytimg.com/vi/${idFromUid(entity.uid)}/mqdefault.jpg`;
-      img.onload = function () {
-        setIsAvailable(img.width !== 120);
-      };
-    }
-
-    console.log('change');
-  }, [entity]);
 
   return (
     <Grid container sx={entityCardMainSx}>
@@ -103,9 +89,7 @@ const EntityCard = ({
       >
         <EntityCardTitle
           uid={entity.uid}
-          title={
-            isAvailable ? entity.metadata.name : t('video.notAvailableAnymore')
-          }
+          title={entity.metadata.name}
           compact={compact}
         />
         <EntityMetadata entity={entity} />

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -77,6 +77,8 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
   const { showSuccessAlert, displayErrorsFrom } = useNotifications();
   const { name: pollName } = useCurrentPoll();
   const [isLoading, setIsLoading] = useState(true);
+  const [firstEntityIsAvailable, setFirstEntityIsAvailable] = useState(true);
+  const [secondEntityIsAvailable, setSecondEntityIsAvailable] = useState(true);
   const [initialComparison, setInitialComparison] =
     useState<ComparisonRequest | null>(null);
 
@@ -128,6 +130,20 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
 
   const onChangeA = useMemo(() => onChange(UID_PARAMS.vidA), [onChange]);
   const onChangeB = useMemo(() => onChange(UID_PARAMS.vidB), [onChange]);
+
+  const switchFirstEntityToAvailable = useCallback(() => {
+    setFirstEntityIsAvailable(true);
+  }, []);
+  const switchSecondEntityToAvailable = useCallback(() => {
+    setSecondEntityIsAvailable(true);
+  }, []);
+
+  const switchFirstEntityToUnavailable = useCallback(() => {
+    setFirstEntityIsAvailable(false);
+  }, []);
+  const switchSecondEntityToUnavailable = useCallback(() => {
+    setSecondEntityIsAvailable(false);
+  }, []);
 
   useEffect(() => {
     setIsLoading(true);
@@ -235,6 +251,8 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
           value={selectorA}
           onChange={onChangeA}
           otherUid={uidB}
+          onEntityCheckedError={switchFirstEntityToUnavailable}
+          onEntityCheckedSuccess={switchFirstEntityToAvailable}
           autoFill
         />
       </Grid>
@@ -251,6 +269,8 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
           value={selectorB}
           onChange={onChangeB}
           otherUid={uidA}
+          onEntityCheckedError={switchSecondEntityToUnavailable}
+          onEntityCheckedSuccess={switchSecondEntityToAvailable}
           autoFill
         />
       </Grid>
@@ -284,7 +304,10 @@ const Comparison = ({ afterSubmitCallback }: Props) => {
         component={Card}
         elevation={2}
       >
-        {selectorA.rating && selectorB.rating ? (
+        {selectorA.rating &&
+        selectorB.rating &&
+        firstEntityIsAvailable &&
+        secondEntityIsAvailable ? (
           isLoading ? (
             <CircularProgress />
           ) : (

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+import { Box, Typography, Grid } from '@mui/material';
 
 import EntityCard from 'src/components/entity/EntityCard';
 import { useCurrentPoll, useLoginState } from 'src/hooks';
 import { Recommendation } from 'src/services/openapi/models/Recommendation';
 import { ActionList, RelatedEntityObject } from 'src/utils/types';
 import { idFromUid } from 'src/utils/video';
+import { entityCardMainSx } from '../../components/entity/style';
 
 interface Props {
   entities: RelatedEntityObject[] | Recommendation[] | undefined;
@@ -18,21 +21,40 @@ interface Props {
 const AvailableEntity = ({
   children,
   uid,
+  errorElement,
+  type,
 }: {
   children: React.ReactNode;
   uid: string;
+  errorElement?: React.ReactNode;
+  type: string;
 }) => {
-  const [isAvailableOnYoutube, setIsAvailableOnYoutube] = useState(false);
+  const { t } = useTranslation();
+  const [isAvailable, setIsAvailable] = useState(false);
+
+  const errorElementDisplay = errorElement ?? (
+    <Box mx={1} my={2}>
+      <Grid container sx={entityCardMainSx}>
+        <Box mx={1} my={2}>
+          {t('video.notAvailableAnymore')}
+        </Box>
+      </Grid>
+    </Box>
+  );
 
   useEffect(() => {
-    const img = new Image();
-    img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
-    img.onload = function () {
-      setIsAvailableOnYoutube(img.width !== 120);
-    };
-  }, [uid]);
+    if (type != 'video') {
+      setIsAvailable(true);
+    } else {
+      const img = new Image();
+      img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
+      img.onload = function () {
+        setIsAvailable(img.width !== 120);
+      };
+    }
+  }, [uid,type]);
 
-  return isAvailableOnYoutube ? <>{children}</> : null;
+  return isAvailable ? <>{children}</> : <>{errorElementDisplay}</>;
 };
 
 /**
@@ -63,7 +85,7 @@ function EntityList({
     <>
       {entities && entities.length ? (
         entities.map((entity: Recommendation | RelatedEntityObject) => (
-          <AvailableEntity key={entity.uid} uid={entity.uid}>
+          <AvailableEntity key={entity.uid} uid={entity.uid} type={entity.type}>
             <Box mx={1} my={2}>
               <EntityCard
                 entity={entity}

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Typography } from '@mui/material';
 
 import EntityCard from 'src/components/entity/EntityCard';
 import { useCurrentPoll, useLoginState } from 'src/hooks';
 import { Recommendation } from 'src/services/openapi/models/Recommendation';
 import { ActionList, RelatedEntityObject } from 'src/utils/types';
+import { idFromUid } from 'src/utils/video';
 
 interface Props {
   entities: RelatedEntityObject[] | Recommendation[] | undefined;
@@ -13,6 +14,26 @@ interface Props {
   emptyMessage?: React.ReactNode;
   personalScores?: { [uid: string]: number };
 }
+
+const AvailableEntity = ({
+  children,
+  uid,
+}: {
+  children: React.ReactNode;
+  uid: string;
+}) => {
+  const [isAvailableOnYoutube, setIsAvailableOnYoutube] = useState(false);
+
+  useEffect(() => {
+    const img = new Image();
+    img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
+    img.onload = function () {
+      setIsAvailableOnYoutube(img.width !== 120);
+    };
+  }, [uid]);
+
+  return isAvailableOnYoutube ? <>{children}</> : null;
+};
 
 /**
  * Display a list of entities.
@@ -42,15 +63,17 @@ function EntityList({
     <>
       {entities && entities.length ? (
         entities.map((entity: Recommendation | RelatedEntityObject) => (
-          <Box key={entity.uid} mx={1} my={2}>
-            <EntityCard
-              entity={entity}
-              actions={actions ?? defaultEntityActions}
-              settings={settings}
-              compact={false}
-              entityTypeConfig={{ video: { displayPlayer: false } }}
-            />
-          </Box>
+          <AvailableEntity key={entity.uid} uid={entity.uid}>
+            <Box mx={1} my={2}>
+              <EntityCard
+                entity={entity}
+                actions={actions ?? defaultEntityActions}
+                settings={settings}
+                compact={false}
+                entityTypeConfig={{ video: { displayPlayer: false } }}
+              />
+            </Box>
+          </AvailableEntity>
         ))
       ) : (
         <Box m={2}>

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -42,7 +42,6 @@ function EntityList({
   const defaultEntityActions = isLoggedIn
     ? options?.defaultAuthEntityActions
     : options?.defaultAnonEntityActions;
-  console.log(entities);
 
   return (
     <>

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -15,7 +15,7 @@ interface Props {
   settings?: ActionList;
   emptyMessage?: React.ReactNode;
   personalScores?: { [uid: string]: number };
-  unavailableActions?: ActionList;
+  actionsIfUnavailable?: ActionList;
 }
 
 /**
@@ -34,7 +34,7 @@ function EntityList({
   settings = [],
   // personalScores,
   emptyMessage,
-  unavailableActions,
+  actionsIfUnavailable,
 }: Props) {
   const { isLoggedIn } = useLoginState();
   const { options } = useCurrentPoll();
@@ -51,7 +51,7 @@ function EntityList({
             key={entity.uid}
             uid={entity.uid}
             type={entity.type}
-            unavailableActions={unavailableActions}
+            actionsIfUnavailable={actionsIfUnavailable}
           >
             <Box mx={1} my={2}>
               <EntityCard

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -1,14 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import React from 'react';
 
-import { Box, Typography, Grid } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 import EntityCard from 'src/components/entity/EntityCard';
+import AvailableEntity from '../../components/entity/AvailableEntity';
+
 import { useCurrentPoll, useLoginState } from 'src/hooks';
 import { Recommendation } from 'src/services/openapi/models/Recommendation';
 import { ActionList, RelatedEntityObject } from 'src/utils/types';
-import { idFromUid } from 'src/utils/video';
-import { entityCardMainSx } from '../../components/entity/style';
 
 interface Props {
   entities: RelatedEntityObject[] | Recommendation[] | undefined;
@@ -17,45 +16,6 @@ interface Props {
   emptyMessage?: React.ReactNode;
   personalScores?: { [uid: string]: number };
 }
-
-const AvailableEntity = ({
-  children,
-  uid,
-  errorElement,
-  type,
-}: {
-  children: React.ReactNode;
-  uid: string;
-  errorElement?: React.ReactNode;
-  type: string;
-}) => {
-  const { t } = useTranslation();
-  const [isAvailable, setIsAvailable] = useState(false);
-
-  const errorElementDisplay = errorElement ?? (
-    <Box mx={1} my={2}>
-      <Grid container sx={entityCardMainSx}>
-        <Box mx={1} my={2}>
-          {t('video.notAvailableAnymore')}
-        </Box>
-      </Grid>
-    </Box>
-  );
-
-  useEffect(() => {
-    if (type != 'video') {
-      setIsAvailable(true);
-    } else {
-      const img = new Image();
-      img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
-      img.onload = function () {
-        setIsAvailable(img.width !== 120);
-      };
-    }
-  }, [uid,type]);
-
-  return isAvailable ? <>{children}</> : <>{errorElementDisplay}</>;
-};
 
 /**
  * Display a list of entities.

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -15,6 +15,7 @@ interface Props {
   settings?: ActionList;
   emptyMessage?: React.ReactNode;
   personalScores?: { [uid: string]: number };
+  unavailableActions?: ActionList;
 }
 
 /**
@@ -33,6 +34,7 @@ function EntityList({
   settings = [],
   // personalScores,
   emptyMessage,
+  unavailableActions,
 }: Props) {
   const { isLoggedIn } = useLoginState();
   const { options } = useCurrentPoll();
@@ -40,12 +42,18 @@ function EntityList({
   const defaultEntityActions = isLoggedIn
     ? options?.defaultAuthEntityActions
     : options?.defaultAnonEntityActions;
+  console.log(entities);
 
   return (
     <>
       {entities && entities.length ? (
         entities.map((entity: Recommendation | RelatedEntityObject) => (
-          <AvailableEntity key={entity.uid} uid={entity.uid} type={entity.type}>
+          <AvailableEntity
+            key={entity.uid}
+            uid={entity.uid}
+            type={entity.type}
+            unavailableActions={unavailableActions}
+          >
             <Box mx={1} my={2}>
               <EntityCard
                 entity={entity}

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -50,7 +50,6 @@ function EntityList({
           <AvailableEntity
             key={entity.uid}
             uid={entity.uid}
-            type={entity.type}
             actionsIfUnavailable={actionsIfUnavailable}
           >
             <Box mx={1} my={2}>

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Theme } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import { Box, Typography } from '@mui/material';
@@ -39,6 +40,22 @@ const useStyles = makeStyles((theme: Theme) => ({
       fontSize: '0.7rem',
     },
   },
+  overlay: {
+    display: 'flex',
+    // flexDirection="column"
+    aspectRatio: '16/9',
+    background: 'rgba(0,0,0,.5)',
+    position: 'absolute',
+    top: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    color: 'white',
+
+    [theme.breakpoints.down('sm')]: {
+      fontSize: '0.8rem',
+    },
+  },
 }));
 
 interface Props {
@@ -48,6 +65,8 @@ interface Props {
   otherUid: string | null;
   variant?: 'regular' | 'noControl';
   autoFill?: boolean;
+  onEntityCheckedError?: CallableFunction;
+  onEntityCheckedSuccess?: CallableFunction;
 }
 
 export interface SelectorValue {
@@ -66,6 +85,8 @@ const EntitySelector = ({
   otherUid,
   variant = 'regular',
   autoFill = false,
+  onEntityCheckedError,
+  onEntityCheckedSuccess,
 }: Props) => {
   const classes = useStyles();
   const { isLoggedIn } = useLoginState();
@@ -80,6 +101,8 @@ const EntitySelector = ({
           otherUid={otherUid}
           variant={variant}
           autoFill={autoFill}
+          onEntityCheckedError={onEntityCheckedError ?? undefined}
+          onEntityCheckedSuccess={onEntityCheckedSuccess ?? undefined}
         />
       ) : (
         <EntitySelectorInnerAnonymous value={value} />
@@ -131,7 +154,11 @@ const EntitySelectorInnerAuth = ({
   otherUid,
   variant,
   autoFill,
+  onEntityCheckedError,
+  onEntityCheckedSuccess,
 }: Props) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
   const { name: pollName, options } = useCurrentPoll();
 
   const { uid, rating, ratingIsExpired } = value;
@@ -143,6 +170,7 @@ const EntitySelectorInnerAuth = ({
     value.uid ?? ''
   );
   const [newEntityIsLoading, setNewEntityIsLoading] = useState(false);
+  const [seamlessLoad, setSeamlessLoad] = useState(true);
   let showEntityInput = true;
   let showRatingControl = true;
 
@@ -154,7 +182,8 @@ const EntitySelectorInnerAuth = ({
 
   useEffect(() => {
     if (!entityIsAvailable && !entityIsChecking) {
-      if (!newEntityIsLoading) {
+      if (onEntityCheckedError) onEntityCheckedError();
+      if (seamlessLoad && !newEntityIsLoading) {
         setNewEntityIsLoading(true);
 
         getVideoForComparison(otherUid, uid).then((newUid) => {
@@ -170,6 +199,8 @@ const EntitySelectorInnerAuth = ({
     entityIsAvailable,
     entityIsChecking,
     newEntityIsLoading,
+    onEntityCheckedError,
+    seamlessLoad,
     otherUid,
     onChange,
   ]);
@@ -216,11 +247,12 @@ const EntitySelectorInnerAuth = ({
 
   useEffect(() => {
     if (entityIsAvailable) {
+      if (onEntityCheckedSuccess) onEntityCheckedSuccess();
       if (isUidValid(uid) && rating == null) {
         loadRating();
       }
     }
-  }, [entityIsAvailable, loadRating, rating, uid]);
+  }, [entityIsAvailable, onEntityCheckedSuccess, loadRating, rating, uid]);
 
   useEffect(() => {
     // Reload rating after the parent (comparison) form has been submitted.
@@ -231,7 +263,6 @@ const EntitySelectorInnerAuth = ({
 
   useEffect(() => {
     // Update input value when "uid" has been changed by the parent component
-
     setInputValue((previousValue) => {
       if (previousValue !== uid) {
         return uid;
@@ -249,12 +280,14 @@ const EntitySelectorInnerAuth = ({
       });
       return;
     }
+    setSeamlessLoad(false);
 
     const videoIdFromValue =
       pollName === YOUTUBE_POLL_NAME ? extractVideoId(value) : null;
     const newUid = videoIdFromValue
       ? UID_YT_NAMESPACE + videoIdFromValue
       : value.trim();
+
     setInputValue(newUid);
     onChange({
       uid: newUid,
@@ -310,6 +343,7 @@ const EntitySelectorInnerAuth = ({
               currentUid={uid}
               otherUid={otherUid}
               onClick={() => {
+                setSeamlessLoad(true);
                 setInputValue('');
                 setLoading(true);
               }}
@@ -329,16 +363,24 @@ const EntitySelectorInnerAuth = ({
           </Box>
         </>
       )}
-
-      {rating && entityIsAvailable ? (
-        <EntityCard
-          compact
-          entity={rating.entity}
-          settings={showRatingControl ? toggleAction : undefined}
-        />
-      ) : (
-        <EmptyEntityCard compact loading={loading || !entityIsAvailable} />
-      )}
+      <Box position="relative">
+        {rating && (entityIsAvailable || !seamlessLoad) ? (
+          <EntityCard
+            compact
+            entity={rating.entity}
+            settings={showRatingControl ? toggleAction : undefined}
+          ></EntityCard>
+        ) : (
+          <EmptyEntityCard compact loading={loading || !entityIsAvailable} />
+        )}
+        {rating && !entityIsAvailable && !seamlessLoad && (
+          <Box className={classes.overlay}>
+            <Typography textAlign="center" fontSize="inherit">
+              {t('video.loadAnother')}
+            </Typography>
+          </Box>
+        )}
+      </Box>
     </>
   );
 };

--- a/frontend/src/hooks/useIsAvailable.ts
+++ b/frontend/src/hooks/useIsAvailable.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+import { idFromUid } from '../utils/video';
+
+const useIsAvailable = (uid: string) => {
+  const [entityIsChecking, setEntityIsChecking] = useState(true);
+  const [entityIsAvailable, setEntityIsAvailable] = useState(false);
+
+  useEffect(() => {
+    if (uid.indexOf('yt:') === -1) {
+      setEntityIsChecking(false);
+      setEntityIsAvailable(true);
+    } else {
+      const img = new Image();
+      img.src = `https://i.ytimg.com/vi/${idFromUid(uid)}/mqdefault.jpg`;
+      img.onload = function () {
+        setEntityIsAvailable(img.width !== 120);
+        setEntityIsChecking(false);
+      };
+    }
+  }, [uid]);
+
+  return { entityIsChecking, entityIsAvailable };
+};
+
+export default useIsAvailable;

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -181,7 +181,7 @@ const RateLaterPage = () => {
               <EntityList
                 entities={entities}
                 actions={rateLaterPageActions}
-                unavailableActions={[RemoveFromRateLater(loadList)]}
+                actionsIfUnavailable={[RemoveFromRateLater(loadList)]}
               />
             </LoaderWrapper>
           </Box>

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -178,7 +178,11 @@ const RateLaterPage = () => {
 
           <Box width="100%" textAlign="center">
             <LoaderWrapper isLoading={isLoading}>
-              <EntityList entities={entities} actions={rateLaterPageActions} />
+              <EntityList
+                entities={entities}
+                actions={rateLaterPageActions}
+                unavailableActions={[RemoveFromRateLater(loadList)]}
+              />
             </LoaderWrapper>
           </Box>
           {!!entityCount && (


### PR DESCRIPTION
**replaced by** https://github.com/tournesol-app/tournesol/pull/1431 (conflicts solved)

---

This PR has for goal to find and apply a good behavior to implement on the comparison page when a video is unavailable.
For the moment when a video is unavailable it displays the tournesol loader till a new video is loaded and displayed.

However, it might be disconcerting not to inform the user the video is not available. So we are looking for the better way to tell the user.

Some options could be : 

- Display a message informing the video is not available with a counter instead of the tournesol loader and reload a new video at the end of the counter.
- Display that message with no counter and wait for the user to reload a new video manually.
- Display the message in place of the video player
- Display the message on a light overlay on top of the video display

To do
- [ ] Fix : the comparison slider flash when a video is not available 