### PR TITLE
[back] fix: delay user deletion to avoid conflicts with score computations

### DIFF
--- a/backend/core/management/commands/delete_inactive_users.py
+++ b/backend/core/management/commands/delete_inactive_users.py
@@ -2,6 +2,7 @@
 Delete users that have not activated their account.
 """
 from django.core.management.base import BaseCommand
+from django.db.models import Q
 from django.utils import timezone
 
 from core.models.user import User

--- a/backend/core/management/commands/delete_inactive_users.py
+++ b/backend/core/management/commands/delete_inactive_users.py
@@ -27,7 +27,9 @@ class Command(BaseCommand):
         # corresponding try/catch and log the number of users to delete still
         # in the database
         deleted = User.objects.filter(
-            is_active=False, date_joined__lt=delete_before
+            Q(last_login__isnull=True) | Q(last_login__lt=delete_before),
+            is_active=False,
+            date_joined__lt=delete_before,
         ).delete()
 
         self.stdout.write(self.style.SUCCESS(f"{deleted[0]} users deleted"))

--- a/backend/core/tests/management/test_delete_inactive_users.py
+++ b/backend/core/tests/management/test_delete_inactive_users.py
@@ -22,27 +22,32 @@ class DeleteInactiveUsersTestCase(TestCase):
         UserFactory(username="still_there_2", is_active=True, date_joined=recent_date)
 
         # only old inactive users must be deleted
-        UserFactory(is_active=False, date_joined=old_date)
-        UserFactory(is_active=False, date_joined=old_date)
+        users_to_delete = [
+            UserFactory(is_active=False, date_joined=old_date),
+            UserFactory(is_active=False, date_joined=old_date),
+            UserFactory(is_active=False, date_joined=old_date, last_login=old_date),
+        ]
         UserFactory(username="still_there_3", is_active=False, date_joined=recent_date)
         UserFactory(username="still_there_4", is_active=False, date_joined=recent_date)
 
+        # inactive users that have recently been marked as deleted should be preserved
+        UserFactory(
+            username="still_there_5", is_active=False, date_joined=old_date, last_login=recent_date
+        )
+
         n_users_before = User.objects.count()
-        n_users_to_delete = User.objects.filter(
-            is_active=False,
-            date_joined__lt=time_ago(days=self.default_period),
-        ).count()
+        n_users_to_delete = len(users_to_delete)
 
         call_command("delete_inactive_users", stdout=out)
         output = out.getvalue()
         n_users_after = User.objects.count()
 
-        self.assertIn("2 users deleted", output)
+        self.assertIn(f"{n_users_to_delete} users deleted", output)
         self.assertIn("success", output)
         self.assertEqual(n_users_after, n_users_before - n_users_to_delete)
 
         # check no exception is raised by retrieving the expected users
-        for i in range(4):
+        for i in range(5):
             User.objects.get(username=f"still_there_{i+1}")
 
     def test_cmd_verbosity_levels(self):
@@ -50,16 +55,12 @@ class DeleteInactiveUsersTestCase(TestCase):
         out = StringIO()
         call_command("delete_inactive_users", stdout=out)
         output = out.getvalue()
-        self.assertNotIn(
-            f"MGMT_DELETE_INACTIVE_USERS_PERIOD: {self.default_period}", output
-        )
+        self.assertNotIn(f"MGMT_DELETE_INACTIVE_USERS_PERIOD: {self.default_period}", output)
 
         # verbosity 2
         out = StringIO()
         call_command("delete_inactive_users", verbosity=2, stdout=out)
         output = out.getvalue()
-        self.assertIn(
-            f"MGMT_DELETE_INACTIVE_USERS_PERIOD: {self.default_period}", output
-        )
+        self.assertIn(f"MGMT_DELETE_INACTIVE_USERS_PERIOD: {self.default_period}", output)
         self.assertIn("0 users deleted", output)
         self.assertIn("success", output)

--- a/backend/ml/inputs.py
+++ b/backend/ml/inputs.py
@@ -145,7 +145,8 @@ class MlInputFromDb(MlInput):
 
     def get_comparisons(self, criteria=None, user_id=None) -> pd.DataFrame:
         scores_queryset = ComparisonCriteriaScore.objects.filter(
-            comparison__poll__name=self.poll_name
+            comparison__poll__name=self.poll_name,
+            comparison__user__is_active=True,
         )
         if criteria is not None:
             scores_queryset = scores_queryset.filter(criteria=criteria)

--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -72,7 +72,6 @@ def get_comparisons_data(poll_name: str, until_: datetime) -> QuerySet:
 
         JOIN core_user
           ON core_user.id = tournesol_comparison.user_id
-          AND core_user.is_active
 
         JOIN tournesol_comparisoncriteriascore AS comparisoncriteriascore
           ON comparisoncriteriascore.comparison_id = tournesol_comparison.id
@@ -101,6 +100,8 @@ def get_comparisons_data(poll_name: str, until_: datetime) -> QuerySet:
           AND rating_2.is_public = true
           -- keep only comparisons made before this datetime
           AND datetime_add < %(until)s
+          -- ignore comparisons by users who deleted their account recently
+          AND core_user.is_active
 
         ORDER BY username, datetime_add
         """,

--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -72,6 +72,7 @@ def get_comparisons_data(poll_name: str, until_: datetime) -> QuerySet:
 
         JOIN core_user
           ON core_user.id = tournesol_comparison.user_id
+          AND core_user.is_active
 
         JOIN tournesol_comparisoncriteriascore AS comparisoncriteriascore
           ON comparisoncriteriascore.comparison_id = tournesol_comparison.id
@@ -151,6 +152,7 @@ def get_users_data(poll_name: str) -> QuerySet:
           -- keep only public ratings
           AND rating_1.is_public = true
           AND rating_2.is_public = true
+          AND core_user.is_active
 
         ORDER BY core_user.username
         """,
@@ -199,6 +201,7 @@ def get_individual_criteria_scores_data(poll_name: str) -> QuerySet:
 
         WHERE tournesol_poll.name = %(poll_name)s
           AND tournesol_contributorrating.is_public
+          AND core_user.is_active
 
         -- this query can be significantly faster by keeping only the username
         -- in the ORDER BY clause

--- a/backend/tournesol/tests/test_api_contributor_recommendations.py
+++ b/backend/tournesol/tests/test_api_contributor_recommendations.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from rest_framework.test import APIClient
 
+from core.models import User
 from core.tests.factories.user import UserFactory
 from tournesol.models import ContributorRating, ContributorRatingCriteriaScore, Poll
 from tournesol.tests.factories.comparison import ComparisonFactory
@@ -192,6 +193,16 @@ class ContributorRecommendationsApiTestCase(TestCase):
         self.client.force_authenticate(self.user1)
         response = self.client.get(
             f"/users/non-existing/recommendations/{self.poll.name}", format="json"
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_users_cant_list_on_inactive_user(self):
+        """
+        Users can't list recommendations of an inactive user.
+        """
+        User.objects.filter(username=self.user1.username).update(is_active=False)
+        response = self.client.get(
+            f"/users/{self.user1.username}/recommendations/{self.poll.name}", format="json"
         )
         self.assertEqual(response.status_code, 404)
 

--- a/backend/tournesol/tests/test_api_user.py
+++ b/backend/tournesol/tests/test_api_user.py
@@ -30,6 +30,9 @@ class UserDeletionTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(User.objects.filter(username=user.username, is_active=True).exists())
 
+        user.refresh_from_db()
+        self.assertRegex(user.email, r".*@deleted.invalid")
+
 
 class UserRegistrationTest(TestCase):
     def test_register_user(self):

--- a/backend/tournesol/tests/test_api_user.py
+++ b/backend/tournesol/tests/test_api_user.py
@@ -28,7 +28,7 @@ class UserDeletionTestCase(TestCase):
 
         response = client.delete("/users/me/")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(User.objects.filter(username=user.username).exists())
+        self.assertFalse(User.objects.filter(username=user.username, is_active=True).exists())
 
 
 class UserRegistrationTest(TestCase):

--- a/backend/tournesol/views/contributor_recommendations.py
+++ b/backend/tournesol/views/contributor_recommendations.py
@@ -83,7 +83,7 @@ class PublicContributorRecommendationsView(ContributorRecommendationsBaseView):
 
     def get_queryset(self):
         poll = self.poll_from_url
-        user = get_object_or_404(User, username=self.kwargs["username"])
+        user = get_object_or_404(User, username=self.kwargs["username"], is_active=True)
 
         queryset = Entity.objects.filter(
             contributorvideoratings__poll=poll,

--- a/backend/tournesol/views/stats.py
+++ b/backend/tournesol/views/stats.py
@@ -102,7 +102,7 @@ class StatisticsView(generics.GenericAPIView):
                 last_month_compared_entity_count,
             )
 
-            comparisons = Comparison.objects.filter(poll=poll)
+            comparisons = Comparison.objects.filter(poll=poll, user__is_active=True)
             comparison_count = comparisons.count()
             last_month_comparison_count = comparisons.filter(
                 datetime_lastedit__gte=time_ago(days=self._days_delta)

--- a/backend/tournesol/views/user.py
+++ b/backend/tournesol/views/user.py
@@ -19,16 +19,17 @@ class CurrentUserView(APIView):
     @extend_schema(responses={204: None})
     def delete(self, request):
         """
-        Deactivate and logout the authenticated user.
-        All related resources (comparisons, etc.) will be deleted separately by 'delete_inactive_users' after
-        a delay, in order to avoid conflicts with ml-train currently running.
+        Deactivate and logout the authenticated user. All related resources (comparisons, etc.)
+        will be deleted separately by 'delete_inactive_users' after a delay, in order to avoid
+        conflicts with ml-train currently running.
         """
         user = request.user
         user.is_active = False
         user.last_login = timezone.now()
 
-        # The email is replaced with a placeholder address, in order to allow the email to be reused immediatly.
-        # Deleting the email would not work as the db expects the email to be present and unique.
+        # The email is replaced with a placeholder address, in order to allow the email
+        # to be reused immediatly. Deleting the email would not work as the db expects the
+        # email to be present and unique.
         deleted_user_email = user.email
         user.email = f"__deleted__{user.id}@deleted.invalid"
         user.save(update_fields=["is_active", "last_login", "email"])

--- a/backend/tournesol/views/user.py
+++ b/backend/tournesol/views/user.py
@@ -13,21 +13,28 @@ logger = logging.getLogger(__name__)
 
 class CurrentUserView(APIView):
     """Manage the deletion of the authenticated user."""
+
     permission_classes = [IsAuthenticated]
 
     @extend_schema(responses={204: None})
     def delete(self, request):
         """
-        Delete and logout the authenticated user.
-        All related resources are also deleted: comparisons, rate-later list, access tokens, etc.
+        Deactivate and logout the authenticated user.
+        All related resources (comparisons, etc.) will be deleted separately by 'delete_inactive_users' after
+        a delay, in order to avoid conflicts with ml-train currently running.
         """
         user = request.user
         user.is_active = False
         user.last_login = timezone.now()
-        user.save(update_fields=["is_active", "last_login"])
+
+        # The email is replaced with a placeholder address, in order to allow the email to be reused immediatly.
+        # Deleting the email would not work as the db expects the email to be present and unique.
+        deleted_user_email = user.email
+        user.email = f"__deleted__{user.id}@deleted.invalid"
+        user.save(update_fields=["is_active", "last_login", "email"])
 
         logout(request)
         logger.info(
-            "User '%s' with email '%s' has been deleted.", user.username, user.email
+            "User '%s' with email '%s' has been deleted.", user.username, deleted_user_email
         )
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/tournesol/views/user.py
+++ b/backend/tournesol/views/user.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.auth import logout
+from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -21,7 +22,10 @@ class CurrentUserView(APIView):
         All related resources are also deleted: comparisons, rate-later list, access tokens, etc.
         """
         user = request.user
-        user.delete()
+        user.is_active = False
+        user.last_login = timezone.now()
+        user.save(update_fields=["is_active", "last_login"])
+
         logout(request)
         logger.info(
             "User '%s' with email '%s' has been deleted.", user.username, user.email

--- a/backend/vouch/serializers.py
+++ b/backend/vouch/serializers.py
@@ -40,7 +40,7 @@ class GivenVoucherSerializer(ModelSerializer):
 
     def validate_to(self, value):
         try:
-            user = User.objects.get(username=value)
+            user = User.objects.get(username=value, is_active=True)
         except User.DoesNotExist as error:
             raise ValidationError(_("The target user doesn't exist.")) from error
 

--- a/backend/vouch/tests/test_api_voucher.py
+++ b/backend/vouch/tests/test_api_voucher.py
@@ -189,6 +189,7 @@ class VoucherGivenListAPIViewTestCase(TestCase):
         self.user1 = User.objects.create(username="user1", email="user1@example.com")
         self.user2 = User.objects.create(username="user2", email="user2@example.com")
         self.user3 = User.objects.create(username="user3", email="user3@example.com")
+        self.user4 = User.objects.create(username="user4", email="user4@example.com", is_active=False)
 
         self.voucher1 = Voucher.objects.create(by=self.user1, to=self.user2, value=1)
         self.voucher2 = Voucher.objects.create(
@@ -202,6 +203,10 @@ class VoucherGivenListAPIViewTestCase(TestCase):
             to=self.user3,
             value=3,
         )
+        self.voucher4 = Voucher.objects.create(
+            by=self.user1,
+            to=self.user4,
+        )
 
     def test_anon_401_list(self):
         """
@@ -212,7 +217,7 @@ class VoucherGivenListAPIViewTestCase(TestCase):
 
     def test_auth_200_list(self):
         """
-        An authenticated user can list its given vouchers.
+        An authenticated user can list its given vouchers (excluding inactive users)
         """
         self.client.force_authenticate(user=self.user1)
         response = self.client.get(self.voucher_base_url, format="json")
@@ -253,6 +258,7 @@ class VoucherReceivedListAPIViewTestCase(TestCase):
         self.user1 = User.objects.create(username="user1", email="user1@example.com")
         self.user2 = User.objects.create(username="user2", email="user2@example.com")
         self.user3 = User.objects.create(username="user3", email="user3@example.com")
+        self.user4 = User.objects.create(username="user4", email="user4@example.com", is_active=False)
 
         self.voucher1 = Voucher.objects.create(by=self.user1, to=self.user2, value=1)
         self.voucher2 = Voucher.objects.create(
@@ -266,6 +272,10 @@ class VoucherReceivedListAPIViewTestCase(TestCase):
             to=self.user3,
             value=3,
         )
+        self.voucher4 = Voucher.objects.create(
+            by=self.user4,
+            to=self.user3,
+        )
 
     def test_anon_401_list(self):
         """
@@ -276,7 +286,7 @@ class VoucherReceivedListAPIViewTestCase(TestCase):
 
     def test_auth_200_list(self):
         """
-        An authenticated user can list its received vouchers.
+        An authenticated user can list its received vouchers
         """
         self.client.force_authenticate(user=self.user3)
         response = self.client.get(self.voucher_base_url, format="json")

--- a/backend/vouch/trust_algo.py
+++ b/backend/vouch/trust_algo.py
@@ -85,7 +85,8 @@ def trust_algo():
     """
     # Import users and pretrust status
     users = list(
-        User.objects.all()
+        User.objects
+        .filter(is_active=True)
         .annotate(with_trusted_email=Q(pk__in=User.with_trusted_email()))
         .only("id")
     )

--- a/backend/vouch/views.py
+++ b/backend/vouch/views.py
@@ -42,6 +42,7 @@ class VoucherGivenListAPIView(generics.ListAPIView):
     def get_queryset(self):
         return Voucher.objects.filter(
             by=self.request.user,
+            to__is_active=True,
         )
 
 
@@ -57,4 +58,5 @@ class VoucherReceivedListAPIView(generics.ListAPIView):
     def get_queryset(self):
         return Voucher.objects.filter(
             to=self.request.user,
+            by__is_active=True,
         )


### PR DESCRIPTION
Fixes #1393

When a user asks for account deletion, the "user" is marked as inactive in the database (with the date stored in "last_login") instead of being deleted immediately.

The command "delete_inactive_users" is modified to cover this case, so that the account is deleted after 7 days.

A placeholder email address is associated to the inactive user, to allow immediate reuse of the original address.

The implementations of ml input, voucher views, and public dataset are updated to ignore such inactive users.
