### PR TITLE
[front] add test of pagination component

### DIFF
--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -21,7 +21,7 @@ const defineMatchMedia = (width: number) => {
     value: width,
   });
   window.matchMedia = jest.fn().mockImplementation((query) => {
-    console.log(width == theme.breakpoints.values.sm);
+
     return {
       matches: width == theme.breakpoints.values.sm ? true : false,
       media: query,

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -126,7 +126,7 @@ describe('Pagination component', () => {
     expect(plus100Button).not.toBeInTheDocument();
   });
 
-  it('default pagination for 100 elements, 20 per page, verify 5 pages', () => {
+  it('displays 5 pages with limit: 20, count: 100', () => {
     const paginationProps: PaginationProps = {
       offset: 0,
       limit: 20,
@@ -136,7 +136,8 @@ describe('Pagination component', () => {
 
     setup(paginationProps);
 
-    // check that there are 5 pages
+    // [WHEN] The PaginationComponent is configured with boundaryCount=2 and
+    // siblingCount=3, we expect 5 pages to be displayed.
     const pages = screen.getAllByRole('button', { name: /page \d+/i });
     expect(pages).toHaveLength(5);
 
@@ -157,7 +158,7 @@ describe('Pagination component', () => {
     expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(80);
   });
 
-  it('default pagination for 270 elements, 20 per page, verify 12 pages because siblingCount is 3 and boundaryCount is 2', () => {
+  it('displays 12 pages with limit: 20, count: 270', () => {
     const paginationProps: PaginationProps = {
       offset: 0,
       limit: 20,
@@ -167,7 +168,8 @@ describe('Pagination component', () => {
 
     setup(paginationProps);
 
-    // check that there are 12 pages
+    // [WHEN] The PaginationComponent is configured with boundaryCount=2 and
+    // siblingCount=3, we expect 12 pages to be displayed.
     const pages = screen.getAllByRole('button', { name: /page \d+/i });
     expect(pages).toHaveLength(12);
 
@@ -180,7 +182,7 @@ describe('Pagination component', () => {
     expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(200);
   });
 
-  it('default pagination for 615 elements, 20 per page, current page is 13 verify 11 pages, because siblingCount is 3 and boundaryCount is 2', () => {
+  it('displays 11 pages when limit: 20, count: 615, offset: 240', () => {
     const paginationProps: PaginationProps = {
       offset: 240,
       limit: 20,
@@ -190,7 +192,8 @@ describe('Pagination component', () => {
 
     setup(paginationProps);
 
-    // check that there are 11 pages
+    // [WHEN] The PaginationComponent is configured with boundaryCount=2 and
+    // siblingCount=3, we expect 11 pages to be displayed.
     const pages = screen.getAllByRole('button', { name: /page \d+/i });
     expect(pages).toHaveLength(11);
 

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -248,6 +248,23 @@ describe('Pagination component', () => {
   });
 
   describe('Screen size: sm', () => {
+    it('-100 / +100 buttons are never displayed', () => {
+      const paginationProps: PaginationProps = {
+        offset: 0,
+        limit: 1,
+        count: 101,
+        onOffsetChange: onOffsetChange,
+        widthScreen: theme.breakpoints.values.sm,
+      };
+
+      setup(paginationProps);
+
+      const plus100 = screen.queryByRole('button', { name: / \+100 >/i });
+      const minus100 = screen.queryByRole('button', { name: /< -100/i });
+      expect(plus100).not.toBeInTheDocument();
+      expect(minus100).not.toBeInTheDocument();
+    });
+
     it('displays 6 pages when limit: 20, count: 270', () => {
       const paginationProps: PaginationProps = {
         offset: 0,
@@ -277,12 +294,6 @@ describe('Pagination component', () => {
       expect(plus1Button).toBeInTheDocument();
       const plus10Button = screen.getByRole('button', { name: /^\+10 >$/i });
       expect(plus10Button).toBeInTheDocument();
-
-      // Check if the -100 and +100 buttons are not visible
-      const minus100Button = screen.queryByRole('button', { name: /< -100/i });
-      const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
-      expect(minus100Button).not.toBeInTheDocument();
-      expect(plus100Button).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -243,12 +243,6 @@ describe('Pagination component', () => {
 
       setup(paginationProps);
 
-      // Check if the -100 and +100 buttons are visible
-      const minus100Button = screen.queryByRole('button', { name: /< -100/i });
-      const plus100Button = screen.queryByRole('button', { name: /\+100 >/i });
-      expect(minus100Button).toBeInTheDocument();
-      expect(plus100Button).toBeInTheDocument();
-
       // click on next 100 page button from page 50
       fireEvent.click(screen.getByRole('button', { name: /\+100 >/i }));
       expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(2980);

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import Pagination from './Pagination';
+import { theme } from 'src/theme';
+
+interface PaginationProps {
+  limit: number;
+  offset: number;
+  count: number;
+  onOffsetChange: (n: number) => void;
+  widthScreen?: number;
+}
+
+const onOffsetChange = jest.fn();
+
+const defineMatchMedia = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: width,
+  });
+  window.matchMedia = jest.fn().mockImplementation((query) => {
+    console.log(width == theme.breakpoints.values.sm);
+    return {
+      matches: width == theme.breakpoints.values.sm ? true : false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    };
+  });
+};
+
+describe('pagination component', () => {
+  const component = ({
+    offset,
+    limit,
+    count,
+    onOffsetChange,
+    widthScreen,
+  }: PaginationProps) => {
+    defineMatchMedia(widthScreen ? widthScreen : theme.breakpoints.values.lg);
+    render(
+      <ThemeProvider theme={theme}>
+        <Pagination
+          offset={offset}
+          count={count}
+          limit={limit}
+          onOffsetChange={onOffsetChange}
+        />
+      </ThemeProvider>
+    );
+  };
+
+  const setup = ({
+    offset,
+    limit,
+    count,
+    onOffsetChange,
+    widthScreen,
+  }: PaginationProps) => {
+    const rendered = component({
+      offset,
+      limit,
+      count,
+      onOffsetChange,
+      widthScreen,
+    });
+    return { rendered };
+  };
+
+  it('default pagination for 100 elements, 20 per page, verify 5 pages', () => {
+    const paginationProps: PaginationProps = {
+      offset: 0,
+      limit: 20,
+      count: 100,
+      onOffsetChange: onOffsetChange,
+    };
+
+    setup(paginationProps);
+
+    // check that there are 5 pages
+    const pages = screen.getAllByRole('button', { name: /page \d+/i });
+    expect(pages).toHaveLength(5);
+
+    // click on page 2
+    fireEvent.click(screen.getByRole('button', { name: /page 2/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(20);
+
+    // click on page 4
+    fireEvent.click(screen.getByRole('button', { name: /page 4/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(60);
+
+    // click on next 1 page button
+    fireEvent.click(screen.getByRole('button', { name: /\+1 >/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(20);
+
+    // click on next 10 page button
+    fireEvent.click(screen.getByRole('button', { name: /\+10 >/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(80);
+  });
+
+  it('default pagination for 270 elements, 20 per page, verify 12 pages because siblingCount is 3 and boundaryCount is 2', () => {
+    const paginationProps: PaginationProps = {
+      offset: 0,
+      limit: 20,
+      count: 270,
+      onOffsetChange: onOffsetChange,
+    };
+
+    setup(paginationProps);
+
+    // check that there are 12 pages
+    const pages = screen.getAllByRole('button', { name: /page \d+/i });
+    expect(pages).toHaveLength(12);
+
+    // click on page 10
+    fireEvent.click(screen.getByRole('button', { name: /page 10/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(180);
+
+    // click on next 10 page button
+    fireEvent.click(screen.getByRole('button', { name: /\+10 >/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(200);
+  });
+
+  it('default pagination for 615 elements, 20 per page, current page is 13 verify 11 pages, because siblingCount is 3 and boundaryCount is 2', () => {
+    const paginationProps: PaginationProps = {
+      offset: 240,
+      limit: 20,
+      count: 615,
+      onOffsetChange: onOffsetChange,
+    };
+
+    setup(paginationProps);
+
+    // check that there are 11 pages
+    const pages = screen.getAllByRole('button', { name: /page \d+/i });
+    expect(pages).toHaveLength(11);
+
+    // check present of last page button
+    const lastPageButton = screen.queryByRole('button', { name: /31/i });
+    expect(lastPageButton).toBeInTheDocument();
+
+    // check for the presence of the penultimate page button
+    const lastPenultimatePageButton = screen.queryByRole('button', {
+      name: /30/i,
+    });
+    expect(lastPenultimatePageButton).toBeInTheDocument();
+
+    // click on page 31
+    fireEvent.click(screen.getByRole('button', { name: /page 31/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(600);
+  });
+
+  it('should render the first two buttons as disabled and hide the -100 and +100 buttons', () => {
+    const paginationProps: PaginationProps = {
+      offset: 0,
+      limit: 20,
+      count: 100,
+      onOffsetChange: onOffsetChange,
+    };
+
+    setup(paginationProps);
+
+    // Check if the first two buttons are disabled
+    const firstButton = screen.getByRole('button', { name: /< -10/i });
+    const secondButton = screen.getByRole('button', { name: /^< -1$/i });
+    expect(firstButton).toBeDisabled();
+    expect(secondButton).toBeDisabled();
+
+    // Check if the -100 and +100 buttons are not visible
+    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
+    const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
+    expect(minus100Button).not.toBeInTheDocument();
+    expect(plus100Button).not.toBeInTheDocument();
+  });
+
+  it('test navigation page buttons from 50 page', () => {
+    const paginationProps: PaginationProps = {
+      offset: 980,
+      limit: 20,
+      count: 3000,
+      onOffsetChange: onOffsetChange,
+    };
+
+    setup(paginationProps);
+
+    // Check if the -100 and +100 buttons are visible
+    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
+    const plus100Button = screen.queryByRole('button', { name: /\+100 >/i });
+    expect(minus100Button).toBeInTheDocument();
+    expect(plus100Button).toBeInTheDocument();
+
+    // click on next 100 page button from page 50
+    fireEvent.click(screen.getByRole('button', { name: /\+100 >/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(2980);
+
+    // click on previous 100 page button from page 50
+    fireEvent.click(screen.getByRole('button', { name: /< -100/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(0);
+
+    // click on previous 10 page button from page 50
+    fireEvent.click(screen.getByRole('button', { name: /^< -10$/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(780);
+
+    // click on previous 1 page button from page 50
+    fireEvent.click(screen.getByRole('button', { name: /^< -1$/i }));
+    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(960);
+  });
+
+  it('default pagination for 270 elements, 20 per page, on small screen, verify 6 pages', () => {
+    const paginationProps: PaginationProps = {
+      offset: 0,
+      limit: 20,
+      count: 270,
+      onOffsetChange: onOffsetChange,
+      widthScreen: theme.breakpoints.values.sm,
+    };
+
+    setup(paginationProps);
+
+    // check that there are 6 pages
+    const pages = screen.getAllByRole('button', { name: /page \d+/i });
+    expect(pages).toHaveLength(6);
+
+    // check that last button is page 14
+    const lastPageButton = screen.queryByRole('button', { name: /14/i });
+    expect(lastPageButton).toBeInTheDocument();
+
+    const minus1Button = screen.getByRole('button', { name: /^< -1$/i });
+    expect(minus1Button).toBeInTheDocument();
+    const minus10Button = screen.getByRole('button', { name: /^< -10$/i });
+    expect(minus10Button).toBeInTheDocument();
+
+    const plus1Button = screen.getByRole('button', { name: /^\+1 >$/i });
+    expect(plus1Button).toBeInTheDocument();
+    const plus10Button = screen.getByRole('button', { name: /^\+10 >$/i });
+    expect(plus10Button).toBeInTheDocument();
+
+    // Check if the -100 and +100 buttons are not visible
+    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
+    const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
+    expect(minus100Button).not.toBeInTheDocument();
+    expect(plus100Button).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -92,12 +92,6 @@ describe('Pagination component', () => {
       const next10 = screen.getByRole('button', { name: /\+10 >/i });
       expect(next1).toBeEnabled();
       expect(next10).toBeEnabled();
-
-      // The buttons -100 and +100 should not be visible.
-      const minus100Button = screen.queryByRole('button', { name: /< -100/i });
-      const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
-      expect(minus100Button).not.toBeInTheDocument();
-      expect(plus100Button).not.toBeInTheDocument();
     });
 
     it('displays buttons +1 and +10 as disabled when current page is last', () => {
@@ -119,12 +113,38 @@ describe('Pagination component', () => {
       const next10 = screen.getByRole('button', { name: /\+10 >/i });
       expect(next1).toBeDisabled();
       expect(next10).toBeDisabled();
+    });
 
-      // The buttons -100 and +100 should not be visible.
-      const minus100Button = screen.queryByRole('button', { name: /< -100/i });
-      const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
-      expect(minus100Button).not.toBeInTheDocument();
-      expect(plus100Button).not.toBeInTheDocument();
+    it("doesn't display buttons -100 and +100 when there is less than 100 pages", () => {
+      const paginationProps: PaginationProps = {
+        offset: 0,
+        limit: 1,
+        count: 100,
+        onOffsetChange: onOffsetChange,
+      };
+
+      setup(paginationProps);
+
+      const plus100 = screen.queryByRole('button', { name: /\+100 >/i });
+      const minus100 = screen.queryByRole('button', { name: /< -100/i });
+      expect(plus100).not.toBeInTheDocument();
+      expect(minus100).not.toBeInTheDocument();
+    });
+
+    it('displays buttons -100 and +100 when there is strictly more than 100 pages', () => {
+      const paginationProps: PaginationProps = {
+        offset: 0,
+        limit: 1,
+        count: 101,
+        onOffsetChange: onOffsetChange,
+      };
+
+      setup(paginationProps);
+
+      const plus100 = screen.getByRole('button', { name: /\+100 >/i });
+      const minus100 = screen.getByRole('button', { name: /< -100/i });
+      expect(plus100).toBeInTheDocument();
+      expect(minus100).toBeInTheDocument();
     });
 
     it('displays 5 pages with limit: 20, count: 100', () => {

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -72,177 +72,179 @@ describe('Pagination component', () => {
     return { rendered };
   };
 
-  it('displays buttons -1 and -10 as disabled when current page is first', () => {
-    const paginationProps: PaginationProps = {
-      offset: 0,
-      limit: 1,
-      count: 5,
-      onOffsetChange: onOffsetChange,
-    };
+  describe('Screen size: lg', () => {
+    it('displays buttons -1 and -10 as disabled when current page is first', () => {
+      const paginationProps: PaginationProps = {
+        offset: 0,
+        limit: 1,
+        count: 5,
+        onOffsetChange: onOffsetChange,
+      };
 
-    setup(paginationProps);
+      setup(paginationProps);
 
-    const prev1 = screen.getByRole('button', { name: /^< -1$/i });
-    const prev10 = screen.getByRole('button', { name: /< -10/i });
-    expect(prev1).toBeDisabled();
-    expect(prev10).toBeDisabled();
+      const prev1 = screen.getByRole('button', { name: /^< -1$/i });
+      const prev10 = screen.getByRole('button', { name: /< -10/i });
+      expect(prev1).toBeDisabled();
+      expect(prev10).toBeDisabled();
 
-    const next1 = screen.getByRole('button', { name: /^\+1 >$/i });
-    const next10 = screen.getByRole('button', { name: /\+10 >/i });
-    expect(next1).toBeEnabled();
-    expect(next10).toBeEnabled();
+      const next1 = screen.getByRole('button', { name: /^\+1 >$/i });
+      const next10 = screen.getByRole('button', { name: /\+10 >/i });
+      expect(next1).toBeEnabled();
+      expect(next10).toBeEnabled();
 
-    // The buttons -100 and +100 should not be visible.
-    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
-    const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
-    expect(minus100Button).not.toBeInTheDocument();
-    expect(plus100Button).not.toBeInTheDocument();
-  });
-
-  it('displays buttons +1 and +10 as disabled when current page is last', () => {
-    const paginationProps: PaginationProps = {
-      offset: 4,
-      limit: 1,
-      count: 5,
-      onOffsetChange: onOffsetChange,
-    };
-
-    setup(paginationProps);
-
-    const prev1 = screen.getByRole('button', { name: /^< -1$/i });
-    const prev10 = screen.getByRole('button', { name: /< -10/i });
-    expect(prev1).toBeEnabled();
-    expect(prev10).toBeEnabled();
-
-    const next1 = screen.getByRole('button', { name: /^\+1 >$/i });
-    const next10 = screen.getByRole('button', { name: /\+10 >/i });
-    expect(next1).toBeDisabled();
-    expect(next10).toBeDisabled();
-
-    // The buttons -100 and +100 should not be visible.
-    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
-    const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
-    expect(minus100Button).not.toBeInTheDocument();
-    expect(plus100Button).not.toBeInTheDocument();
-  });
-
-  it('displays 5 pages with limit: 20, count: 100', () => {
-    const paginationProps: PaginationProps = {
-      offset: 0,
-      limit: 20,
-      count: 100,
-      onOffsetChange: onOffsetChange,
-    };
-
-    setup(paginationProps);
-
-    // [WHEN] The PaginationComponent is configured with boundaryCount=2 and
-    // siblingCount=3, we expect 5 pages to be displayed.
-    const pages = screen.getAllByRole('button', { name: /page \d+/i });
-    expect(pages).toHaveLength(5);
-
-    // click on page 2
-    fireEvent.click(screen.getByRole('button', { name: /page 2/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(20);
-
-    // click on page 4
-    fireEvent.click(screen.getByRole('button', { name: /page 4/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(60);
-
-    // click on next 1 page button
-    fireEvent.click(screen.getByRole('button', { name: /\+1 >/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(20);
-
-    // click on next 10 page button
-    fireEvent.click(screen.getByRole('button', { name: /\+10 >/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(80);
-  });
-
-  it('displays 12 pages with limit: 20, count: 270', () => {
-    const paginationProps: PaginationProps = {
-      offset: 0,
-      limit: 20,
-      count: 270,
-      onOffsetChange: onOffsetChange,
-    };
-
-    setup(paginationProps);
-
-    // [WHEN] The PaginationComponent is configured with boundaryCount=2 and
-    // siblingCount=3, we expect 12 pages to be displayed.
-    const pages = screen.getAllByRole('button', { name: /page \d+/i });
-    expect(pages).toHaveLength(12);
-
-    // click on page 10
-    fireEvent.click(screen.getByRole('button', { name: /page 10/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(180);
-
-    // click on next 10 page button
-    fireEvent.click(screen.getByRole('button', { name: /\+10 >/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(200);
-  });
-
-  it('displays 11 pages when limit: 20, count: 615, offset: 240', () => {
-    const paginationProps: PaginationProps = {
-      offset: 240,
-      limit: 20,
-      count: 615,
-      onOffsetChange: onOffsetChange,
-    };
-
-    setup(paginationProps);
-
-    // [WHEN] The PaginationComponent is configured with boundaryCount=2 and
-    // siblingCount=3, we expect 11 pages to be displayed.
-    const pages = screen.getAllByRole('button', { name: /page \d+/i });
-    expect(pages).toHaveLength(11);
-
-    // check present of last page button
-    const lastPageButton = screen.queryByRole('button', { name: /31/i });
-    expect(lastPageButton).toBeInTheDocument();
-
-    // check for the presence of the penultimate page button
-    const lastPenultimatePageButton = screen.queryByRole('button', {
-      name: /30/i,
+      // The buttons -100 and +100 should not be visible.
+      const minus100Button = screen.queryByRole('button', { name: /< -100/i });
+      const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
+      expect(minus100Button).not.toBeInTheDocument();
+      expect(plus100Button).not.toBeInTheDocument();
     });
-    expect(lastPenultimatePageButton).toBeInTheDocument();
 
-    // click on page 31
-    fireEvent.click(screen.getByRole('button', { name: /page 31/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(600);
-  });
+    it('displays buttons +1 and +10 as disabled when current page is last', () => {
+      const paginationProps: PaginationProps = {
+        offset: 4,
+        limit: 1,
+        count: 5,
+        onOffsetChange: onOffsetChange,
+      };
 
-  it('test navigation page buttons from 50 page', () => {
-    const paginationProps: PaginationProps = {
-      offset: 980,
-      limit: 20,
-      count: 3000,
-      onOffsetChange: onOffsetChange,
-    };
+      setup(paginationProps);
 
-    setup(paginationProps);
+      const prev1 = screen.getByRole('button', { name: /^< -1$/i });
+      const prev10 = screen.getByRole('button', { name: /< -10/i });
+      expect(prev1).toBeEnabled();
+      expect(prev10).toBeEnabled();
 
-    // Check if the -100 and +100 buttons are visible
-    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
-    const plus100Button = screen.queryByRole('button', { name: /\+100 >/i });
-    expect(minus100Button).toBeInTheDocument();
-    expect(plus100Button).toBeInTheDocument();
+      const next1 = screen.getByRole('button', { name: /^\+1 >$/i });
+      const next10 = screen.getByRole('button', { name: /\+10 >/i });
+      expect(next1).toBeDisabled();
+      expect(next10).toBeDisabled();
 
-    // click on next 100 page button from page 50
-    fireEvent.click(screen.getByRole('button', { name: /\+100 >/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(2980);
+      // The buttons -100 and +100 should not be visible.
+      const minus100Button = screen.queryByRole('button', { name: /< -100/i });
+      const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
+      expect(minus100Button).not.toBeInTheDocument();
+      expect(plus100Button).not.toBeInTheDocument();
+    });
 
-    // click on previous 100 page button from page 50
-    fireEvent.click(screen.getByRole('button', { name: /< -100/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(0);
+    it('displays 5 pages with limit: 20, count: 100', () => {
+      const paginationProps: PaginationProps = {
+        offset: 0,
+        limit: 20,
+        count: 100,
+        onOffsetChange: onOffsetChange,
+      };
 
-    // click on previous 10 page button from page 50
-    fireEvent.click(screen.getByRole('button', { name: /^< -10$/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(780);
+      setup(paginationProps);
 
-    // click on previous 1 page button from page 50
-    fireEvent.click(screen.getByRole('button', { name: /^< -1$/i }));
-    expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(960);
+      // [WHEN] The PaginationComponent is configured with boundaryCount=2 and
+      // siblingCount=3, we expect 5 pages to be displayed.
+      const pages = screen.getAllByRole('button', { name: /page \d+/i });
+      expect(pages).toHaveLength(5);
+
+      // click on page 2
+      fireEvent.click(screen.getByRole('button', { name: /page 2/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(20);
+
+      // click on page 4
+      fireEvent.click(screen.getByRole('button', { name: /page 4/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(60);
+
+      // click on next 1 page button
+      fireEvent.click(screen.getByRole('button', { name: /\+1 >/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(20);
+
+      // click on next 10 page button
+      fireEvent.click(screen.getByRole('button', { name: /\+10 >/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(80);
+    });
+
+    it('displays 12 pages with limit: 20, count: 270', () => {
+      const paginationProps: PaginationProps = {
+        offset: 0,
+        limit: 20,
+        count: 270,
+        onOffsetChange: onOffsetChange,
+      };
+
+      setup(paginationProps);
+
+      // [WHEN] The PaginationComponent is configured with boundaryCount=2 and
+      // siblingCount=3, we expect 12 pages to be displayed.
+      const pages = screen.getAllByRole('button', { name: /page \d+/i });
+      expect(pages).toHaveLength(12);
+
+      // click on page 10
+      fireEvent.click(screen.getByRole('button', { name: /page 10/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(180);
+
+      // click on next 10 page button
+      fireEvent.click(screen.getByRole('button', { name: /\+10 >/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(200);
+    });
+
+    it('displays 11 pages when limit: 20, count: 615, offset: 240', () => {
+      const paginationProps: PaginationProps = {
+        offset: 240,
+        limit: 20,
+        count: 615,
+        onOffsetChange: onOffsetChange,
+      };
+
+      setup(paginationProps);
+
+      // [WHEN] The PaginationComponent is configured with boundaryCount=2 and
+      // siblingCount=3, we expect 11 pages to be displayed.
+      const pages = screen.getAllByRole('button', { name: /page \d+/i });
+      expect(pages).toHaveLength(11);
+
+      // check present of last page button
+      const lastPageButton = screen.queryByRole('button', { name: /31/i });
+      expect(lastPageButton).toBeInTheDocument();
+
+      // check for the presence of the penultimate page button
+      const lastPenultimatePageButton = screen.queryByRole('button', {
+        name: /30/i,
+      });
+      expect(lastPenultimatePageButton).toBeInTheDocument();
+
+      // click on page 31
+      fireEvent.click(screen.getByRole('button', { name: /page 31/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(600);
+    });
+
+    it('test navigation page buttons from 50 page', () => {
+      const paginationProps: PaginationProps = {
+        offset: 980,
+        limit: 20,
+        count: 3000,
+        onOffsetChange: onOffsetChange,
+      };
+
+      setup(paginationProps);
+
+      // Check if the -100 and +100 buttons are visible
+      const minus100Button = screen.queryByRole('button', { name: /< -100/i });
+      const plus100Button = screen.queryByRole('button', { name: /\+100 >/i });
+      expect(minus100Button).toBeInTheDocument();
+      expect(plus100Button).toBeInTheDocument();
+
+      // click on next 100 page button from page 50
+      fireEvent.click(screen.getByRole('button', { name: /\+100 >/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(2980);
+
+      // click on previous 100 page button from page 50
+      fireEvent.click(screen.getByRole('button', { name: /< -100/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(0);
+
+      // click on previous 10 page button from page 50
+      fireEvent.click(screen.getByRole('button', { name: /^< -10$/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(780);
+
+      // click on previous 1 page button from page 50
+      fireEvent.click(screen.getByRole('button', { name: /^< -1$/i }));
+      expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(960);
+    });
   });
 
   describe('Screen size: sm', () => {

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -245,39 +245,42 @@ describe('Pagination component', () => {
     expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(960);
   });
 
-  it('default pagination for 270 elements, 20 per page, on small screen, verify 6 pages', () => {
-    const paginationProps: PaginationProps = {
-      offset: 0,
-      limit: 20,
-      count: 270,
-      onOffsetChange: onOffsetChange,
-      widthScreen: theme.breakpoints.values.sm,
-    };
+  describe('Screen size: sm', () => {
+    it('displays 6 pages when limit: 20, count: 270', () => {
+      const paginationProps: PaginationProps = {
+        offset: 0,
+        limit: 20,
+        count: 270,
+        onOffsetChange: onOffsetChange,
+        widthScreen: theme.breakpoints.values.sm,
+      };
 
-    setup(paginationProps);
+      setup(paginationProps);
 
-    // check that there are 6 pages
-    const pages = screen.getAllByRole('button', { name: /page \d+/i });
-    expect(pages).toHaveLength(6);
+      // [WHEN] The PaginationComponent is configured with boundaryCount=1 and
+      // siblingCount=1, we expect 6 pages to be displayed.
+      const pages = screen.getAllByRole('button', { name: /page \d+/i });
+      expect(pages).toHaveLength(6);
 
-    // check that last button is page 14
-    const lastPageButton = screen.queryByRole('button', { name: /14/i });
-    expect(lastPageButton).toBeInTheDocument();
+      // check that last button is page 14
+      const lastPageButton = screen.queryByRole('button', { name: /14/i });
+      expect(lastPageButton).toBeInTheDocument();
 
-    const minus1Button = screen.getByRole('button', { name: /^< -1$/i });
-    expect(minus1Button).toBeInTheDocument();
-    const minus10Button = screen.getByRole('button', { name: /^< -10$/i });
-    expect(minus10Button).toBeInTheDocument();
+      const minus1Button = screen.getByRole('button', { name: /^< -1$/i });
+      expect(minus1Button).toBeInTheDocument();
+      const minus10Button = screen.getByRole('button', { name: /^< -10$/i });
+      expect(minus10Button).toBeInTheDocument();
 
-    const plus1Button = screen.getByRole('button', { name: /^\+1 >$/i });
-    expect(plus1Button).toBeInTheDocument();
-    const plus10Button = screen.getByRole('button', { name: /^\+10 >$/i });
-    expect(plus10Button).toBeInTheDocument();
+      const plus1Button = screen.getByRole('button', { name: /^\+1 >$/i });
+      expect(plus1Button).toBeInTheDocument();
+      const plus10Button = screen.getByRole('button', { name: /^\+10 >$/i });
+      expect(plus10Button).toBeInTheDocument();
 
-    // Check if the -100 and +100 buttons are not visible
-    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
-    const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
-    expect(minus100Button).not.toBeInTheDocument();
-    expect(plus100Button).not.toBeInTheDocument();
+      // Check if the -100 and +100 buttons are not visible
+      const minus100Button = screen.queryByRole('button', { name: /< -100/i });
+      const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
+      expect(minus100Button).not.toBeInTheDocument();
+      expect(plus100Button).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -21,7 +21,6 @@ const defineMatchMedia = (width: number) => {
     value: width,
   });
   window.matchMedia = jest.fn().mockImplementation((query) => {
-
     return {
       matches: width == theme.breakpoints.values.sm ? true : false,
       media: query,
@@ -35,7 +34,7 @@ const defineMatchMedia = (width: number) => {
   });
 };
 
-describe('pagination component', () => {
+describe('Pagination component', () => {
   const component = ({
     offset,
     limit,
@@ -72,6 +71,60 @@ describe('pagination component', () => {
     });
     return { rendered };
   };
+
+  it('displays buttons -1 and -10 as disabled when current page is first', () => {
+    const paginationProps: PaginationProps = {
+      offset: 0,
+      limit: 1,
+      count: 5,
+      onOffsetChange: onOffsetChange,
+    };
+
+    setup(paginationProps);
+
+    const prev1 = screen.getByRole('button', { name: /^< -1$/i });
+    const prev10 = screen.getByRole('button', { name: /< -10/i });
+    expect(prev1).toBeDisabled();
+    expect(prev10).toBeDisabled();
+
+    const next1 = screen.getByRole('button', { name: /^\+1 >$/i });
+    const next10 = screen.getByRole('button', { name: /\+10 >/i });
+    expect(next1).toBeEnabled();
+    expect(next10).toBeEnabled();
+
+    // The buttons -100 and +100 should not be visible.
+    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
+    const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
+    expect(minus100Button).not.toBeInTheDocument();
+    expect(plus100Button).not.toBeInTheDocument();
+  });
+
+  it('displays buttons +1 and +10 as disabled when current page is last', () => {
+    const paginationProps: PaginationProps = {
+      offset: 4,
+      limit: 1,
+      count: 5,
+      onOffsetChange: onOffsetChange,
+    };
+
+    setup(paginationProps);
+
+    const prev1 = screen.getByRole('button', { name: /^< -1$/i });
+    const prev10 = screen.getByRole('button', { name: /< -10/i });
+    expect(prev1).toBeEnabled();
+    expect(prev10).toBeEnabled();
+
+    const next1 = screen.getByRole('button', { name: /^\+1 >$/i });
+    const next10 = screen.getByRole('button', { name: /\+10 >/i });
+    expect(next1).toBeDisabled();
+    expect(next10).toBeDisabled();
+
+    // The buttons -100 and +100 should not be visible.
+    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
+    const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
+    expect(minus100Button).not.toBeInTheDocument();
+    expect(plus100Button).not.toBeInTheDocument();
+  });
 
   it('default pagination for 100 elements, 20 per page, verify 5 pages', () => {
     const paginationProps: PaginationProps = {
@@ -154,29 +207,6 @@ describe('pagination component', () => {
     // click on page 31
     fireEvent.click(screen.getByRole('button', { name: /page 31/i }));
     expect(paginationProps.onOffsetChange).toHaveBeenCalledWith(600);
-  });
-
-  it('should render the first two buttons as disabled and hide the -100 and +100 buttons', () => {
-    const paginationProps: PaginationProps = {
-      offset: 0,
-      limit: 20,
-      count: 100,
-      onOffsetChange: onOffsetChange,
-    };
-
-    setup(paginationProps);
-
-    // Check if the first two buttons are disabled
-    const firstButton = screen.getByRole('button', { name: /< -10/i });
-    const secondButton = screen.getByRole('button', { name: /^< -1$/i });
-    expect(firstButton).toBeDisabled();
-    expect(secondButton).toBeDisabled();
-
-    // Check if the -100 and +100 buttons are not visible
-    const minus100Button = screen.queryByRole('button', { name: /< -100/i });
-    const plus100Button = screen.queryByRole('button', { name: / \+100 >/i });
-    expect(minus100Button).not.toBeInTheDocument();
-    expect(plus100Button).not.toBeInTheDocument();
   });
 
   it('test navigation page buttons from 50 page', () => {


### PR DESCRIPTION
Add test on newly version of pagination component

checked:

- The default navigation
- The calculation of the total number of pages
- The offset of elements when choosing a page 
- The click on the different buttons -1 / -10 / -100 / +1 / +10 / +10
- That the -100 / +100 buttons are not displayed by default
- That the buttons are well deactivated according to the selected page
