### PR TITLE
[back] docs: fix broken table of content is the `README.md`

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,7 +6,7 @@ The API of the Tournesol platform, made with Python and Django.
 
 - [Install](#install)
     - [Automatic installation (recommended)](#automatic-installation-recommended)
-    - [Manual installation](#manual-installation-advanced)
+    - [Manual installation](#manual-installation)
     - [Set up a Google API key](#set-up-a-google-api-key)
 - [Management commands](#management-commands)
 - [Tests](#tests)


### PR DESCRIPTION
Clicking on the `Manual installation` item of the table of content now redirects to the correct section.

You can test here:
https://github.com/tournesol-app/tournesol/blob/2168f5ad1b347dc2e5b09882f136c9ece72c34a6/backend/README.md