### PR TITLE
[back] refactor: indent the `metadata.json` file of the dataset

### DIFF
--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -276,7 +276,7 @@ def write_metadata_file(write_target, data_until: Optional[datetime] = None) -> 
             },
         },
     }
-    json.dump(metadata_dict, write_target)
+    json.dump(metadata_dict, write_target, indent=2)
 
 
 def write_comparisons_file(


### PR DESCRIPTION
Before:

```json
{"data_included_until": "2023-03-20", "generated_by": "https://api.tournesol.app/", "tournesol_version": "d4e7d28eed20395c5cc65ee2cb9afd031160034d", "license": "ODC-By-1.0", "algorithms_parameters": {"byztrust": {"SINK_VOUCH": 5, "TRUSTED_EMAIL_PRETRUST": 0.8, "VOUCH_DECAY": 0.8}, "mehestan": {"ALPHA": 1.0, "R_MAX": 10.0, "W": 20.0, "SCALING_WEIGHT_CALIBRATION": 20.0, "VOTE_WEIGHT_PUBLIC_RATINGS": 1.0, "VOTE_WEIGHT_PRIVATE_RATINGS": 0.5, "OVER_TRUST_BIAS": 2, "OVER_TRUST_SCALE": 0.1, "MAX_SCALED_SCORE": 100.0, "POLL_SCALING_MIN_CONTRIBUTORS": 4, "POLL_SCALING_QUANTILE": 0.75, "POLL_SCALING_SCORE_AT_QUANTILE": 25.0}}}
```

After:

```json
{
  "data_included_until": "2023-03-20",
  "generated_by": "https://api.tournesol.app/",
  "tournesol_version": "d4e7d28eed20395c5cc65ee2cb9afd031160034d",
  "license": "ODC-By-1.0",
  "algorithms_parameters": {
    "byztrust": {
      "SINK_VOUCH": 5,
      "TRUSTED_EMAIL_PRETRUST": 0.8,
      "VOUCH_DECAY": 0.8
    },
    "mehestan": {
      "ALPHA": 1,
      "R_MAX": 10,
      "W": 20,
      "SCALING_WEIGHT_CALIBRATION": 20,
      "VOTE_WEIGHT_PUBLIC_RATINGS": 1,
      "VOTE_WEIGHT_PRIVATE_RATINGS": 0.5,
      "OVER_TRUST_BIAS": 2,
      "OVER_TRUST_SCALE": 0.1,
      "MAX_SCALED_SCORE": 100,
      "POLL_SCALING_MIN_CONTRIBUTORS": 4,
      "POLL_SCALING_QUANTILE": 0.75,
      "POLL_SCALING_SCORE_AT_QUANTILE": 25
    }
  }
}
```