### PR TITLE
Improve Distribution Histogram readability

### DIFF
--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -297,7 +297,7 @@ class Entity(models.Model):
         criteria_distributions = []
         for key, values in scores_dict.items():
             score_range = (min_score_base, max_score_base)
-            distribution, bins = np.histogram(np.clip(values, *score_range), range=score_range)
+            distribution, bins = np.histogram(np.clip(values, *score_range), bins=20, range=score_range)
 
             criteria_distributions.append(CriteriaDistributionScore(
                 key, distribution, bins))


### PR DESCRIPTION
**related to** #932 

---

This PR has for goal to make the chart on the video analysis page more readable.

- [ ] Change the number of criteria_scores bins requested from the backend (Thanks to  @GresilleSiffle)
- [ ] Change the visual range display in the frontend 
