### PR TITLE
[back] fix: comparison preview url without trailing slash

### DIFF
--- a/backend/tournesol/tests/test_api_preview.py
+++ b/backend/tournesol/tests/test_api_preview.py
@@ -255,6 +255,15 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
         # check is not very robust.
         self.assertNotIn("Content-Disposition", response.headers)
 
+        # Test without the trailing slash
+        response = self.client.get(
+            self.preview_url[:-1], {"uidA": self.valid_uid, "uidB": self.valid_uid2}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.headers["Content-Type"], "image/png")
+        self.assertNotIn("Content-Disposition", response.headers)
+
+
     @patch("requests.get", mock_yt_thumbnail_response)
     @patch("tournesol.entities.video.VideoEntity.update_search_vector", lambda x: None)
     def test_anon_200_get_existing_entities(self):

--- a/backend/tournesol/tests/test_api_preview.py
+++ b/backend/tournesol/tests/test_api_preview.py
@@ -48,7 +48,7 @@ class DynamicWebsitePreviewDefaultTestCase(TestCase):
             response.headers["Content-Disposition"],
             'inline; filename="tournesol_screenshot_og.png"',
         )
-        content = b''.join(response.streaming_content)
+        content = b"".join(response.streaming_content)
         self.assertGreater(len(content), 0)
 
     def test_anon_200_get(self):
@@ -187,7 +187,7 @@ class DynamicWebsitePreviewEntityTestCase(TestCase):
                 "video_id": self.valid_uid.split(":")[-1],
                 "name": "name",
                 "uploader": "uploader",
-                "duration": 1337
+                "duration": 1337,
             },
         )
         response = self.client.get(f"{self.preview_url}{self.valid_uid}")
@@ -211,7 +211,7 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
         self.client = APIClient()
         self.user = UserFactory(username=self._user)
 
-        self.preview_url = "/preview/comparison/"
+        self.preview_url = "/preview/comparison"
         self.valid_uid = "yt:sDPk-r18sb0"
         self.valid_uid2 = "yt:VKsekCHBuHI"
 
@@ -229,7 +229,7 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
                 "video_id": self.valid_uid.split(":")[-1],
                 "name": "name",
                 "uploader": "uploader",
-                "duration": 1337
+                "duration": 1337,
             },
         )
         Entity.objects.create(
@@ -239,7 +239,7 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
                 "video_id": self.valid_uid2.split(":")[-1],
                 "name": "name2",
                 "uploader": "uploader2",
-                "duration": 1337
+                "duration": 1337,
             },
         )
 
@@ -255,14 +255,13 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
         # check is not very robust.
         self.assertNotIn("Content-Disposition", response.headers)
 
-        # Test without the trailing slash
+        # Ensure the URL with a trailing slash is also accepted.
         response = self.client.get(
-            self.preview_url[:-1], {"uidA": self.valid_uid, "uidB": self.valid_uid2}
+            f"{self.preview_url}/", {"uidA": self.valid_uid, "uidB": self.valid_uid2}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.headers["Content-Type"], "image/png")
         self.assertNotIn("Content-Disposition", response.headers)
-
 
     @patch("requests.get", mock_yt_thumbnail_response)
     @patch("tournesol.entities.video.VideoEntity.update_search_vector", lambda x: None)
@@ -279,7 +278,7 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
                 "video_id": self.valid_uid.split(":")[-1],
                 "name": "name",
                 "uploader": "uploader",
-                "duration": 4242 # testing for >1 hour
+                "duration": 4242,  # testing for >1 hour
             },
         )
         Entity.objects.create(
@@ -289,7 +288,7 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
                 "video_id": self.valid_uid2.split(":")[-1],
                 "name": "name2",
                 "uploader": "uploader2",
-                "duration": 1337 #testing for <1 hour
+                "duration": 1337,  # testing for <1 hour
             },
         )
         response = self.client.get(
@@ -348,9 +347,7 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
         the comparison preview without using the required query parameters.
         """
         # Missing `uidA` parameter.
-        response = self.client.get(
-            self.preview_url, {"uidB": self.valid_uid}
-        )
+        response = self.client.get(self.preview_url, {"uidB": self.valid_uid})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.headers["Content-Type"], "image/png")
         self.assertEqual(
@@ -359,9 +356,7 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
         )
 
         # Missing `uidB` parameter.
-        response = self.client.get(
-            self.preview_url, {"uidA": self.valid_uid2}
-        )
+        response = self.client.get(self.preview_url, {"uidA": self.valid_uid2})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.headers["Content-Type"], "image/png")
         self.assertEqual(
@@ -393,9 +388,7 @@ class DynamicWebsitePreviewComparisonTestCase(TestCase):
                 "language": "en",
             },
         )
-        response = self.client.get(
-            f"{self.preview_url}{self.valid_uid}/zz:an_invalid_id"
-        )
+        response = self.client.get(f"{self.preview_url}{self.valid_uid}/zz:an_invalid_id")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.headers["Content-Type"], "image/png")
         self.assertEqual(

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -196,6 +196,11 @@ urlpatterns = [
         name="website_preview_comparison",
     ),
     path(
+        "preview/comparison",
+        DynamicWebsitePreviewComparison.as_view(),
+        name="website_preview_comparison",
+    ),
+    path(
         "preview/entities/<str:uid>",
         DynamicWebsitePreviewEntity.as_view(),
         name="website_preview_entity",

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -190,15 +190,10 @@ urlpatterns = [
         name="polls_score_distribution",
     ),
     # Website Previews
-    path(
-        "preview/comparison",
+    re_path(
+        "^preview/comparison/?$",
         DynamicWebsitePreviewComparison.as_view(),
         name="website_preview_comparison",
-    ),
-    path(
-        "preview/comparison/",
-        DynamicWebsitePreviewComparison.as_view(),
-        name="website_preview_comparison_slash",
     ),
     path(
         "preview/entities/<str:uid>",

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -191,14 +191,14 @@ urlpatterns = [
     ),
     # Website Previews
     path(
-        "preview/comparison/",
-        DynamicWebsitePreviewComparison.as_view(),
-        name="website_preview_comparison_slash",
-    ),
-    path(
         "preview/comparison",
         DynamicWebsitePreviewComparison.as_view(),
         name="website_preview_comparison",
+    ),
+    path(
+        "preview/comparison/",
+        DynamicWebsitePreviewComparison.as_view(),
+        name="website_preview_comparison_slash",
     ),
     path(
         "preview/entities/<str:uid>",

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -193,7 +193,7 @@ urlpatterns = [
     path(
         "preview/comparison/",
         DynamicWebsitePreviewComparison.as_view(),
-        name="website_preview_comparison",
+        name="website_preview_comparison_slash",
     ),
     path(
         "preview/comparison",


### PR DESCRIPTION
The comparison preview was not display for url like:
<https://tournesol.app/comparison?uidA=yt%3AWHUJL-EjsGY&uidB=yt%3ADjwxOH3N-gc>

This is a quick fix, but a more general one should be done with #1051 


Questions:
- Is it OK to use the same name for the path?
- Should we copy/paste all the `DynamicWebsitePreviewComparisonTestCase` to test without the trailling slash?