### PR TITLE
Backend criteria scores distribution personal score visual clue on the chart

### DIFF
--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -297,7 +297,7 @@ class Entity(models.Model):
         criteria_distributions = []
         for key, values in scores_dict.items():
             score_range = (min_score_base, max_score_base)
-            distribution, bins = np.histogram(np.clip(values, *score_range), range=score_range)
+            distribution, bins = np.histogram(np.clip(values, *score_range), bins=20, range=score_range)
 
             criteria_distributions.append(CriteriaDistributionScore(
                 key, distribution, bins))

--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -297,7 +297,8 @@ class Entity(models.Model):
         criteria_distributions = []
         for key, values in scores_dict.items():
             score_range = (min_score_base, max_score_base)
-            distribution, bins = np.histogram(np.clip(values, *score_range), bins=20, range=score_range)
+            distribution, bins = np.histogram(np.clip(
+                values, *score_range), bins=20, range=score_range)
 
             criteria_distributions.append(CriteriaDistributionScore(
                 key, distribution, bins))

--- a/backend/tournesol/tests/test_api_polls.py
+++ b/backend/tournesol/tests/test_api_polls.py
@@ -494,7 +494,7 @@ class PollsCriteriaScoreDistributionTestCase(TestCase):
         ContributorRatingCriteriaScoreFactory(
             contributor_rating=self.contributor_ratings_1,
             criteria="reliability",
-            score=0.2,
+            score=0.1,
         )
         response = self.client.get(
             f"/polls/videos/entities/{self.entity_public.uid}/criteria_scores_distributions"
@@ -505,10 +505,10 @@ class PollsCriteriaScoreDistributionTestCase(TestCase):
         self.assertEqual(
             response.data["criteria_scores_distributions"][0]["criteria"], "reliability"
         )
-        # The sixth position are values between (0, 0.2) because
-        # we use a 10 bins between (-1, 1)
+        # The eleventh position are values between (0, 0.1) because
+        # we use a 20 bins between (-1, 1)
         self.assertEqual(
-            response.data["criteria_scores_distributions"][0]["distribution"][5], 1
+            response.data["criteria_scores_distributions"][0]["distribution"][10], 1
         )
 
     def test_two_criteria_score_should_have_right_distribution(self):
@@ -520,7 +520,7 @@ class PollsCriteriaScoreDistributionTestCase(TestCase):
         ContributorRatingCriteriaScoreFactory(
             contributor_rating=self.contributor_ratings_2,
             criteria="reliability",
-            score=85,
+            score=95,
         )
 
         response = self.client.get(
@@ -532,14 +532,14 @@ class PollsCriteriaScoreDistributionTestCase(TestCase):
         self.assertEqual(
             response.data["criteria_scores_distributions"][0]["criteria"], "reliability"
         )
-        # The sixth position are values between (0, 20) because
-        # we use a 10 bins between (-100, 100)
+        # The eleventh position are values between (0, 10) because
+        # we use a 20 bins between (-100, 100)
         self.assertEqual(
-            response.data["criteria_scores_distributions"][0]["distribution"][5], 1
+            response.data["criteria_scores_distributions"][0]["distribution"][10], 1
         )
-        # The 10th position are all values above 80 because we use a 10 bins between (-100, 100)
+        # The 20th position are all values above 90 because we use a 20 bins between (-100, 100)
         self.assertEqual(
-            response.data["criteria_scores_distributions"][0]["distribution"][9], 1
+            response.data["criteria_scores_distributions"][0]["distribution"][19], 1
         )
         # Distribution is always in a range [-100,100]
         self.assertEqual(

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -3,8 +3,6 @@ import React, {
   useLayoutEffect,
   useState,
   useMemo,
-  createContext,
-  useContext,
   useCallback,
 } from 'react';
 import {
@@ -17,67 +15,22 @@ import useCriteriaChartData, {
   CriterionChartScores,
 } from 'src/hooks/useCriteriaChartData';
 import { useTranslation } from 'react-i18next';
-import { lighten } from 'src/utils/color';
 import { Tooltip } from '@mui/material';
 import useResizeObserver from '@react-hook/resize-observer';
 import useSelectedCriterion from 'src/hooks/useSelectedCriterion';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-
+import useCriterionScoreData, {
+  useChartContext,
+  ChartContext,
+  ChartContextValue,
+} from 'src/hooks/useCriterionScoreData';
 const barMargin = 40; // The horizontal margin around the bar (must be enough for the icon and the score value)
 const criterionChartHeight = 40; // The height of a single criterion chart (circle + icon + bars)
 const scoreBarHeight = 10;
 const scoreBarsSpacing = 4;
 const scoreLabelSpacingWithBar = 4;
 const selectedCriterionBackgroundColor = 'rgb(238, 238, 238)';
-
-interface ChartContextValue {
-  data: CriterionChartScores[];
-  domain: number[];
-  chartWidth: number;
-  chartHeight: number;
-  personalScoresActivated: boolean;
-}
-const ChartContext = createContext<ChartContextValue>({
-  data: [],
-  domain: [0.0, 1.0],
-  chartWidth: 0,
-  chartHeight: 0,
-  personalScoresActivated: false,
-});
-const useChartContext = () => useContext(ChartContext);
-
-const useCriterionScoreData = ({
-  index,
-  personal,
-}: {
-  index: number;
-  personal: boolean;
-}) => {
-  const { data } = useChartContext();
-  const criterionScores = data[index];
-  const {
-    criterion,
-    score,
-    clippedScore,
-    personalScore,
-    clippedPersonalScore,
-  } = criterionScores;
-  const color = criterionColor(criterion);
-
-  if (personal)
-    return {
-      score: personalScore,
-      clippedScore: clippedPersonalScore,
-      color: lighten(color, 0.5),
-    };
-  else
-    return {
-      score,
-      clippedScore,
-      color,
-    };
-};
 
 const calculateScoreBarY = ({
   index,

--- a/frontend/src/features/charts/CriteriaScoresDistribution.tsx
+++ b/frontend/src/features/charts/CriteriaScoresDistribution.tsx
@@ -72,6 +72,18 @@ const CriteriaScoresDistributionChart = ({
             textAnchor: 'middle',
           }}
           dataKey="label"
+          interval={0}
+          height={60}
+          tickMargin={8}
+          tickFormatter={(value, index) => {
+            const split = value.split(' ');
+
+            if (index == 0 || index % 2) {
+              return '';
+            } else {
+              return split.length > 2 ? split[0] : split[1];
+            }
+          }}
         />
         <YAxis
           label={{

--- a/frontend/src/features/charts/CriteriaScoresDistribution.tsx
+++ b/frontend/src/features/charts/CriteriaScoresDistribution.tsx
@@ -8,11 +8,22 @@ import {
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
+  Cell,
 } from 'recharts';
 
 import { Box } from '@mui/material';
 
+import {
+  VideoSerializerWithCriteria,
+  Recommendation,
+} from 'src/services/openapi';
+
 import CriteriaSelector from 'src/features/criteria/CriteriaSelector';
+import useCriterionScoreData, {
+  ChartContext,
+  ChartContextValue,
+} from 'src/hooks/useCriterionScoreData';
+import useCriteriaChartData from 'src/hooks/useCriteriaChartData';
 import { useCurrentPoll } from 'src/hooks';
 import { PollsService, CriteriaDistributionScore } from 'src/services/openapi';
 import useSelectedCriterion from 'src/hooks/useSelectedCriterion';
@@ -43,6 +54,26 @@ const CriteriaScoresDistributionChart = ({
 }) => {
   const { t } = useTranslation();
   const { bins, distribution } = criteriaDistributionScore;
+  const barColors = new Array(20).fill(criterionColor(criterion));
+
+  const { score: userScore } = useCriterionScoreData({
+    index: criterion,
+    personal: true,
+  });
+
+  if (userScore) {
+    // transform a score like 78.75 to 70
+    const roundedScore = Math.floor(userScore / 10) * 10;
+
+    // step are 10 since granularity is 20
+    // Beware if granularity change
+    for (let i = -100, j = 0; i <= 100; i += 10, j++) {
+      if (i == roundedScore) {
+        barColors[j] = 'pink';
+        break;
+      }
+    }
+  }
 
   const data = useMemo(
     () =>
@@ -57,8 +88,6 @@ const CriteriaScoresDistributionChart = ({
     (value: number) => [value, t('criteriaScoresDistribution.label')],
     [t]
   );
-
-  const barColor = criterionColor(criterion);
 
   return (
     <ResponsiveContainer width="100%" height={360}>
@@ -94,18 +123,24 @@ const CriteriaScoresDistributionChart = ({
           }}
         />
         <Tooltip formatter={tooltipFormatter} />
-        <Bar dataKey="value" fill={barColor} />
+        <Bar dataKey="value">
+          {data.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={barColors[index]} />
+          ))}
+        </Bar>
       </BarChart>
     </ResponsiveContainer>
   );
 };
 
 interface CriteriaScoresDistributionProps {
-  uid: string;
+  video: VideoSerializerWithCriteria;
+  entity?: Recommendation;
 }
 
 const CriteriaScoresDistribution = ({
-  uid,
+  video,
+  entity,
 }: CriteriaScoresDistributionProps) => {
   const { name: pollName } = useCurrentPoll();
   const { selectedCriterion, setSelectedCriterion } = useSelectedCriterion();
@@ -114,17 +149,33 @@ const CriteriaScoresDistribution = ({
     CriteriaDistributionScore[]
   >([]);
 
+  const { data, personalScoresActivated, domain } = useCriteriaChartData({
+    video,
+    entity,
+  });
+
+  const contextValue = useMemo<ChartContextValue>(
+    () => ({
+      data,
+      domain,
+      chartWidth: 250,
+      chartHeight: 400,
+      personalScoresActivated,
+    }),
+    [data, domain, personalScoresActivated]
+  );
+
   useEffect(() => {
     const getDistribution = async () => {
       const result =
         await PollsService.pollsEntitiesCriteriaScoresDistributionsRetrieve({
           name: pollName,
-          uid,
+          uid: video.uid,
         });
       setCriteriaScoresDistribution(result.criteria_scores_distributions);
     };
     getDistribution();
-  }, [uid, pollName]);
+  }, [video.uid, pollName]);
 
   const criteriaDistributionScore = useMemo(
     () =>
@@ -135,7 +186,7 @@ const CriteriaScoresDistribution = ({
   );
 
   return (
-    <>
+    <ChartContext.Provider value={contextValue}>
       <Box px={2} pt={1} pb={1}>
         <CriteriaSelector
           criteria={selectedCriterion}
@@ -150,7 +201,7 @@ const CriteriaScoresDistribution = ({
           />
         </Box>
       )}
-    </>
+    </ChartContext.Provider>
   );
 };
 

--- a/frontend/src/features/charts/CriteriaScoresDistribution.tsx
+++ b/frontend/src/features/charts/CriteriaScoresDistribution.tsx
@@ -56,7 +56,7 @@ const CriteriaScoresDistributionChart = ({
   const { bins, distribution } = criteriaDistributionScore;
   const barColors = new Array(20).fill(criterionColor(criterion));
 
-  const { score: userScore } = useCriterionScoreData({
+  const { score: userScore, color } = useCriterionScoreData({
     index: criterion,
     personal: true,
   });
@@ -69,7 +69,7 @@ const CriteriaScoresDistributionChart = ({
     // Beware if granularity change
     for (let i = -100, j = 0; i <= 100; i += 10, j++) {
       if (i == roundedScore) {
-        barColors[j] = 'pink';
+        barColors[j] = color;
         break;
       }
     }

--- a/frontend/src/hooks/useCriterionScoreData.ts
+++ b/frontend/src/hooks/useCriterionScoreData.ts
@@ -1,0 +1,60 @@
+import { createContext, useContext } from 'react';
+import { lighten } from 'src/utils/color';
+import { CriterionChartScores } from 'src/hooks/useCriteriaChartData';
+import { criterionColor } from 'src/utils/criteria';
+
+export interface ChartContextValue {
+  data: CriterionChartScores[];
+  domain: number[];
+  chartWidth: number;
+  chartHeight: number;
+  personalScoresActivated: boolean;
+}
+
+export const ChartContext = createContext<ChartContextValue>({
+  data: [],
+  domain: [0.0, 1.0],
+  chartWidth: 0,
+  chartHeight: 0,
+  personalScoresActivated: false,
+});
+export const useChartContext = () => useContext(ChartContext);
+
+const useCriterionScoreData = ({
+  index,
+  personal,
+}: {
+  index: number | string;
+  personal: boolean;
+}) => {
+  const { data } = useChartContext();
+
+  const criterionScores =
+    typeof index == 'number'
+      ? data[index]
+      : data[data.findIndex(({ criterion }) => criterion == index)];
+
+  const {
+    criterion,
+    score,
+    clippedScore,
+    personalScore,
+    clippedPersonalScore,
+  } = criterionScores;
+  const color = criterionColor(criterion);
+
+  if (personal)
+    return {
+      score: personalScore,
+      clippedScore: clippedPersonalScore,
+      color: lighten(color, 0.5),
+    };
+  else
+    return {
+      score,
+      clippedScore,
+      color,
+    };
+};
+
+export default useCriterionScoreData;

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -125,7 +125,7 @@ export const VideoAnalysis = ({
                   </Paper>
                 </Grid>
                 <Grid item xs={12} sm={12} md={6}>
-                  <Paper>
+                  <Paper sx={{ height: '100%' }}>
                     <Box
                       p={1}
                       bgcolor="rgb(238, 238, 238)"

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -103,45 +103,45 @@ export const VideoAnalysis = ({
           {/* Data visualization. */}
           {shouldDisplayCharts && (
             <SelectedCriterionProvider>
-              <Grid item xs={12} sm={12} md={6}>
-                <Paper>
-                  <Box
-                    p={1}
-                    bgcolor="rgb(238, 238, 238)"
-                    display="flex"
-                    justifyContent="center"
-                  >
-                    <Typography variant="h5">
-                      {t('entityAnalysisPage.chart.criteriaScores.title')}
-                    </Typography>
-                  </Box>
-                  <PersonalCriteriaScoresContextProvider uid={uid}>
+              <PersonalCriteriaScoresContextProvider uid={uid}>
+                <Grid item xs={12} sm={12} md={6}>
+                  <Paper>
+                    <Box
+                      p={1}
+                      bgcolor="rgb(238, 238, 238)"
+                      display="flex"
+                      justifyContent="center"
+                    >
+                      <Typography variant="h5">
+                        {t('entityAnalysisPage.chart.criteriaScores.title')}
+                      </Typography>
+                    </Box>
                     <Box px={2} pt={1}>
                       <PersonalScoreCheckbox />
                     </Box>
                     <Box p={1}>
                       <CriteriaBarChart video={video} />
                     </Box>
-                  </PersonalCriteriaScoresContextProvider>
-                </Paper>
-              </Grid>
-              <Grid item xs={12} sm={12} md={6}>
-                <Paper>
-                  <Box
-                    p={1}
-                    bgcolor="rgb(238, 238, 238)"
-                    display="flex"
-                    justifyContent="center"
-                  >
-                    <Typography variant="h5">
-                      {t('criteriaScoresDistribution.title')}
-                    </Typography>
-                  </Box>
-                  <Box p={1}>
-                    <CriteriaScoresDistribution uid={uid} />
-                  </Box>
-                </Paper>
-              </Grid>
+                  </Paper>
+                </Grid>
+                <Grid item xs={12} sm={12} md={6}>
+                  <Paper>
+                    <Box
+                      p={1}
+                      bgcolor="rgb(238, 238, 238)"
+                      display="flex"
+                      justifyContent="center"
+                    >
+                      <Typography variant="h5">
+                        {t('criteriaScoresDistribution.title')}
+                      </Typography>
+                    </Box>
+                    <Box p={1}>
+                      <CriteriaScoresDistribution video={video} />
+                    </Box>
+                  </Paper>
+                </Grid>
+              </PersonalCriteriaScoresContextProvider>
             </SelectedCriterionProvider>
           )}
         </Grid>


### PR DESCRIPTION
**replaced by** https://github.com/tournesol-app/tournesol/pull/1472

---

This PR has for goal the display of a visual clue on the rechart chart so the user can locate easily where his personal score is.

- [x] display a visual clue on the chart when display personal scores is checked

![capture1](https://user-images.githubusercontent.com/50485333/227249487-4cf8b6de-af66-45d5-8e21-48648c00a1df.PNG)

![Capture2](https://user-images.githubusercontent.com/50485333/227249526-0dfec2e4-f53c-43d1-b161-76e7d2acda99.PNG)

![Capture3](https://user-images.githubusercontent.com/50485333/227249560-ee3ea91d-9c7b-448b-871c-22352bf4ba78.PNG)

![Capture4](https://user-images.githubusercontent.com/50485333/227249580-cd37ad10-2165-4638-a319-39535a887aa6.PNG)
