### PR TITLE
[back] fix: server error on video preview when duration is null

### DIFF
--- a/backend/tournesol/serializers/metadata.py
+++ b/backend/tournesol/serializers/metadata.py
@@ -14,7 +14,7 @@ class VideoMetadata(serializers.Serializer):
     duration = serializers.IntegerField(
         allow_null=True,
         default=None,
-        help_text="Duration in seconds"
+        help_text="Duration in seconds. May be null (e.g on live streams)"
     )
     views = serializers.IntegerField(allow_null=True, default=None)
     language = serializers.CharField(allow_null=True, default=None)

--- a/backend/tournesol/tests/test_api_preview.py
+++ b/backend/tournesol/tests/test_api_preview.py
@@ -10,6 +10,8 @@ from core.tests.factories.user import UserFactory
 from tournesol.entities.video import TYPE_VIDEO
 from tournesol.models import Entity
 
+from .factories.entity import VideoFactory
+
 
 def raise_(exception):
     raise exception
@@ -171,6 +173,12 @@ class DynamicWebsitePreviewEntityTestCase(TestCase):
             response.headers["Content-Disposition"],
             'inline; filename="tournesol_screenshot_og.png"',
         )
+
+    def test_get_preview_no_duration(self):
+        video = VideoFactory(metadata__duration=None)
+        response = self.client.get(f"{self.preview_url}{video.uid}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.headers["Content-Type"], "image/png")
 
     @patch("requests.get", lambda x, timeout=None: raise_(ConnectionError))
     @patch("tournesol.entities.video.VideoEntity.update_search_vector", lambda x: None)

--- a/backend/tournesol/views/preview.py
+++ b/backend/tournesol/views/preview.py
@@ -340,7 +340,9 @@ class DynamicWebsitePreviewEntity(BasePreviewAPIView):
         Adapts the overlay position and size in function of the duration text size.
         """
 
-        duration = entity.metadata.get("duration", 0)
+        duration = entity.metadata.get("duration")
+        if not duration:
+            return
         minutes, seconds = divmod(duration, 60)
         hours, minutes = divmod(minutes, 60)
 


### PR DESCRIPTION
Server error were observed when fetching the preview related to a video entity with `"duration": null` in its metadata. (For example this is the case for live streams).

After this fix, the duration overlay will not be drawn on the preview image for such videos.