### PR TITLE
[dataviz] Correcting dependency for data-visualization

### DIFF
--- a/data-visualization/requirements.txt
+++ b/data-visualization/requirements.txt
@@ -1,5 +1,5 @@
 streamlit==1.18.1
-numpy==1.22.4
+numpy==1.24.2
 seaborn==0.11.1
 matplotlib==3.3.4
 pillow==9.3.0


### PR DESCRIPTION
With numpy==1.22.4, the command "streamlit run Tournesol_Data_Visualization.py" produce an the error "ImportError: numpy.core.multiarray failed to import" in User comparisons's page.

Installing numpy==1.24.2 in virtual env corrected the problem.

Cf. https://stackoverflow.com/questions/20518632/importerror-numpy-core-multiarray-failed-to-import?page=1&tab=scoredesc#tab-top

I am new to contributing on an open source project. I hope I'm not missing something @tournesol-app/maintainers .