### PR TITLE
[back] fix: initialize settings scope if it's not defined yet when patching user settings

### DIFF
--- a/backend/core/serializers/user_settings.py
+++ b/backend/core/serializers/user_settings.py
@@ -85,5 +85,7 @@ class TournesolUserSettingsSerializer(serializers.Serializer):
 
     def update(self, instance, validated_data):
         for scope, settings in self.validated_data.items():
+            if scope not in instance:
+                instance[scope] = {}
             instance[scope].update(settings)
         return instance

--- a/backend/core/tests/test_api_user_settings.py
+++ b/backend/core/tests/test_api_user_settings.py
@@ -172,3 +172,23 @@ class UserSettingsDetailTestCase(TestCase):
                 }
             },
         )
+
+    def test_patch_without_initial_settings(self):
+        """An authenticated user can update a subset of its settings."""
+        self.client.force_authenticate(self.user)
+
+        initial_settings = {}
+        self.user.settings = initial_settings
+        self.user.save(update_fields=["settings"])
+
+        new_settings = {"videos": {"rate_later__auto_remove": 99}}
+        response = self.client.patch(self.settings_base_url, data=new_settings, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertDictEqual(
+            response.data,
+            new_settings,
+            {"videos": {"rate_later__auto_remove": 99}},
+        )
+        self.user.refresh_from_db()
+        self.assertDictEqual(self.user.settings, new_settings)


### PR DESCRIPTION
I observed this bug when reviewing #1501 

The default value for settings is `{}`, so PATCH should be able to initialize the scope if it's not present yet.