### PR TITLE
[front] chore: clear user's settings in the store after a logout

### DIFF
--- a/frontend/src/features/settings/userSettingsSlice.ts
+++ b/frontend/src/features/settings/userSettingsSlice.ts
@@ -17,6 +17,10 @@ export const userSettingsSlice = createSlice({
   name: 'settings',
   initialState: userSettingsInitialState,
   reducers: {
+    // Clear all user's settings.
+    clearSettings: (state) => {
+      state.settings = {};
+    },
     // Replace all user's settings of all polls by new ones.
     replaceSettings: (state, action) => {
       state.settings = action.payload;
@@ -32,6 +36,6 @@ export const userSettingsSlice = createSlice({
 
 export const selectSettings = (state: RootState) => state.settings;
 
-export const { replaceSettings } = userSettingsSlice.actions;
+export const { clearSettings, replaceSettings } = userSettingsSlice.actions;
 
 export default userSettingsSlice.reducer;

--- a/frontend/src/hooks/useLoginState.ts
+++ b/frontend/src/hooks/useLoginState.ts
@@ -15,7 +15,12 @@ export const useLoginState = () => {
 
   const logout = useCallback(() => {
     dispatch(logoutAction());
-    dispatch(clearSettings());
+    /**
+     * Ensure that the user's settings retrieved after the login are cleared 
+     * after a logout, to not leave trace of the user's preferences in the
+     * browser. 
+     */
+     dispatch(clearSettings());
   }, [dispatch]);
 
   const updateUsername = useCallback(

--- a/frontend/src/hooks/useLoginState.ts
+++ b/frontend/src/hooks/useLoginState.ts
@@ -5,6 +5,7 @@ import {
   logout as logoutAction,
   updateUsername as updateUsernameAction,
 } from 'src/features/login/loginSlice';
+import { clearSettings } from 'src/features/settings/userSettingsSlice';
 import { LoginState } from 'src/features/login/LoginState.model';
 import { isLoggedIn as isStateLoggedIn } from 'src/features/login/loginUtils';
 
@@ -14,6 +15,7 @@ export const useLoginState = () => {
 
   const logout = useCallback(() => {
     dispatch(logoutAction());
+    dispatch(clearSettings());
   }, [dispatch]);
 
   const updateUsername = useCallback(

--- a/frontend/src/hooks/useLoginState.ts
+++ b/frontend/src/hooks/useLoginState.ts
@@ -16,11 +16,11 @@ export const useLoginState = () => {
   const logout = useCallback(() => {
     dispatch(logoutAction());
     /**
-     * Ensure that the user's settings retrieved after the login are cleared 
+     * Ensure that the user's settings retrieved after the login are cleared
      * after a logout, to not leave trace of the user's preferences in the
-     * browser. 
+     * browser.
      */
-     dispatch(clearSettings());
+    dispatch(clearSettings());
   }, [dispatch]);
 
   const updateUsername = useCallback(


### PR DESCRIPTION
Close #1510

The goal is to prevent the user to leave tracks of its preferences in the browser after having finished to use Tournesol.