### PR TITLE
Unavailable videos comparisons list

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -53,7 +53,7 @@ const EntityCard = ({
   const [settingsVisible, setSettingsVisible] = useState(!isSmallScreen);
 
   useEffect(() => {
-    setContentDisplayed(isAvailable);
+    setContentDisplayed(isAvailable || compact);
   }, [isAvailable]);
 
   const displayEntityCardScores = () => {
@@ -75,7 +75,7 @@ const EntityCard = ({
 
   return (
     <Grid container sx={entityCardMainSx}>
-      {!isAvailable && (
+      {!isAvailable && !compact && (
         <Grid container justifyContent="space-between" alignItems="center">
           <Grid item pl={1} py={2}>
             <Typography>
@@ -104,6 +104,7 @@ const EntityCard = ({
             sx={{
               display: 'flex',
               justifyContent: 'center',
+              position: 'relative',
               ...(compact
                 ? {}
                 : { minWidth: '240px', maxWidth: { sm: '240px' } }),
@@ -114,6 +115,30 @@ const EntityCard = ({
               compact={compact}
               config={entityTypeConfig}
             />
+            {!isAvailable && compact && (
+              <Box
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+                position="absolute"
+                top="0"
+                color="white"
+                bgcolor="rgba(0,0,0,.6)"
+                width="100%"
+                height="100%"
+                sx={{
+                  [theme.breakpoints.down('sm')]: {
+                    fontSize: '0.8rem',
+                  },
+                }}
+              >
+                <Typography textAlign="center" fontSize="inherit">
+                  {entity.type == TypeEnum.VIDEO
+                    ? t('video.notAvailableAnymore')
+                    : t('entityCard.thisElementIsNotAvailable')}
+                </Typography>
+              </Box>
+            )}
           </Grid>
           <Grid
             item

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -54,7 +54,7 @@ const EntityCard = ({
 
   useEffect(() => {
     setContentDisplayed(isAvailable || compact);
-  }, [isAvailable]);
+  }, [isAvailable, compact]);
 
   const displayEntityCardScores = () => {
     if ('tournesol_score' in entity && !compact) {

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -7,6 +7,7 @@ import { Compare as CompareIcon } from '@mui/icons-material';
 import type { Comparison } from 'src/services/openapi';
 import EntityCard from 'src/components/entity/EntityCard';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import AvailableEntity from 'src/components/entity/AvailableEntity';
 
 const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
   const { t } = useTranslation();
@@ -24,11 +25,15 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
         gap: '16px',
       }}
     >
-      <EntityCard
-        compact
-        entity={entity_a}
-        entityTypeConfig={{ video: { displayPlayer: false } }}
-      />
+      <AvailableEntity
+        uid={entity_a.uid}
+      >
+        <EntityCard
+          compact
+          entity={entity_a}
+          entityTypeConfig={{ video: { displayPlayer: false } }}
+        />
+      </AvailableEntity>
       <Box
         sx={{
           position: 'relative',
@@ -56,11 +61,15 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
           </Fab>
         </Tooltip>
       </Box>
-      <EntityCard
-        compact
-        entity={entity_b}
-        entityTypeConfig={{ video: { displayPlayer: false } }}
-      />
+      <AvailableEntity
+        uid={entity_b.uid}
+      >
+        <EntityCard
+          compact
+          entity={entity_b}
+          entityTypeConfig={{ video: { displayPlayer: false } }}
+        />
+      </AvailableEntity>
     </Box>
   );
 };


### PR DESCRIPTION
***Related to #1070#issuecomment-1517741134***

---------------------------

This PR has for goal the display of unavailable entity on the comparisons list page.
The unavailable video must be highlighted with a message overlay on top of the image life for the comparison page

- [ ] Fix entity card uneven on the comparisons list

