### PR TITLE
[ext] fix: rate buttons sometimes not displayed on YT video page

### DIFF
--- a/browser-extension/src/addRateButtons.js
+++ b/browser-extension/src/addRateButtons.js
@@ -55,7 +55,7 @@ function addRateButtons() {
       return;
     }
 
-    // Remove existing buttons to prevent doubles
+    // Remove the existing buttons to avoid duplicates.
     if (document.getElementById('tournesol-rate-later-button')) {
       document.getElementById('tournesol-rate-later-button').remove();
     }

--- a/browser-extension/src/addRateButtons.js
+++ b/browser-extension/src/addRateButtons.js
@@ -55,10 +55,13 @@ function addRateButtons() {
       return;
     }
 
-    // If the button already exists, don't create a new one
+    // Remove existing buttons to prevent doubles
     if (document.getElementById('tournesol-rate-later-button')) {
-      window.clearInterval(timer);
-      return;
+      document.getElementById('tournesol-rate-later-button').remove();
+    }
+
+    if (document.getElementById('tournesol-rate-now-button')) {
+      document.getElementById('tournesol-rate-now-button').remove();
     }
 
     window.clearInterval(timer);

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
**related to** #1517

---

This PR has for goal the fix of the buttons rate later and rate now on a video page that sometimes don't appear

As for previous behavior if the button rate-later already exists, the script stops and no buttons are added to prevent duplicating them

This behavior works well when the page is reloaded but when you navigate to the page the script sometimes detects the rate-later and rate-now buttons before YouTube delete them so the script does not display new buttons to replace the one removed by YouTube.

The new behavior remove the rate later and rate now buttons if they exist then display them again.
It may not be necessary to delete them when you navigate to a page since youtube remove them from the page but it is necessary when you reload the page.