### PR TITLE
[infra] sec: run manage.py watch_account_number with a scheduled task

### DIFF
--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -57,9 +57,10 @@ all:
           tournesol_api_deleteinactiveusers_schedule: "*-*-* 02:20:00" # daily at 2:20am
           tournesol_api_clearsessions_schedule: "*-*-* 02:40:00" # daily at 2:40am
 
-          # Watch account creation
+          # Watch account creations
           tournesol_api_watch_account_creation_1h_schedule: "*-*-* *:01:00"
           tournesol_api_watch_account_creation_24h_schedule: "*-*-* 00:01:10"
+          tournesol_api_watch_account_number_yesterday_schedule: "*-*-* 00:01:20"
 
           ml_train_schedule: "*-*-* 0,6,12,18:20:00" # every 6 hours
           tournesol_api_createdataset_schedule: "Mon 00:02" # weekly, before the new week
@@ -126,9 +127,10 @@ all:
           tournesol_api_deleteinactiveusers_schedule: "*-*-* 02:20:00" # daily at 2:20am
           tournesol_api_clearsessions_schedule: "*-*-* 02:40:00" # daily at 2:40am
 
-          # Watch account creation
+          # Watch account creations
           tournesol_api_watch_account_creation_1h_schedule: "*-*-* *:01:00"
           tournesol_api_watch_account_creation_24h_schedule: "*-*-* 00:01:10"
+          tournesol_api_watch_account_number_yesterday_schedule: "*-*-* 00:01:20"
 
           ml_train_schedule: "*-*-* 0,6,12,18:20:00" # every 6 hours
           tournesol_api_createdataset_schedule: "Mon 00:02" # weekly, before the new week
@@ -199,9 +201,10 @@ all:
           tournesol_api_deleteinactiveusers_schedule: "*-*-* 02:20:00" # daily at 2:20am
           tournesol_api_clearsessions_schedule: "*-*-* 02:40:00" # daily at 2:40am
 
-          # Watch account creation
+          # Watch account creations
           tournesol_api_watch_account_creation_1h_schedule: "*-*-* *:01:00"
           tournesol_api_watch_account_creation_24h_schedule: "*-*-* 00:01:10"
+          tournesol_api_watch_account_number_yesterday_schedule: "*-*-* 00:01:20"
 
           # twitterbot: the service script is responsible for running the bot in
           # different languages depending on the day of the week.

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -316,6 +316,25 @@
     enabled: yes
     daemon_reload: yes
 
+# scheduled task: watch the total number of accounts daily
+
+- name: Copy Tournesol API watch-account-number-yesterday service
+  template:
+    dest: /etc/systemd/system/tournesol-api-watch-account-number-yesterday.service
+    src: tournesol-api-watch-account-number-yesterday.service.j2
+
+- name: Copy Tournesol API watch-account-number-yesterday timer
+  template:
+    dest: /etc/systemd/system/tournesol-api-watch-account-number-yesterday.timer
+    src: tournesol-api-watch-account-number-yesterday.timer.j2
+
+- name: Enable and start Tournesol API watch-account-number-yesterday timer
+  systemd:
+    name: tournesol-api-watch-account-number-yesterday.timer
+    state: started
+    enabled: yes
+    daemon_reload: yes
+
 # scheduled task: Twitterbot daily tweet
 
 - name: Copy twitterbot service

--- a/infra/ansible/roles/django/templates/tournesol-api-watch-account-number-yesterday.service.j2
+++ b/infra/ansible/roles/django/templates/tournesol-api-watch-account-number-yesterday.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Tournesol API watch total accounts number of yesterday
+
+[Service]
+Type=oneshot
+User=gunicorn
+Group=gunicorn
+WorkingDirectory=/srv/tournesol-backend
+Environment="SETTINGS_FILE=/etc/tournesol/settings.yaml"
+ExecStart=/usr/bin/bash -c "source venv/bin/activate && python manage.py watch_account_number -d $(date --date 'yesterday' --iso-8601)"
+ExecStopPost=/usr/bin/bash -c "if [ "$$EXIT_STATUS" != 0 ]; then /usr/local/bin/post-on-discord.sh -c infra_alert -m 'Tournesol API watch total accounts number of yesterday job failed for {{ansible_host}}'; fi"

--- a/infra/ansible/roles/django/templates/tournesol-api-watch-account-number-yesterday.timer.j2
+++ b/infra/ansible/roles/django/templates/tournesol-api-watch-account-number-yesterday.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Tournesol API watch total accounts number of yesterday
+
+[Timer]
+OnCalendar={{tournesol_api_watch_account_number_yesterday_schedule}}
+Persistent=yes
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
close https://github.com/tournesol-app/tournesol/issues/1454

---

This PR adds a scheduled task running the Django mgmt command `watch_account_number` every day, one minute after midnight.

The command will count the total number of accounts created yesterday, and will send alerts on Discord when appropriate.