### PR TITLE
[ext][front] fix: do not call the API /stats/ when it's not needed

### DIFF
--- a/browser-extension/src/addModal.js
+++ b/browser-extension/src/addModal.js
@@ -16,7 +16,7 @@ const EXT_MODAL_INVISIBLE_STATE = 'none';
 const IFRAME_TOURNESOL_LOGIN_ID = 'x-tournesol-iframe-login';
 
 // iframe URL of tournesol login
-const IFRAME_TOURNESOL_LOGIN_URL = 'https://tournesol.app/login?embed=1&dnt=1';
+const IFRAME_TOURNESOL_LOGIN_URL = 'https://tournesol.app/login?embed=1&dnt=1&page_not_displayed=1';
 /**
  * Youtube doesnt completely load a page, so content script doesn't
  * launch correctly without these events.

--- a/browser-extension/src/addModal.js
+++ b/browser-extension/src/addModal.js
@@ -16,7 +16,8 @@ const EXT_MODAL_INVISIBLE_STATE = 'none';
 const IFRAME_TOURNESOL_LOGIN_ID = 'x-tournesol-iframe-login';
 
 // iframe URL of tournesol login
-const IFRAME_TOURNESOL_LOGIN_URL = 'https://tournesol.app/login?embed=1&dnt=1&page_not_displayed=1';
+const IFRAME_TOURNESOL_LOGIN_URL =
+  'https://tournesol.app/login?embed=1&dnt=1&page_not_displayed=1';
 /**
  * Youtube doesnt completely load a page, so content script doesn't
  * launch correctly without these events.

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -67,12 +67,26 @@ const InitGlobalStates = () => {
   const dispatch = useDispatch();
   const { name: pollName } = useCurrentPoll();
 
+  const notDisplayed = new URLSearchParams(location.search).get(
+    'page_not_displayed'
+  );
+
   /**
    * Refresh the global states that contain poll specific data.
    */
   useEffect(() => {
-    dispatch(fetchStats());
-  }, [dispatch, pollName]);
+    /**
+     * For now it's not required to call the /stats/ API when the page is not
+     * displayed.
+     *
+     * This temporary hack prevents the hidden iframe of the extension to
+     * trigger a consequent amount of costly and not required requests to the
+     * API.
+     */
+    if (notDisplayed !== '1') {
+      dispatch(fetchStats());
+    }
+  }, [dispatch, notDisplayed, pollName]);
 
   useRefreshSettings();
 


### PR DESCRIPTION
**related to** #1527 

---

This temporary fix should reduce the number of useless call to /stats/ generated by the browser extension hidden iframe, and appease our monitoring system.

As discussed with Adrien, we agreed to replace this temporary fix by a more robust system that will lazily fetch the statistics from the back end when the front end needs to display them (see #1527)