### PR TITLE
[front] feat : display limit, offset and count in the pagination 

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -40,8 +40,8 @@
     "totalScoreBasedOnRankingChoice": "Score based on selected ranking parameters"
   },
   "pagination": {
-    "showingCounts_one": "Showing {{pageFirstVideo}} - {{pageLastVideo}} of {{count}}",
-    "showingCounts_other": "Showing {{pageFirstVideo}} - {{pageLastVideo}} of {{count}}"
+    "showingCounts_one": "Showing {{firstElementIdx}} - {{lastElementIdx}} of {{count}}",
+    "showingCounts_other": "Showing {{firstElementIdx}} - {{lastElementIdx}} of {{count}}"
   },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -39,6 +39,10 @@
   "score": {
     "totalScoreBasedOnRankingChoice": "Score based on selected ranking parameters"
   },
+  "pagination": {
+    "showingCounts_one": "Showing {{pageFirstVideo}} - {{pageLastVideo}} of {{count}}",
+    "showingCounts_other": "Showing {{pageFirstVideo}} - {{pageLastVideo}} of {{count}}"
+  },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {
       "notLoggedIn": "You must be logged in to display personal scores.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -43,9 +43,9 @@
     "totalScoreBasedOnRankingChoice": "Score basé sur les critères de classement selectionnés"
   },
   "pagination": {
-    "showingCounts_one": "De {{pageFirstVideo}} à {{pageLastVideo}} sur {{count}}",
-    "showingCounts_many": "De {{pageFirstVideo}} à {{pageLastVideo}} sur {{count}}",
-    "showingCounts_other": "De {{pageFirstVideo}} à {{pageLastVideo}} sur {{count}}"
+    "showingCounts_one": "Élément {{firstElementIdx}} à {{lastElementIdx}} sur {{count}}",
+    "showingCounts_many": "Éléments {{firstElementIdx}} à {{lastElementIdx}} sur {{count}}",
+    "showingCounts_other": "Éléments {{firstElementIdx}} à {{lastElementIdx}} sur {{count}}"
   },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -42,6 +42,11 @@
   "score": {
     "totalScoreBasedOnRankingChoice": "Score basé sur les critères de classement selectionnés"
   },
+  "pagination": {
+    "showingCounts_one": "De {{pageFirstVideo}} à {{pageLastVideo}} sur {{count}}",
+    "showingCounts_many": "De {{pageFirstVideo}} à {{pageLastVideo}} sur {{count}}",
+    "showingCounts_other": "De {{pageFirstVideo}} à {{pageLastVideo}} sur {{count}}"
+  },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {
       "notLoggedIn": "Vous devez être connecté.e pour afficher les scores personnels.",

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -73,7 +73,7 @@ describe('Pagination component', () => {
   };
 
   describe('Screen size: lg', () => {
-    it('display the correct number of elements', () => {
+    it('displays the correct number of elements', () => {
       const paginationProps: PaginationProps = {
         offset: 20,
         limit: 20,

--- a/frontend/src/components/Pagination.spec.tsx
+++ b/frontend/src/components/Pagination.spec.tsx
@@ -73,6 +73,19 @@ describe('Pagination component', () => {
   };
 
   describe('Screen size: lg', () => {
+    it('display the correct number of elements', () => {
+      const paginationProps: PaginationProps = {
+        offset: 20,
+        limit: 20,
+        count: 64,
+        onOffsetChange: onOffsetChange,
+      };
+
+      setup(paginationProps);
+
+      screen.getByText(/showing 21 - 40 of 64/i);
+    });
+
     it('displays buttons -1 and -10 as disabled when current page is first', () => {
       const paginationProps: PaginationProps = {
         offset: 0,

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -27,6 +27,7 @@ const Pagination = ({
   count,
 }: PaginationProps) => {
   const theme = useTheme();
+  const { t } = useTranslation();
 
   const lessThanSm = useMediaQuery(theme.breakpoints.down('sm'), {
     noSsr: true,
@@ -37,18 +38,10 @@ const Pagination = ({
 
   const currentPage = (offset + limit) / limit;
   const totalPages = Math.floor(count / limit) + (count % limit === 0 ? 0 : 1);
-  const pageFirstVideo = (function () {
-    if (count == 0){
-      return 0;
-    } else return offset + 1;
-  })();
-  const pageLastVideo = (function () {
-    if (currentPage == totalPages) {
-      return count;
-    } else return currentPage * 20;
-  })();
 
-  const { t } = useTranslation();
+  const firstElementIdx = count === 0 ? 0 : offset + 1;
+  const lastElementIdx =
+    currentPage === totalPages ? count : currentPage * limit;
 
   const handleChangePage = (
     _event: React.ChangeEvent<unknown>,
@@ -88,63 +81,44 @@ const Pagination = ({
         flexWrap: 'wrap',
       }}
     >
-      <Box
-        width="100%"
-        display="flex"
-        justifyContent="center"
-        flexWrap="wrap"
-      >
-        <Typography>
+      <Box width="100%" display="flex" justifyContent="center" flexWrap="wrap">
+        <Typography variant="body2">
           <Trans t={t} i18nKey="pagination.showingCounts" count={count}>
-            Showing {{ pageFirstVideo }} - {{ pageLastVideo }} of {{ count }}
+            Showing {{ firstElementIdx }} - {{ lastElementIdx }} of {{ count }}
           </Trans>
         </Typography>
       </Box>
+      {/* Do not display the navigation when the number of elements is low. */}
       {count > limit && (
-      <>
-      <PaginationComponent
-        count={totalPages}
-        page={currentPage}
-        siblingCount={lessThanLg ? 1 : 3}
-        boundaryCount={lessThanLg ? 1 : 2}
-        onChange={handleChangePage}
-        hidePrevButton
-        hideNextButton
-      />
-      <Box
-        width="100%"
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        flexWrap="wrap"
-        gap={1}
-      >
-        <Button
-          id="pagination_1_prev"
-          size="small"
-          variant="contained"
-          disabled={currentPage <= 1}
-          onClick={() => previousPageStep(1)}
-        >
-          {'< -1'}
-        </Button>
-        <Button
-          id="pagination_10_prev"
-          size="small"
-          variant="outlined"
-          disabled={currentPage <= 1}
-          sx={{
-            color: theme.palette.text.primary,
-            borderColor: theme.palette.text.primary,
-          }}
-          onClick={() => previousPageStep(10)}
-        >
-          {'< -10'}
-        </Button>
-        {totalPages > 100 && !lessThanSm && (
-          <>
+        <>
+          <PaginationComponent
+            count={totalPages}
+            page={currentPage}
+            siblingCount={lessThanLg ? 1 : 3}
+            boundaryCount={lessThanLg ? 1 : 2}
+            onChange={handleChangePage}
+            hidePrevButton
+            hideNextButton
+          />
+          <Box
+            width="100%"
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            flexWrap="wrap"
+            gap={1}
+          >
             <Button
-              id="pagination_100_prev"
+              id="pagination_1_prev"
+              size="small"
+              variant="contained"
+              disabled={currentPage <= 1}
+              onClick={() => previousPageStep(1)}
+            >
+              {'< -1'}
+            </Button>
+            <Button
+              id="pagination_10_prev"
               size="small"
               variant="outlined"
               disabled={currentPage <= 1}
@@ -152,12 +126,42 @@ const Pagination = ({
                 color: theme.palette.text.primary,
                 borderColor: theme.palette.text.primary,
               }}
-              onClick={() => previousPageStep(100)}
+              onClick={() => previousPageStep(10)}
             >
-              {'< -100'}
+              {'< -10'}
             </Button>
+            {totalPages > 100 && !lessThanSm && (
+              <>
+                <Button
+                  id="pagination_100_prev"
+                  size="small"
+                  variant="outlined"
+                  disabled={currentPage <= 1}
+                  sx={{
+                    color: theme.palette.text.primary,
+                    borderColor: theme.palette.text.primary,
+                  }}
+                  onClick={() => previousPageStep(100)}
+                >
+                  {'< -100'}
+                </Button>
+                <Button
+                  id="pagination_100_next"
+                  size="small"
+                  variant="outlined"
+                  disabled={currentPage >= totalPages}
+                  sx={{
+                    color: theme.palette.text.primary,
+                    borderColor: theme.palette.text.primary,
+                  }}
+                  onClick={() => nextPageStep(100)}
+                >
+                  {'+100 >'}
+                </Button>
+              </>
+            )}
             <Button
-              id="pagination_100_next"
+              id="pagination_10_next"
               size="small"
               variant="outlined"
               disabled={currentPage >= totalPages}
@@ -165,40 +169,24 @@ const Pagination = ({
                 color: theme.palette.text.primary,
                 borderColor: theme.palette.text.primary,
               }}
-              onClick={() => nextPageStep(100)}
+              onClick={() => nextPageStep(10)}
             >
-              {'+100 >'}
+              {'+10 >'}
             </Button>
-          </>
-        )}
-        <Button
-          id="pagination_10_next"
-          size="small"
-          variant="outlined"
-          disabled={currentPage >= totalPages}
-          sx={{
-            color: theme.palette.text.primary,
-            borderColor: theme.palette.text.primary,
-          }}
-          onClick={() => nextPageStep(10)}
-        >
-          {'+10 >'}
-        </Button>
-        <Button
-          id="pagination_1_next"
-          size="small"
-          variant="contained"
-          disabled={currentPage >= totalPages}
-          onClick={() => nextPageStep(1)}
-        >
-          {'+1 >'}
-        </Button>
-      </Box>
-      </>
-    )}
+            <Button
+              id="pagination_1_next"
+              size="small"
+              variant="contained"
+              disabled={currentPage >= totalPages}
+              onClick={() => nextPageStep(1)}
+            >
+              {'+1 >'}
+            </Button>
+          </Box>
+        </>
+      )}
     </Paper>
   );
-
 };
 
 export default Pagination;

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation, Trans } from 'react-i18next';
 
 import {
   Button,
@@ -7,6 +8,7 @@ import {
   Box,
   useMediaQuery,
   useTheme,
+  Typography,
 } from '@mui/material';
 
 import { scrollToTop } from 'src/utils/ui';
@@ -35,6 +37,16 @@ const Pagination = ({
 
   const currentPage = (offset + limit) / limit;
   const totalPages = Math.floor(count / limit) + (count % limit === 0 ? 0 : 1);
+  const pageFirstVideo = offset + 1;
+  const pageLastVideo = (function () {
+    let x;
+    if (currentPage == totalPages) {
+      x = count;
+    } else x = currentPage * 20;
+    return x;
+  })();
+
+  const { t } = useTranslation();
 
   const handleChangePage = (
     _event: React.ChangeEvent<unknown>,
@@ -59,115 +71,158 @@ const Pagination = ({
       onOffsetChange(page * limit - limit);
     }
   };
-
-  return (
-    <Paper
-      square
-      variant="outlined"
-      sx={{
-        padding: 2,
-        gap: 1,
-        display: 'flex',
-        alignItems: 'center',
-        flexDirection: 'row',
-        justifyContent: 'center',
-        flexWrap: 'wrap',
-      }}
-    >
-      <PaginationComponent
-        count={totalPages}
-        page={currentPage}
-        siblingCount={lessThanLg ? 1 : 3}
-        boundaryCount={lessThanLg ? 1 : 2}
-        onChange={handleChangePage}
-        hidePrevButton
-        hideNextButton
-      />
+  
+  if (count > 20){
+    return (
+      <Paper
+        square
+        variant="outlined"
+        sx={{
+          padding: 2,
+          gap: 1,
+          display: 'flex',
+          alignItems: 'center',
+          flexDirection: 'row',
+          justifyContent: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box
+          width="100%"
+          display="flex"
+          justifyContent="center"
+          flexWrap="wrap"
+        >
+          <Typography>
+            <Trans t={t} i18nKey="pagination.showingCounts" count={count}>
+              Showing {{ pageFirstVideo }} - {{ pageLastVideo }} of {{ count }}
+            </Trans>
+          </Typography>
+        </Box>
+        <PaginationComponent
+          count={totalPages}
+          page={currentPage}
+          siblingCount={lessThanLg ? 1 : 3}
+          boundaryCount={lessThanLg ? 1 : 2}
+          onChange={handleChangePage}
+          hidePrevButton
+          hideNextButton
+        />
+        <Box
+          width="100%"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          flexWrap="wrap"
+          gap={1}
+        >
+          <Button
+            id="pagination_1_prev"
+            size="small"
+            variant="contained"
+            disabled={currentPage <= 1}
+            onClick={() => previousPageStep(1)}
+          >
+            {'< -1'}
+          </Button>
+          <Button
+            id="pagination_10_prev"
+            size="small"
+            variant="outlined"
+            disabled={currentPage <= 1}
+            sx={{
+              color: theme.palette.text.primary,
+              borderColor: theme.palette.text.primary,
+            }}
+            onClick={() => previousPageStep(10)}
+          >
+            {'< -10'}
+          </Button>
+          {totalPages > 100 && !lessThanSm && (
+            <>
+              <Button
+                id="pagination_100_prev"
+                size="small"
+                variant="outlined"
+                disabled={currentPage <= 1}
+                sx={{
+                  color: theme.palette.text.primary,
+                  borderColor: theme.palette.text.primary,
+                }}
+                onClick={() => previousPageStep(100)}
+              >
+                {'< -100'}
+              </Button>
+              <Button
+                id="pagination_100_next"
+                size="small"
+                variant="outlined"
+                disabled={currentPage >= totalPages}
+                sx={{
+                  color: theme.palette.text.primary,
+                  borderColor: theme.palette.text.primary,
+                }}
+                onClick={() => nextPageStep(100)}
+              >
+                {'+100 >'}
+              </Button>
+            </>
+          )}
+          <Button
+            id="pagination_10_next"
+            size="small"
+            variant="outlined"
+            disabled={currentPage >= totalPages}
+            sx={{
+              color: theme.palette.text.primary,
+              borderColor: theme.palette.text.primary,
+            }}
+            onClick={() => nextPageStep(10)}
+          >
+            {'+10 >'}
+          </Button>
+          <Button
+            id="pagination_1_next"
+            size="small"
+            variant="contained"
+            disabled={currentPage >= totalPages}
+            onClick={() => nextPageStep(1)}
+          >
+            {'+1 >'}
+          </Button>
+        </Box>
+      </Paper>
+    );}
+  else{
+    return (
+      <Paper
+        square
+        variant="outlined"
+        sx={{
+          padding: 2,
+          gap: 1,
+          display: 'flex',
+          alignItems: 'center',
+          flexDirection: 'row',
+          justifyContent: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
       <Box
         width="100%"
         display="flex"
         justifyContent="center"
-        alignItems="center"
         flexWrap="wrap"
-        gap={1}
       >
-        <Button
-          id="pagination_1_prev"
-          size="small"
-          variant="contained"
-          disabled={currentPage <= 1}
-          onClick={() => previousPageStep(1)}
-        >
-          {'< -1'}
-        </Button>
-        <Button
-          id="pagination_10_prev"
-          size="small"
-          variant="outlined"
-          disabled={currentPage <= 1}
-          sx={{
-            color: theme.palette.text.primary,
-            borderColor: theme.palette.text.primary,
-          }}
-          onClick={() => previousPageStep(10)}
-        >
-          {'< -10'}
-        </Button>
-        {totalPages > 100 && !lessThanSm && (
-          <>
-            <Button
-              id="pagination_100_prev"
-              size="small"
-              variant="outlined"
-              disabled={currentPage <= 1}
-              sx={{
-                color: theme.palette.text.primary,
-                borderColor: theme.palette.text.primary,
-              }}
-              onClick={() => previousPageStep(100)}
-            >
-              {'< -100'}
-            </Button>
-            <Button
-              id="pagination_100_next"
-              size="small"
-              variant="outlined"
-              disabled={currentPage >= totalPages}
-              sx={{
-                color: theme.palette.text.primary,
-                borderColor: theme.palette.text.primary,
-              }}
-              onClick={() => nextPageStep(100)}
-            >
-              {'+100 >'}
-            </Button>
-          </>
-        )}
-        <Button
-          id="pagination_10_next"
-          size="small"
-          variant="outlined"
-          disabled={currentPage >= totalPages}
-          sx={{
-            color: theme.palette.text.primary,
-            borderColor: theme.palette.text.primary,
-          }}
-          onClick={() => nextPageStep(10)}
-        >
-          {'+10 >'}
-        </Button>
-        <Button
-          id="pagination_1_next"
-          size="small"
-          variant="contained"
-          disabled={currentPage >= totalPages}
-          onClick={() => nextPageStep(1)}
-        >
-          {'+1 >'}
-        </Button>
+        <Typography>
+          <Trans t={t} i18nKey="pagination.showingCounts" count={count}>
+            Showing {{ pageFirstVideo }} - {{ pageLastVideo }} of {{ count }}
+          </Trans>
+        </Typography> 
       </Box>
-    </Paper>
-  );
-};
+      </Paper>
+    );
+  }
+  };
 
 export default Pagination;

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -71,8 +71,8 @@ const Pagination = ({
       onOffsetChange(page * limit - limit);
     }
   };
-  
-  if (count > 20){
+
+  if (count > limit) {
     return (
       <Paper
         square
@@ -192,8 +192,8 @@ const Pagination = ({
           </Button>
         </Box>
       </Paper>
-    );}
-  else{
+    );
+  } else {
     return (
       <Paper
         square
@@ -208,21 +208,21 @@ const Pagination = ({
           flexWrap: 'wrap',
         }}
       >
-      <Box
-        width="100%"
-        display="flex"
-        justifyContent="center"
-        flexWrap="wrap"
-      >
-        <Typography>
-          <Trans t={t} i18nKey="pagination.showingCounts" count={count}>
-            Showing {{ pageFirstVideo }} - {{ pageLastVideo }} of {{ count }}
-          </Trans>
-        </Typography> 
-      </Box>
+        <Box
+          width="100%"
+          display="flex"
+          justifyContent="center"
+          flexWrap="wrap"
+        >
+          <Typography>
+            <Trans t={t} i18nKey="pagination.showingCounts" count={count}>
+              Showing {{ pageFirstVideo }} - {{ pageLastVideo }} of {{ count }}
+            </Trans>
+          </Typography>
+        </Box>
       </Paper>
     );
   }
-  };
+};
 
 export default Pagination;

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -43,7 +43,7 @@ const Pagination = ({
     } else return offset + 1;
   })();
   const pageLastVideo = (function () {
-    if (currentPage == totalPages || totalPages == 0) {
+    if (currentPage == totalPages) {
       return count;
     } else return currentPage * 20;
   })();

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -81,7 +81,7 @@ const Pagination = ({
         flexWrap: 'wrap',
       }}
     >
-      <Box width="100%" display="flex" justifyContent="center" flexWrap="wrap">
+      <Box width="100%" display="flex" justifyContent="center">
         <Typography variant="body2">
           <Trans t={t} i18nKey="pagination.showingCounts" count={count}>
             Showing {{ firstElementIdx }} - {{ lastElementIdx }} of {{ count }}
@@ -99,6 +99,9 @@ const Pagination = ({
             onChange={handleChangePage}
             hidePrevButton
             hideNextButton
+            sx={{
+              mt: 1,
+            }}
           />
           <Box
             width="100%"

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -72,157 +72,131 @@ const Pagination = ({
     }
   };
 
-  if (count > limit) {
-    return (
-      <Paper
-        square
-        variant="outlined"
-        sx={{
-          padding: 2,
-          gap: 1,
-          display: 'flex',
-          alignItems: 'center',
-          flexDirection: 'row',
-          justifyContent: 'center',
-          flexWrap: 'wrap',
-        }}
+  return (
+    <Paper
+      square
+      variant="outlined"
+      sx={{
+        padding: 2,
+        gap: 1,
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'row',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <Box
+        width="100%"
+        display="flex"
+        justifyContent="center"
+        flexWrap="wrap"
       >
-        <Box
-          width="100%"
-          display="flex"
-          justifyContent="center"
-          flexWrap="wrap"
-        >
-          <Typography>
-            <Trans t={t} i18nKey="pagination.showingCounts" count={count}>
-              Showing {{ pageFirstVideo }} - {{ pageLastVideo }} of {{ count }}
-            </Trans>
-          </Typography>
-        </Box>
-        <PaginationComponent
-          count={totalPages}
-          page={currentPage}
-          siblingCount={lessThanLg ? 1 : 3}
-          boundaryCount={lessThanLg ? 1 : 2}
-          onChange={handleChangePage}
-          hidePrevButton
-          hideNextButton
-        />
-        <Box
-          width="100%"
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          flexWrap="wrap"
-          gap={1}
-        >
-          <Button
-            id="pagination_1_prev"
-            size="small"
-            variant="contained"
-            disabled={currentPage <= 1}
-            onClick={() => previousPageStep(1)}
-          >
-            {'< -1'}
-          </Button>
-          <Button
-            id="pagination_10_prev"
-            size="small"
-            variant="outlined"
-            disabled={currentPage <= 1}
-            sx={{
-              color: theme.palette.text.primary,
-              borderColor: theme.palette.text.primary,
-            }}
-            onClick={() => previousPageStep(10)}
-          >
-            {'< -10'}
-          </Button>
-          {totalPages > 100 && !lessThanSm && (
-            <>
-              <Button
-                id="pagination_100_prev"
-                size="small"
-                variant="outlined"
-                disabled={currentPage <= 1}
-                sx={{
-                  color: theme.palette.text.primary,
-                  borderColor: theme.palette.text.primary,
-                }}
-                onClick={() => previousPageStep(100)}
-              >
-                {'< -100'}
-              </Button>
-              <Button
-                id="pagination_100_next"
-                size="small"
-                variant="outlined"
-                disabled={currentPage >= totalPages}
-                sx={{
-                  color: theme.palette.text.primary,
-                  borderColor: theme.palette.text.primary,
-                }}
-                onClick={() => nextPageStep(100)}
-              >
-                {'+100 >'}
-              </Button>
-            </>
-          )}
-          <Button
-            id="pagination_10_next"
-            size="small"
-            variant="outlined"
-            disabled={currentPage >= totalPages}
-            sx={{
-              color: theme.palette.text.primary,
-              borderColor: theme.palette.text.primary,
-            }}
-            onClick={() => nextPageStep(10)}
-          >
-            {'+10 >'}
-          </Button>
-          <Button
-            id="pagination_1_next"
-            size="small"
-            variant="contained"
-            disabled={currentPage >= totalPages}
-            onClick={() => nextPageStep(1)}
-          >
-            {'+1 >'}
-          </Button>
-        </Box>
-      </Paper>
-    );
-  } else {
-    return (
-      <Paper
-        square
-        variant="outlined"
-        sx={{
-          padding: 2,
-          gap: 1,
-          display: 'flex',
-          alignItems: 'center',
-          flexDirection: 'row',
-          justifyContent: 'center',
-          flexWrap: 'wrap',
-        }}
+        <Typography>
+          <Trans t={t} i18nKey="pagination.showingCounts" count={count}>
+            Showing {{ pageFirstVideo }} - {{ pageLastVideo }} of {{ count }}
+          </Trans>
+        </Typography>
+      </Box>
+      {count > limit && (
+      <>
+      <PaginationComponent
+        count={totalPages}
+        page={currentPage}
+        siblingCount={lessThanLg ? 1 : 3}
+        boundaryCount={lessThanLg ? 1 : 2}
+        onChange={handleChangePage}
+        hidePrevButton
+        hideNextButton
+      />
+      <Box
+        width="100%"
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        flexWrap="wrap"
+        gap={1}
       >
-        <Box
-          width="100%"
-          display="flex"
-          justifyContent="center"
-          flexWrap="wrap"
+        <Button
+          id="pagination_1_prev"
+          size="small"
+          variant="contained"
+          disabled={currentPage <= 1}
+          onClick={() => previousPageStep(1)}
         >
-          <Typography>
-            <Trans t={t} i18nKey="pagination.showingCounts" count={count}>
-              Showing {{ pageFirstVideo }} - {{ pageLastVideo }} of {{ count }}
-            </Trans>
-          </Typography>
-        </Box>
-      </Paper>
-    );
-  }
+          {'< -1'}
+        </Button>
+        <Button
+          id="pagination_10_prev"
+          size="small"
+          variant="outlined"
+          disabled={currentPage <= 1}
+          sx={{
+            color: theme.palette.text.primary,
+            borderColor: theme.palette.text.primary,
+          }}
+          onClick={() => previousPageStep(10)}
+        >
+          {'< -10'}
+        </Button>
+        {totalPages > 100 && !lessThanSm && (
+          <>
+            <Button
+              id="pagination_100_prev"
+              size="small"
+              variant="outlined"
+              disabled={currentPage <= 1}
+              sx={{
+                color: theme.palette.text.primary,
+                borderColor: theme.palette.text.primary,
+              }}
+              onClick={() => previousPageStep(100)}
+            >
+              {'< -100'}
+            </Button>
+            <Button
+              id="pagination_100_next"
+              size="small"
+              variant="outlined"
+              disabled={currentPage >= totalPages}
+              sx={{
+                color: theme.palette.text.primary,
+                borderColor: theme.palette.text.primary,
+              }}
+              onClick={() => nextPageStep(100)}
+            >
+              {'+100 >'}
+            </Button>
+          </>
+        )}
+        <Button
+          id="pagination_10_next"
+          size="small"
+          variant="outlined"
+          disabled={currentPage >= totalPages}
+          sx={{
+            color: theme.palette.text.primary,
+            borderColor: theme.palette.text.primary,
+          }}
+          onClick={() => nextPageStep(10)}
+        >
+          {'+10 >'}
+        </Button>
+        <Button
+          id="pagination_1_next"
+          size="small"
+          variant="contained"
+          disabled={currentPage >= totalPages}
+          onClick={() => nextPageStep(1)}
+        >
+          {'+1 >'}
+        </Button>
+      </Box>
+      </>
+    )}
+    </Paper>
+  );
+
 };
 
 export default Pagination;

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -37,13 +37,15 @@ const Pagination = ({
 
   const currentPage = (offset + limit) / limit;
   const totalPages = Math.floor(count / limit) + (count % limit === 0 ? 0 : 1);
-  const pageFirstVideo = offset + 1;
+  const pageFirstVideo = (function () {
+    if (count == 0){
+      return 0;
+    } else return offset + 1;
+  })();
   const pageLastVideo = (function () {
-    let x;
-    if (currentPage == totalPages) {
-      x = count;
-    } else x = currentPage * 20;
-    return x;
+    if (currentPage == totalPages || totalPages == 0) {
+      return count;
+    } else return currentPage * 20;
   })();
 
   const { t } = useTranslation();

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -174,7 +174,7 @@ function RecommendationsPage() {
             }
           />
         </LoaderWrapper>
-        {!isLoading && (
+        {!isLoading && entitiesCount > 0 && (
           <Pagination
             offset={offset}
             count={entitiesCount}

--- a/frontend/src/pages/recommendations/RecommendationPage.tsx
+++ b/frontend/src/pages/recommendations/RecommendationPage.tsx
@@ -174,7 +174,7 @@ function RecommendationsPage() {
             }
           />
         </LoaderWrapper>
-        {!isLoading && entitiesCount > limit && (
+        {!isLoading && (
           <Pagination
             offset={offset}
             count={entitiesCount}


### PR DESCRIPTION
The goal is to show the counter of the videos currently displayed on the recommendations page
(e.g. Showing 61 - 80 of 615)
![image](https://user-images.githubusercontent.com/89401728/235675601-a67707c2-de7c-4a42-8529-09fe0da202bc.png)
