### PR TITLE
[infra] Upgrade and pin Uvicorn version, attempt to fix timeout issues on previews

### DIFF
--- a/backend/tournesol/utils/constants.py
+++ b/backend/tournesol/utils/constants.py
@@ -8,8 +8,8 @@ YOUTUBE_VIDEO_ID_REGEX_SYMBOL = "[A-Za-z0-9-_]"
 # The whole video ID
 YOUTUBE_VIDEO_ID_REGEX = rf"{YOUTUBE_VIDEO_ID_REGEX_SYMBOL}{{11}}"
 
-# 10 seconds timeout to avoid staying blocked if an outgoing HTTP request fails
-REQUEST_TIMEOUT = 10
+# 3 seconds timeout to avoid staying blocked if an outgoing HTTP request fails
+REQUEST_TIMEOUT = 3
 
 # Maximal entity score after poll scaling is applied
 MEHESTAN_MAX_SCALED_SCORE = 100.0

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -102,8 +102,8 @@
 - name: Create Virtualenv for Django project
   pip:
     name:
-      - gunicorn
-      - uvicorn
+      - "gunicorn==20.1.0"
+      - "uvicorn[standard]==0.22.0"
     virtualenv: /srv/tournesol-backend/venv
     virtualenv_python: python3.9
   become: yes


### PR DESCRIPTION
On 2023-05-01, between 08:10 and 08:12 UTC, many server errors were observed on the backend, due to too many concurrent connections to the database:
```
May 01 08:10:31 tournesol gunicorn[3862359]: psycopg2.OperationalError: connection to server at "localhost" (::1), port 5432 failed: FATAL:  remaining connection slots are reserved for non-replication superuser connections
```

The causes are unclear, but it seems to be related to many "/preview" requests being interrupted by clients after a 5-sec timeout starting from 08:09:37 UTC. Maybe these requests created connections to the db that were not properly closed after the client gave up. 

Anyway, this led me to realize that our deployment does not specify the version of uvicorn + gunicorn used to run the django application. There could be something wrong with our configuration, but upgrading the packages seems to be a good first step, as the version used on the server is the one installed on provisioning and has not changed since.

---
So this PR applies 2 changes:
 1. upgrade and pin gunicorn and uvicorn. 
     - gunicorn 20.1 (latest version, released in april 2021) is already the version used on the production server
     - uvicorn 0.22.0 (instead of 0.17.6 currently used on the production server).   
     Using `uvicorn[standard]` also includes [`uvloop`](https://github.com/MagicStack/uvloop) as a faster event loop, as recommended [here](https://github.com/encode/uvicorn#quickstart)

 2. Set the timeout for external requests (e.g to YouTube thumbnails) to 3 seconds instead of 10. 
 It will make the issue more explicit if some requests to img.youtube.com are actually slow (the exception will be raised before the client aborts the request), or if the problem is caused by something else.
