### PR TITLE
[back] sec: upgrade Django to 4.1.9 (from 4.1.7)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 # Full stack Web Framework used for Tournesol's backend
 # https://docs.djangoproject.com
-Django==4.1.7
+Django==4.1.9
 # Used for fields computed on save for Django models
 # See https://github.com/brechin/django-computed-property/
 django-computed-property==0.3.0


### PR DESCRIPTION
Fix:
- CVE-2023-31047

See:
- https://docs.djangoproject.com/en/4.2/releases/4.1.9/
- https://docs.djangoproject.com/en/4.2/releases/4.1.8/