### PR TITLE
[front] fix: user settings not retrieved after a login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,11 +62,6 @@ const ScrollToTop = () => {
   return null;
 };
 
-const InitGlobalStates = () => {
-  useRefreshSettings();
-  return null;
-};
-
 function App() {
   const { i18n } = useTranslation();
   const { isLoggedIn, loginState } = useLoginState();
@@ -78,11 +73,12 @@ function App() {
     initializeOpenAPI(loginState, i18n);
   }, [loginState, i18n]);
 
+  useRefreshSettings();
+
   return (
     <PollProvider>
       <StatsLazyProvider>
         <ScrollToTop />
-        <InitGlobalStates />
         <Frame>
           <Switch>
             {/* About routes */}

--- a/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -84,6 +84,18 @@ const VideosPollUserSettingsForm = () => {
     }
     setDisabled(false);
   };
+
+  //Use effect to refresh settings when user logs in on the preferences form
+  useEffect(() => {
+    setCompUiWeeklyColGoalDisplay(
+      userSettings?.[pollName]?.comparison_ui__weekly_collective_goal_display ??
+        ComparisonUi_weeklyCollectiveGoalDisplayEnum.ALWAYS
+    );
+    setRateLaterAutoRemoval(
+      userSettings?.[pollName]?.rate_later__auto_remove ??
+        DEFAULT_RATE_LATER_AUTO_REMOVAL
+    );
+  }, [userSettings, pollName]);
 
   return (
     <form onSubmit={handleSubmit}>

--- a/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -84,18 +84,6 @@ const VideosPollUserSettingsForm = () => {
     }
     setDisabled(false);
   };
-
-  //Use effect to refresh settings when user logs in on the preferences form
-  useEffect(() => {
-    setCompUiWeeklyColGoalDisplay(
-      userSettings?.[pollName]?.comparison_ui__weekly_collective_goal_display ??
-        ComparisonUi_weeklyCollectiveGoalDisplayEnum.ALWAYS
-    );
-    setRateLaterAutoRemoval(
-      userSettings?.[pollName]?.rate_later__auto_remove ??
-        DEFAULT_RATE_LATER_AUTO_REMOVAL
-    );
-  }, [userSettings, pollName]);
 
   return (
     <form onSubmit={handleSubmit}>


### PR DESCRIPTION
**to-do**
- [x] trigger `fetchUserSettings` after the user is logged, not before

**to-do in the following PRs**
- [x] refresh the settings when the user arrives on its preferences form (this will fix the following edge case)
  - if the user is redirected to `/settings/preferences` after a log in, the displayed settings should be the user's preference and not the default values of the settings
- [ ] add e2e tests of each setting