### PR TITLE
[front] fix: retrieve user's settings from API when login on preferences page

### DIFF
--- a/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.spec.tsx
+++ b/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.spec.tsx
@@ -47,6 +47,11 @@ describe('GenericPollUserSettingsForm', () => {
   const api_url = process.env.REACT_APP_API_URL || '';
   OpenAPI.BASE = api_url;
 
+  // The values used by the store and the API are different to ensure the form
+  // is initialized with the correct source of information.
+  const INIT_AUTO_REMOVAL_API = 8;
+  const INIT_AUTO_REMOVAL_STORE = 0;
+
   fetchMock
     .mock(
       {
@@ -59,10 +64,7 @@ describe('GenericPollUserSettingsForm', () => {
         status: 200,
         body: {
           videos: {
-            // The value of `rate_later__auto_remove` should be different
-            // than the one used to initialize the store to make the tests
-            // relevant.
-            rate_later__auto_remove: 8,
+            rate_later__auto_remove: INIT_AUTO_REMOVAL_API,
           },
         },
       },
@@ -145,7 +147,7 @@ describe('GenericPollUserSettingsForm', () => {
         videos: {
           // Here we don't define all the settings so we can ensure the form
           // behaves correctly when initialized with undefined settings.
-          rate_later__auto_remove: 0,
+          rate_later__auto_remove: INIT_AUTO_REMOVAL_STORE,
         },
       },
     };

--- a/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
@@ -84,15 +84,19 @@ const VideosPollUserSettingsForm = () => {
   //Use effect to refresh settings when user logs in on the preferences form
   useEffect(() => {
     async function retrieveProfile() {
-      const response = await UsersService.usersMeSettingsRetrieve();
-      setCompUiWeeklyColGoalDisplay(
-        response?.[pollName]?.comparison_ui__weekly_collective_goal_display ??
-          ComparisonUi_weeklyCollectiveGoalDisplayEnum.ALWAYS
-      );
-      setRateLaterAutoRemoval(
-        response?.[pollName]?.rate_later__auto_remove ??
-          DEFAULT_RATE_LATER_AUTO_REMOVAL
-      );
+      const settings = await UsersService.usersMeSettingsRetrieve();
+      const pollSettings = settings?.[pollName];
+      if (
+        pollSettings?.comparison_ui__weekly_collective_goal_display !==
+        undefined
+      ) {
+        setCompUiWeeklyColGoalDisplay(
+          pollSettings.comparison_ui__weekly_collective_goal_display
+        );
+      }
+      if (pollSettings?.rate_later__auto_remove !== undefined) {
+        setRateLaterAutoRemoval(pollSettings.rate_later__auto_remove);
+      }
     }
     retrieveProfile();
   }, [userSettings, pollName]);

--- a/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -42,15 +42,11 @@ const VideosPollUserSettingsForm = () => {
   // Comparison (page)
   const [compUiWeeklyColGoalDisplay, setCompUiWeeklyColGoalDisplay] = useState<
     ComparisonUi_weeklyCollectiveGoalDisplayEnum | BlankEnum
-  >(
-    userSettings?.[pollName]?.comparison_ui__weekly_collective_goal_display ??
-      ComparisonUi_weeklyCollectiveGoalDisplayEnum.ALWAYS
-  );
+  >(ComparisonUi_weeklyCollectiveGoalDisplayEnum.ALWAYS);
 
   // Rate-later settings
   const [rateLaterAutoRemoval, setRateLaterAutoRemoval] = useState(
-    userSettings?.[pollName]?.rate_later__auto_remove ??
-      DEFAULT_RATE_LATER_AUTO_REMOVAL
+    DEFAULT_RATE_LATER_AUTO_REMOVAL
   );
 
   const handleSubmit = async (event: React.FormEvent) => {
@@ -84,6 +80,22 @@ const VideosPollUserSettingsForm = () => {
     }
     setDisabled(false);
   };
+
+  //Use effect to refresh settings when user logs in on the preferences form
+  useEffect(() => {
+    async function retrieveProfile() {
+      const response = await UsersService.usersMeSettingsRetrieve();
+      setCompUiWeeklyColGoalDisplay(
+        response?.[pollName]?.comparison_ui__weekly_collective_goal_display ??
+          ComparisonUi_weeklyCollectiveGoalDisplayEnum.ALWAYS
+      );
+      setRateLaterAutoRemoval(
+        response?.[pollName]?.rate_later__auto_remove ??
+          DEFAULT_RATE_LATER_AUTO_REMOVAL
+      );
+    }
+    retrieveProfile();
+  }, [userSettings, pollName]);
 
   return (
     <form onSubmit={handleSubmit}>

--- a/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { Button, Grid, Typography } from '@mui/material';
 
@@ -8,10 +8,7 @@ import {
   DEFAULT_RATE_LATER_AUTO_REMOVAL,
   YOUTUBE_POLL_NAME,
 } from 'src/utils/constants';
-import {
-  replaceSettings,
-  selectSettings,
-} from 'src/features/settings/userSettingsSlice';
+import { replaceSettings } from 'src/features/settings/userSettingsSlice';
 import { useNotifications } from 'src/hooks';
 import {
   ApiError,
@@ -36,9 +33,6 @@ const VideosPollUserSettingsForm = () => {
   const [disabled, setDisabled] = useState(false);
   const [apiErrors, setApiErrors] = useState<ApiError | null>(null);
 
-  // List of user's settings.
-  const userSettings = useSelector(selectSettings).settings;
-
   // Comparison (page)
   const [compUiWeeklyColGoalDisplay, setCompUiWeeklyColGoalDisplay] = useState<
     ComparisonUi_weeklyCollectiveGoalDisplayEnum | BlankEnum
@@ -48,6 +42,25 @@ const VideosPollUserSettingsForm = () => {
   const [rateLaterAutoRemoval, setRateLaterAutoRemoval] = useState(
     DEFAULT_RATE_LATER_AUTO_REMOVAL
   );
+
+  useEffect(() => {
+    UsersService.usersMeSettingsRetrieve().then((settings) => {
+      const pollSettings = settings?.[pollName];
+      if (
+        pollSettings?.comparison_ui__weekly_collective_goal_display != undefined
+      ) {
+        setCompUiWeeklyColGoalDisplay(
+          pollSettings.comparison_ui__weekly_collective_goal_display
+        );
+      }
+      if (pollSettings?.rate_later__auto_remove != undefined) {
+        setRateLaterAutoRemoval(pollSettings.rate_later__auto_remove);
+      }
+
+      dispatch(replaceSettings(settings));
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -80,26 +93,6 @@ const VideosPollUserSettingsForm = () => {
     }
     setDisabled(false);
   };
-
-  //Use effect to refresh settings when user logs in on the preferences form
-  useEffect(() => {
-    async function retrieveProfile() {
-      const settings = await UsersService.usersMeSettingsRetrieve();
-      const pollSettings = settings?.[pollName];
-      if (
-        pollSettings?.comparison_ui__weekly_collective_goal_display !==
-        undefined
-      ) {
-        setCompUiWeeklyColGoalDisplay(
-          pollSettings.comparison_ui__weekly_collective_goal_display
-        );
-      }
-      if (pollSettings?.rate_later__auto_remove !== undefined) {
-        setRateLaterAutoRemoval(pollSettings.rate_later__auto_remove);
-      }
-    }
-    retrieveProfile();
-  }, [userSettings, pollName]);
 
   return (
     <form onSubmit={handleSubmit}>


### PR DESCRIPTION
**related to #1554**