### PR TITLE
[back] fix: recommendations preview is empty when all languages are explicitly requested

### DIFF
--- a/backend/tournesol/tests/test_api_preview.py
+++ b/backend/tournesol/tests/test_api_preview.py
@@ -456,6 +456,15 @@ class DynamicRecommendationsPreviewTestCase(TestCase):
             rf"{self.preview_internal_url}/\?metadata%5Blanguage%5D=fr&date_gte=.*",
         )
 
+    def test_recommendations_preview_query_redirection_all_languages_filter(self):
+        response = self.client.get(f"{self.preview_url}/?language=")
+        self.assertEqual(response.status_code, 302)
+        # No filter should be present in the redirection
+        self.assertEqual(
+            response.headers["location"],
+            f"{self.preview_internal_url}/?"
+        )
+
     def test_recommendations_preview_internal_route(self):
         response = self.client.get(f"{self.preview_internal_url}/?metadata[language]=fr")
         self.assertEqual(response.status_code, 200)

--- a/backend/tournesol/views/preview_recommendations.py
+++ b/backend/tournesol/views/preview_recommendations.py
@@ -61,7 +61,7 @@ def get_preview_recommendations_redirect_params(request):
 
     for (key, value) in params.items():
         if key == "language":
-            languages = value.split(",")
+            languages = [lang for lang in value.split(",") if lang != ""]
             if languages:
                 query.setlist("metadata[language]", languages)
         elif key == "date":


### PR DESCRIPTION
Did you know that `"".split(",")` returns `[""]` ?  
Whereas `"".split()` without a separator returns `[]` 