### PR TITLE
[ml] Update QrUnc definition, and use QrDev to compute uncertainty on global scores

### DIFF
--- a/backend/ml/mehestan/global_scores.py
+++ b/backend/ml/mehestan/global_scores.py
@@ -332,12 +332,10 @@ def get_global_scores(scaled_scores: pd.DataFrame):
         theta = scores.score
         delta = scores.uncertainty
         rho = QrMed(2 * W, w, theta, delta)
-        rho_uncertainty = QrUnc(2 * W, 1, w, theta, delta, qr_med=rho)
-        rho_deviation = QrDev(2 * W, 1, w, theta, delta, qr_med=rho)
+        rho_uncertainty = QrDev(2 * W, 1, w, theta, delta, qr_med=rho)
         global_scores[entity_id] = {
             "score": rho,
             "uncertainty": rho_uncertainty,
-            "deviation": rho_deviation,
             "n_contributors": len(scores),
         }
 

--- a/backend/ml/mehestan/primitives.py
+++ b/backend/ml/mehestan/primitives.py
@@ -93,22 +93,10 @@ def QrUnc(
 
     if qr_med is None:
         qr_med = QrMed(W, w, x, delta)
-    qr_dev = QrDev(W, default_dev, w, x, delta, qr_med=qr_med)
-    delta_2 = delta ** 2
+    delta_2 = delta**2
     bound = np.inf if W <= 0 else 1 / W
-    h = W + np.sum(
-        w * np.minimum(bound, delta_2 * (delta_2 + (x - qr_med) ** 2) ** (-3 / 2))
-    )
-
-    if h <= W:
-        return qr_dev
-
-    k = (h - W) ** (-1 / 2)
-
-    # Use LogSumExp with a negative value of alpha to have a smooth minimum instead
-    # of a smooth maximum (c.f. https://github.com/tournesol-app/tournesol/issues/1232).
-    alpha = -1.0
-    return np.maximum(0.0, alpha * np.log(np.exp(alpha * qr_dev) + np.exp(alpha * k)))
+    L_second_capped = W + np.sum(w * np.minimum(bound, delta_2 * (delta_2 + (x - qr_med) ** 2) ** (-3 / 2)))
+    return ((default_dev**-2) + 2 * default_dev**-3 * (L_second_capped - W)) ** (-1 / 2)
 
 
 def Clip(x: np.ndarray, center: float, radius: float):

--- a/backend/ml/mehestan/primitives.py
+++ b/backend/ml/mehestan/primitives.py
@@ -95,7 +95,9 @@ def QrUnc(
         qr_med = QrMed(W, w, x, delta)
     delta_2 = delta**2
     bound = np.inf if W <= 0 else 1 / W
-    L_second_capped = W + np.sum(w * np.minimum(bound, delta_2 * (delta_2 + (x - qr_med) ** 2) ** (-3 / 2)))
+    L_second_capped = W + np.sum(
+        w * np.minimum(bound, delta_2 * (delta_2 + (x - qr_med) ** 2) ** (-3 / 2))
+    )
     return ((default_dev**-2) + 2 * default_dev**-3 * (L_second_capped - W)) ** (-1 / 2)
 
 

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -167,11 +167,10 @@ def run_mehestan_for_criterion(
             scale_function(global_scores["score"] + global_scores["uncertainty"])
             - scale_function(global_scores["score"] - global_scores["uncertainty"])
         )
-        global_scores["deviation"] = 0.5 * (
-            scale_function(global_scores["score"] + global_scores["deviation"])
-            - scale_function(global_scores["score"] - global_scores["deviation"])
-        )
         global_scores["score"] = scale_function(global_scores["score"])
+
+        # 2023-05-20: deviation is no longer computed by Mehestan
+        global_scores["deviation"] = None
 
         logger.info(
             "Mehestan for poll '%s': scores computed for crit '%s' and mode '%s'",

--- a/backend/ml/tests/test_mehestan_primitives.py
+++ b/backend/ml/tests/test_mehestan_primitives.py
@@ -67,7 +67,7 @@ class QrDevTest(TestCase):
         self.assertAlmostEqual(
             QrDev(
                 W=2.,
-                default_dev=0.,
+                default_dev=1.,
                 w=100000.,
                 x=x,
                 delta=0.,
@@ -82,7 +82,7 @@ class QrDevTest(TestCase):
         self.assertAlmostEqual(
             QrDev(
                 W=0.,
-                default_dev=0.,
+                default_dev=1.,
                 w=1.,
                 x=x,
                 delta=0.,
@@ -119,12 +119,12 @@ class QrUncTest(TestCase):
         self.assertAlmostEqual(
             QrUnc(
                 W,
-                default_dev=0,
+                default_dev=1,
                 w=weight,
                 x=np.array([-10.0, 1.0, 10.0]),
                 delta=np.array([1e-3, 1e-3, 1e-3]),
             ),
-            0.506,
+            1.0,
             places=3,
         )
 
@@ -134,11 +134,11 @@ class QrUncTest(TestCase):
         self.assertAlmostEqual(
             QrUnc(
                 W,
-                default_dev=0,
+                default_dev=1,
                 w=weight,
                 x=np.array([-10.0, 1.0, 10.0]),
                 delta=np.array([1e-3, 1e-3, 1e-3]),
             ),
-            0.03,
+            0.02,
             places=2,
         )


### PR DESCRIPTION
Related to the latest updates in https://www.overleaf.com/project/5f44dd8e84c8540001bf1552