### PR TITLE
infra: disable Tournesol wiki

### DIFF
--- a/infra/ansible/roles/mediawiki/tasks/main.yml
+++ b/infra/ansible/roles/mediawiki/tasks/main.yml
@@ -94,8 +94,7 @@
 
 - name: Enable Nginx Mediawiki configuration
   file:
-    src: /etc/nginx/sites-available/mediawiki
-    dest: /etc/nginx/sites-enabled/mediawiki
+    path: /etc/nginx/site-enabled/mediawiki
     state: absent  # 2023-05-21: wiki is disabled
   notify:
     - Reload Nginx

--- a/infra/ansible/roles/mediawiki/tasks/main.yml
+++ b/infra/ansible/roles/mediawiki/tasks/main.yml
@@ -96,7 +96,7 @@
   file:
     src: /etc/nginx/sites-available/mediawiki
     dest: /etc/nginx/sites-enabled/mediawiki
-    state: link
+    state: absent  # 2023-05-21: wiki is disabled
   notify:
     - Reload Nginx
 


### PR DESCRIPTION
Once the wiki is disabled and no issue is observed, the infra configuration will be removed

Related to #557 