### PR TITLE
[front] refactor: increase collective goal to 2500 from 2000

### DIFF
--- a/frontend/src/features/goals/collective.tsx
+++ b/frontend/src/features/goals/collective.tsx
@@ -1,11 +1,11 @@
-export const WEEKLY_COMPARISON_GOAL = 2000;
+export const WEEKLY_COMPARISON_GOAL = 2500;
 
 /**
  * Return an emoji to reward the users for their progression in the weekly
  * collective goal.
  */
 export const getWeeklyProgressionEmoji = (progression: number) => {
-  if (progression > 140) return '❤️‍🔥';
+  if (progression > 125) return '❤️‍🔥';
   if (progression > 100) return '🥳 🎉';
   if (progression > 75) return '🌻';
   if (progression > 50) return '🌷';


### PR DESCRIPTION
As discussed with the rest of the team, we increase the weekly collective comparisons goal to 2500.

We reached several times in a row the goal 2000, and we think we can now aim for 2500 : ) I also reduced the amount of work required to reach the "secret" emoji, to better match the new goal.