### PR TITLE
[front] fix: remove extra trailing slash in comparison URL

### DIFF
--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -48,7 +48,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
         <Tooltip title={`${t('comparisons.goToComparison')}`} placement="top">
           <Fab
             component={Link}
-            to={`${baseUrl}/comparison/?uidA=${entity_a.uid}&uidB=${entity_b.uid}`}
+            to={`${baseUrl}/comparison?uidA=${entity_a.uid}&uidB=${entity_b.uid}`}
             sx={{ backgroundColor: '#F1EFE7' }}
             size="small"
           >

--- a/frontend/src/pages/home/videos/sections/HomeComparison.tsx
+++ b/frontend/src/pages/home/videos/sections/HomeComparison.tsx
@@ -205,8 +205,8 @@ const HomeComparison = () => {
                 component={Link}
                 to={
                   tutoRedirect
-                    ? `/comparison/?series=true&uidA=${uidA}&uidB=${uidB}`
-                    : `/comparison/?uidA=${uidA}&uidB=${uidB}`
+                    ? `/comparison?series=true&uidA=${uidA}&uidB=${uidB}`
+                    : `/comparison?uidA=${uidA}&uidB=${uidB}`
                 }
               >
                 {t('homeComparison.compareTheVideos')}

--- a/frontend/src/utils/action.tsx
+++ b/frontend/src/utils/action.tsx
@@ -27,7 +27,7 @@ export const CompareNowAction = ({ uid }: { uid: string }) => {
         sx={{ color: '#CDCABC' }}
         size="medium"
         component={Link}
-        to={`${baseUrl}/comparison/?uidA=${uid}`}
+        to={`${baseUrl}/comparison?uidA=${uid}`}
       >
         <CompareIcon />
       </IconButton>

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -253,7 +253,7 @@ describe('Comparison page', () => {
       const videoAId = 'u83A7DUNMHs';
       const videoBId = '6jK9bFWE--g';
 
-      cy.visit(`/comparison/?videoA=${videoAId}&videoB=${videoBId}`);
+      cy.visit(`/comparison?videoA=${videoAId}&videoB=${videoBId}`);
       cy.focused().type('user1');
       cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
 
@@ -270,7 +270,7 @@ describe('Comparison page', () => {
       const videoAId = 'u83A7DUNMHs';
       const videoBId = '6jK9bFWE--g';
 
-      cy.visit(`/comparison/?videoA=${videoAId}&uidB=yt:${videoBId}`);
+      cy.visit(`/comparison?videoA=${videoAId}&uidB=yt:${videoBId}`);
       cy.focused().type('user1');
       cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
 


### PR DESCRIPTION
This should fix the duplicates "comparison" and "comparison/" entries in our web analytics tool.