### PR TITLE
[front] feat: add an info msg explaning the behaviour of the default search filter.

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -329,7 +329,7 @@
     "comparisonPage": "Comparison page",
     "rateLater": "Rate-later list",
     "recommendationsPage": "Recommendations page",
-    "customizeYourDefaultSearchFilter": "Customize <1>the default search filters</1> according to your own preferences. Those filters are applied <4>only</4> when you access the recommendations from the left <6>side bar</6>.",
+    "customizeYourDefaultSearchFilter": "Customize <1>the default search filters</1> according to your own preferences. Those filters are applied <4>only</4> when you access the recommendations from the <6>main menu</6>.",
     "updatePreferences": "Update preferences"
   },
   "videosUserSettingsForm": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -337,7 +337,7 @@
     "comparisonPage": "Comparaison (page)",
     "rateLater": "Liste à comparer plus tard",
     "recommendationsPage": "Recommandations (page)",
-    "customizeYourDefaultSearchFilter": "Personnalisez <1>les filtres de recherche par défaut</1> selon vos préférences. Ces filtres sont appliqués <4>seulement</4> lorsque vous accédez aux recommandations depuis la <6>barre latérale</6> à gauche de l'écran.",
+    "customizeYourDefaultSearchFilter": "Personnalisez <1>les filtres de recherche par défaut</1> selon vos préférences. Ces filtres sont appliqués <4>seulement</4> lorsque vous accédez aux recommandations depuis le <6>menu principal</6>.",
     "updatePreferences": "Mettre à jour les préférences"
   },
   "videosUserSettingsForm": {

--- a/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
@@ -169,7 +169,7 @@ const VideosPollUserSettingsForm = () => {
                 Customize <strong>the default search filters</strong> according
                 to your own preferences. Those filters are applied{' '}
                 <strong>only</strong> when you access the recommendations from
-                the <strong>side bar</strong>.
+                the <strong>main menu</strong>.
               </Trans>
             </Alert>
           </Grid>


### PR DESCRIPTION
This PR adds a paragraph in the Preferences page explaining how to use the default search filters.

I think it may not be obvious for all users to:
1. discover the Preferences page
2. realize that some are related to the default search filters of the recommendations page
3. understand when those default filters are used

To address the point 1 (and a bit of the point 2) we added a link to the preferences in the recommendations page :heavy_check_mark: 

To address the point 3 (and one more bit of the point 2) I added a small paragraph inviting the users to customize their preferences, and explain how to access the newly configured recommendations page.

This small addition should make the settings more friendly, and I hope avoid us to receive too much questions about "why the recommendations page doesn't use my preferences".

### preview
  
![capture](https://github.com/tournesol-app/tournesol/assets/39056254/09fd6cb7-1c47-4c1a-9e15-e4a02ba0688d)
