### PR TITLE
[ext] fix: the video actions are now displayed in their own container

### DIFF
--- a/browser-extension/src/addRateButtons.css
+++ b/browser-extension/src/addRateButtons.css
@@ -1,10 +1,19 @@
+#ts-video-actions-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+
+  margin-top: 12px;
+}
+
 button.tournesol-rate-button {
   background: transparent;
   border: none;
   border-radius: 2px;
   cursor: pointer;
   font-family: 'Roboto', 'Noto', sans-serif;
-  margin-left: 8px;
   display: flex;
   align-items: center;
   padding: 0 16px;
@@ -38,21 +47,7 @@ img.tournesol-button-image.tournesol-rate-later {
   margin-right: 2px;
 }
 
-@media (min-width: 656px) and (max-width: 990px) {
-  button.tournesol-rate-button {
-    font-size: 0;
-  }
-
-  img.tournesol-button-image {
-    margin: 0;
-  }
-
-  img.tournesol-button-image.tournesol-rate-later {
-    margin: 0;
-  }
-}
-
-@media (min-width: 1017px) and (max-width: 1366px) {
+@media (max-width: 990px) {
   button.tournesol-rate-button {
     font-size: 0;
   }

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",


### PR DESCRIPTION
fix #1587

---

The buttons are now displayed in a flex container to avoid breaking the YouTube layout and hiding the YouTube buttons.

### preview

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/ddcb117f-935e-479e-8089-66e7ffa12f4b)


![capture2](https://github.com/tournesol-app/tournesol/assets/39056254/5fdc999a-5cc2-4311-b866-589cc6fc2515)
