### PR TITLE
[ext] Adjustements in style of Tournesol recommendations container

### DIFF
--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -24,8 +24,16 @@
     "description": "Title of the main Tournesol container."
   },
   "learnMore": {
-    "message": "learn more",
+    "message": "Learn more",
     "description": "Invite the users to learn more about the project (should be very short)."
+  },
+  "refreshRecommendations": {
+    "message": "Refresh",
+    "description": "Button title to refresh the Tournesol container content with other videos."
+  },
+  "seeMoreRecommendations": {
+    "message": "See more videos",
+    "description": "Button title to expand the Tournesol container to show more recommended videos."
   },
   "views": {
     "message": "$1 views",

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -27,6 +27,12 @@
     "message": "En savoir plus",
     "description": "Inviter les utilisateurs à en savoir plus sur le projet (texte très court)."
   },
+  "refreshRecommendations": {
+    "message": "Rafraîchir"
+  },
+  "seeMoreRecommendations": {
+    "message": "Voir plus de vidéos"
+  },
   "views": {
     "message": "$1 vues",
     "description": "Affiche le nombre de vues d'une vidéo."

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -387,7 +387,7 @@ html[dark] #tournesol_campaign_button {
 
 #tournesol_container.search #tournesol_refresh_button,
 #tournesol_container.search #tournesol_expand_button,
-#tournesol_container.search .video_card .dot {
+#tournesol_container.search .video_tournesol_rating .dot {
   display: none;
 }
 
@@ -436,10 +436,7 @@ html[dark] #tournesol_campaign_button {
   display: flex;
   flex-direction: row-reverse;
   justify-content: flex-end;
-}
-
-#tournesol_container.search .video_channel_details :first-child {
-  margin-left: 8px;
+  column-gap: 16px;
 }
 
 #tournesol_view_more_results {

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -12,7 +12,7 @@
 
   margin-left: 0;
   margin-right: 0;
-  margin-top: 45px;
+  margin-top: 24px;
   margin-bottom: 16px; /* 40px for tournesol container - 24px for margin-top of youtube recommendations */
 
   padding: var(--ts-container-padding);
@@ -98,13 +98,13 @@ html[dark] #tournesol_banner_close_icon {
   font-family: 'Roboto', 'Arial', sans-serif;
   font-size: 22px;
   font-weight: normal;
-  margin-right: auto;
 }
 
 #tournesol_link {
-  color: var(--yt-spec-text-primary);
+  color: var(--yt-spec-text-secondary);
   font-family: 'Roboto', 'Arial', sans-serif;
-  align-self: flex-start;
+  font-size: 12px;
+  margin-right: auto;
 }
 
 #ts_container_bottom_action_bar {
@@ -130,11 +130,6 @@ html[dark] #tournesol_campaign_button {
   opacity: 1;
 }
 
-#tournesol_refresh_button {
-  float: right;
-  margin-top: 4px;
-}
-
 .video_title_link,
 .video_channel_link {
   text-decoration: none;
@@ -147,7 +142,7 @@ html[dark] #tournesol_campaign_button {
 
 .tournesol_score_logo {
   width: 16px;
-  margin-right: 4px;
+  vertical-align: text-top;
 }
 
 .tournesol_mui_like_button {

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -133,11 +133,18 @@ html[dark] #tournesol_campaign_button {
 .video_title_link,
 .video_channel_link {
   text-decoration: none;
+}
+
+.video_title_link {
   color: inherit;
 }
 
 .video_channel_link {
-  text-decoration: underline;
+  color: var(--yt-spec-text-secondary);
+}
+
+.video_channel_link:hover {
+  color: var(--yt-spec-text-primary);
 }
 
 .tournesol_score_logo {

--- a/browser-extension/src/models/tournesolContainer/TournesolContainer.js
+++ b/browser-extension/src/models/tournesolContainer/TournesolContainer.js
@@ -165,7 +165,9 @@ export class TournesolContainer {
     bottomActionBar.id = 'ts_container_bottom_action_bar';
     const expand_button = document.createElement('button');
     expand_button.id = 'tournesol_expand_button';
-    expand_button.title = chrome.i18n.getMessage('seeMoreRecommendations');
+    if (!this.isExpanded) {
+      expand_button.title = chrome.i18n.getMessage('seeMoreRecommendations');
+    }
 
     // A new button is created on each video loading, the image must be loaded accordingly
     fetch(

--- a/browser-extension/src/models/tournesolContainer/TournesolContainer.js
+++ b/browser-extension/src/models/tournesolContainer/TournesolContainer.js
@@ -144,7 +144,8 @@ export class TournesolContainer {
 
     // Refresh button
     const refreshButton = document.createElement('button');
-    refreshButton.setAttribute('id', 'tournesol_refresh_button');
+    refreshButton.id = 'tournesol_refresh_button';
+    refreshButton.title = chrome.i18n.getMessage('refreshRecommendations');
     fetch(chrome.runtime.getURL('images/sync-alt.svg'))
       .then((r) => r.text())
       .then((svg) => (refreshButton.innerHTML = svg));
@@ -163,7 +164,8 @@ export class TournesolContainer {
     const bottomActionBar = document.createElement('div');
     bottomActionBar.id = 'ts_container_bottom_action_bar';
     const expand_button = document.createElement('button');
-    expand_button.setAttribute('id', 'tournesol_expand_button');
+    expand_button.id = 'tournesol_expand_button';
+    expand_button.title = chrome.i18n.getMessage('seeMoreRecommendations');
 
     // A new button is created on each video loading, the image must be loaded accordingly
     fetch(

--- a/browser-extension/src/models/tournesolContainer/TournesolContainer.js
+++ b/browser-extension/src/models/tournesolContainer/TournesolContainer.js
@@ -110,6 +110,15 @@ export class TournesolContainer {
     tournesolTitle.append(chrome.i18n.getMessage('recommendedByTournesol'));
     topActionBar.append(tournesolTitle);
 
+    // Learn more
+    const learnMore = document.createElement('a');
+    learnMore.id = 'tournesol_link';
+    learnMore.href = 'https://tournesol.app?utm_source=extension';
+    learnMore.target = '_blank';
+    learnMore.rel = 'noopener';
+    learnMore.append(chrome.i18n.getMessage('learnMore'));
+    topActionBar.append(learnMore);
+
     // Display the campaign button only if there is a banner.
     if (this.banner.bannerShouldBeDisplayed()) {
       const campaignButton = document.createElement('button');
@@ -146,15 +155,6 @@ export class TournesolContainer {
       this.recommendations.loadRecommandations();
     };
     topActionBar.append(refreshButton);
-
-    // Learn more
-    const learnMore = document.createElement('a');
-    learnMore.id = 'tournesol_link';
-    learnMore.href = 'https://tournesol.app?utm_source=extension';
-    learnMore.target = '_blank';
-    learnMore.rel = 'noopener';
-    learnMore.append(chrome.i18n.getMessage('learnMore'));
-    topActionBar.append(learnMore);
 
     return topActionBar;
   }


### PR DESCRIPTION
Minor changes, mostly CSS
- Make style of channel links consistent with Youtube video cards (no underline, and hover effect)
- Fix vertical alignment of container header, and align all buttons to the right
- Add "title" tooltips on "refresh" and "expand" buttons
- Fix missing separator between "views" and "date" in search results

|Before|After|
|-|-|
|![image](https://github.com/tournesol-app/tournesol/assets/4726554/995305f3-ef84-455f-abad-7d2a6d6f36a4)|![image](https://github.com/tournesol-app/tournesol/assets/4726554/2e57095e-7c56-46bc-941e-c395f9324c80)


