### PR TITLE
[front] style: add missing content padding in the Rate Later page

### DIFF
--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -193,6 +193,7 @@ const RateLaterPage = () => {
           spacing={2}
           justifyContent="space-between"
           alignItems="stretch"
+          sx={{ p: 1 }}
         >
           <Grid item sm={6} display="flex" width="100%">
             <Paper sx={{ p: 2, display: 'flex', width: '100%' }}>
@@ -257,6 +258,7 @@ const RateLaterPage = () => {
               variant="subtitle1"
               mb={0}
               sx={{
+                p: 1,
                 '& strong': {
                   color: 'secondary.main',
                   fontSize: '1.4em',

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -183,7 +183,7 @@ const RateLaterPage = () => {
   return (
     <>
       <ContentHeader title={t('myRateLaterListPage.title')} />
-      <ContentBox noMinPaddingX maxWidth="lg">
+      <ContentBox maxWidth="lg">
         <Box display={'flex'} justifyContent={'end'} mb={2}>
           <PreferencesIconButtonLink hash="#rate_later" />
         </Box>
@@ -193,7 +193,6 @@ const RateLaterPage = () => {
           spacing={2}
           justifyContent="space-between"
           alignItems="stretch"
-          sx={{ p: 1 }}
         >
           <Grid item sm={6} display="flex" width="100%">
             <Paper sx={{ p: 2, display: 'flex', width: '100%' }}>
@@ -258,7 +257,6 @@ const RateLaterPage = () => {
               variant="subtitle1"
               mb={0}
               sx={{
-                p: 1,
                 '& strong': {
                   color: 'secondary.main',
                   fontSize: '1.4em',


### PR DESCRIPTION
I found that some padding on the rate later page would make it look better on mobile.

Without padding (current state):

<img width="392" alt="Screenshot 2023-05-29 at 21 28 19" src="https://github.com/tournesol-app/tournesol/assets/8818081/0dbc1b5c-fddb-4126-afd5-a9e9b3e3ad27">

With some padding (this PR):

<img width="390" alt="Screenshot 2023-05-29 at 21 29 00" src="https://github.com/tournesol-app/tournesol/assets/8818081/127bb77f-a9f8-45fd-bd94-5175cf656f18">
