### PR TITLE
[back] fix: handle uploader and duration filters for the recommendation page preview

### DIFF
--- a/backend/tournesol/views/preview_recommendations.py
+++ b/backend/tournesol/views/preview_recommendations.py
@@ -60,7 +60,15 @@ def get_preview_recommendations_redirect_params(request):
     query = QueryDict("", mutable=True)
 
     for (key, value) in params.items():
-        if key == "language":
+        if key == "uploader":
+            query["metadata[uploader]"] = params[key]
+        elif key == "duration_lte":
+            # Durations are in seconds in the backend but minutes in the frontend URL
+            query["metadata[duration:lte:int]"] = int(params[key]) * 60
+        elif key == "duration_gte":
+            # Durations are in seconds in the backend but minutes in the frontend URL
+            query["metadata[duration:gte:int]"] = int(params[key]) * 60
+        elif key == "language":
             languages = [lang for lang in value.split(",") if lang != ""]
             if languages:
                 query.setlist("metadata[language]", languages)
@@ -283,6 +291,7 @@ class DynamicWebsitePreviewRecommendations(BasePreviewAPIView, PollsRecommendati
     @method_decorator(cache_page_no_i18n(CACHE_RECOMMENDATIONS_PREVIEW))
     @extend_schema(exclude=True)
     def get(self, request, *args, **kwargs):
+        print("HELLO")
         upscale_ratio = self.upscale_ratio
 
         preview_image = Image.new("RGBA", (440 * upscale_ratio, 240 * upscale_ratio), "#FAFAFA")

--- a/backend/tournesol/views/preview_recommendations.py
+++ b/backend/tournesol/views/preview_recommendations.py
@@ -291,7 +291,6 @@ class DynamicWebsitePreviewRecommendations(BasePreviewAPIView, PollsRecommendati
     @method_decorator(cache_page_no_i18n(CACHE_RECOMMENDATIONS_PREVIEW))
     @extend_schema(exclude=True)
     def get(self, request, *args, **kwargs):
-        print("HELLO")
         upscale_ratio = self.upscale_ratio
 
         preview_image = Image.new("RGBA", (440 * upscale_ratio, 240 * upscale_ratio), "#FAFAFA")


### PR DESCRIPTION
Previews for links such as https://tournesol.app/recommendations?language=fr&uploader=Tout+Simplement+%E2%80%93+Kurzgesagt&unsafe=true&duration_lte=7&duration_gte=1 do not filter correctly the expected videos