### PR TITLE
solves unmounting and memory leak issues of ComparisonSeries

### DIFF
--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -128,12 +128,14 @@ const ComparisonSeries = ({
    * series.
    */
   useEffect(() => {
+    let isMounted = true;
+
     async function getAlternativesAsync(
       getAlts: () => Promise<Array<Entity | Recommendation>>
     ) {
       const alts = await getAlts();
       if (alts.length > 0) {
-        setAlternatives(alts);
+        if (isMounted) setAlternatives(alts);
         return alts;
       }
       return [];
@@ -145,7 +147,7 @@ const ComparisonSeries = ({
         (c) => c.entity_a.uid + '/' + c.entity_b.uid
       );
 
-      setComparisonsMade(formattedComparisons);
+      if (isMounted) setComparisonsMade(formattedComparisons);
       return formattedComparisons;
     }
 
@@ -158,23 +160,29 @@ const ComparisonSeries = ({
       Promise.all([comparisonsPromise, alternativesPromise])
         .then(([comparisons, entities]) => {
           if (resumable && comparisons.length > 0) {
-            setStep(comparisons.length);
+            if (isMounted) setStep(comparisons.length);
           }
 
           if (entities && initialize.current && (uidA === '' || uidB === '')) {
-            setFirstComparisonParams(
-              genInitialComparisonParams(entities, comparisons, uidA, uidB)
-            );
+            if (isMounted) {
+              setFirstComparisonParams(
+                genInitialComparisonParams(entities, comparisons, uidA, uidB)
+              );
+            }
           }
         })
         .then(() => {
-          setIsLoading(false);
+          if (isMounted) setIsLoading(false);
         });
     } else {
       // stop loading if no series is going to be rendered
-      setIsLoading(false);
+      if (isMounted) setIsLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const afterSubmitCallback = (

--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -128,14 +128,14 @@ const ComparisonSeries = ({
    * series.
    */
   useEffect(() => {
-    let isMounted = true;
+    if (skipped) return;
 
     async function getAlternativesAsync(
       getAlts: () => Promise<Array<Entity | Recommendation>>
     ) {
       const alts = await getAlts();
       if (alts.length > 0) {
-        if (isMounted) setAlternatives(alts);
+        setAlternatives(alts);
         return alts;
       }
       return [];
@@ -147,7 +147,7 @@ const ComparisonSeries = ({
         (c) => c.entity_a.uid + '/' + c.entity_b.uid
       );
 
-      if (isMounted) setComparisonsMade(formattedComparisons);
+      setComparisonsMade(formattedComparisons);
       return formattedComparisons;
     }
 
@@ -160,29 +160,23 @@ const ComparisonSeries = ({
       Promise.all([comparisonsPromise, alternativesPromise])
         .then(([comparisons, entities]) => {
           if (resumable && comparisons.length > 0) {
-            if (isMounted) setStep(comparisons.length);
+            setStep(comparisons.length);
           }
 
           if (entities && initialize.current && (uidA === '' || uidB === '')) {
-            if (isMounted) {
-              setFirstComparisonParams(
-                genInitialComparisonParams(entities, comparisons, uidA, uidB)
-              );
-            }
+            setFirstComparisonParams(
+              genInitialComparisonParams(entities, comparisons, uidA, uidB)
+            );
           }
         })
         .then(() => {
-          if (isMounted) setIsLoading(false);
+          setIsLoading(false);
         });
     } else {
       // stop loading if no series is going to be rendered
-      if (isMounted) setIsLoading(false);
+      setIsLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-
-    return () => {
-      isMounted = false;
-    };
   }, []);
 
   const afterSubmitCallback = (


### PR DESCRIPTION
Solves #1519 by declaring a variable `isMounted` in the useEffect of `<ComparisonSeries>`. This variable checks if the component is mounted whenever we call any setState within the useEffect.

Working behavior can be seen below:

https://github.com/tournesol-app/tournesol/assets/20269286/6531876c-8c0f-4bfb-94d0-dd5202588575
 
I request you to test it as well and let me know if there are any changes to be made.