### PR TITLE
[dev-env][back] refresh dev-env dataset, update `load_public_dataset` to read trust scores

### DIFF
--- a/backend/ml/management/commands/ml_train.py
+++ b/backend/ml/management/commands/ml_train.py
@@ -8,14 +8,19 @@ from vouch.trust_algo import trust_algo
 
 
 class Command(BaseCommand):
-    """
-    Runs Machine Learning task, to update scores periodically
-    """
-    help = "Runs the ml"
+    help = "Runs Machine Learning tasks, to update scores periodically"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--no-trust-algo",
+            action="store_true",
+            help="Disable trust scores computation and preserve existing trust_score values",
+        )
 
     def handle(self, *args, **options):
-        # Update "trust_score" for all users
-        trust_algo()
+        if not options["no_trust_algo"]:
+            # Update "trust_score" for all users
+            trust_algo()
 
         # Update scores for all polls
         for poll in Poll.objects.filter(active=True):

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.3"
 services:
   db:
     container_name: tournesol-dev-db
-    image: ${DB_IMAGE:-ghcr.io/tournesol-app/postgres-dev-env:2022-11-09}
+    image: ${DB_IMAGE:-ghcr.io/tournesol-app/postgres-dev-env:2023-06-01}
     user: ${DB_UID}:${DB_GID}
     volumes:
       - ./db-data:/var/lib/postgresql/data

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -69,7 +69,7 @@ describe('Comparison page', () => {
   });
 
   describe('video selectors', () => {
-    const videoAUrl = 'https://www.youtube.com/watch?v=u83A7DUNMHs';
+    const videoAUrl = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
 
     it('support pasting YouTube URLs', () => {
       cy.visit('/comparison');
@@ -104,15 +104,15 @@ describe('Comparison page', () => {
         .type(videoAUrl.split('?v=')[1], {delay: 0});
 
       // wait for the auto filled video to be replaced
-      cy.contains('Science4VeryAll');
+      cy.contains('5 IA surpuissantes');
 
       // the video title, upload date, and the number of views must be displayed
       cy.get('div[data-testid=video-card-info]').first().within(() => {
         cy.contains(
-          'Science4VeryAll : Lê fait enfin un effort de vulgarisation sur Étincelles !!',
+          '5 IA surpuissantes',
           {matchCase: false}
         ).should('be.visible');
-        cy.contains('2021-11-22', {matchCase: false}).should('be.visible');
+        cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
         cy.contains('views', {matchCase: false}).should('be.visible');
       });
     })


### PR DESCRIPTION
* The management command `load_public_dataset` read the "new" dataset format instead of comparison.csv only
* The dev-env database contains non-null `trust_score` values, imported from the public dataset.
   As the vouchers are not included in the dataset and to preserve realistic values, the "trust algo" is not executed when importing the dataset.
* All users with a trust_score > 0.5 are created with a fictional trusted email address. This previous implementation used a random status with 10% probabilty to be trusted.
* The new database built in image [`ghcr.io/tournesol-app/postgres-dev-env:2023-06-01` ](https://github.com/tournesol-app/tournesol/pkgs/container/postgres-dev-env/98006768?tag=2023-06-01) has been initialized with `./run-docker-compose.sh download --user-sampling 0.06`