### PR TITLE
[back] fix: server errors on recommendation and preview when duration filter is empty

### DIFF
--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -103,7 +103,7 @@ class EntityType(ABC):
                 return func(value)
             except ValueError as exc:
                 raise ValidationError(
-                    f"invalid value '{value}' for function '{asked_func}"
+                    f"invalid value '{value}' for function '{asked_func}'"
                 ) from exc
         return value
 

--- a/backend/tournesol/entities/base.py
+++ b/backend/tournesol/entities/base.py
@@ -99,7 +99,12 @@ class EntityType(ABC):
         func = cls._get_meta_filter_func(asked_func)
 
         if func:
-            return func(value)
+            try:
+                return func(value)
+            except ValueError as exc:
+                raise ValidationError(
+                    f"invalid value '{value}' for function '{asked_func}"
+                ) from exc
         return value
 
     @classmethod

--- a/backend/tournesol/tests/test_api_polls.py
+++ b/backend/tournesol/tests/test_api_polls.py
@@ -347,7 +347,12 @@ class PollsRecommendationsTestCase(TestCase):
         response = self.client.get(
             "/polls/videos/recommendations/?metadata[duration__lte::int]=10"
         )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_anon_can_list_videos_duration_reject_empty_value(self):
+        response = self.client.get(
+            "/polls/videos/recommendations/?metadata[duration:lte:int]="
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_can_list_recommendations_with_score_mode(self):

--- a/backend/tournesol/tests/test_api_preview.py
+++ b/backend/tournesol/tests/test_api_preview.py
@@ -469,6 +469,11 @@ class DynamicRecommendationsPreviewTestCase(TestCase):
         # No filter should be present in the redirection
         self.assertEqual(response.headers["location"], f"{self.preview_internal_url}/?")
 
+    def test_recommendations_preview_empty_fields(self):
+        response = self.client.get(f"{self.preview_url}/?duration_lte&duration_gte")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers["location"], f"{self.preview_internal_url}/?")
+
     def test_recommendations_preview_internal_route(self):
         response = self.client.get(f"{self.preview_internal_url}/?metadata[language]=fr")
         self.assertEqual(response.status_code, 200)

--- a/backend/tournesol/views/preview_recommendations.py
+++ b/backend/tournesol/views/preview_recommendations.py
@@ -64,11 +64,15 @@ def get_preview_recommendations_redirect_params(request):
         if key == "uploader":
             query["metadata[uploader]"] = params[key]
         elif key == "duration_lte":
+            if value == "":
+                continue
             # Durations are in seconds in the backend but minutes in the frontend URL
-            query["metadata[duration:lte:int]"] = int(params[key]) * 60
+            query["metadata[duration:lte:int]"] = f"{int(params[key]) * 60}"
         elif key == "duration_gte":
+            if value == "":
+                continue
             # Durations are in seconds in the backend but minutes in the frontend URL
-            query["metadata[duration:gte:int]"] = int(params[key]) * 60
+            query["metadata[duration:gte:int]"] = f"{int(params[key]) * 60}"
         elif key == "language":
             languages = [lang for lang in value.split(",") if lang != ""]
             if languages:


### PR DESCRIPTION
2 distinct views where the server error could occur, when trying to parsing empty string as int:
 * on recommendation preview, when transforming the query into API parameters
 * on recommendations route, when applying the "filter_func" (i.e the `:int` transformation)