### PR TITLE
[dev-env] improvement: define separate volume for node_modules

### DIFF
--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - yarn install --frozen-lockfile && ./scripts/generate-services-from-openapi.sh && yarn run $$START_SCRIPT
     volumes:
       - ../frontend:/frontend
+      - type: volume  # Use non-mounted volume for better performance with Docker Desktop (esp. on MacOS and Windows)
+        target: /frontend/node_modules
     ports:
       - "127.0.0.1:3000:3000"
     networks:


### PR DESCRIPTION
`node_modules` contains a _lot_ of small files, and this contributes to make the dev-env initialisation really slow on some systems when mounted volumes introduce a significant overhead. This was observed when using Docker Desktop on Windows or MacOS.

Using a separate volume (non shared with the host filesystem) should improve performance.