### PR TITLE
[solidago] fix missing license classifier in package

### DIFF
--- a/solidago/pyproject.toml
+++ b/solidago/pyproject.toml
@@ -14,6 +14,7 @@ license = "LGPL-3.0-or-later"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
 ]
 keywords = ["tournesol", "collaborative recommendations", "judgement aggregation", "comparison based", "mehestan"]
 dependencies = [

--- a/solidago/src/solidago/__version__.py
+++ b/solidago/src/solidago/__version__.py
@@ -1,4 +1,4 @@
 # Changing the version will automatically publish a new version on PyPI.
 # (see /.github/workflows/solidago-publish.yml)
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"


### PR DESCRIPTION
The `license` field defined in "pyproject.toml" in #1638  is not enough :shrug: 