### PR TITLE
[front] style: harmonize and simplify the layout of the settings pages

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -459,7 +459,7 @@
     "notificationsEmailResearch": "Receive invitations to research studies and surveys about the project (~ 6 per year).",
     "emailNotifications": "Email notifications",
     "joinTheResearchStudies": "Join the research studies!",
-    "joinTheResearchStudiesDesc": "Several research projects have chosen Tournesol or its community as the subject their study. If you would like to help advance science, we invite you to accept email invitations. You will be notified when new projects are launched."
+    "joinTheResearchStudiesDesc": "Several research projects have chosen Tournesol or its community as the subject their study. If you would like to help advance science, we invite you to accept email invitations. You will be notified when any studies begin."
   },
   "videosUserSettingsForm": {
     "recommendations": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -467,7 +467,7 @@
     "notificationsEmailResearch": "Recevoir les invitations aux études de recherches et aux enquêtes concernant le projet (~ 6 par an).",
     "emailNotifications": "Notifications par e-mail",
     "joinTheResearchStudies": "Participez aux études de recherche !",
-    "joinTheResearchStudiesDesc": "Plusieurs projets de recherches ont choisi Tournesol ou sa communauté comme objet d'étude. Si vous souhaitez faire avancer la science nous vous invitons à accepter de recevoir des invitations par e-mail. Vous serez ainsi notifié·e lorsque de nouveaux projets démarrent."
+    "joinTheResearchStudiesDesc": "Plusieurs projets de recherches ont choisi Tournesol ou sa communauté comme sujet d'étude. Si vous souhaitez faire avancer la science nous vous invitons à accepter de recevoir des invitations par e-mail. Vous serez notifié·e lorsque d'éventuelles études démarreront."
   },
   "videosUserSettingsForm": {
     "recommendations": {

--- a/frontend/src/components/SettingsSection.tsx
+++ b/frontend/src/components/SettingsSection.tsx
@@ -25,7 +25,7 @@ const SettingsSection = ({
     );
 
   return (
-    <Grid item container sx={{ paddingBottom: '40px' }}>
+    <Grid item container>
       <Grid item xs={12}>
         <Box marginBottom={2}>
           {sectionTitle}

--- a/frontend/src/features/settings/preferences/TournesolUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/TournesolUserSettingsForm.tsx
@@ -12,7 +12,10 @@ import {
 } from 'src/features/settings/userSettingsSlice';
 import { useNotifications, useScrollToLocation } from 'src/hooks';
 import { theme } from 'src/theme';
-import { subSectionBreakpoints } from 'src/pages/settings/layout';
+import {
+  mainSectionGridSpacing,
+  subSectionBreakpoints,
+} from 'src/pages/settings/layout';
 import {
   ApiError,
   BlankEnum,
@@ -175,36 +178,44 @@ const TournesolUserSettingsForm = () => {
 
   return (
     <form onSubmit={handleSubmit}>
-      <SettingsSection
-        title={t('preferences.generalPreferences')}
-        {...subSectionBreakpoints}
+      <Grid
+        container
+        direction="column"
+        alignItems="stretch"
+        spacing={mainSectionGridSpacing}
       >
-        <GeneralUserSettingsForm
-          notificationsEmailResearch={notificationsEmailResearch}
-          setNotificationsEmailResearch={setNotificationsEmailResearch}
-          notificationsEmailNewFeatures={notificationsEmailNewFeatures}
-          setNotificationsEmailNewFeatures={setNotificationsEmailNewFeatures}
-        />
-      </SettingsSection>
-      <SettingsSection
-        title={`${t('preferences.preferencesRegarding')} ${t('poll.videos')}`}
-        {...subSectionBreakpoints}
-      >
-        <VideosPollUserSettingsForm
-          compUiWeeklyColGoalDisplay={compUiWeeklyColGoalDisplay}
-          setCompUiWeeklyColGoalDisplay={setCompUiWeeklyColGoalDisplay}
-          displayedCriteria={displayedCriteria}
-          setDisplayedCriteria={setDisplayedCriteria}
-          rateLaterAutoRemoval={rateLaterAutoRemoval}
-          setRateLaterAutoRemoval={setRateLaterAutoRemoval}
-          recoDefaultUnsafe={recoDefaultUnsafe}
-          setRecoDefaultUnsafe={setRecoDefaultUnsafe}
-          recoDefaultUploadDate={recoDefaultUploadDate}
-          setRecoDefaultUploadDate={setRecoDefaultUploadDate}
-          apiErrors={apiErrors}
-        />
-      </SettingsSection>
+        <SettingsSection
+          title={t('preferences.generalPreferences')}
+          {...subSectionBreakpoints}
+        >
+          <GeneralUserSettingsForm
+            notificationsEmailResearch={notificationsEmailResearch}
+            setNotificationsEmailResearch={setNotificationsEmailResearch}
+            notificationsEmailNewFeatures={notificationsEmailNewFeatures}
+            setNotificationsEmailNewFeatures={setNotificationsEmailNewFeatures}
+          />
+        </SettingsSection>
+        <SettingsSection
+          title={`${t('preferences.preferencesRegarding')} ${t('poll.videos')}`}
+          {...subSectionBreakpoints}
+        >
+          <VideosPollUserSettingsForm
+            compUiWeeklyColGoalDisplay={compUiWeeklyColGoalDisplay}
+            setCompUiWeeklyColGoalDisplay={setCompUiWeeklyColGoalDisplay}
+            displayedCriteria={displayedCriteria}
+            setDisplayedCriteria={setDisplayedCriteria}
+            rateLaterAutoRemoval={rateLaterAutoRemoval}
+            setRateLaterAutoRemoval={setRateLaterAutoRemoval}
+            recoDefaultUnsafe={recoDefaultUnsafe}
+            setRecoDefaultUnsafe={setRecoDefaultUnsafe}
+            recoDefaultUploadDate={recoDefaultUploadDate}
+            setRecoDefaultUploadDate={setRecoDefaultUploadDate}
+            apiErrors={apiErrors}
+          />
+        </SettingsSection>
+      </Grid>
       <Box
+        mt={4}
         position="sticky"
         bottom={theme.spacing(2)}
         zIndex={theme.zIndex.fab}

--- a/frontend/src/pages/settings/account/Account.tsx
+++ b/frontend/src/pages/settings/account/Account.tsx
@@ -10,6 +10,7 @@ import ExportAllDataForm from 'src/features/settings/account/ExportAllDataForm';
 import SettingsMenu from 'src/features/settings/SettingsMenu';
 import {
   mainSectionBreakpoints,
+  mainSectionGridSpacing,
   settingsMenuBreakpoints,
   subSectionBreakpoints,
 } from 'src/pages/settings/layout';
@@ -33,7 +34,7 @@ export const AccountPage = () => {
             item
             direction="column"
             alignItems="stretch"
-            spacing={3}
+            spacing={mainSectionGridSpacing}
             {...mainSectionBreakpoints}
           >
             <SettingsSection
@@ -48,13 +49,13 @@ export const AccountPage = () => {
             >
               <PasswordForm />
             </SettingsSection>
-            <Box marginTop={8} />
             <SettingsSection
               title={t('settings.exportAllData')}
               {...subSectionBreakpoints}
             >
               <ExportAllDataForm />
             </SettingsSection>
+            <Box mt={8}></Box>
             <SettingsSection
               title={
                 <Typography

--- a/frontend/src/pages/settings/layout.ts
+++ b/frontend/src/pages/settings/layout.ts
@@ -10,4 +10,5 @@ export const mainSectionBreakpoints = {
   lg: 10,
   xl: 10,
 };
+export const mainSectionGridSpacing = 8;
 export const subSectionBreakpoints = { xs: 12, sm: 12, md: 12, lg: 12, xl: 10 };

--- a/frontend/src/pages/settings/profile/Profile.tsx
+++ b/frontend/src/pages/settings/profile/Profile.tsx
@@ -8,6 +8,7 @@ import SettingsMenu from 'src/features/settings/SettingsMenu';
 import ProfileForm from 'src/features/settings/profile/ProfileForm';
 import {
   mainSectionBreakpoints,
+  mainSectionGridSpacing,
   settingsMenuBreakpoints,
   subSectionBreakpoints,
 } from 'src/pages/settings/layout';
@@ -28,6 +29,7 @@ function ProfilePage() {
             item
             direction="column"
             alignItems="stretch"
+            spacing={mainSectionGridSpacing}
             {...mainSectionBreakpoints}
           >
             <SettingsSection title={t('profile')} {...subSectionBreakpoints}>


### PR DESCRIPTION
The `<SettingsSection>` component is a Grid item but not all Grid using it have the same spacing, making all settings pages slightly different. Moreover this component was using a custom padding bottom in addition to the spacing used by its parent, making it difficult to precisely control the whole Grid layout without updating the container and its items at the same time.

This PR introduces a new layout variable `mainSectionGridSpacing` that can be used in all settings page to keep their layout coherent, and removes the hardcoded  padding bottom of `<SettingsSection>` to ease the Grid customization.