### PR TITLE
[back] feat: /accounts/register/ can now officially save user settings

### DIFF
--- a/backend/core/serializers/user.py
+++ b/backend/core/serializers/user.py
@@ -9,6 +9,7 @@ from rest_registration.api.serializers import (
 )
 
 from core.models.user import User
+from core.serializers.user_settings import TournesolUserSettingsSerializer
 
 RESERVED_USERNAMES = ["me"]
 
@@ -33,6 +34,7 @@ def _validate_username(value):
 
 class RegisterUserSerializer(DefaultRegisterUserSerializer):
     email = iunique_email
+    settings = TournesolUserSettingsSerializer(required=False)
 
     def validate_username(self, value):
         return _validate_username(value)

--- a/backend/core/serializers/user_settings.py
+++ b/backend/core/serializers/user_settings.py
@@ -6,6 +6,15 @@ from tournesol.models.poll import Poll
 from tournesol.utils.video_language import ACCEPTED_LANGUAGE_CODES
 
 
+class GeneralUserSettingsSerializer(serializers.Serializer):
+    """
+    The general user settings that are not related to Tournesol polls.
+    """
+
+    notifications_email__research = serializers.BooleanField(required=False)
+    notifications_email__new_features = serializers.BooleanField(required=False)
+
+
 class GenericPollUserSettingsSerializer(serializers.Serializer):
     """
     The settings common to each poll.
@@ -82,17 +91,9 @@ class VideosPollUserSettingsSerializer(GenericPollUserSettingsSerializer):
         return default_languages
 
 
-class GeneralUserSettingsSerializer(serializers.Serializer):
-    """
-    The general user settings that are not related to Tournesol polls.
-    """
-
-    notifications_email__research = serializers.BooleanField(required=False)
-    notifications_email__new_features = serializers.BooleanField(required=False)
-
-
 class TournesolUserSettingsSerializer(serializers.Serializer):
-    """A representation of all settings of the Tournesol project.
+    """
+    A representation of all user's settings of the Tournesol project.
 
     This representation includes poll-agnostic settings in addition to the
     specific settings of each poll.

--- a/backend/core/serializers/user_settings.py
+++ b/backend/core/serializers/user_settings.py
@@ -93,7 +93,7 @@ class VideosPollUserSettingsSerializer(GenericPollUserSettingsSerializer):
 
 class TournesolUserSettingsSerializer(serializers.Serializer):
     """
-    A representation of all user's settings of the Tournesol project.
+    A representation of all user settings of the Tournesol project.
 
     This representation includes poll-agnostic settings in addition to the
     specific settings of each poll.


### PR DESCRIPTION
**related to** #1654

---

It looks like the user settings were already handled by `/accounts/register/` but not properly documented in the API schema.

I used the `TournesolUserSettingsSerializer` so that all settings can be defined during the registration. In case of need, we can always limit the settings to the general settings (the notifications) or even to specific fields.

(I also re-ordered the serializers in the `user_settings.py` module, so that the most generic appear first.)