### PR TITLE
[back] Restrict writable fields in /accounts routes

### DIFF
--- a/backend/core/serializers/user.py
+++ b/backend/core/serializers/user.py
@@ -36,6 +36,10 @@ class RegisterUserSerializer(DefaultRegisterUserSerializer):
     email = iunique_email
     settings = TournesolUserSettingsSerializer(required=False)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.Meta.read_only_fields += ("trust_score",)
+
     def validate_username(self, value):
         return _validate_username(value)
 
@@ -53,10 +57,11 @@ class RegisterEmailSerializer(DefaultRegisterEmailSerializer):
 
 
 class UserProfileSerializer(DefaultUserProfileSerializer):
-    is_trusted = BooleanField()
+    is_trusted = BooleanField(read_only=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Default writable fields are defined in setting REST_REGISTRATION.USER_EDITABLE_FIELDS
         extra_fields = ("is_trusted",)
         self.Meta.fields += extra_fields
         self.Meta.read_only_fields += extra_fields

--- a/backend/core/tests/test_api_accounts.py
+++ b/backend/core/tests/test_api_accounts.py
@@ -29,10 +29,49 @@ class AccountRegisterMixin:
         )
 
 
-class AccountsRegisterUserSettingsTestCase(AccountRegisterMixin, TestCase):
+class AccountRegisterUser(AccountRegisterMixin, TestCase):
     """
     TestCase of the /accounts/register/ API related to the user settings.
     """
+    def test_register_account(self):
+        new_username = self._non_existing_username
+        new_email = self._non_existing_email
+
+        response = self.client.post(
+            "/accounts/register/",
+            data={
+                "username": new_username,
+                "email": new_email,
+                "password": "very_uncommon_pwd",
+                "password_confirm": "very_uncommon_pwd",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response_data = response.json()
+        self.assertEqual(response_data["username"], new_username)
+        new_user = User.objects.get(username=new_username)
+        self.assertEqual(new_user.email, new_email)
+
+    def test_register_account_trust_score_read_only(self):
+        new_username = self._non_existing_username
+        new_email = self._non_existing_email
+        response = self.client.post(
+            "/accounts/register/",
+            data={
+                "username": new_username,
+                "email": new_email,
+                "password": "very_uncommon_pwd",
+                "password_confirm": "very_uncommon_pwd",
+                "trust_score": 0.99,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response_data = response.json()
+        self.assertEqual(response_data["trust_score"], None)
+        new_user = User.objects.get(username=new_username)
+        self.assertEqual(new_user.trust_score, None)
 
     def test_register_account_with_settings(self) -> None:
         """

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -117,6 +117,11 @@ REST_REGISTRATION = {
     "REGISTER_EMAIL_VERIFICATION_URL": REST_REGISTRATION_MAIN_URL + "verify-email/",
     "REGISTER_SERIALIZER_CLASS": "core.serializers.user.RegisterUserSerializer",
     "PROFILE_SERIALIZER_CLASS": "core.serializers.user.UserProfileSerializer",
+    "USER_EDITABLE_FIELDS": [
+        "username",
+        "first_name",
+        "last_name",
+    ],
     "VERIFICATION_FROM_EMAIL": "noreply@tournesol.app",
     "REGISTER_VERIFICATION_EMAIL_TEMPLATES": {
         "html_body": "accounts/register/body.html",


### PR DESCRIPTION
Fixes 2 minor oversights with the serializers used by `/accounts/register` and `/accounts/profile`:

1. `settings` was readable and writable on `/accounts/profile`: as dedicated routes exist to update (and validate) the settings, I think it makes sense to remove this possibility.   
This does not affect `/accounts/register` where the `settings` field has been explicitly defined in #1656

2. `trust_score` was readable and writable on both routes. It's now read-only (e.g used by the Voucher page). 
It was not deliberate to have it writable here. This is not exploitable though, as the value is recomputed on each run before entity scores are updated.

