### PR TITLE
[front] chore: update the OpenAPI schema

### DIFF
--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -729,7 +729,7 @@ paths:
       responses:
         '200':
           content:
-            application/json:
+            image/*:
               schema:
                 type: string
                 format: binary
@@ -757,7 +757,7 @@ paths:
       responses:
         '200':
           content:
-            application/json:
+            image/*:
               schema:
                 type: string
                 format: binary
@@ -780,7 +780,48 @@ paths:
       responses:
         '200':
           content:
-            application/json:
+            image/*:
+              schema:
+                type: string
+                format: binary
+          description: ''
+  /preview/faq/:
+    get:
+      operationId: preview_faq_retrieve
+      description: FAQ preview
+      parameters:
+      - in: query
+        name: scrollTo
+        schema:
+          type: string
+      tags:
+      - preview
+      security:
+      - oauth2:
+        - read write groups
+      responses:
+        '200':
+          content:
+            image/*:
+              schema:
+                type: string
+                format: binary
+          description: ''
+  /preview/recommendations/:
+    get:
+      operationId: preview_recommendations_retrieve
+      description: |-
+        Preview of a Recommendations page.
+        Returns HTTP redirection to transform the query parameters into the format used by the backend.
+      tags:
+      - preview
+      security:
+      - oauth2:
+        - read write groups
+      responses:
+        '200':
+          content:
+            image/jpeg:
               schema:
                 type: string
                 format: binary
@@ -3290,7 +3331,7 @@ components:
     PatchedTournesolUserSettingsRequest:
       type: object
       description: |-
-        A representation of all settings of the Tournesol project.
+        A representation of all user settings of the Tournesol project.
 
         This representation includes poll-agnostic settings in addition to the
         specific settings of each poll.
@@ -3328,18 +3369,6 @@ components:
           nullable: true
           description: Last name
           maxLength: 100
-        trust_score:
-          type: number
-          format: double
-          nullable: true
-          description: The trust score assigned to the user based on trusted domains
-            and the vouching mechanism.
-        settings:
-          type: object
-          additionalProperties: {}
-          description: The user' preferences.
-        is_trusted:
-          type: boolean
     Poll:
       type: object
       properties:
@@ -3547,6 +3576,7 @@ components:
         trust_score:
           type: number
           format: double
+          readOnly: true
           nullable: true
           description: The trust score assigned to the user based on trusted domains
             and the vouching mechanism.
@@ -3558,6 +3588,7 @@ components:
       - email
       - id
       - password
+      - trust_score
       - username
     RegisterUserRequest:
       type: object
@@ -3595,12 +3626,6 @@ components:
           nullable: true
           description: Last name
           maxLength: 100
-        trust_score:
-          type: number
-          format: double
-          nullable: true
-          description: The trust score assigned to the user based on trusted domains
-            and the vouching mechanism.
         settings:
           type: object
           additionalProperties: {}
@@ -3796,7 +3821,7 @@ components:
           type: string
           description: Used as an URL slug. Leave it blank to automatically build
             it from the title.
-          maxLength: 50
+          maxLength: 255
           pattern: ^[-a-zA-Z0-9_]+$
         title:
           type: string
@@ -3806,7 +3831,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Date and time of the Talk (please mind the server time zone).
+          description: Date and time of the Talk according to the server time.
         date_as_tz_europe_paris:
           type: string
           nullable: true
@@ -3824,7 +3849,7 @@ components:
           type: string
           format: uri
           nullable: true
-          description: Allow the users to join the Talk.
+          description: Allows the users to join the Talk.
           maxLength: 200
         youtube_link:
           type: string
@@ -3838,7 +3863,7 @@ components:
     TournesolUserSettings:
       type: object
       description: |-
-        A representation of all settings of the Tournesol project.
+        A representation of all user settings of the Tournesol project.
 
         This representation includes poll-agnostic settings in addition to the
         specific settings of each poll.
@@ -3850,7 +3875,7 @@ components:
     TournesolUserSettingsRequest:
       type: object
       description: |-
-        A representation of all settings of the Tournesol project.
+        A representation of all user settings of the Tournesol project.
 
         This representation includes poll-agnostic settings in addition to the
         specific settings of each poll.
@@ -3906,19 +3931,24 @@ components:
         trust_score:
           type: number
           format: double
+          readOnly: true
           nullable: true
           description: The trust score assigned to the user based on trusted domains
             and the vouching mechanism.
         settings:
           type: object
           additionalProperties: {}
+          readOnly: true
           description: The user' preferences.
         is_trusted:
           type: boolean
+          readOnly: true
       required:
       - email
       - id
       - is_trusted
+      - settings
+      - trust_score
       - username
     UserProfileRequest:
       type: object
@@ -3949,20 +3979,7 @@ components:
           nullable: true
           description: Last name
           maxLength: 100
-        trust_score:
-          type: number
-          format: double
-          nullable: true
-          description: The trust score assigned to the user based on trusted domains
-            and the vouching mechanism.
-        settings:
-          type: object
-          additionalProperties: {}
-          description: The user' preferences.
-        is_trusted:
-          type: boolean
       required:
-      - is_trusted
       - username
     VerifyEmail:
       type: object


### PR DESCRIPTION
I ran `yarn update-schema` to update our `openapi.yaml`.

To avoid conflicts as much as possible I removed the changes that are going to be merged by the PR adding settings at sign up (https://github.com/tournesol-app/tournesol/pull/1657).

I also removed the changes related to the recently added banners API as they are already present in a feature branch (https://github.com/tournesol-app/tournesol/tree/front-add_banners).