### PR TITLE
[back] sec: upgrade Django to 4.1.10 (from 4.1.9)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@
 
 # Full stack Web Framework used for Tournesol's backend
 # https://docs.djangoproject.com
-Django==4.1.9
+Django==4.1.10
 # Used for fields computed on save for Django models
 # See https://github.com/brechin/django-computed-property/
 django-computed-property==0.3.0
@@ -62,3 +62,4 @@ requests==2.31.0
 tweepy==4.14.0
 # dotenv for .env file
 python-dotenv==1.0.0
+


### PR DESCRIPTION
Fix:
- CVE-2023-36053

See:
- https://docs.djangoproject.com/en/4.1/releases/4.1.10/