### PR TITLE
[front] fix: remove the extra trailing slash in `recommendations`

### DIFF
--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Open Tournesol directly from Youtube",
   "permissions": [
     "https://tournesol.app/",

--- a/browser-extension/src/models/tournesolContainer/TournesolContainer.js
+++ b/browser-extension/src/models/tournesolContainer/TournesolContainer.js
@@ -74,7 +74,7 @@ export class TournesolContainer {
         'tournesol_mui_like_button view_more_link small';
       view_more_link.target = '_blank';
       view_more_link.rel = 'noopener';
-      view_more_link.href = `https://tournesol.app/recommendations/?search=${
+      view_more_link.href = `https://tournesol.app/recommendations?search=${
         this.recommendations.searchQuery
       }&language=${this.recommendations.recommandationsLanguages.replaceAll(
         ',',

--- a/frontend/src/features/frame/components/topbar/Search.tsx
+++ b/frontend/src/features/frame/components/topbar/Search.tsx
@@ -55,7 +55,7 @@ const Search = () => {
     searchParams.delete('search');
     searchParams.append('search', search);
     searchParams.delete('offset');
-    history.push('/recommendations/?' + searchParams.toString());
+    history.push('/recommendations?' + searchParams.toString());
   };
 
   return (


### PR DESCRIPTION
This will fix the duplicate entries we have in Plausible.

In the following capture, we can see both `recommendation` and `recommendations/`

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/7271c62c-95e8-433b-8227-5db69b876ebc)
