### PR TITLE
WIP / [tests] fix: attempt to fix the failing Signup test

### DIFF
--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -67,7 +67,5 @@ describe('Signup', () => {
     // [THEN] only the selected notifications are checked
     cy.get('[data-testid=notifications_email__research]').should('be.checked');
     cy.get('[data-testid=notifications_email__new_features]').should('not.be.checked');
-
-    // trigger CI
   });
 });

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -53,6 +53,7 @@ describe('Signup', () => {
     cy.get('[data-testid=notifications_email__research]').check();
 
     cy.contains('Sign up').click();
+    cy.contains('verification link').should('be.visible');
     cy.getEmailLink().then(verificationLink => cy.visit(verificationLink));
 
     // [WHEN] the user goes to its preference page
@@ -65,6 +66,6 @@ describe('Signup', () => {
 
     // [THEN] only the selected notifications are checked
     cy.get('[data-testid=notifications_email__research]').should('be.checked');
-    cy.get('input[name=notifications_email__new_features]').should('not.be.checked');
+    cy.get('[data-testid=notifications_email__new_features]').should('not.be.checked');
   });
 });

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -38,7 +38,7 @@ describe('Signup', () => {
     cy.get('form input[name=accept_terms]').check();
 
     // [GIVEN] the notification "research" is selected
-    cy.get('input[name=notifications_email__research]').check();
+    cy.get('[data-testid=notifications_email__research]').check();
 
     cy.contains('Sign up').click();
     cy.getEmailLink().then(verificationLink => cy.visit(verificationLink));

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -51,7 +51,7 @@ describe('Signup', () => {
     cy.visit('/settings/preferences');
 
     // [THEN] only the selected notifications are checked
-    cy.get('input[name=notifications_email__research]').should('be.checked');
+    cy.get('[data-testid=notifications_email__research]').should('be.checked');
     cy.get('input[name=notifications_email__new_features]').should('not.be.checked');
   });
 });

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -49,7 +49,7 @@ describe('Signup', () => {
     cy.get('input[name="password"]').click().type('tourne50l').type('{enter}');
     cy.visit('/settings/preferences');
 
-    cy.wait(400);
+    cy.wait(2000);
     // [THEN] only the selected notifications are checked
     cy.get('[data-testid=notifications_email__research]').should('be.checked');
     cy.get('input[name=notifications_email__new_features]').should('not.be.checked');

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -67,5 +67,7 @@ describe('Signup', () => {
     // [THEN] only the selected notifications are checked
     cy.get('[data-testid=notifications_email__research]').should('be.checked');
     cy.get('[data-testid=notifications_email__new_features]').should('not.be.checked');
+
+    // trigger CI
   });
 });

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -47,9 +47,9 @@ describe('Signup', () => {
     cy.contains('Log in').click();
     cy.focused().type('test-register');
     cy.get('input[name="password"]').click().type('tourne50l').type('{enter}');
-    cy.wait(500);
     cy.visit('/settings/preferences');
 
+    cy.wait(400);
     // [THEN] only the selected notifications are checked
     cy.get('[data-testid=notifications_email__research]').should('be.checked');
     cy.get('input[name=notifications_email__new_features]').should('not.be.checked');

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -47,9 +47,10 @@ describe('Signup', () => {
     cy.contains('Log in').click();
     cy.focused().type('test-register');
     cy.get('input[name="password"]').click().type('tourne50l').type('{enter}');
-    cy.visit('/settings/preferences');
 
     cy.wait(2000);
+    cy.visit('/settings/preferences');
+
     // [THEN] only the selected notifications are checked
     cy.get('[data-testid=notifications_email__research]').should('be.checked');
     cy.get('input[name=notifications_email__new_features]').should('not.be.checked');

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -47,7 +47,7 @@ describe('Signup', () => {
     cy.get('input[name=username]').type('test-register');
     cy.get('input[name=password]').type('tourne50l');
     cy.get('input[name=password_confirm]').type('tourne50l');
-    cy.get('form input[name=accept_terms]').check();
+    cy.get('input[name=accept_terms]').check();
 
     // [GIVEN] the notification "research" is selected
     cy.get('[data-testid=notifications_email__research]').check();

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -1,8 +1,20 @@
 describe('Signup', () => {
 
   beforeEach(() => {
-    cy.sql("DELETE FROM oauth2_provider_refreshtoken");
-    cy.sql("DELETE FROM oauth2_provider_accesstoken");
+    cy.sql(`
+      DELETE FROM oauth2_provider_refreshtoken
+      WHERE user_id IN (
+        SELECT user_id FROM core_user WHERE username = 'test-register'
+      );
+    `);
+
+    cy.sql(`
+      DELETE FROM oauth2_provider_accesstoken
+      WHERE user_id IN (
+        SELECT user_id FROM core_user WHERE username = 'test-register'
+      );
+    `);
+
     cy.sql("DELETE FROM core_user where username = 'test-register'");
   });
 
@@ -48,7 +60,7 @@ describe('Signup', () => {
     cy.focused().type('test-register');
     cy.get('input[name="password"]').click().type('tourne50l').type('{enter}');
 
-    cy.wait(2000);
+    cy.wait(500);
     cy.visit('/settings/preferences');
 
     // [THEN] only the selected notifications are checked


### PR DESCRIPTION
This PR tries to fix the e2e test related to the sign up that was failing very often.

The `cy.getEmailLink()` should now be called after the activation link is sent, and the user should be able to log in properly after a sign up and a verification.