### PR TITLE
[front] feat: display a description of the video selector tabs

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -112,6 +112,10 @@
   },
   "tabsBox": {
     "errorOnLoading": "An error occurred while loading the results.",
+    "rateLater": "Your rate-later videos will appear here. You can add some to your list by clicking on the '+' sign on the video cards. You can also add them directly from the extension.",
+    "compared": "Compared videos will appear here.",
+    "recommendations": "Recommended videos will appear here.",
+    "toConnect": "Videos isolated from your other comparisons appear here. Compare them to improve the recommendations",
     "emptyList": "This list is empty."
   },
   "stackedCandidatesPaper": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -115,7 +115,7 @@
     "rateLater": "Your rate-later videos will appear here. You can add some to your list by clicking on the '+' sign on the video cards. You can also add them directly from the extension.",
     "compared": "Compared videos will appear here.",
     "recommendations": "Recommended videos will appear here.",
-    "toConnect": "Videos isolated from your other comparisons appear here. Compare them to improve the recommendations",
+    "toConnect": "Videos isolated from your other comparisons appear here. Compare them to improve the recommendations.",
     "emptyList": "This list is empty."
   },
   "stackedCandidatesPaper": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -112,9 +112,9 @@
   },
   "tabsBox": {
     "errorOnLoading": "An error occurred while loading the results.",
-    "rateLater": "Your rate-later videos will appear here. You can add some to your list by clicking on the '+' sign on the video cards. You can also add them directly from the extension.",
-    "compared": "Compared videos will appear here.",
-    "recommendations": "Recommended videos will appear here.",
+    "rateLater": "Your rate-later videos appear here. You can add some to your list by clicking on the '+' sign on the video cards. You can also add them directly from the extension.",
+    "compared": "Compared videos appear here.",
+    "recommendations": "Videos recommended by the community appear here.",
     "toConnect": "Videos isolated from your other comparisons appear here. Compare them to improve the recommendations.",
     "emptyList": "This list is empty."
   },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -112,7 +112,7 @@
   },
   "tabsBox": {
     "errorOnLoading": "An error occurred while loading the results.",
-    "rateLater": "Your rate-later videos appear here. You can add some to your list by clicking on the '+' sign on the video cards. You can also add them directly from the extension.",
+    "rateLater": "Your rate-later videos appear here. You can add some to your list by clicking on the '+' sign on the video cards. You can also add them directly from <2>the extension</2>.",
     "compared": "Compared videos appear here.",
     "recommendations": "Videos recommended by the community appear here.",
     "toConnect": "Videos isolated from your other comparisons appear here. Compare them to improve the recommendations.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -116,6 +116,10 @@
   },
   "tabsBox": {
     "errorOnLoading": "Une erreur est survenue lors du chargement des résultats.",
+    "rateLater": "Vos vidéos à comparer plus tard apparaissent ici. Vous pouvez en ajouter sur le site web via le bouton '+'. Vous pouvez aussi les ajouter directement depuis YouTube grâce à l'extension.",
+    "compared": "Les vidéos comparées apparaissent ici.",
+    "recommendations": "Les vidéos recommandées apparaissent ici.",
+    "toConnect": "Les vidéos isolées du reste de vos comparaisons apparaissent ici. Comparez-les pour améliorer les recommandations.",
     "emptyList": "Cette liste est vide."
   },
   "stackedCandidatesPaper": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -117,8 +117,8 @@
   "tabsBox": {
     "errorOnLoading": "Une erreur est survenue lors du chargement des résultats.",
     "rateLater": "Vos vidéos à comparer plus tard apparaissent ici. Vous pouvez en ajouter sur le site web via le bouton '+'. Vous pouvez aussi les ajouter directement depuis YouTube grâce à <2>l'extension</2>.",
-    "compared": "Les vidéos comparées apparaissent ici.",
-    "recommendations": "Les vidéos recommandées apparaissent ici.",
+    "compared": "Les vidéos que vous avez comparées apparaissent ici.",
+    "recommendations": "Les vidéos recommandées par la communauté apparaissent ici.",
     "toConnect": "Les vidéos isolées du reste de vos comparaisons apparaissent ici. Comparez-les pour améliorer les recommandations.",
     "emptyList": "Cette liste est vide."
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -116,7 +116,7 @@
   },
   "tabsBox": {
     "errorOnLoading": "Une erreur est survenue lors du chargement des résultats.",
-    "rateLater": "Vos vidéos à comparer plus tard apparaissent ici. Vous pouvez en ajouter sur le site web via le bouton '+'. Vous pouvez aussi les ajouter directement depuis YouTube grâce à l'extension.",
+    "rateLater": "Vos vidéos à comparer plus tard apparaissent ici. Vous pouvez en ajouter sur le site web via le bouton '+'. Vous pouvez aussi les ajouter directement depuis YouTube grâce à <2>l'extension</2>.",
     "compared": "Les vidéos comparées apparaissent ici.",
     "recommendations": "Les vidéos recommandées apparaissent ici.",
     "toConnect": "Les vidéos isolées du reste de vos comparaisons apparaissent ici. Comparez-les pour améliorer les recommandations.",

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -163,6 +163,7 @@ const VideoInput = ({ value, onChange, otherUid }: Props) => {
               value: value,
               onChange: onChange,
             }}
+            displayDescription={true}
           />
         </SelectorPopper>
       </Box>

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -163,7 +163,7 @@ const VideoInput = ({ value, onChange, otherUid }: Props) => {
               value: value,
               onChange: onChange,
             }}
-            displayDescription={true}
+            displayDescription={false}
           />
         </SelectorPopper>
       </Box>

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Autocomplete,
   Box,
@@ -20,6 +20,7 @@ import { getAllCandidates } from 'src/utils/polls/presidentielle2022';
 import SelectorListBox, { EntitiesTab } from './EntityTabsBox';
 import SelectorPopper from './SelectorPopper';
 import { useLoginState } from 'src/hooks';
+import { ComparisonsCountContext } from 'src/pages/comparisons/Comparison';
 
 // in milliseconds
 const TYPING_DELAY = 50;
@@ -42,6 +43,8 @@ const VideoInput = ({ value, onChange, otherUid }: Props) => {
     (theme: Theme) => `${theme.breakpoints.down('sm')}, (pointer: coarse)`,
     { noSsr: true }
   );
+
+  const comparisonsCount = useContext(ComparisonsCountContext).comparisonsCount;
 
   const handleOptionClick = (uid: string) => {
     onChange(uid);
@@ -163,7 +166,7 @@ const VideoInput = ({ value, onChange, otherUid }: Props) => {
               value: value,
               onChange: onChange,
             }}
-            displayDescription={false}
+            displayDescription={comparisonsCount < 8}
           />
         </SelectorPopper>
       </Box>

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -4,13 +4,12 @@ import {
   Tab,
   Paper,
   Alert,
-  Button,
   Link,
   Box,
   Typography,
   IconButton,
 } from '@mui/material';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { RelatedEntityObject } from 'src/utils/types';
 import { RowEntityCard } from 'src/components/entity/EntityCard';
 import LoaderWrapper from 'src/components/LoaderWrapper';
@@ -60,7 +59,6 @@ const TabInfo = ({
   const { t } = useTranslation();
 
   const emptyListMessages: { [key: string]: string } = {
-    'rate-later': 'tabsBox.rateLater',
     'recently-compared': 'tabsBox.compared',
     recommendations: 'tabsBox.recommendations',
     unconnected: 'tabsBox.toConnect',
@@ -76,16 +74,25 @@ const TabInfo = ({
         {t(emptyListMessages[messageKey])}
         {messageKey === 'rate-later' ? (
           <Box display="flex" justifyContent="flex-end">
-            <Button
-              color="info"
-              size="small"
-              variant="outlined"
-              component={Link}
-              href={getWebExtensionUrl()}
-              target="_blank"
-            >
-              {t('videos.dialogs.tutorial.installTheExtension')}
-            </Button>
+            <Typography fontSize="100%">
+              <Trans t={t} i18nKey="tabsBox.rateLater">
+                Your rate-later videos appear here. You can add some to your
+                list by clicking on the &apos;+&apos; sign on the video cards.
+                You can also add them directly from{' '}
+                <Link
+                  href={getWebExtensionUrl()}
+                  target="_blank"
+                  rel="noopener"
+                  sx={{
+                    color: 'revert',
+                    textDecoration: 'revert',
+                  }}
+                >
+                  the extension
+                </Link>
+                .
+              </Trans>
+            </Typography>
           </Box>
         ) : undefined}
       </Alert>

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -42,7 +42,7 @@ export enum TabStatus {
 }
 
 const TabError = ({ message }: { message: string }) => (
-  <Typography variant="subtitle1" paragraph m={2} mt={0} color="neutral.main">
+  <Typography variant="subtitle1" paragraph m={2} color="neutral.main">
     {message}
   </Typography>
 );
@@ -65,38 +65,36 @@ const TabInfo = ({
   };
 
   return (
-    <Box pb={2}>
-      <Alert
-        severity="info"
-        onClose={canClose ? handleClose : undefined}
-        icon={false}
-      >
-        {t(emptyListMessages[messageKey])}
-        {messageKey === 'rate-later' ? (
-          <Box display="flex" justifyContent="flex-end">
-            <Typography fontSize="100%">
-              <Trans t={t} i18nKey="tabsBox.rateLater">
-                Your rate-later videos appear here. You can add some to your
-                list by clicking on the &apos;+&apos; sign on the video cards.
-                You can also add them directly from{' '}
-                <Link
-                  href={getWebExtensionUrl()}
-                  target="_blank"
-                  rel="noopener"
-                  sx={{
-                    color: 'revert',
-                    textDecoration: 'revert',
-                  }}
-                >
-                  the extension
-                </Link>
-                .
-              </Trans>
-            </Typography>
-          </Box>
-        ) : undefined}
-      </Alert>
-    </Box>
+    <Alert
+      severity="info"
+      onClose={canClose ? handleClose : undefined}
+      icon={false}
+    >
+      {t(emptyListMessages[messageKey])}
+      {messageKey === 'rate-later' ? (
+        <Box display="flex" justifyContent="flex-end">
+          <Typography fontSize="100%">
+            <Trans t={t} i18nKey="tabsBox.rateLater">
+              Your rate-later videos appear here. You can add some to your list
+              by clicking on the &apos;+&apos; sign on the video cards. You can
+              also add them directly from{' '}
+              <Link
+                href={getWebExtensionUrl()}
+                target="_blank"
+                rel="noopener"
+                sx={{
+                  color: 'revert',
+                  textDecoration: 'revert',
+                }}
+              >
+                the extension
+              </Link>
+              .
+            </Trans>
+          </Typography>
+        </Box>
+      ) : undefined}
+    </Alert>
   );
 };
 
@@ -172,9 +170,6 @@ const EntityTabsBox = ({
           cursor: onSelectEntity && 'pointer',
           '&:hover': {
             bgcolor: 'grey.100',
-          },
-          '&:first-of-type': {
-            marginTop: 1,
           },
         },
         width: width,

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -50,9 +50,11 @@ const TabError = ({ message }: { message: string }) => (
 
 const TabInfo = ({
   messageKey,
+  canClose = true,
   handleClose,
 }: {
   messageKey: string;
+  canClose?: boolean;
   handleClose?: () => void;
 }) => {
   const { t } = useTranslation();
@@ -66,7 +68,11 @@ const TabInfo = ({
 
   return (
     <Box pb={2}>
-      <Alert severity="info" onClose={handleClose} icon={false}>
+      <Alert
+        severity="info"
+        onClose={canClose ? handleClose : undefined}
+        icon={false}
+      >
         {t(emptyListMessages[messageKey])}
         {messageKey === 'rate-later' ? (
           <Box display="flex" justifyContent="flex-end">
@@ -95,7 +101,7 @@ const EntityTabsBox = ({
   maxHeight = '40vh',
   withLink = false,
   entityTextInput,
-  displayDescription,
+  displayDescription = false,
 }: Props) => {
   const { t } = useTranslation();
 
@@ -104,6 +110,8 @@ const EntityTabsBox = ({
   const [options, setOptions] = useState<RelatedEntityObject[]>([]);
   const [toggleDescription, setToggleDescription] =
     useState(displayDescription);
+
+  const canCloseDescription = !displayDescription;
 
   const handleToggleDescription = () => {
     setToggleDescription(!toggleDescription);
@@ -206,6 +214,7 @@ const EntityTabsBox = ({
             handleClose={() => {
               setToggleDescription(false);
             }}
+            canClose={canCloseDescription}
           />
         ) : (
           <Box display="flex" justifyContent="flex-end">

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -87,10 +87,6 @@ const EntityTabsBox = ({
   const [toggleDescription, setToggleDescription] =
     useState(displayDescription);
 
-  const closeDescription = () => {
-    setToggleDescription(false);
-  };
-
   useEffect(() => {
     const tab = tabs.find((t) => t.name === tabValue);
     if (!tab) {
@@ -160,7 +156,10 @@ const EntityTabsBox = ({
         textColor="secondary"
         indicatorColor="secondary"
         value={tabValue}
-        onChange={(e, value) => setTabValue(value)}
+        onChange={(e, value) => {
+          setToggleDescription(true);
+          setTabValue(value);
+        }}
         variant="scrollable"
         scrollButtons="auto"
         sx={{
@@ -180,7 +179,12 @@ const EntityTabsBox = ({
         sx={{ overflowY: 'scroll' }}
       >
         {toggleDescription && (
-          <TabError messageKey={tabValue} handleClose={closeDescription} />
+          <TabError
+            messageKey={tabValue}
+            handleClose={() => {
+              setToggleDescription(false);
+            }}
+          />
         )}
         {status === TabStatus.Error ? (
           <TabError messageKey={'error'} />

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -95,7 +95,7 @@ const EntityTabsBox = ({
   maxHeight = '40vh',
   withLink = false,
   entityTextInput,
-  displayDescription = false,
+  displayDescription,
 }: Props) => {
   const { t } = useTranslation();
 

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -115,13 +115,13 @@ const EntityTabsBox = ({
   const [tabValue, setTabValue] = useState(tabs[0]?.name);
   const [status, setStatus] = useState<TabStatus>(TabStatus.Ok);
   const [options, setOptions] = useState<RelatedEntityObject[]>([]);
-  const [toggleDescription, setToggleDescription] =
+  const [isDescriptionVisible, setIsDescriptionVisible] =
     useState(displayDescription);
 
   const canCloseDescription = !displayDescription;
 
   const handleToggleDescription = () => {
-    setToggleDescription(!toggleDescription);
+    setIsDescriptionVisible(!isDescriptionVisible);
   };
 
   useEffect(() => {
@@ -215,11 +215,11 @@ const EntityTabsBox = ({
         isLoading={status === TabStatus.Loading}
         sx={{ overflowY: 'scroll' }}
       >
-        {toggleDescription ? (
+        {isDescriptionVisible ? (
           <TabInfo
             messageKey={tabValue}
             handleClose={() => {
-              setToggleDescription(false);
+              setIsDescriptionVisible(false);
             }}
             canClose={canCloseDescription}
           />

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -55,6 +55,12 @@ const displayWeeklyCollectiveGoal = (
   return false;
 };
 
+interface ComparisonsCountContextValue {
+  comparisonsCount: number;
+}
+export const ComparisonsCountContext =
+  React.createContext<ComparisonsCountContextValue>({ comparisonsCount: 0 });
+
 /**
  * Display the standard comparison UI or the poll tutorial.
  */
@@ -193,7 +199,14 @@ const ComparisonPage = () => {
                   weeklyCollectiveGoalDisplay,
                   isEmbedded
                 ) && <CollectiveGoalWeeklyProgress />}
-                <Comparison autoFillSelectorA={true} autoFillSelectorB={true} />
+                <ComparisonsCountContext.Provider
+                  value={{ comparisonsCount: comparisonsCount }}
+                >
+                  <Comparison
+                    autoFillSelectorA={true}
+                    autoFillSelectorB={true}
+                  />
+                </ComparisonsCountContext.Provider>
               </>
             ))}
         </Box>


### PR DESCRIPTION
**related to #1696**

---

We have multiple ways of handling the display of the description.

Different approaches :
- (1) Always displayed by default, if the user close it, it's stored locally
- (2) Never displayed, there is an icon if we want to show it manually
- (3) Displayed and cant close if NbComp < 2*TutoLength, then it has (2) behavior

(1) Everyone will see it at least once but we need to implement storage
(2) Users might not pay attention and never read the descriptions
(3) New users will see it since they are the ones who should need it the most but we don't give them the choice

![image](https://github.com/tournesol-app/tournesol/assets/89401728/07d8e92f-7b8e-47a8-9136-dac47991154e)
![image](https://github.com/tournesol-app/tournesol/assets/89401728/77477eda-cb8a-4b63-b370-4f6699923848)
