### PR TITLE
[back] feat: add the comparison__fill_entity_selector to the generic settings

### DIFF
--- a/backend/core/serializers/user_settings.py
+++ b/backend/core/serializers/user_settings.py
@@ -39,6 +39,9 @@ class GenericPollUserSettingsSerializer(serializers.Serializer):
     comparison__criteria_order = serializers.ListField(
         child=serializers.CharField(), required=False
     )
+
+    comparison__entity_selector_auto = serializers.BooleanField(required=False)
+
     comparison_ui__weekly_collective_goal_display = serializers.ChoiceField(
         choices=COMPONENT_DISPLAY_STATE, allow_blank=True, required=False
     )

--- a/backend/core/serializers/user_settings.py
+++ b/backend/core/serializers/user_settings.py
@@ -40,7 +40,7 @@ class GenericPollUserSettingsSerializer(serializers.Serializer):
         child=serializers.CharField(), required=False
     )
 
-    comparison__entity_selector_auto = serializers.BooleanField(required=False)
+    comparison__fill_entity_selector = serializers.BooleanField(required=False)
 
     comparison_ui__weekly_collective_goal_display = serializers.ChoiceField(
         choices=COMPONENT_DISPLAY_STATE, allow_blank=True, required=False

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -4362,6 +4362,8 @@ components:
           type: array
           items:
             type: string
+        comparison__entity_selector_auto:
+          type: boolean
         comparison_ui__weekly_collective_goal_display:
           oneOf:
           - $ref: '#/components/schemas/ComparisonUi_weeklyCollectiveGoalDisplayEnum'
@@ -4390,6 +4392,8 @@ components:
           items:
             type: string
             minLength: 1
+        comparison__entity_selector_auto:
+          type: boolean
         comparison_ui__weekly_collective_goal_display:
           oneOf:
           - $ref: '#/components/schemas/ComparisonUi_weeklyCollectiveGoalDisplayEnum'

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -4362,7 +4362,7 @@ components:
           type: array
           items:
             type: string
-        comparison__entity_selector_auto:
+        comparison__fill_entity_selector:
           type: boolean
         comparison_ui__weekly_collective_goal_display:
           oneOf:
@@ -4392,7 +4392,7 @@ components:
           items:
             type: string
             minLength: 1
-        comparison__entity_selector_auto:
+        comparison__fill_entity_selector:
           type: boolean
         comparison_ui__weekly_collective_goal_display:
           oneOf:


### PR DESCRIPTION
Will allow the user to chose between the current behavior (Tournesol chose a video for you) or this one designed with miro.

![image](https://github.com/tournesol-app/tournesol/assets/89401728/4665dedc-6ad8-4d6d-a70d-f60b16bc15fc)
