### PR TITLE
[front] feat: implement the fill entity selector feature

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -100,12 +100,14 @@
   "entitySelector": {
     "newVideo": "Select a new video automatically",
     "autoEntityButton": "Auto",
+    "autoEntityButtonLong": "Let Tournesol select a video",
     "suggestions": "Suggestions",
     "rateLater": "Rate later",
     "recentlyCompared": "Compared",
     "recommendations": "Top of the month",
     "unconnected": "To connect",
     "select": "Select",
+    "selectLong": "Select a video",
     "youtubeVideoUnavailable": "YouTube video unavailable.",
     "pasteUrlOrVideoId": "Paste URL or Video ID",
     "backButton": "Back"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -107,7 +107,7 @@
     "recommendations": "Top of the month",
     "unconnected": "To connect",
     "select": "Select",
-    "selectLong": "Select a video",
+    "selectAVideo": "Select a video",
     "youtubeVideoUnavailable": "YouTube video unavailable.",
     "pasteUrlOrVideoId": "Paste URL or Video ID",
     "backButton": "Back"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -99,8 +99,8 @@
   },
   "entitySelector": {
     "newVideo": "Select a new video automatically",
-    "autoEntityButton": "Auto",
-    "autoEntityButtonLong": "Let Tournesol select a video",
+    "auto": "Auto",
+    "letTournesolSelectAVideo": "Let Tournesol select a video",
     "suggestions": "Suggestions",
     "rateLater": "Rate later",
     "recentlyCompared": "Compared",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -103,8 +103,8 @@
   },
   "entitySelector": {
     "newVideo": "Sélectionner une nouvelle vidéo automatiquement",
-    "autoEntityButton": "Auto",
-    "autoEntityButtonLong": "Laisser Tournesol choisir une vidéo",
+    "auto": "Auto",
+    "letTournesolSelectAVideo": "Laisser Tournesol choisir une vidéo",
     "suggestions": "Suggestions",
     "rateLater": "À comparer",
     "recentlyCompared": "Comparées",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -43,7 +43,7 @@
     "thisElementIsNotAvailable": "Cet élément n'est plus disponible."
   },
   "score": {
-    "totalScoreBasedOnRankingChoice": "Score basé sur les critères de classement selectionnés"
+    "totalScoreBasedOnRankingChoice": "Score basé sur les critères de classement sélectionnés"
   },
   "pagination": {
     "showingCounts_one": "Élément {{firstElementIdx}} à {{lastElementIdx}} sur {{count}}",
@@ -76,7 +76,7 @@
   },
   "comparison": {
     "successfullySubmitted": "Comparaison bien enregistrée.",
-    "pleaseSelectTwoItems": "Selectionnez 2 éléments pour les comparer.",
+    "pleaseSelectTwoItems": "Sélectionnez 2 éléments pour les comparer.",
     "itemsAreSimilar": "Ces deux éléments sont très similaires, ce n'est probablement pas une bonne idée de les comparer.",
     "removeOptionalCriterias": "Supprimer les critères optionnels",
     "addOptionalCriterias": "Ajouter les critères optionnels",
@@ -102,14 +102,16 @@
     "skipTheSeries": "Passer la série"
   },
   "entitySelector": {
-    "newVideo": "Selectionner une nouvelle vidéo automatiquement",
+    "newVideo": "Sélectionner une nouvelle vidéo automatiquement",
     "autoEntityButton": "Auto",
+    "autoEntityButtonLong": "Laisser Tournesol choisir une vidéo",
     "suggestions": "Suggestions",
     "rateLater": "À comparer",
     "recentlyCompared": "Comparées",
     "recommendations": "Top du mois",
     "unconnected": "À relier",
-    "select": "Selectionner",
+    "select": "Sélectionner",
+    "selectLong": "Sélectionner une vidéo",
     "youtubeVideoUnavailable": "Vidéo YouTube indisponible.",
     "pasteUrlOrVideoId": "Coller une URL ou un ID de vidéo",
     "backButton": "Retour"

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -111,7 +111,7 @@
     "recommendations": "Top du mois",
     "unconnected": "À relier",
     "select": "Sélectionner",
-    "selectLong": "Sélectionner une vidéo",
+    "selectAVideo": "Sélectionner une vidéo",
     "youtubeVideoUnavailable": "Vidéo YouTube indisponible.",
     "pasteUrlOrVideoId": "Coller une URL ou un ID de vidéo",
     "backButton": "Retour"

--- a/frontend/src/components/entity/EmptyEntityCard.tsx
+++ b/frontend/src/components/entity/EmptyEntityCard.tsx
@@ -19,7 +19,13 @@ const useStyles = makeStyles({
   },
 });
 
-const EmptyEntityCard = ({ compact }: { compact?: boolean }) => {
+const EmptyEntityCard = ({
+  compact,
+  loading = false,
+}: {
+  compact?: boolean;
+  loading?: boolean;
+}) => {
   const classes = useStyles();
 
   return (
@@ -39,7 +45,7 @@ const EmptyEntityCard = ({ compact }: { compact?: boolean }) => {
         <img
           src="/svg/LogoSmall.svg"
           alt="logo"
-          className={classes.loadingEffect}
+          className={loading ? classes.loadingEffect : undefined}
           style={{ opacity: '0.3' }}
         />
       </Grid>

--- a/frontend/src/components/entity/EmptyEntityCard.tsx
+++ b/frontend/src/components/entity/EmptyEntityCard.tsx
@@ -19,13 +19,7 @@ const useStyles = makeStyles({
   },
 });
 
-const EmptyEntityCard = ({
-  compact,
-  loading = false,
-}: {
-  compact?: boolean;
-  loading?: boolean;
-}) => {
+const EmptyEntityCard = ({ compact }: { compact?: boolean }) => {
   const classes = useStyles();
 
   return (
@@ -45,7 +39,7 @@ const EmptyEntityCard = ({
         <img
           src="/svg/LogoSmall.svg"
           alt="logo"
-          className={loading ? classes.loadingEffect : undefined}
+          className={classes.loadingEffect}
           style={{ opacity: '0.3' }}
         />
       </Grid>

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -87,25 +87,29 @@ const AutoEntityButton = ({
 
   return (
     <Tooltip title={`${t('entitySelector.newVideo')}`} aria-label="new_video">
-      <Button
-        fullWidth={variant === 'full' ? true : false}
-        disabled={disabled}
-        color="secondary"
-        variant="outlined"
-        size="small"
-        onClick={askNewVideo}
-        startIcon={variant === 'full' ? undefined : <Autorenew />}
-        sx={
-          variant === 'full'
-            ? { minHeight: '100px', fontSize: '1rem' }
-            : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
-        }
-        data-testid={`auto-entity-button-${variant}`}
-      >
-        {variant === 'full'
-          ? t('entitySelector.letTournesolSelectAVideo')
-          : t('entitySelector.auto')}
-      </Button>
+      {/* A non-disabled element, such as <span>, is required by the Tooltip
+          component to properly listen to fired events. */}
+      <span>
+        <Button
+          fullWidth={variant === 'full' ? true : false}
+          disabled={disabled}
+          color="secondary"
+          variant="outlined"
+          size="small"
+          onClick={askNewVideo}
+          startIcon={variant === 'full' ? undefined : <Autorenew />}
+          sx={
+            variant === 'full'
+              ? { minHeight: '100px', fontSize: '1rem' }
+              : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
+          }
+          data-testid={`auto-entity-button-${variant}`}
+        >
+          {variant === 'full'
+            ? t('entitySelector.letTournesolSelectAVideo')
+            : t('entitySelector.auto')}
+        </Button>
+      </span>
     </Tooltip>
   );
 };

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -87,27 +87,25 @@ const AutoEntityButton = ({
 
   return (
     <Tooltip title={`${t('entitySelector.newVideo')}`} aria-label="new_video">
-      {/* A <span> element is required to allow wrapping a disabled button.  */}
-      <span>
-        <Button
-          disabled={disabled}
-          color="secondary"
-          variant="outlined"
-          size="small"
-          onClick={askNewVideo}
-          startIcon={variant === 'full' ? undefined : <Autorenew />}
-          sx={
-            variant === 'full'
-              ? { minWidth: '180px', minHeight: '100px', fontSize: '1rem' }
-              : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
-          }
-          data-testid={`auto-entity-button-${variant}`}
-        >
-          {variant === 'full'
-            ? t('entitySelector.letTournesolSelectAVideo')
-            : t('entitySelector.auto')}
-        </Button>
-      </span>
+      <Button
+        fullWidth={variant === 'full' ? true : false}
+        disabled={disabled}
+        color="secondary"
+        variant="outlined"
+        size="small"
+        onClick={askNewVideo}
+        startIcon={variant === 'full' ? undefined : <Autorenew />}
+        sx={
+          variant === 'full'
+            ? { minHeight: '100px', fontSize: '1rem' }
+            : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
+        }
+        data-testid={`auto-entity-button-${variant}`}
+      >
+        {variant === 'full'
+          ? t('entitySelector.letTournesolSelectAVideo')
+          : t('entitySelector.auto')}
+      </Button>
     </Tooltip>
   );
 };

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -101,6 +101,9 @@ const AutoEntityButton = ({
               ? { minWidth: '180px', minHeight: '100px', fontSize: '100%' }
               : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
           }
+          data-testid={
+            inSelector ? 'auto-entity-button-inSelector' : 'auto-entity-button'
+          }
         >
           {inSelector
             ? t('entitySelector.autoEntityButtonLong')

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -98,7 +98,7 @@ const AutoEntityButton = ({
           startIcon={variant === 'full' ? undefined : <Autorenew />}
           sx={
             variant === 'full'
-              ? { minWidth: '180px', minHeight: '100px', fontSize: '100%' }
+              ? { minWidth: '180px', minHeight: '100px', fontSize: '1rem' }
               : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
           }
           data-testid={`auto-entity-button-${variant}`}

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -13,7 +13,7 @@ interface Props {
   onClick: () => void;
   disabled?: boolean;
   autoFill?: boolean;
-  inSelector?: boolean;
+  variant?: 'compact' | 'full';
 }
 
 const AutoEntityButton = ({
@@ -23,7 +23,7 @@ const AutoEntityButton = ({
   onClick,
   disabled = false,
   autoFill = false,
-  inSelector = false,
+  variant = 'compact',
 }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
@@ -95,17 +95,15 @@ const AutoEntityButton = ({
           variant="outlined"
           size="small"
           onClick={askNewVideo}
-          startIcon={inSelector ? undefined : <Autorenew />}
+          startIcon={variant === 'full' ? undefined : <Autorenew />}
           sx={
-            inSelector
+            variant === 'full'
               ? { minWidth: '180px', minHeight: '100px', fontSize: '100%' }
               : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
           }
-          data-testid={
-            inSelector ? 'auto-entity-button-inSelector' : 'auto-entity-button'
-          }
+          data-testid={`auto-entity-button-${variant}`}
         >
-          {inSelector
+          {variant === 'full'
             ? t('entitySelector.letTournesolSelectAVideo')
             : t('entitySelector.auto')}
         </Button>

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -106,8 +106,8 @@ const AutoEntityButton = ({
           }
         >
           {inSelector
-            ? t('entitySelector.autoEntityButtonLong')
-            : t('entitySelector.autoEntityButton')}
+            ? t('entitySelector.letTournesolSelectAVideo')
+            : t('entitySelector.auto')}
         </Button>
       </span>
     </Tooltip>

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -13,6 +13,7 @@ interface Props {
   onClick: () => void;
   disabled?: boolean;
   autoFill?: boolean;
+  inSelector?: boolean;
 }
 
 const AutoEntityButton = ({
@@ -22,6 +23,7 @@ const AutoEntityButton = ({
   onClick,
   disabled = false,
   autoFill = false,
+  inSelector = false,
 }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
@@ -93,10 +95,16 @@ const AutoEntityButton = ({
           variant="outlined"
           size="small"
           onClick={askNewVideo}
-          startIcon={<Autorenew />}
-          sx={{ fontSize: { xs: '0.7rem', sm: '0.8rem' } }}
+          startIcon={inSelector ? undefined : <Autorenew />}
+          sx={
+            inSelector
+              ? { minWidth: '180px', minHeight: '100px', fontSize: '100%' }
+              : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
+          }
         >
-          {t('entitySelector.autoEntityButton')}
+          {inSelector
+            ? t('entitySelector.autoEntityButtonLong')
+            : t('entitySelector.autoEntityButton')}
         </Button>
       </span>
     </Tooltip>

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -155,7 +155,11 @@ const VideoInput = ({
               : { minWidth: '80px', fontSize: { xs: '0.7rem', sm: '0.8rem' } }
           }
           disableElevation
-          data-testid="entity-select-button"
+          data-testid={
+            inSelector
+              ? 'entity-select-button-inSelector'
+              : 'entity-select-button'
+          }
         >
           {inSelector
             ? t('entitySelector.selectLong')

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -28,14 +28,14 @@ interface Props {
   value: string;
   onChange: (value: string) => void;
   otherUid: string | null;
-  inSelector?: boolean;
+  variant?: 'compact' | 'full';
 }
 
 const VideoInput = ({
   value,
   onChange,
   otherUid,
-  inSelector = false,
+  variant = 'compact',
 }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
@@ -150,19 +150,15 @@ const VideoInput = ({
           variant="contained"
           color="secondary"
           sx={
-            inSelector
-              ? { minWidth: '180px', minHeight: '100px', fontSize: '100%' }
+            variant === 'full'
+              ? { width: '180px', minHeight: '100px', fontSize: '1rem' }
               : { minWidth: '80px', fontSize: { xs: '0.7rem', sm: '0.8rem' } }
           }
           disableElevation
-          data-testid={
-            inSelector
-              ? 'entity-select-button-inSelector'
-              : 'entity-select-button'
-          }
+          data-testid={`entity-select-button-${variant}`}
         >
-          {inSelector
-            ? t('entitySelector.selectLong')
+          {variant === 'full'
+            ? t('entitySelector.selectAVideo')
             : t('entitySelector.select')}
         </Button>
         <SelectorPopper

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -29,6 +29,7 @@ interface Props {
   onChange: (value: string) => void;
   otherUid: string | null;
   variant?: 'compact' | 'full';
+  disabled?: boolean;
 }
 
 const VideoInput = ({
@@ -36,6 +37,7 @@ const VideoInput = ({
   onChange,
   otherUid,
   variant = 'compact',
+  disabled = false,
 }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
@@ -155,6 +157,7 @@ const VideoInput = ({
           size="small"
           variant="contained"
           color="secondary"
+          disabled={disabled}
           sx={
             variant === 'full'
               ? { minHeight: '100px', fontSize: '1rem' }

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -28,9 +28,15 @@ interface Props {
   value: string;
   onChange: (value: string) => void;
   otherUid: string | null;
+  inSelector?: boolean;
 }
 
-const VideoInput = ({ value, onChange, otherUid }: Props) => {
+const VideoInput = ({
+  value,
+  onChange,
+  otherUid,
+  inSelector = false,
+}: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
 
@@ -143,11 +149,17 @@ const VideoInput = ({ value, onChange, otherUid }: Props) => {
           size="small"
           variant="contained"
           color="secondary"
-          sx={{ minWidth: '80px', fontSize: { xs: '0.7rem', sm: '0.8rem' } }}
+          sx={
+            inSelector
+              ? { minWidth: '180px', minHeight: '100px', fontSize: '100%' }
+              : { minWidth: '80px', fontSize: { xs: '0.7rem', sm: '0.8rem' } }
+          }
           disableElevation
           data-testid="entity-select-button"
         >
-          {t('entitySelector.select')}
+          {inSelector
+            ? t('entitySelector.selectLong')
+            : t('entitySelector.select')}
         </Button>
         <SelectorPopper
           modal={fullScreenModal}

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -143,15 +143,21 @@ const VideoInput = ({
 
   return (
     <ClickAwayListener onClickAway={() => setSuggestionsOpen(false)}>
-      <Box ref={selectorAnchor}>
+      <Box
+        ref={selectorAnchor}
+        sx={{
+          width: variant === 'full' ? '100%' : 'auto',
+        }}
+      >
         <Button
+          fullWidth={variant === 'full' ? true : false}
           onClick={toggleSuggestions}
           size="small"
           variant="contained"
           color="secondary"
           sx={
             variant === 'full'
-              ? { width: '180px', minHeight: '100px', fontSize: '1rem' }
+              ? { minHeight: '100px', fontSize: '1rem' }
               : { minWidth: '80px', fontSize: { xs: '0.7rem', sm: '0.8rem' } }
           }
           disableElevation

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -280,39 +280,49 @@ const EntitySelectorInnerAuth = ({
           <Box
             m={1}
             display="flex"
-            flexDirection={alignment === 'left' ? 'row' : 'row-reverse'}
+            flexDirection={
+              autoFill
+                ? alignment === 'left'
+                  ? 'row'
+                  : 'row-reverse'
+                : alignment !== 'left'
+                ? 'row'
+                : 'row-reverse'
+            }
             alignItems="center"
             justifyContent="space-between"
           >
-            <Grid
-              container
-              spacing={1}
-              display="flex"
-              direction={alignment === 'left' ? 'row' : 'row-reverse'}
-            >
-              <Grid item>
-                <EntitySelectButton
-                  value={inputValue || uid || ''}
-                  onChange={handleChange}
-                  otherUid={otherUid}
-                />
+            {autoFill && (
+              <Grid
+                container
+                spacing={1}
+                display="flex"
+                direction={alignment === 'left' ? 'row' : 'row-reverse'}
+              >
+                <Grid item>
+                  <EntitySelectButton
+                    value={inputValue || uid || ''}
+                    onChange={handleChange}
+                    otherUid={otherUid}
+                  />
+                </Grid>
+                <Grid item>
+                  <AutoEntityButton
+                    disabled={loading}
+                    currentUid={uid}
+                    otherUid={otherUid}
+                    onClick={() => {
+                      setLoading(true);
+                      setInputValue('');
+                    }}
+                    onResponse={(uid) => {
+                      uid ? onChange({ uid, rating: null }) : setLoading(false);
+                    }}
+                    autoFill={autoFill}
+                  />
+                </Grid>
               </Grid>
-              <Grid item>
-                <AutoEntityButton
-                  disabled={loading}
-                  currentUid={uid}
-                  otherUid={otherUid}
-                  onClick={() => {
-                    setLoading(true);
-                    setInputValue('');
-                  }}
-                  onResponse={(uid) => {
-                    uid ? onChange({ uid, rating: null }) : setLoading(false);
-                  }}
-                  autoFill={autoFill}
-                />
-              </Grid>
-            </Grid>
+            )}
             <Typography
               variant="h6"
               color="secondary"

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -341,7 +341,7 @@ const EntitySelectorInnerAuth = ({
             settings={showRatingControl ? toggleAction : undefined}
           ></EntityCard>
         ) : filled ? (
-          <EmptyEntityCard compact />
+          <EmptyEntityCard compact loading={loading} />
         ) : (
           <Grid container sx={entityCardMainSx}>
             <Grid

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -397,7 +397,7 @@ const EntitySelectorInnerAuth = ({
                           : setLoading(false);
                       }}
                       autoFill={filled}
-                      inSelector={true}
+                      variant="full"
                     />
                   </Grid>
                 </Grid>

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -372,7 +372,7 @@ const EntitySelectorInnerAuth = ({
                       value={inputValue || uid || ''}
                       onChange={handleChange}
                       otherUid={otherUid}
-                      inSelector={true}
+                      variant="full"
                     />
                   </Grid>
                   <Grid

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -144,7 +144,8 @@ const EntitySelectorInnerAuth = ({
 
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);
-  const [filled, setFilled] = useState(autoFill);
+
+  const [bigSelectors, setBigSelectors] = useState(!autoFill);
 
   const { availability: entityAvailability } = useEntityAvailable(
     value.uid ?? ''
@@ -196,7 +197,7 @@ const EntitySelectorInnerAuth = ({
       }
     }
     setLoading(false);
-    setFilled(true);
+    setBigSelectors(false);
   }, [onChange, options?.comparisonsCanBePublic, pollName, uid]);
 
   /**
@@ -282,18 +283,18 @@ const EntitySelectorInnerAuth = ({
           m={1}
           display="flex"
           flexDirection={
-            filled
+            bigSelectors
               ? alignment === 'left'
-                ? 'row'
-                : 'row-reverse'
-              : alignment !== 'left'
+                ? 'row-reverse'
+                : 'row'
+              : alignment === 'left'
               ? 'row'
               : 'row-reverse'
           }
           alignItems="center"
           justifyContent="space-between"
         >
-          {filled && (
+          {!bigSelectors && (
             <Grid
               container
               spacing={1}
@@ -340,7 +341,7 @@ const EntitySelectorInnerAuth = ({
             entity={rating.entity}
             settings={showRatingControl ? toggleAction : undefined}
           ></EntityCard>
-        ) : filled ? (
+        ) : !bigSelectors ? (
           <EmptyEntityCard compact loading={loading} />
         ) : (
           <Grid container sx={entityCardMainSx}>

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -278,62 +278,60 @@ const EntitySelectorInnerAuth = ({
   return (
     <>
       {showEntityInput && (
-        <>
-          <Box
-            m={1}
-            display="flex"
-            flexDirection={
-              filled
-                ? alignment === 'left'
-                  ? 'row'
-                  : 'row-reverse'
-                : alignment !== 'left'
+        <Box
+          m={1}
+          display="flex"
+          flexDirection={
+            filled
+              ? alignment === 'left'
                 ? 'row'
                 : 'row-reverse'
-            }
-            alignItems="center"
-            justifyContent="space-between"
-          >
-            {filled && (
-              <Grid
-                container
-                spacing={1}
-                display="flex"
-                direction={alignment === 'left' ? 'row' : 'row-reverse'}
-              >
-                <Grid item>
-                  <EntitySelectButton
-                    value={inputValue || uid || ''}
-                    onChange={handleChange}
-                    otherUid={otherUid}
-                  />
-                </Grid>
-                <Grid item>
-                  <AutoEntityButton
-                    disabled={loading}
-                    currentUid={uid}
-                    otherUid={otherUid}
-                    onClick={() => {
-                      setLoading(true);
-                      setInputValue('');
-                    }}
-                    onResponse={(uid) => {
-                      uid ? onChange({ uid, rating: null }) : setLoading(false);
-                    }}
-                    autoFill={filled}
-                  />
-                </Grid>
-              </Grid>
-            )}
-            <Typography
-              variant="h6"
-              color="secondary"
-              sx={{ '&:first-letter': { textTransform: 'capitalize' } }}
+              : alignment !== 'left'
+              ? 'row'
+              : 'row-reverse'
+          }
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          {filled && (
+            <Grid
+              container
+              spacing={1}
+              display="flex"
+              direction={alignment === 'left' ? 'row' : 'row-reverse'}
             >
-              {title}
-            </Typography>
-          </Box>
-        </>
+              <Grid item>
+                <EntitySelectButton
+                  value={inputValue || uid || ''}
+                  onChange={handleChange}
+                  otherUid={otherUid}
+                />
+              </Grid>
+              <Grid item>
+                <AutoEntityButton
+                  disabled={loading}
+                  currentUid={uid}
+                  otherUid={otherUid}
+                  onClick={() => {
+                    setLoading(true);
+                    setInputValue('');
+                  }}
+                  onResponse={(uid) => {
+                    uid ? onChange({ uid, rating: null }) : setLoading(false);
+                  }}
+                  autoFill={filled}
+                />
+              </Grid>
+            </Grid>
+          )}
+          <Typography
+            variant="h6"
+            color="secondary"
+            sx={{ '&:first-letter': { textTransform: 'capitalize' } }}
+          >
+            {title}
+          </Typography>
+        </Box>
       )}
       <Box position="relative">
         {rating ? (
@@ -342,68 +340,62 @@ const EntitySelectorInnerAuth = ({
             entity={rating.entity}
             settings={showRatingControl ? toggleAction : undefined}
           ></EntityCard>
+        ) : filled ? (
+          <EmptyEntityCard compact />
         ) : (
-          <>
-            {filled ? (
-              <EmptyEntityCard compact />
-            ) : (
-              <Grid container sx={entityCardMainSx}>
-                <Grid
-                  item
-                  xs={12}
-                  sx={{
-                    aspectRatio: '16 / 9',
-                    backgroundColor: '#fafafa',
-                  }}
-                  container
-                  spacing={1}
-                  alignItems="center"
-                  justifyContent="space-evenly"
-                >
-                  <Grid
-                    container
-                    item
-                    xs={6}
-                    md={5}
-                    justifyContent="center"
-                    sx={{ ml: '1px' }}
-                  >
-                    <EntitySelectButton
-                      value={inputValue || uid || ''}
-                      onChange={handleChange}
-                      otherUid={otherUid}
-                      variant="full"
-                    />
-                  </Grid>
-                  <Grid
-                    container
-                    item
-                    xs={6}
-                    md={5}
-                    justifyContent="center"
-                    sx={{ mr: '1px' }}
-                  >
-                    <AutoEntityButton
-                      disabled={loading}
-                      currentUid={uid}
-                      otherUid={otherUid}
-                      onClick={() => {
-                        setLoading(true);
-                        setInputValue('');
-                      }}
-                      onResponse={(uid) => {
-                        uid
-                          ? onChange({ uid, rating: null })
-                          : setLoading(false);
-                      }}
-                      autoFill={filled}
-                      variant="full"
-                    />
-                  </Grid>
-                </Grid>
+          <Grid container sx={entityCardMainSx}>
+            <Grid
+              item
+              xs={12}
+              sx={{
+                aspectRatio: '16 / 9',
+                backgroundColor: '#fafafa',
+              }}
+              container
+              spacing={1}
+              alignItems="center"
+              justifyContent="space-evenly"
+            >
+              <Grid
+                container
+                item
+                xs={6}
+                md={5}
+                justifyContent="center"
+                sx={{ ml: '1px' }}
+              >
+                <EntitySelectButton
+                  value={inputValue || uid || ''}
+                  onChange={handleChange}
+                  otherUid={otherUid}
+                  variant="full"
+                />
               </Grid>
-            )}
-          </>
+              <Grid
+                container
+                item
+                xs={6}
+                md={5}
+                justifyContent="center"
+                sx={{ mr: '1px' }}
+              >
+                <AutoEntityButton
+                  disabled={loading}
+                  currentUid={uid}
+                  otherUid={otherUid}
+                  onClick={() => {
+                    setLoading(true);
+                    setInputValue('');
+                  }}
+                  onResponse={(uid) => {
+                    uid ? onChange({ uid, rating: null }) : setLoading(false);
+                  }}
+                  autoFill={filled}
+                  variant="full"
+                />
+              </Grid>
+            </Grid>
+          </Grid>
         )}
         {entityAvailability === ENTITY_AVAILABILITY.UNAVAILABLE && !loading && (
           <Box

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -23,6 +23,7 @@ import { UID_YT_NAMESPACE, YOUTUBE_POLL_NAME } from 'src/utils/constants';
 import AutoEntityButton from './AutoEntityButton';
 import EntitySelectButton from './EntitySelectButton';
 import { extractVideoId } from 'src/utils/video';
+import { entityCardMainSx } from 'src/components/entity/style';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -101,8 +102,6 @@ const EntitySelectorInnerAnonymous = ({ value }: { value: SelectorValue }) => {
   const { uid } = value;
   const [entityFallback, setEntityFallback] = useState<Recommendation>();
 
-  const [loading, setLoading] = useState(false);
-
   useEffect(() => {
     async function getEntity() {
       return await PollsService.pollsEntitiesRetrieve({
@@ -114,7 +113,6 @@ const EntitySelectorInnerAnonymous = ({ value }: { value: SelectorValue }) => {
     // Wait for a not null / not empty UID before making an HTTP request.
     if (uid) {
       getEntity().then((entity) => {
-        setLoading(false);
         setEntityFallback(entity);
       });
     }
@@ -123,7 +121,7 @@ const EntitySelectorInnerAnonymous = ({ value }: { value: SelectorValue }) => {
   return entityFallback ? (
     <EntityCard compact entity={entityFallback} settings={undefined} />
   ) : (
-    <EmptyEntityCard compact loading={loading} />
+    <EmptyEntityCard compact />
   );
 };
 
@@ -144,6 +142,7 @@ const EntitySelectorInnerAuth = ({
 
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);
+  const [filled, setFilled] = useState(autoFill);
 
   const { availability: entityAvailability } = useEntityAvailable(
     value.uid ?? ''
@@ -195,6 +194,7 @@ const EntitySelectorInnerAuth = ({
       }
     }
     setLoading(false);
+    setFilled(true);
   }, [onChange, options?.comparisonsCanBePublic, pollName, uid]);
 
   /**
@@ -281,7 +281,7 @@ const EntitySelectorInnerAuth = ({
             m={1}
             display="flex"
             flexDirection={
-              autoFill
+              filled
                 ? alignment === 'left'
                   ? 'row'
                   : 'row-reverse'
@@ -292,7 +292,7 @@ const EntitySelectorInnerAuth = ({
             alignItems="center"
             justifyContent="space-between"
           >
-            {autoFill && (
+            {filled && (
               <Grid
                 container
                 spacing={1}
@@ -318,7 +318,7 @@ const EntitySelectorInnerAuth = ({
                     onResponse={(uid) => {
                       uid ? onChange({ uid, rating: null }) : setLoading(false);
                     }}
-                    autoFill={autoFill}
+                    autoFill={filled}
                   />
                 </Grid>
               </Grid>
@@ -341,7 +341,67 @@ const EntitySelectorInnerAuth = ({
             settings={showRatingControl ? toggleAction : undefined}
           ></EntityCard>
         ) : (
-          <EmptyEntityCard compact loading={loading} />
+          <>
+            {filled ? (
+              <EmptyEntityCard compact />
+            ) : (
+              <Grid container sx={entityCardMainSx}>
+                <Grid
+                  item
+                  xs={12}
+                  sx={{
+                    aspectRatio: '16 / 9',
+                    backgroundColor: '#fafafa',
+                  }}
+                  container
+                  spacing={1}
+                  alignItems="center"
+                  justifyContent="space-evenly"
+                >
+                  <Grid
+                    container
+                    item
+                    xs={6}
+                    md={5}
+                    justifyContent="center"
+                    sx={{ ml: '1px' }}
+                  >
+                    <EntitySelectButton
+                      value={inputValue || uid || ''}
+                      onChange={handleChange}
+                      otherUid={otherUid}
+                      inSelector={true}
+                    />
+                  </Grid>
+                  <Grid
+                    container
+                    item
+                    xs={6}
+                    md={5}
+                    justifyContent="center"
+                    sx={{ mr: '1px' }}
+                  >
+                    <AutoEntityButton
+                      disabled={loading}
+                      currentUid={uid}
+                      otherUid={otherUid}
+                      onClick={() => {
+                        setLoading(true);
+                        setInputValue('');
+                      }}
+                      onResponse={(uid) => {
+                        uid
+                          ? onChange({ uid, rating: null })
+                          : setLoading(false);
+                      }}
+                      autoFill={filled}
+                      inSelector={true}
+                    />
+                  </Grid>
+                </Grid>
+              </Grid>
+            )}
+          </>
         )}
         {entityAvailability === ENTITY_AVAILABILITY.UNAVAILABLE && !loading && (
           <Box

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -145,7 +145,10 @@ const EntitySelectorInnerAuth = ({
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);
 
-  const [bigSelectors, setBigSelectors] = useState(!autoFill);
+  // The initial UI should be displayed only if no entity has been selected by
+  // the user, or automatically selected .
+  const [showInitialUi, setShowInitialUi] = useState(!autoFill);
+  const [initialSelectDisabled, setInitialSelectDisabled] = useState(false);
 
   const { availability: entityAvailability } = useEntityAvailable(
     value.uid ?? ''
@@ -197,7 +200,7 @@ const EntitySelectorInnerAuth = ({
       }
     }
     setLoading(false);
-    setBigSelectors(false);
+    setShowInitialUi(false);
   }, [onChange, options?.comparisonsCanBePublic, pollName, uid]);
 
   /**
@@ -283,7 +286,7 @@ const EntitySelectorInnerAuth = ({
           m={1}
           display="flex"
           flexDirection={
-            bigSelectors
+            showInitialUi
               ? alignment === 'left'
                 ? 'row-reverse'
                 : 'row'
@@ -294,7 +297,7 @@ const EntitySelectorInnerAuth = ({
           alignItems="center"
           justifyContent="space-between"
         >
-          {!bigSelectors && (
+          {!showInitialUi && (
             <Grid
               container
               spacing={1}
@@ -341,7 +344,7 @@ const EntitySelectorInnerAuth = ({
             entity={rating.entity}
             settings={showRatingControl ? toggleAction : undefined}
           ></EntityCard>
-        ) : !bigSelectors ? (
+        ) : !showInitialUi ? (
           <EmptyEntityCard compact loading={loading} />
         ) : (
           <Grid container sx={entityCardMainSx}>
@@ -364,6 +367,7 @@ const EntitySelectorInnerAuth = ({
                   onChange={handleChange}
                   otherUid={otherUid}
                   variant="full"
+                  disabled={initialSelectDisabled}
                 />
               </Grid>
               <Grid container item xs={12} sm={5} justifyContent="center">
@@ -374,9 +378,15 @@ const EntitySelectorInnerAuth = ({
                   onClick={() => {
                     setLoading(true);
                     setInputValue('');
+                    setInitialSelectDisabled(true);
                   }}
                   onResponse={(uid) => {
-                    uid ? onChange({ uid, rating: null }) : setLoading(false);
+                    if (uid) {
+                      onChange({ uid, rating: null });
+                    } else {
+                      setLoading(false);
+                      setInitialSelectDisabled(false);
+                    }
                   }}
                   autoFill={autoFill}
                   variant="full"

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -319,7 +319,7 @@ const EntitySelectorInnerAuth = ({
                   onResponse={(uid) => {
                     uid ? onChange({ uid, rating: null }) : setLoading(false);
                   }}
-                  autoFill={filled}
+                  autoFill={autoFill}
                 />
               </Grid>
             </Grid>
@@ -390,7 +390,7 @@ const EntitySelectorInnerAuth = ({
                   onResponse={(uid) => {
                     uid ? onChange({ uid, rating: null }) : setLoading(false);
                   }}
-                  autoFill={filled}
+                  autoFill={autoFill}
                   variant="full"
                 />
               </Grid>

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -354,16 +354,10 @@ const EntitySelectorInnerAuth = ({
               container
               spacing={1}
               alignItems="center"
-              justifyContent="space-evenly"
+              justifyContent="space-around"
+              wrap="wrap"
             >
-              <Grid
-                container
-                item
-                xs={6}
-                md={5}
-                justifyContent="center"
-                sx={{ ml: '1px' }}
-              >
+              <Grid container item xs={12} sm={5} justifyContent="center">
                 <EntitySelectButton
                   value={inputValue || uid || ''}
                   onChange={handleChange}
@@ -371,14 +365,7 @@ const EntitySelectorInnerAuth = ({
                   variant="full"
                 />
               </Grid>
-              <Grid
-                container
-                item
-                xs={6}
-                md={5}
-                justifyContent="center"
-                sx={{ mr: '1px' }}
-              >
+              <Grid container item xs={12} sm={5} justifyContent="center">
                 <AutoEntityButton
                   disabled={loading}
                   currentUid={uid}

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -101,6 +101,7 @@ const EntitySelectorInnerAnonymous = ({ value }: { value: SelectorValue }) => {
 
   const { uid } = value;
   const [entityFallback, setEntityFallback] = useState<Recommendation>();
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     async function getEntity() {
@@ -113,6 +114,7 @@ const EntitySelectorInnerAnonymous = ({ value }: { value: SelectorValue }) => {
     // Wait for a not null / not empty UID before making an HTTP request.
     if (uid) {
       getEntity().then((entity) => {
+        setLoading(false);
         setEntityFallback(entity);
       });
     }
@@ -121,7 +123,7 @@ const EntitySelectorInnerAnonymous = ({ value }: { value: SelectorValue }) => {
   return entityFallback ? (
     <EntityCard compact entity={entityFallback} settings={undefined} />
   ) : (
-    <EmptyEntityCard compact />
+    <EmptyEntityCard compact loading={loading} />
   );
 };
 

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -135,6 +135,10 @@ const ComparisonPage = () => {
       ?.comparison_ui__weekly_collective_goal_display ??
     ComparisonUi_weeklyCollectiveGoalDisplayEnum.ALWAYS;
 
+  const fillEntitySelector =
+    userSettings?.[pollName as PollUserSettingsKeys]
+      ?.comparison__fill_entity_selector ?? true;
+
   return (
     <>
       <ContentHeader title={t('comparison.submitAComparison')} />
@@ -193,7 +197,10 @@ const ComparisonPage = () => {
                   weeklyCollectiveGoalDisplay,
                   isEmbedded
                 ) && <CollectiveGoalWeeklyProgress />}
-                <Comparison autoFillSelectorA={true} autoFillSelectorB={true} />
+                <Comparison
+                  autoFillSelectorA={fillEntitySelector}
+                  autoFillSelectorB={fillEntitySelector}
+                />
               </>
             ))}
         </Box>

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -135,9 +135,11 @@ const ComparisonPage = () => {
       ?.comparison_ui__weekly_collective_goal_display ??
     ComparisonUi_weeklyCollectiveGoalDisplayEnum.ALWAYS;
 
-  const fillEntitySelector =
+  const autoFillSelectors =
     userSettings?.[pollName as PollUserSettingsKeys]
-      ?.comparison__fill_entity_selector ?? true;
+      ?.comparison__fill_entity_selector ??
+    options?.autoFillEmptySelectors ??
+    false;
 
   return (
     <>
@@ -198,8 +200,8 @@ const ComparisonPage = () => {
                   isEmbedded
                 ) && <CollectiveGoalWeeklyProgress />}
                 <Comparison
-                  autoFillSelectorA={fillEntitySelector}
-                  autoFillSelectorB={fillEntitySelector}
+                  autoFillSelectorA={autoFillSelectors}
+                  autoFillSelectorB={autoFillSelectors}
                 />
               </>
             ))}

--- a/frontend/src/pages/home/videos/sections/HomeComparison.tsx
+++ b/frontend/src/pages/home/videos/sections/HomeComparison.tsx
@@ -151,6 +151,7 @@ const HomeComparison = () => {
           value={selectorA}
           onChange={setSelectorA}
           otherUid={uidB}
+          autoFill={true}
         />
       </Grid>
       <Grid
@@ -167,6 +168,7 @@ const HomeComparison = () => {
           value={selectorB}
           onChange={setSelectorB}
           otherUid={uidA}
+          autoFill={true}
         />
       </Grid>
       <Grid item xs={12} mt={1} component={Card} elevation={2}>

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -209,6 +209,7 @@ export const polls: Array<SelectablePoll> = [
     withSearchBar: true,
     topBarBackground: null,
     comparisonsCanBePublic: true,
+    autoFillEmptySelectors: true,
     extraMetadataOrderBy: ['duration', 'publication_date'],
     tutorialLength: 4,
     tutorialAlternatives: getTutorialVideos,

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -107,6 +107,8 @@ export type SelectablePoll = {
   // comparisons as public, and contributor ratings must be created with
   // is_public = false
   comparisonsCanBePublic?: boolean;
+  // indicates if empty entity selectors should be filled by default
+  autoFillEmptySelectors?: boolean;
   tutorialLength?: number;
   // can be used by comparison series to limit the pool of entities
   // that are suggested after each comparison

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -121,8 +121,8 @@ describe('Comparison page', () => {
     cy.focused().type(username);
     cy.get('input[name="password"]').click().type('tournesol').type('{enter}');
 
-    cy.get("[data-testid=entity-select-button]").should('have.length', 2);
-    cy.get("[data-testid=entity-select-button]").first().click();
+    cy.get("[data-testid=entity-select-button-compact]").should('have.length', 2);
+    cy.get("[data-testid=entity-select-button-compact]").first().click();
 
     cy.visit('/');
     cy.location('pathname').should('equal', '/');
@@ -144,7 +144,7 @@ describe('Comparison page', () => {
 
       waitForAutoFill();
 
-      cy.get("[data-testid=entity-select-button]").first().click();
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url]")
         .type(videoAUrl, {delay: 0});
 
@@ -161,7 +161,7 @@ describe('Comparison page', () => {
         cy.contains('views', {matchCase: false}).should('be.visible');
       });
 
-      cy.get("[data-testid=entity-select-button]").first().click();
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url] input[type=text]")
         .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
     });
@@ -174,11 +174,11 @@ describe('Comparison page', () => {
         .type('tournesol').type('{enter}');
 
       // two cards must be displayed
-      cy.get("[data-testid=entity-select-button]").should('have.length', 2);
+      cy.get("[data-testid=entity-select-button-compact]").should('have.length', 2);
 
       waitForAutoFill();
 
-      cy.get("[data-testid=entity-select-button]").first().click();
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url]")
         .type(videoAUrl.split('?v=')[1], {delay: 0});
 
@@ -195,7 +195,7 @@ describe('Comparison page', () => {
         cy.contains('views', {matchCase: false}).should('be.visible');
       });
 
-      cy.get("[data-testid=entity-select-button]").first().click();
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url] input[type=text]")
         .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
     });
@@ -243,11 +243,11 @@ describe('Comparison page', () => {
       waitForAutoFill();
 
       // add one video, and ask for a second one
-      cy.get("[data-testid=entity-select-button]").first().click();
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url]")
         .type(videoAId, {delay: 0});
 
-      cy.get("[data-testid=entity-select-button]").last().click();
+      cy.get("[data-testid=entity-select-button-compact]").last().click();
       cy.get("[data-testid=paste-video-url]")
         .type(videoBId, {delay: 0});
 
@@ -280,10 +280,10 @@ describe('Comparison page', () => {
 
       waitForAutoFill();
 
-      cy.get("[data-testid=entity-select-button]").first().click();
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url]")
         .type(videoAId, {delay: 0});
-      cy.get("[data-testid=entity-select-button]").last().click();
+      cy.get("[data-testid=entity-select-button-compact]").last().click();
       cy.get("[data-testid=paste-video-url]")
         .type(videoBId, {delay: 0});
 
@@ -317,10 +317,10 @@ describe('Comparison page', () => {
 
       waitForAutoFill();
 
-      cy.get("[data-testid=entity-select-button]").first().click();
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url]")
         .type(videoAId, {delay: 0});
-      cy.get("[data-testid=entity-select-button]").last().click();
+      cy.get("[data-testid=entity-select-button-compact]").last().click();
       cy.get("[data-testid=paste-video-url]")
         .type(videoAId, {delay: 0});
 
@@ -347,10 +347,10 @@ describe('Comparison page', () => {
       cy.location('search').should('contain', `uidA=yt%3A${videoAId}`)
       cy.location('search').should('contain', `uidB=yt%3A${videoBId}`)
 
-      cy.get("[data-testid=entity-select-button]").first().click();
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url]").find("[type=text]")
         .should('have.value', `yt:${videoAId}`);
-      cy.get("[data-testid=entity-select-button]").last().click();
+      cy.get("[data-testid=entity-select-button-compact]").last().click();
       cy.get("[data-testid=paste-video-url]").find("[type=text]")
         .should('have.value', `yt:${videoBId}`);
     });
@@ -368,10 +368,10 @@ describe('Comparison page', () => {
       cy.location('search').should('contain', `uidA=yt%3A${videoAId}`)
       cy.location('search').should('contain', `uidB=yt%3A${videoBId}`)
 
-      cy.get("[data-testid=entity-select-button]").first().click();
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url]").find("[type=text]")
         .should('have.value', `yt:${videoAId}`);
-      cy.get("[data-testid=entity-select-button]").last().click();
+      cy.get("[data-testid=entity-select-button-compact]").last().click();
       cy.get("[data-testid=paste-video-url]").find("[type=text]")
         .should('have.value', `yt:${videoBId}`);
     });

--- a/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
+++ b/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
@@ -142,6 +142,24 @@ describe('Settings - preferences page', () => {
     });
   });
 
+  describe('Setting - fill entity selector', () => {
+    it("doesn't fill the selector if set to false", () => {
+      cy.visit('/settings/preferences');
+      login();
+
+      cy.get('[data-testid="videos_comparison__fill_entity_selector"]').click();
+      cy.contains('Update preferences').click();
+
+      cy.visit('/comparison');
+
+      cy.get('button[data-testid="entity-select-button"]').should('not.exist');
+      cy.get('button[data-testid="entity-select-button-inSelector"]');
+      cy.get('button[data-testid="auto-entity-button-inSelector"]').first().click();
+      cy.get('button[data-testid="entity-select-button"]');
+      cy.get('[class="react-player__preview"]');
+    });
+  });
+
   describe('Setting - optional criteria display', () => {
     it('handles selecting and ordering criteria', () => {
       cy.visit('/comparison');

--- a/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
+++ b/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
@@ -154,7 +154,7 @@ describe('Settings - preferences page', () => {
 
       cy.get('button[data-testid="entity-select-button"]').should('not.exist');
       cy.get('button[data-testid="entity-select-button-inSelector"]');
-      cy.get('button[data-testid="auto-entity-button-inSelector"]').first().click();
+      cy.get('button[data-testid="auto-entity-button-full"]').first().click();
       cy.get('button[data-testid="entity-select-button"]');
       cy.get('[class="react-player__preview"]');
     });

--- a/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
+++ b/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
@@ -142,8 +142,9 @@ describe('Settings - preferences page', () => {
     });
   });
 
-  describe('Setting - fill entity selector', () => {
-    it("doesn't fill the selector if set to false", () => {
+  describe('Setting - automatically select entity', () => {
+
+    it("when false, selectors are not automatically pre-filled", () => {
       cy.visit('/settings/preferences');
       login();
 
@@ -152,10 +153,15 @@ describe('Settings - preferences page', () => {
 
       cy.visit('/comparison');
 
+      cy.get('button[data-testid="auto-entity-button-compact"]').should('not.exist');
       cy.get('button[data-testid="entity-select-button-compact"]').should('not.exist');
-      cy.get('button[data-testid="entity-select-button-full"]');
+
+      cy.get('button[data-testid="auto-entity-button-full"]').should('have.length', 2);
+      cy.get('button[data-testid="entity-select-button-full"]').should('have.length', 2);
+
       cy.get('button[data-testid="auto-entity-button-full"]').first().click();
-      cy.get('button[data-testid="entity-select-button-compact"]');
+
+      cy.get('button[data-testid="entity-select-button-compact"]').should('have.length', 1);
       cy.get('[class="react-player__preview"]');
     });
   });

--- a/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
+++ b/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
@@ -152,10 +152,10 @@ describe('Settings - preferences page', () => {
 
       cy.visit('/comparison');
 
-      cy.get('button[data-testid="entity-select-button"]').should('not.exist');
-      cy.get('button[data-testid="entity-select-button-inSelector"]');
+      cy.get('button[data-testid="entity-select-button-compact"]').should('not.exist');
+      cy.get('button[data-testid="entity-select-button-full"]');
       cy.get('button[data-testid="auto-entity-button-full"]').first().click();
-      cy.get('button[data-testid="entity-select-button"]');
+      cy.get('button[data-testid="entity-select-button-compact"]');
       cy.get('[class="react-player__preview"]');
     });
   });


### PR DESCRIPTION
**following #1699 and #1700**

---
The buttons have the same behavior as the current ones.
No video (entity) is loaded if the setting is set to false, default value is true.
![image](https://github.com/tournesol-app/tournesol/assets/89401728/d0888380-eb00-45f9-ac69-4dac16478af5)