### PR TITLE
feat: Add filtering option for already compared videos

### DIFF
--- a/backend/tournesol/views/previews/recommendations.py
+++ b/backend/tournesol/views/previews/recommendations.py
@@ -79,6 +79,8 @@ def get_preview_recommendations_redirect_params(request):
                 now = timezone.now()
                 date_gte = now - datetime.timedelta(seconds=seconds_max_age)
                 query["date_gte"] = date_gte.isoformat(timespec="seconds")
+        elif key == "advanced":
+            query["unsafe"] = "unsafe" in value.split(",")
         else:
             query[key] = params[key]
 

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -331,6 +331,8 @@
   "filter": {
     "filterByVisibility": "Filter by visibility",
     "includeAllVideos": "Include all videos",
+    "excludeComparedVideos": "Exclude compared videos",
+    "excludeComparedTooltip": "Remove from the list of recommendations the videos that you have already compared.",
     "advanced": "Advanced",
     "unsafeTooltip": "Also display videos with a low number of contributors and those with a negative score.",
     "ignore": "Ignore",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -338,6 +338,8 @@
   "filter": {
     "filterByVisibility": "Filtrer par visibilité",
     "includeAllVideos": "Inclure toutes les vidéos",
+    "excludeComparedVideos": "Exclure les vidéos comparées",
+    "excludeComparedTooltip": "Enlever de la liste de recommandations les vidéos que vous avez déjà comparées",
     "advanced": "Avancés",
     "unsafeTooltip": "Afficher aussi les vidéos avec peu de contributeurs et les vidéos avec des scores négatifs.",
     "ignore": "Ignoré",

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -713,6 +713,13 @@ paths:
         description: If true, entities considered as unsafe recommendations because
           of a low score or due to too few contributions will be included.
       - in: query
+        name: exclude_compared_entities
+        schema:
+          type: boolean
+          default: false
+        description: If true and a user is authenticated, then entities compared by
+          the user will be removed from the response
+      - in: query
         name: weights
         schema:
           type: object
@@ -1098,6 +1105,13 @@ paths:
           default: false
         description: If true, entities considered as unsafe recommendations because
           of a low score or due to too few contributions will be included.
+      - in: query
+        name: exclude_compared_entities
+        schema:
+          type: boolean
+          default: false
+        description: If true and a user is authenticated, then entities compared by
+          the user will be removed from the response
       - in: query
         name: weights
         schema:
@@ -1993,6 +2007,13 @@ paths:
           default: false
         description: If true, entities considered as unsafe recommendations because
           of a low score or due to too few contributions will be included.
+      - in: query
+        name: exclude_compared_entities
+        schema:
+          type: boolean
+          default: false
+        description: If true and a user is authenticated, then entities compared by
+          the user will be removed from the response
       - in: query
         name: weights
         schema:

--- a/frontend/src/components/ChoicesFilterSection.tsx
+++ b/frontend/src/components/ChoicesFilterSection.tsx
@@ -23,7 +23,7 @@ interface Props {
   choices: Record<string, React.ReactNode>;
   multipleChoice?: boolean;
   radio?: boolean;
-  tooltip?: string;
+  tooltips?: Record<string, React.ReactNode>;
   onChange: (value: string) => void;
 }
 
@@ -33,7 +33,7 @@ const ChoicesFilterSection = ({
   choices,
   multipleChoice = false,
   radio = false,
-  tooltip = '',
+  tooltips,
   onChange,
 }: Props) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -108,7 +108,10 @@ const ChoicesFilterSection = ({
                     },
                   }}
                 >
-                  <Tooltip title={tooltip} placement="bottom">
+                  <Tooltip
+                    title={tooltips?.[choiceValue] || ''}
+                    placement="right"
+                  >
                     <span>{choiceLabel}</span>
                   </Tooltip>
                 </Typography>

--- a/frontend/src/features/recommendation/AdvancedFilter.tsx
+++ b/frontend/src/features/recommendation/AdvancedFilter.tsx
@@ -10,16 +10,22 @@ interface Props {
 function AdvancedFilter(props: Props) {
   const { t } = useTranslation();
 
-  const safeChoice = {
-    true: t('filter.includeAllVideos'),
+  const choices = {
+    unsafe: t('filter.includeAllVideos'),
+    exclude_compared: t('filter.excludeComparedVideos'),
+  };
+
+  const tooltips = {
+    unsafe: t('filter.unsafeTooltip'),
+    exclude_compared: t('filter.excludeComparedTooltip'),
   };
 
   return (
     <ChoicesFilterSection
       title={t('filter.advanced')}
       multipleChoice
-      choices={safeChoice}
-      tooltip={t('filter.unsafeTooltip')}
+      choices={choices}
+      tooltips={tooltips}
       {...props}
     ></ChoicesFilterSection>
   );

--- a/frontend/src/features/recommendation/AdvancedFilter.tsx
+++ b/frontend/src/features/recommendation/AdvancedFilter.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChoicesFilterSection } from 'src/components';
+import { useLoginState } from 'src/hooks';
 
 interface Props {
   value: string;
@@ -9,16 +10,22 @@ interface Props {
 
 function AdvancedFilter(props: Props) {
   const { t } = useTranslation();
+  const { isLoggedIn } = useLoginState();
 
-  const choices = {
+  const choices: { unsafe: string; exclude_compared?: string } = {
     unsafe: t('filter.includeAllVideos'),
     exclude_compared: t('filter.excludeComparedVideos'),
   };
 
-  const tooltips = {
+  const tooltips: { unsafe: string; exclude_compared?: string } = {
     unsafe: t('filter.unsafeTooltip'),
     exclude_compared: t('filter.excludeComparedTooltip'),
   };
+
+  if (!isLoggedIn) {
+    delete choices['exclude_compared'];
+    delete tooltips['exclude_compared'];
+  }
 
   return (
     <ChoicesFilterSection

--- a/frontend/src/features/recommendation/SearchFilter.spec.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.spec.tsx
@@ -87,10 +87,12 @@ describe('Filters feature', () => {
 
   function verifyFiltersPresence() {
     // Check date and safe filters presence
-    const dateFilter = document.querySelector(
-      '[data-testid=search-date-safe-filter]'
+    const dateAndAdvancedFilter = document.querySelector(
+      '[data-testid=search-date-and-advanced-filter]'
     );
-    expect(queryAllByTestId(dateFilter, /checkbox-choice/i)).toHaveLength(6);
+    expect(
+      queryAllByTestId(dateAndAdvancedFilter, /checkbox-choice/i)
+    ).toHaveLength(7);
 
     // Check language filters presence
     const languageFilter = document.querySelector(

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -83,7 +83,7 @@ function SearchFilter({
                 xs={6}
                 md={3}
                 lg={3}
-                data-testid="search-date-safe-filter"
+                data-testid="search-date-and-advanced-filter"
               >
                 <DateFilter
                   value={filterParams.get(recommendationFilters.date) ?? ''}

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -94,8 +94,8 @@ function SearchFilter({
                 {showAdvancedFilter && (
                   <Box mt={2}>
                     <AdvancedFilter
-                      value={filterParams.get('unsafe') ?? ''}
-                      onChange={(value) => setFilter('unsafe', value)}
+                      value={filterParams.get('advanced') ?? ''}
+                      onChange={(value) => setFilter('advanced', value)}
                     />
                   </Box>
                 )}

--- a/frontend/src/utils/api/recommendations.tsx
+++ b/frontend/src/utils/api/recommendations.tsx
@@ -27,7 +27,7 @@ const getParamValueAsNumber = (
 /**
  * Replace the key `date` of `params` by a new one compatible with the API.
  */
-const buildDateURLParameter = (
+const overwriteDateURLParameter = (
   pollName: string,
   params: URLSearchParams
 ): void => {
@@ -123,7 +123,7 @@ export const getRecommendations = async (
 ): Promise<PaginatedRecommendationList> => {
   const params = new URLSearchParams(searchString);
 
-  buildDateURLParameter(pollName, params);
+  overwriteDateURLParameter(pollName, params);
 
   let criteriaWeights = Object.fromEntries(
     criterias.map((c) => [c.name, getParamValueAsNumber(params, c.name)])
@@ -148,6 +148,9 @@ export const getRecommendations = async (
     };
   }
 
+  const advanced = params.get('advanced') || '';
+  const advanced_options = advanced.split(',');
+
   try {
     return await PollsService.pollsRecommendationsList({
       name: pollName,
@@ -155,9 +158,8 @@ export const getRecommendations = async (
       offset: getParamValueAsNumber(params, 'offset'),
       search: params.get('search') ?? undefined,
       dateGte: params.get('date_gte') ?? undefined,
-      unsafe: params.has('unsafe')
-        ? params.get('unsafe') === 'true'
-        : pollOptions?.unsafeDefault,
+      unsafe: advanced_options.includes('unsafe') || pollOptions?.unsafeDefault,
+      excludeComparedEntities: advanced_options.includes('exclude_compared'),
       metadata: getMetadataFilter(pollName, params),
       scoreMode: (params.get('score_mode') as ScoreModeEnum) ?? undefined,
       weights: criteriaWeights,
@@ -184,7 +186,7 @@ export const getPublicPersonalRecommendations = async (
 ): Promise<PaginatedContributorRecommendationsList> => {
   const params = new URLSearchParams(searchString);
 
-  buildDateURLParameter(pollName, params);
+  overwriteDateURLParameter(pollName, params);
 
   const criteriaWeights = Object.fromEntries(
     criterias.map((c) => [c.name, getParamValueAsNumber(params, c.name)])

--- a/frontend/src/utils/userSettings.ts
+++ b/frontend/src/utils/userSettings.ts
@@ -10,17 +10,6 @@ import { YOUTUBE_POLL_NAME } from './constants';
 import { SelectablePoll, PollUserSettingsKeys } from './types';
 
 /**
- * Cast the value of the setting recommendations__default_unsafe to a value
- * expected by the recommendations' search filter 'safe/usafe'.
- */
-const recoDefaultUnsafeToSearchFilter = (setting: boolean): string => {
-  if (setting) {
-    return 'true';
-  }
-  return '';
-};
-
-/**
  * Cast the value of the setting recommendations__default_date to a value
  * expected by the recommendations' search filter 'date'.
  */
@@ -39,12 +28,9 @@ export const buildVideosDefaultRecoSearchParams = (
   userSettings: VideosPollUserSettings | undefined
 ) => {
   if (userSettings?.recommendations__default_unsafe != undefined) {
-    searchParams.set(
-      'unsafe',
-      recoDefaultUnsafeToSearchFilter(
-        userSettings.recommendations__default_unsafe
-      )
-    );
+    if (userSettings.recommendations__default_unsafe) {
+      searchParams.set('advanced', 'unsafe');
+    }
   }
 
   if (userSettings?.recommendations__default_date != undefined) {

--- a/tests/cypress/e2e/frontend/recommendationsPage.cy.ts
+++ b/tests/cypress/e2e/frontend/recommendationsPage.cy.ts
@@ -60,7 +60,7 @@ describe('Recommendations page', () => {
         });
 
         it('allows to filter: a year ago', () => {
-          cy.visit('/recommendations?unsafe=true');
+          cy.visit('/recommendations?advanced=unsafe');
           cy.contains('Filters', {matchCase: false}).click();
 
           cy.contains('A year ago', {matchCase: false}).should('be.visible');
@@ -73,7 +73,7 @@ describe('Recommendations page', () => {
         });
 
         it('shows no videos for 1 day ago', () => {
-          cy.visit('/recommendations?unsafe=true');
+          cy.visit('/recommendations?advanced=unsafe');
           cy.contains('Filters', {matchCase: false}).click();
           cy.contains('A day ago', {matchCase: false}).should('be.visible');
           cy.get('input[type=checkbox][name="Today"]').check();
@@ -82,7 +82,7 @@ describe('Recommendations page', () => {
         });
 
         it('allows to filter: all time', () => {
-          cy.visit('/recommendations?unsafe=true');
+          cy.visit('/recommendations?advanced=unsafe');
           cy.contains('Filters', {matchCase: false}).click();
 
           cy.contains('A year ago', {matchCase: false}).should('be.visible');
@@ -95,7 +95,7 @@ describe('Recommendations page', () => {
     });
     describe('List of recommendations', () => {
       it('entities\'s thumbnails are clickable', () => {
-        cy.visit('/recommendations?unsafe=true&date=');
+        cy.visit('/recommendations?advanced=unsafe&date=');
 
         const thumbnail = cy.get('img.entity-thumbnail').first();
         thumbnail.click();
@@ -103,7 +103,7 @@ describe('Recommendations page', () => {
       });
 
       it('entities\'s titles are clickable', () => {
-        cy.visit('/recommendations?unsafe=true&date=');
+        cy.visit('/recommendations?advanced=unsafe&date=');
 
         const videoCard = cy.get('div[data-testid=video-card-info]').first();
         videoCard.find('h6').click();

--- a/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
+++ b/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
@@ -225,7 +225,7 @@ describe('Settings - preferences page', () => {
       cy.contains('Update preferences').click();
 
       cy.get('a[aria-label="Link to the recommendations page"]').should(
-        'have.attr', 'href', '/recommendations?date=Today&unsafe='
+        'have.attr', 'href', '/recommendations?date=Today'
       );
     });
 
@@ -238,7 +238,7 @@ describe('Settings - preferences page', () => {
       cy.contains('Update preferences').click();
 
       cy.get('a[aria-label="Link to the recommendations page"]').should(
-        'have.attr', 'href', '/recommendations?date=Week&unsafe='
+        'have.attr', 'href', '/recommendations?date=Week'
       );
     });
 
@@ -251,7 +251,7 @@ describe('Settings - preferences page', () => {
       cy.contains('Update preferences').click();
 
       cy.get('a[aria-label="Link to the recommendations page"]').should(
-        'have.attr', 'href', '/recommendations?date=Year&unsafe='
+        'have.attr', 'href', '/recommendations?date=Year'
       );
     });
 
@@ -264,7 +264,7 @@ describe('Settings - preferences page', () => {
       cy.contains('Update preferences').click();
 
       cy.get('a[aria-label="Link to the recommendations page"]').should(
-        'have.attr', 'href', '/recommendations?date=&unsafe='
+        'have.attr', 'href', '/recommendations?date='
       );
     });
   });
@@ -278,7 +278,7 @@ describe('Settings - preferences page', () => {
       cy.contains('Update preferences').click();
 
       cy.get('a[aria-label="Link to the recommendations page"]').should(
-        'have.attr', 'href', '/recommendations?date=Month&unsafe='
+        'have.attr', 'href', '/recommendations?date=Month'
       );
     });
 
@@ -290,7 +290,7 @@ describe('Settings - preferences page', () => {
       cy.contains('Update preferences').click();
 
       cy.get('a[aria-label="Link to the recommendations page"]').should(
-        'have.attr', 'href', '/recommendations?date=Month&unsafe=true'
+        'have.attr', 'href', '/recommendations?date=Month&advanced=unsafe'
       );
     });
   });


### PR DESCRIPTION
Changes:
* chore: update api yaml schema
* Add filtering option for already compared videos available for logged-in users
* Change frontend URLs to use a parameter `advanced` that support the safe option and the exclude option instead of `unsafe`
* Adapt the preview link redirect to support the `advanced=unsafe` option
