### PR TITLE
[front] feat: add new tabs to the Scientific Literature Box

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -105,10 +105,10 @@
     "recentlyCompared": "Compared",
     "recommendations": "Top of the month",
     "unconnected": "To connect",
-    "pasteUrlOrVideoId": "Paste URL or Video ID",
+    "select": "Select",
     "youtubeVideoUnavailable": "YouTube video unavailable.",
-    "backButton": "Back",
-    "select": "Select"
+    "pasteUrlOrVideoId": "Paste URL or Video ID",
+    "backButton": "Back"
   },
   "tabsBox": {
     "errorOnLoading": "An error occurred while loading the results.",
@@ -782,8 +782,8 @@
     "weSeekToSupportResearch": "\"We seek to support research on the ethics of algorithms by providing a large and reliable database of human judgments.\""
   },
   "scientificLiteratureBox": {
-    "ourPublications": "Our publications",
-    "papers": "Papers",
+    "publications": "Publications",
+    "ourPapers": "Our papers",
     "studenWorks": "Student works",
     "theyCiteUs": "They cite us",
     "inTheMedia": "In the media"
@@ -986,12 +986,12 @@
   "videos": {
     "dialogs": {
       "tutorial": {
+        "installTheExtension": "Install the extension",
         "title4": "Compare easily with the extension",
         "message4": {
           "p10": "The Tournesol browser extension lets you add the videos you watch on YouTube to your rate-later list.",
           "p20": "You can also make comparisons directly from YouTube!"
-        },
-        "installTheExtension": "Install the extension"
+        }
       }
     },
     "tips": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -784,7 +784,9 @@
   "scientificLiteratureBox": {
     "ourPublications": "Our publications",
     "papers": "Papers",
-    "studenWorks": "Student works"
+    "studenWorks": "Student works",
+    "theyCiteUs": "They cite us",
+    "inTheMedia": "In the media"
   },
   "visualizeDataBox": {
     "visualizeTheData": "Visualize the data",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -109,10 +109,10 @@
     "recentlyCompared": "Comparées",
     "recommendations": "Top du mois",
     "unconnected": "À relier",
-    "pasteUrlOrVideoId": "Coller une URL ou un ID de vidéo",
+    "select": "Selectionner",
     "youtubeVideoUnavailable": "Vidéo YouTube indisponible.",
-    "backButton": "Retour",
-    "select": "Selectionner"
+    "pasteUrlOrVideoId": "Coller une URL ou un ID de vidéo",
+    "backButton": "Retour"
   },
   "tabsBox": {
     "errorOnLoading": "Une erreur est survenue lors du chargement des résultats.",
@@ -790,8 +790,8 @@
     "weSeekToSupportResearch": "« Nous voulons soutenir la recherche sur l'éthique des algorithmes en publiant une grande base de données fiable de jugements humains. »"
   },
   "scientificLiteratureBox": {
-    "ourPublications": "Nos publications",
-    "papers": "Articles",
+    "publications": "Publications",
+    "ourPapers": "Nos articles",
     "studenWorks": "Travaux étudiants",
     "theyCiteUs": "Ils nous citent",
     "inTheMedia": "Dans les médias"
@@ -995,12 +995,12 @@
   "videos": {
     "dialogs": {
       "tutorial": {
+        "installTheExtension": "Installer l'extension",
         "title4": "Comparez facilement avec l'extension",
         "message4": {
           "p10": "L'extension de navigateur Tournesol vous permet d'ajouter les vidéos que vous regardez sur YouTube à votre lister à comparer plus tard.",
           "p20": "Vous pouvez aussi faire des comparaisons directement depuis YouTube ! Pratique."
-        },
-        "installTheExtension": "Installer l'extension"
+        }
       }
     },
     "tips": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -792,7 +792,9 @@
   "scientificLiteratureBox": {
     "ourPublications": "Nos publications",
     "papers": "Articles",
-    "studenWorks": "Travaux étudiants"
+    "studenWorks": "Travaux étudiants",
+    "theyCiteUs": "Ils nous citent",
+    "inTheMedia": "Dans les médias"
   },
   "visualizeDataBox": {
     "visualizeTheData": "Visualisez les données",

--- a/frontend/src/pages/home/videos/sections/research/ScientificLiteratureBox.tsx
+++ b/frontend/src/pages/home/videos/sections/research/ScientificLiteratureBox.tsx
@@ -21,6 +21,9 @@ import {
   VerifiedUser,
   School,
   QueryStats,
+  FormatQuote,
+  Newspaper,
+  Headphones,
 } from '@mui/icons-material';
 import TitledPaper from 'src/components/TitledPaper';
 
@@ -131,6 +134,106 @@ const ScientificLiteratureBox = () => {
     },
   ];
 
+  const theyCiteUs = [
+    {
+      name: 'Volition Learning: What Would You Prefer to Prefer?',
+      authors:
+        'Mohamed Lechiakh, Alexandre Maurer (2023). Artificial Intelligence in Human-Computer Interaction.',
+      url: 'https://link.springer.com/chapter/10.1007/978-3-031-35891-3_35',
+      icon: FormatQuote,
+    },
+    {
+      name: "Algocratie : Vivre libre à l'heure des algorithmes",
+      authors: 'Arthur Grimonpont (2022). Actes Sud.',
+      url: 'https://www.actes-sud.fr/catalogue/sciences-humaines-et-sociales-sciences/algocratie',
+      icon: FormatQuote,
+    },
+    {
+      name: 'The human cost of ethical artificial intelligence',
+      authors:
+        'James Ruffle, Chris Foulon, Parashkev Nachev (2023). Brain Structure and Function.',
+      url: 'https://link.springer.com/article/10.1007/s00429-023-02662-7',
+      icon: FormatQuote,
+    },
+    {
+      name: 'Model reports, a supervision tool for Machine Learning engineers and users',
+      authors:
+        'Amine Saboni, Mohamed Ouamane, Ouafae Bennis, Frédéric Krat (2021). European Conference on Electrical Engineering & COmputer Science.',
+      url: 'https://hal.science/hal-03410903/',
+      icon: FormatQuote,
+    },
+    {
+      name: 'Identify ambiguous tasks combining crowdsourced labels by weighting Areas Under the Margin.',
+      authors:
+        'Tanguy Lefort, Benjamin Charlier, Alexis Joly, Joseph Salmon (2022). ArXiV.',
+      url: 'https://arxiv.org/abs/2209.15380',
+      icon: FormatQuote,
+    },
+  ];
+
+  const inTheMedia = [
+    {
+      name: 'Les grands modèles de langage : quels risques ? Échange avec Lê Nguyên Hoang.',
+      authors: 'Paroles de (2023). Conseil national du numérique',
+      url: 'https://cnnumerique.fr/paroles-de/les-grands-modeles-de-langage-quels-risques-echange-avec-le-nguyen-hoang',
+      icon: Newspaper,
+    },
+    {
+      name: 'Researchers turn to crowdsourcing for better YouTube recommendations',
+      authors: 'Kyle Wiggers (2022). VentureBeat.',
+      url: 'https://venturebeat.com/ai/researchers-turn-to-crowdsourcing-for-better-youtube-recommendations/',
+      icon: Newspaper,
+    },
+    {
+      name: 'AIs are out of (democratic) control',
+      authors: 'Lê Nguyên Hoang (2023). SwissInfo.',
+      url: 'https://www.swissinfo.ch/eng/ais-are-out-of--democratic--control/48427358',
+      icon: Newspaper,
+    },
+    {
+      name: 'Podcast - Comment dompter un algorithme ?',
+      authors: 'Andreia Glanville, Huma Khamis (2023). RTS Micro-sciences.',
+      url: 'https://www.rts.ch/info/sciences-tech/14000339-podcast-comment-dompter-un-algorithme.html',
+      icon: Headphones,
+    },
+    {
+      name: 'L’intelligence artificielle : outil de domination ou d’émancipation ?',
+      authors: 'Julien Hernandez (2023). Polytechnique Insights.',
+      url: 'https://www.polytechnique-insights.com/tribunes/digital/lintelligence-artificielle-outil-de-domination-ou-demancipation/',
+      icon: Newspaper,
+    },
+    {
+      name: "L'AI contre la désinformation",
+      authors: "Adrien Zerbini (2022). RTS Ça n'a pas de science !",
+      url: 'https://www.rts.ch/la-1ere/programmes/cqfd/11969483-ca-n-a-pas-de-science-.html',
+      icon: Headphones,
+    },
+    {
+      name: "Les Lumières à l'ère du numérique.",
+      authors: 'Rapport de la Commission (2022).',
+      url: 'https://www.elysee.fr/emmanuel-macron/2022/01/11/remise-du-rapport-de-la-commission-bronner',
+      icon: Newspaper,
+    },
+    {
+      name: 'AI thinkers grapple with modern war',
+      authors: 'Kate Kaye (2022). Protocol Enterprise. ',
+      url: 'https://www.protocol.com/newsletters/protocol-enterprise/ai-russia-ukraine-zendesk-momentive',
+      icon: Newspaper,
+    },
+    {
+      name: "«L’industrie de l'information est probablement la plus dangereuse pour la société»",
+      authors: 'Grégoire Barbey (2022). Heidi.News.',
+      url: 'https://www.heidi.news/cyber/l-industrie-de-l-information-est-probablement-la-plus-dangereuse-pour-la-societe',
+      icon: Newspaper,
+    },
+    {
+      name: "Tournesol : l'algorithme d'utilité publique qui a besoin de vous !",
+      authors: 'Julien Hernandez (2021). Futura Sciences.',
+      url: 'https://www.futura-sciences.com/tech/actualites/intelligence-artificielle-tournesol-algorithme-utilite-publique-besoin-vous-87301/',
+      icon: Newspaper,
+    },
+  ];
+
   return (
     <TitledPaper
       title={t('scientificLiteratureBox.ourPublications')}
@@ -152,6 +255,14 @@ const ScientificLiteratureBox = () => {
             <Tab
               label={t('scientificLiteratureBox.studenWorks')}
               {...a11yProps(1)}
+            />
+            <Tab
+              label={t('scientificLiteratureBox.theyCiteUs')}
+              {...a11yProps(2)}
+            />
+            <Tab
+              label={t('scientificLiteratureBox.inTheMedia')}
+              {...a11yProps(3)}
             />
           </Tabs>
         </Box>
@@ -186,7 +297,11 @@ const ScientificLiteratureBox = () => {
             {studentWorks.map((article, idx) => (
               <React.Fragment key={article.name.replace(' ', '_')}>
                 <ListItem disablePadding>
-                  <ListItemButton href={article.url}>
+                  <ListItemButton
+                    href={article.url}
+                    target="_blank"
+                    rel="noopener"
+                  >
                     <ListItemAvatar>
                       <Avatar>
                         <article.icon />
@@ -199,6 +314,58 @@ const ScientificLiteratureBox = () => {
                   </ListItemButton>
                 </ListItem>
                 {idx !== studentWorks.length - 1 && <Divider />}
+              </React.Fragment>
+            ))}
+          </List>
+        </TabPanel>
+        <TabPanel value={selectedTab} index={2}>
+          <List>
+            {theyCiteUs.map((article, idx) => (
+              <React.Fragment key={article.name.replace(' ', '_')}>
+                <ListItem disablePadding>
+                  <ListItemButton
+                    href={article.url}
+                    target="_blank"
+                    rel="noopener"
+                  >
+                    <ListItemAvatar>
+                      <Avatar>
+                        <article.icon />
+                      </Avatar>
+                    </ListItemAvatar>
+                    <ListItemText
+                      primary={article.name}
+                      secondary={article.authors}
+                    />
+                  </ListItemButton>
+                </ListItem>
+                {idx !== theyCiteUs.length - 1 && <Divider />}
+              </React.Fragment>
+            ))}
+          </List>
+        </TabPanel>
+        <TabPanel value={selectedTab} index={3}>
+          <List>
+            {inTheMedia.map((article, idx) => (
+              <React.Fragment key={article.name.replace(' ', '_')}>
+                <ListItem disablePadding>
+                  <ListItemButton
+                    href={article.url}
+                    target="_blank"
+                    rel="noopener"
+                  >
+                    <ListItemAvatar>
+                      <Avatar>
+                        <article.icon />
+                      </Avatar>
+                    </ListItemAvatar>
+                    <ListItemText
+                      primary={article.name}
+                      secondary={article.authors}
+                    />
+                  </ListItemButton>
+                </ListItem>
+                {idx !== inTheMedia.length - 1 && <Divider />}
               </React.Fragment>
             ))}
           </List>

--- a/frontend/src/pages/home/videos/sections/research/ScientificLiteratureBox.tsx
+++ b/frontend/src/pages/home/videos/sections/research/ScientificLiteratureBox.tsx
@@ -236,7 +236,7 @@ const ScientificLiteratureBox = () => {
 
   return (
     <TitledPaper
-      title={t('scientificLiteratureBox.ourPublications')}
+      title={t('scientificLiteratureBox.publications')}
       contentBoxPadding={0}
     >
       <>
@@ -249,7 +249,7 @@ const ScientificLiteratureBox = () => {
             indicatorColor="secondary"
           >
             <Tab
-              label={t('scientificLiteratureBox.papers')}
+              label={t('scientificLiteratureBox.ourPapers')}
               {...a11yProps(0)}
             />
             <Tab


### PR DESCRIPTION
Add the tabs "They cite us" and "In the media" with the content sent on Discord.

*Note : The "student works" tab opened the links over the tournesol website tab unlike in the "papers" tab, I took the liberty of changing it, we can delete this fix if that was intentional.*