### PR TITLE
[front] feat: add support of YouTube mobile and /live/ URLs

### DIFF
--- a/frontend/src/utils/video.spec.ts
+++ b/frontend/src/utils/video.spec.ts
@@ -6,6 +6,7 @@ describe('video module', () => {
     const ytUrlPattern1 = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
     const ytUrlPattern2 =
       'https://www.youtube.com/live/lYXQvHhfKuM?feature=share';
+    const ytUrlPattern3 = 'https://youtu.be/lYXQvHhfKuM';
 
     it('handles video id', () => {
       const id = extractVideoId(videoId);
@@ -17,13 +18,18 @@ describe('video module', () => {
       expect(id).toEqual(videoId);
     });
 
+    it("handles the pattern 'live'", () => {
+      const id = extractVideoId(ytUrlPattern2);
+      expect(id).toEqual(videoId);
+    });
+
     it("handles the pattern 'watch'", () => {
       const id = extractVideoId(ytUrlPattern1);
       expect(id).toEqual(videoId);
     });
 
-    it("handles the pattern 'live'", () => {
-      const id = extractVideoId(ytUrlPattern2);
+    it("handles the pattern 'youtu.be'", () => {
+      const id = extractVideoId(ytUrlPattern3);
       expect(id).toEqual(videoId);
     });
 

--- a/frontend/src/utils/video.spec.ts
+++ b/frontend/src/utils/video.spec.ts
@@ -3,10 +3,12 @@ import { extractVideoId } from './video';
 describe('video module', () => {
   describe('function - extractVideoId', () => {
     const videoId = 'lYXQvHhfKuM';
-    const ytUrlPattern1 = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
-    const ytUrlPattern2 =
+
+    const ytUrlPatternLive =
       'https://www.youtube.com/live/lYXQvHhfKuM?feature=share';
-    const ytUrlPattern3 = 'https://youtu.be/lYXQvHhfKuM';
+    const ytUrlPatternMobile = 'https://m.youtube.com/watch?v=lYXQvHhfKuM';
+    const ytUrlPatternShort = 'https://youtu.be/lYXQvHhfKuM';
+    const ytUrlPatternWatch = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
 
     it('handles video id', () => {
       const id = extractVideoId(videoId);
@@ -19,26 +21,29 @@ describe('video module', () => {
     });
 
     it("handles the pattern 'live'", () => {
-      const id = extractVideoId(ytUrlPattern2);
+      const id1 = extractVideoId(ytUrlPatternLive);
+      expect(id1).toEqual(videoId);
+
+      const id2 = extractVideoId(ytUrlPatternLive.replace('://www.', '://'));
+      expect(id2).toEqual(videoId);
+    });
+
+    it("handles the pattern 'mobile'", () => {
+      const id = extractVideoId(ytUrlPatternMobile);
       expect(id).toEqual(videoId);
     });
 
     it("handles the pattern 'watch'", () => {
-      const id = extractVideoId(ytUrlPattern1);
-      expect(id).toEqual(videoId);
+      const id1 = extractVideoId(ytUrlPatternWatch);
+      expect(id1).toEqual(videoId);
+
+      const id2 = extractVideoId(ytUrlPatternWatch.replace('://www.', '://'));
+      expect(id2).toEqual(videoId);
     });
 
     it("handles the pattern 'youtu.be'", () => {
-      const id = extractVideoId(ytUrlPattern3);
+      const id = extractVideoId(ytUrlPatternShort);
       expect(id).toEqual(videoId);
-    });
-
-    it("also works without the 'www' subdomain", () => {
-      const id1 = extractVideoId(ytUrlPattern1.replace('://www.', '://'));
-      expect(id1).toEqual(videoId);
-
-      const id2 = extractVideoId(ytUrlPattern2.replace('://www.', '://'));
-      expect(id2).toEqual(videoId);
     });
   });
 });

--- a/frontend/src/utils/video.spec.ts
+++ b/frontend/src/utils/video.spec.ts
@@ -1,0 +1,38 @@
+import { extractVideoId } from './video';
+
+describe('video module', () => {
+  describe('function - extractVideoId', () => {
+    const videoId = 'lYXQvHhfKuM';
+    const ytUrlPattern1 = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
+    const ytUrlPattern2 =
+      'https://www.youtube.com/live/lYXQvHhfKuM?feature=share';
+
+    it('handles video id', () => {
+      const id = extractVideoId(videoId);
+      expect(id).toEqual(videoId);
+    });
+
+    it('handles Tournesol UID', () => {
+      const id = extractVideoId(`yt:${videoId}`);
+      expect(id).toEqual(videoId);
+    });
+
+    it("handles the pattern 'watch'", () => {
+      const id = extractVideoId(ytUrlPattern1);
+      expect(id).toEqual(videoId);
+    });
+
+    it("handles the pattern 'live'", () => {
+      const id = extractVideoId(ytUrlPattern2);
+      expect(id).toEqual(videoId);
+    });
+
+    it("also works without the 'www' subdomain", () => {
+      const id1 = extractVideoId(ytUrlPattern1.replace('://www.', '://'));
+      expect(id1).toEqual(videoId);
+
+      const id2 = extractVideoId(ytUrlPattern2.replace('://www.', '://'));
+      expect(id2).toEqual(videoId);
+    });
+  });
+});

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -8,7 +8,7 @@ export function extractVideoId(idOrUrl: string) {
 
   const matchUrl = idOrUrl.match(
     new RegExp(
-      '(?:https?:\\/\\/)?(?:www\\.)?' +
+      '(?:https?:\\/\\/)?(?:www\\.|m\\.)?' +
         '(?:youtube\\.com\\/watch\\?v=|youtube\\.com\\/live\\/|youtu\\.be\\/|' +
         escapedCurrentHost +
         '\\/entities\\/yt:|yt:)([A-Za-z0-9-_]{11})'

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -11,7 +11,7 @@ export function extractVideoId(idOrUrl: string) {
       '(?:https?:\\/\\/)?(?:www\\.)?' +
         '(?:youtube\\.com\\/watch\\?v=|youtube\\.com\\/live\\/|youtu\\.be\\/|' +
         escapedCurrentHost +
-        '\\/entities\\/yt:|yt:)([A-Za-z0-9-_]+)'
+        '\\/entities\\/yt:|yt:)([A-Za-z0-9-_]{11})'
     )
   );
   const id = matchUrl ? matchUrl[1] : idOrUrl.trim();

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -8,7 +8,8 @@ export function extractVideoId(idOrUrl: string) {
 
   const matchUrl = idOrUrl.match(
     new RegExp(
-      '(?:https?:\\/\\/)?(?:www\\.)?(?:youtube\\.com\\/watch\\?v=|youtu\\.be\\/|' +
+      '(?:https?:\\/\\/)?(?:www\\.)?' +
+        '(?:youtube\\.com\\/watch\\?v=|youtube\\.com\\/live\\/|youtu\\.be\\/|' +
         escapedCurrentHost +
         '\\/entities\\/yt:|yt:)([A-Za-z0-9-_]+)'
     )

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -11,7 +11,7 @@ export function extractVideoId(idOrUrl: string) {
       '(?:https?:\\/\\/)?(?:www\\.)?' +
         '(?:youtube\\.com\\/watch\\?v=|youtube\\.com\\/live\\/|youtu\\.be\\/|' +
         escapedCurrentHost +
-        '\\/entities\\/yt:|yt:)([A-Za-z0-9-_]{11})'
+        '\\/entities\\/yt:|yt:)([A-Za-z0-9-_]+)'
     )
   );
   const id = matchUrl ? matchUrl[1] : idOrUrl.trim();

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -133,7 +133,8 @@ describe('Comparison page', () => {
   });
 
   describe('video selectors', () => {
-    const videoAUrl = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
+    const videoAUrl1 = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
+    const videoAUrl2 = 'https://www.youtube.com/live/lYXQvHhfKuM?feature=share';
 
     it('support pasting YouTube URLs', () => {
       cy.visit('/comparison');
@@ -144,26 +145,28 @@ describe('Comparison page', () => {
 
       waitForAutoFill();
 
-      cy.get("[data-testid=entity-select-button-compact]").first().click();
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoAUrl, {delay: 0});
+      [videoAUrl1, videoAUrl2].forEach((videoAUrl) => {
+        cy.get("[data-testid=entity-select-button-compact]").first().click();
+        cy.get("[data-testid=paste-video-url]")
+          .type(videoAUrl, {delay: 0});
 
-      // wait for the auto filled video to be replaced
-      cy.contains('5 IA surpuissantes');
+        // wait for the auto filled video to be replaced
+        cy.contains('5 IA surpuissantes');
 
-      // the video title, upload date, and the number of views must be displayed
-      cy.get('div[data-testid=video-card-info]').first().within(() => {
-        cy.contains(
-          '5 IA surpuissantes',
-          {matchCase: false}
-        ).should('be.visible');
-        cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
-        cy.contains('views', {matchCase: false}).should('be.visible');
+        // the video title, upload date, and the number of views must be displayed
+        cy.get('div[data-testid=video-card-info]').first().within(() => {
+          cy.contains(
+            '5 IA surpuissantes',
+            {matchCase: false}
+          ).should('be.visible');
+          cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
+          cy.contains('views', {matchCase: false}).should('be.visible');
+        });
+
+        cy.get("[data-testid=entity-select-button-compact]").first().click();
+        cy.get("[data-testid=paste-video-url] input[type=text]")
+          .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
       });
-
-      cy.get("[data-testid=entity-select-button-compact]").first().click();
-      cy.get("[data-testid=paste-video-url] input[type=text]")
-        .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
     });
 
     it('support pasting YouTube video ID', () => {
@@ -180,7 +183,7 @@ describe('Comparison page', () => {
 
       cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url]")
-        .type(videoAUrl.split('?v=')[1], {delay: 0});
+        .type(videoAUrl1.split('?v=')[1], {delay: 0});
 
       // wait for the auto filled video to be replaced
       cy.contains('5 IA surpuissantes');
@@ -197,7 +200,7 @@ describe('Comparison page', () => {
 
       cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url] input[type=text]")
-        .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
+        .should('have.attr', 'value', `yt:${videoAUrl1.split('?v=')[1]}`);
     });
   });
 

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -133,8 +133,7 @@ describe('Comparison page', () => {
   });
 
   describe('video selectors', () => {
-    const videoAUrl1 = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
-    const videoAUrl2 = 'https://www.youtube.com/live/lYXQvHhfKuM?feature=share';
+    const videoAUrl = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
 
     it('support pasting YouTube URLs', () => {
       cy.visit('/comparison');
@@ -145,45 +144,9 @@ describe('Comparison page', () => {
 
       waitForAutoFill();
 
-      [videoAUrl1, videoAUrl2].forEach((videoAUrl) => {
-        cy.get("[data-testid=entity-select-button-compact]").first().click();
-        cy.get("[data-testid=paste-video-url]")
-          .type(videoAUrl, {delay: 0});
-
-        // wait for the auto filled video to be replaced
-        cy.contains('5 IA surpuissantes');
-
-        // the video title, upload date, and the number of views must be displayed
-        cy.get('div[data-testid=video-card-info]').first().within(() => {
-          cy.contains(
-            '5 IA surpuissantes',
-            {matchCase: false}
-          ).should('be.visible');
-          cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
-          cy.contains('views', {matchCase: false}).should('be.visible');
-        });
-
-        cy.get("[data-testid=entity-select-button-compact]").first().click();
-        cy.get("[data-testid=paste-video-url] input[type=text]")
-          .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
-      });
-    });
-
-    it('support pasting YouTube video ID', () => {
-      cy.visit('/comparison');
-
-      cy.focused().type(username);
-      cy.get('input[name="password"]').click()
-        .type('tournesol').type('{enter}');
-
-      // two cards must be displayed
-      cy.get("[data-testid=entity-select-button-compact]").should('have.length', 2);
-
-      waitForAutoFill();
-
       cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url]")
-        .type(videoAUrl1.split('?v=')[1], {delay: 0});
+        .type(videoAUrl, {delay: 0});
 
       // wait for the auto filled video to be replaced
       cy.contains('5 IA surpuissantes');
@@ -200,7 +163,41 @@ describe('Comparison page', () => {
 
       cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url] input[type=text]")
-        .should('have.attr', 'value', `yt:${videoAUrl1.split('?v=')[1]}`);
+        .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
+    });
+
+    it('support pasting YouTube video ID', () => {
+      cy.visit('/comparison');
+
+      cy.focused().type(username);
+      cy.get('input[name="password"]').click()
+        .type('tournesol').type('{enter}');
+
+      // two cards must be displayed
+      cy.get("[data-testid=entity-select-button-compact]").should('have.length', 2);
+
+      waitForAutoFill();
+
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
+      cy.get("[data-testid=paste-video-url]")
+        .type(videoAUrl.split('?v=')[1], {delay: 0});
+
+      // wait for the auto filled video to be replaced
+      cy.contains('5 IA surpuissantes');
+
+      // the video title, upload date, and the number of views must be displayed
+      cy.get('div[data-testid=video-card-info]').first().within(() => {
+        cy.contains(
+          '5 IA surpuissantes',
+          {matchCase: false}
+        ).should('be.visible');
+        cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
+        cy.contains('views', {matchCase: false}).should('be.visible');
+      });
+
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
+      cy.get("[data-testid=paste-video-url] input[type=text]")
+        .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
     });
   });
 

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -133,9 +133,8 @@ describe('Comparison page', () => {
   });
 
   describe('video selectors', () => {
-    const videoId = 'lYXQvHhfKuM';
-    const videoAUrl1 = `https://www.youtube.com/watch?v=${videoId}`;
-    const videoAUrl2 = `https://www.youtube.com/live/${videoId}?feature=share`;
+    const videoAUrl1 = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
+    const videoAUrl2 = 'https://www.youtube.com/live/lYXQvHhfKuM?feature=share';
 
     it('support pasting YouTube URLs', () => {
       cy.visit('/comparison');
@@ -146,46 +145,28 @@ describe('Comparison page', () => {
 
       waitForAutoFill();
 
-      cy.get("[data-testid=entity-select-button-compact]").first().click();
+      [videoAUrl1, videoAUrl2].forEach((videoAUrl) => {
+        cy.get("[data-testid=entity-select-button-compact]").first().click();
+        cy.get("[data-testid=paste-video-url]")
+          .type(videoAUrl, {delay: 0});
 
-      // YouTube pattern 1: watch?v={video_id}
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoAUrl1, {delay: 0});
+        // wait for the auto filled video to be replaced
+        cy.contains('5 IA surpuissantes');
 
-      // wait for the auto filled video to be replaced
-      cy.contains('5 IA surpuissantes');
+        // the video title, upload date, and the number of views must be displayed
+        cy.get('div[data-testid=video-card-info]').first().within(() => {
+          cy.contains(
+            '5 IA surpuissantes',
+            {matchCase: false}
+          ).should('be.visible');
+          cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
+          cy.contains('views', {matchCase: false}).should('be.visible');
+        });
 
-      cy.get('div[data-testid=video-card-info]').first().within(() => {
-        cy.contains(
-          '5 IA surpuissantes',
-          {matchCase: false}
-        ).should('be.visible');
-        cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
-        cy.contains('views', {matchCase: false}).should('be.visible');
+        cy.get("[data-testid=entity-select-button-compact]").first().click();
+        cy.get("[data-testid=paste-video-url] input[type=text]")
+          .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
       });
-
-      cy.get("[data-testid=entity-select-button-compact]").first().click();
-      cy.get("[data-testid=paste-video-url] input[type=text]")
-        .should('have.attr', 'value', `yt:${videoId}`);
-
-      // YouTube pattern 2: /live/${video_id}
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoAUrl2, {delay: 0});
-
-      cy.contains('5 IA surpuissantes');
-
-      cy.get('div[data-testid=video-card-info]').first().within(() => {
-        cy.contains(
-          '5 IA surpuissantes',
-          {matchCase: false}
-        ).should('be.visible');
-        cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
-        cy.contains('views', {matchCase: false}).should('be.visible');
-      });
-
-      cy.get("[data-testid=entity-select-button-compact]").first().click();
-      cy.get("[data-testid=paste-video-url] input[type=text]")
-        .should('have.attr', 'value', `yt:${videoId}`);
     });
 
     it('support pasting YouTube video ID', () => {

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -133,8 +133,9 @@ describe('Comparison page', () => {
   });
 
   describe('video selectors', () => {
-    const videoAUrl1 = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
-    const videoAUrl2 = 'https://www.youtube.com/live/lYXQvHhfKuM?feature=share';
+    const videoId = 'lYXQvHhfKuM';
+    const videoAUrl1 = `https://www.youtube.com/watch?v=${videoId}`;
+    const videoAUrl2 = `https://www.youtube.com/live/${videoId}?feature=share`;
 
     it('support pasting YouTube URLs', () => {
       cy.visit('/comparison');
@@ -145,28 +146,46 @@ describe('Comparison page', () => {
 
       waitForAutoFill();
 
-      [videoAUrl1, videoAUrl2].forEach((videoAUrl) => {
-        cy.get("[data-testid=entity-select-button-compact]").first().click();
-        cy.get("[data-testid=paste-video-url]")
-          .type(videoAUrl, {delay: 0});
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
 
-        // wait for the auto filled video to be replaced
-        cy.contains('5 IA surpuissantes');
+      // YouTube pattern 1: watch?v={video_id}
+      cy.get("[data-testid=paste-video-url]")
+        .type(videoAUrl1, {delay: 0});
 
-        // the video title, upload date, and the number of views must be displayed
-        cy.get('div[data-testid=video-card-info]').first().within(() => {
-          cy.contains(
-            '5 IA surpuissantes',
-            {matchCase: false}
-          ).should('be.visible');
-          cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
-          cy.contains('views', {matchCase: false}).should('be.visible');
-        });
+      // wait for the auto filled video to be replaced
+      cy.contains('5 IA surpuissantes');
 
-        cy.get("[data-testid=entity-select-button-compact]").first().click();
-        cy.get("[data-testid=paste-video-url] input[type=text]")
-          .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
+      cy.get('div[data-testid=video-card-info]').first().within(() => {
+        cy.contains(
+          '5 IA surpuissantes',
+          {matchCase: false}
+        ).should('be.visible');
+        cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
+        cy.contains('views', {matchCase: false}).should('be.visible');
       });
+
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
+      cy.get("[data-testid=paste-video-url] input[type=text]")
+        .should('have.attr', 'value', `yt:${videoId}`);
+
+      // YouTube pattern 2: /live/${video_id}
+      cy.get("[data-testid=paste-video-url]")
+        .type(videoAUrl2, {delay: 0});
+
+      cy.contains('5 IA surpuissantes');
+
+      cy.get('div[data-testid=video-card-info]').first().within(() => {
+        cy.contains(
+          '5 IA surpuissantes',
+          {matchCase: false}
+        ).should('be.visible');
+        cy.contains('2022-06-20', {matchCase: false}).should('be.visible');
+        cy.contains('views', {matchCase: false}).should('be.visible');
+      });
+
+      cy.get("[data-testid=entity-select-button-compact]").first().click();
+      cy.get("[data-testid=paste-video-url] input[type=text]")
+        .should('have.attr', 'value', `yt:${videoId}`);
     });
 
     it('support pasting YouTube video ID', () => {


### PR DESCRIPTION
**related to** #1717 

---

The function responsible of extracting the video id from YouTube URLs is now able to extract id from these additional patterns:
- https://youtube.com/live/{video_id}
- https://youtube.com/live/{video_id}?feature=share
- https://www.youtube.com/live/{video_id}
- https://www.youtube.com/live/{video_id}?feature=share
- https://m.youtube.com/watch?v={video_id}

We might want in the future to support more exotic patterns, like a mobile URL used in a desktop environment:
- https://www.youtube.com/watch?app=desktop&v={video_id}