### PR TITLE
[back] feat: refactor rate-later API with individual and collective ratings

### DIFF
--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import IntegerField, ModelSerializer
 
-from tournesol.models import CriteriaRank, Entity, EntityPollRating, Poll
+from tournesol.models import ContributorRating, CriteriaRank, Entity, EntityPollRating, Poll
 from tournesol.models.entity_poll_rating import UNSAFE_REASONS
 from tournesol.serializers.entity import EntityCriteriaScoreSerializer
 
@@ -35,6 +35,30 @@ class UnsafeStatusSerializer(ModelSerializer):
         fields = [
             "status",
             "reasons",
+        ]
+
+
+class CollectiveRatingSerializer(ModelSerializer):
+    unsafe = UnsafeStatusSerializer(source="*")
+
+    class Meta:
+        model = EntityPollRating
+        fields = [
+            "n_comparisons",
+            "n_contributors",
+            "tournesol_score",
+            "unsafe",
+        ]
+
+
+class IndividualRatingSerializer(ModelSerializer):
+    n_comparisons = IntegerField()
+
+    class Meta:
+        model = ContributorRating
+        fields = [
+            "is_public",
+            "n_comparisons",
         ]
 
 

--- a/backend/tournesol/serializers/rate_later.py
+++ b/backend/tournesol/serializers/rate_later.py
@@ -6,15 +6,35 @@ from rest_framework.serializers import ModelSerializer
 from tournesol.errors import ConflictError
 from tournesol.models import Entity, RateLater
 from tournesol.serializers.entity import RelatedEntitySerializer
+from tournesol.serializers.poll import CollectiveRatingSerializer, IndividualRatingSerializer
+
+
+class RateLaterMetadataSerializer(ModelSerializer):
+    class Meta:
+        model = RateLater
+        fields = ["created_at"]
 
 
 class RateLaterSerializer(ModelSerializer):
-    entity = RelatedEntitySerializer(True)
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
+    entity = RelatedEntitySerializer()
+    collective_rating = CollectiveRatingSerializer(
+        source="entity.single_poll_rating", read_only=True
+    )
+    individual_rating = IndividualRatingSerializer(
+        source="entity.single_contributor_rating", read_only=True
+    )
+    rate_later_metadata = RateLaterMetadataSerializer(source="*", read_only=True)
 
     class Meta:
         model = RateLater
-        fields = ["entity", "user", "created_at"]
+        fields = [
+            "user",
+            "entity",
+            "collective_rating",
+            "individual_rating",
+            "rate_later_metadata",
+        ]
 
     def create(self, validated_data):
         uid = validated_data.pop("entity").get("uid")

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -1,8 +1,5 @@
-from django.db.models import Q
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema_field
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import BooleanField, CharField, SerializerMethodField
+from rest_framework.fields import BooleanField, CharField, DateTimeField, IntegerField
 from rest_framework.serializers import ModelSerializer, Serializer
 
 from tournesol.models import ContributorRating, ContributorRatingCriteriaScore, Entity
@@ -18,10 +15,12 @@ class ContributorCriteriaScore(ModelSerializer):
 class ContributorRatingSerializer(ModelSerializer):
     entity = EntityNoExtraFieldSerializer(read_only=True)
     criteria_scores = ContributorCriteriaScore(many=True, read_only=True)
-    n_comparisons = SerializerMethodField(
+    n_comparisons = IntegerField(
+        default=0,
+        read_only=True,
         help_text="Number of comparisons submitted by the current user about the current video",
     )
-    last_compared_at = SerializerMethodField(read_only=True)
+    last_compared_at = DateTimeField(read_only=True, default=None, required=False)
 
     class Meta:
         model = ContributorRating
@@ -32,39 +31,6 @@ class ContributorRatingSerializer(ModelSerializer):
             "n_comparisons",
             "last_compared_at",
         ]
-
-    @extend_schema_field(OpenApiTypes.INT)
-    def get_n_comparisons(self, obj):
-        """
-        The number of comparisons is always computed for a specific poll for
-        now.
-        """
-        if hasattr(obj, "n_comparisons"):
-            # Use annotated field if it has been defined by the queryset
-            return obj.n_comparisons
-        return obj.user.comparisons.filter(
-            Q(poll=self.context["poll"])
-            & (Q(entity_1=obj.entity) | Q(entity_2=obj.entity))
-        ).count()
-
-    @extend_schema_field(OpenApiTypes.DATETIME)
-    def get_last_compared_at(self, obj):
-        if hasattr(obj, "last_compared_at"):
-            # Use annotated field if it has been defined by the queryset
-            return obj.last_compared_at
-
-        last_comparison = (
-            obj.user.comparisons.filter(poll=self.context["poll"])
-            .filter(Q(entity_1=obj.entity) | Q(entity_2=obj.entity))
-            .values("datetime_lastedit")
-            .order_by("-datetime_lastedit")[:1]
-        ).first()
-
-        # When a `ContributorRating` doesn't have any related comparison.
-        if not last_comparison:
-            return None
-
-        return last_comparison["datetime_lastedit"]
 
     def to_internal_value(self, data):
         """
@@ -91,9 +57,7 @@ class ContributorRatingCreateSerializer(ContributorRatingSerializer):
 
     def validate(self, attrs):
         uid = attrs.pop("uid")
-        entity_serializer = RelatedEntitySerializer(
-            data={"uid": uid}, context=self.context
-        )
+        entity_serializer = RelatedEntitySerializer(data={"uid": uid}, context=self.context)
         entity_serializer.is_valid(raise_exception=True)
         entity = Entity.objects.get(uid=uid)
 


### PR DESCRIPTION
Closes #1466 

This PR also introduces new serializers that should be reused for other changes described in #606, especially
* `CollectiveRatingSerializer` to build the `collective_rating` object, derived from an `EntityPollRating` 
* `IndividualRatingSerializer` to build the `individual_rating` object, derived from a `ContributorRating` 

-- 
The field `created_at` is moved into `rate_later_metadata`. I don't expect any incompatibility in the application, but I still need to check that, by updating the OpenAPI schema.