### PR TITLE
[back] chore: upgrade several dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -30,11 +30,11 @@ drf-spectacular==0.26.4
 # Pillow is used to generate the Previews for links shared on social media
 Pillow==9.5.0
 # Needed for postgres database
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.7
 # PyYAML is used for reading the settings 
 PyYAML==6.0
 # tqdm is used to display a progressbar in some slow ML algorithms
-tqdm==4.65.0
+tqdm==4.66.1
 # langdetect is used to detect the language of video
 langdetect==1.0.9
 # Pandas is used extensively in the ML algorithms and for some data management

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ django-oauth-toolkit==1.7.1
 django-prometheus==2.2.0
 # Registration, profile, password and email management
 # https://github.com/apragacz/django-rest-registration
-django-rest-registration==0.7.3
+django-rest-registration==0.8.2
 # Useful helpers for queries such as SubqueryCount
 django-sql-utils==0.6.1
 # Django REST Framework is used for most of the API routes

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ Django==4.1.10
 django-computed-property==0.3.0
 # CORS middleware
 # See https://github.com/adamchainz/django-cors-headers
-django-cors-headers==3.14.0
+django-cors-headers==4.2.0
 # Used to support OAuth
 # See https://github.com/jazzband/django-oauth-toolkit
 django-oauth-toolkit==1.7.1
@@ -19,7 +19,7 @@ django-prometheus==2.2.0
 # Registration, profile, password and email management
 # https://github.com/apragacz/django-rest-registration
 django-rest-registration==0.7.3
-# Useful helpers for quesries such as SubqueryCount
+# Useful helpers for queries such as SubqueryCount
 django-sql-utils==0.6.1
 # Django REST Framework is used for most of the API routes
 # https://github.com/encode/django-rest-framework
@@ -28,7 +28,7 @@ djangorestframework==3.14.0
 # See https://github.com/tfranzel/drf-spectacular
 drf-spectacular==0.26.0
 # Pillow is used to generate the Previews for links shared on social media
-Pillow==9.4.0
+Pillow==9.5.0
 # Needed for postgres database
 psycopg2-binary==2.9.5
 # PyYAML is used for reading the settings 
@@ -48,13 +48,13 @@ numba==0.57.1
 # Check the compatibility with Numba before upgrading.
 numpy==1.24.3
 # Scipy is used in some ML algorithms
-scipy==1.10.1
+scipy==1.11.2
 # API Youtube data
-google-api-python-client==2.81.0
+google-api-python-client==2.97.0
 google-auth-httplib2==0.1.0
 # matplotlib is used to generate a graph that the twitter bot tweets every
 # month
-matplotlib==3.7.1
+matplotlib==3.7.2
 # requests is used to trigger a few external tools such as Discord or fetch
 # information 
 requests==2.31.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,7 +26,7 @@ django-sql-utils==0.6.1
 djangorestframework==3.14.0
 # Used to generate OpenAPI documentation exposed by Swagger UI
 # See https://github.com/tfranzel/drf-spectacular
-drf-spectacular==0.26.0
+drf-spectacular==0.26.4
 # Pillow is used to generate the Previews for links shared on social media
 Pillow==9.5.0
 # Needed for postgres database

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -34,7 +34,6 @@ paths:
   /accounts/profile/:
     get:
       operationId: accounts_profile_retrieve
-      description: Get or set user profile.
       tags:
       - accounts
       security:
@@ -49,7 +48,6 @@ paths:
           description: ''
     post:
       operationId: accounts_profile_create
-      description: Get or set user profile.
       tags:
       - accounts
       requestBody:
@@ -76,7 +74,6 @@ paths:
           description: ''
     put:
       operationId: accounts_profile_update
-      description: Get or set user profile.
       tags:
       - accounts
       requestBody:
@@ -103,7 +100,6 @@ paths:
           description: ''
     patch:
       operationId: accounts_profile_partial_update
-      description: Get or set user profile.
       tags:
       - accounts
       requestBody:


### PR DESCRIPTION
This PR upgrades several Python packages used by the back end.

In the near future we may want upgrade `django-oauth-toolkit` to the latest major release 2.x to benefit from the security improvements. This might involve updating the set-up of the dev-env.