### PR TITLE
[tests] fix flaky test about Profile page when typing in non-empty field

### DIFF
--- a/tests/cypress/e2e/frontend/settingsAccountPage.cy.ts
+++ b/tests/cypress/e2e/frontend/settingsAccountPage.cy.ts
@@ -48,7 +48,7 @@ describe('Settings - account page', () => {
     })
 
     it('can update password', () => {
-      const newPaswsword = 'new_password';
+      const newPassword = 'new_password';
 
       cy.visit('/settings/account');
       cy.focused().type(username);
@@ -57,8 +57,8 @@ describe('Settings - account page', () => {
 
       cy.contains('Change password').should('be.visible');
       cy.get('input[name=old_password]').type(oldPassword);
-      cy.get('input[name=password]').type(newPaswsword);
-      cy.get('input[name=password_confirm]').type(newPaswsword).type('{enter}');
+      cy.get('input[name=password]').type(newPassword);
+      cy.get('input[name=password_confirm]').type(newPassword).type('{enter}');
       cy.contains('Password changed successfully');
 
       cy.get('button#personal-menu-button').click();
@@ -72,7 +72,8 @@ describe('Settings - account page', () => {
       cy.contains('Invalid credentials given.');
 
       // only new password must work
-      cy.get('input[name="password"]').click().clear().type(newPaswsword).type('{enter}');
+      cy.get('input[name="password"]').click().clear();
+      cy.get('input[name="password"]').type(newPassword).type('{enter}');
       cy.location('pathname').should('equal', '/settings/account');
       cy.contains('Forgot password?').should('not.exist');
     })

--- a/tests/cypress/e2e/frontend/settingsProfilePage.cy.ts
+++ b/tests/cypress/e2e/frontend/settingsProfilePage.cy.ts
@@ -2,11 +2,11 @@ describe('Settings - profile page', () => {
   describe('Change username flow', () => {
     const user1username = 'nobody';
     const user1NewUsername = 'noone';
-    const user1email = 'mr@nobody.org';
-    const user1password = 'password'
+    const user1email = 'user1@nobody.test';
+    const user1password = 'user1password'
 
     const user2username = 'already';
-    const user2email = 'al@ready.org';
+    const user2email = 'user2@nobody.test';
     const user2password = 'user2password';
 
     beforeEach(() => {
@@ -22,7 +22,8 @@ describe('Settings - profile page', () => {
       cy.location('pathname').should('equal', '/settings/profile');
 
       cy.contains('Profile').should('be.visible');
-      cy.get('input[name=username]').clear().type(user1NewUsername).type('{enter}');
+      cy.get('input[name=username]').should("have.value", user1username).clear();
+      cy.get('input[name=username]').type(user1NewUsername).type('{enter}');
       cy.contains('Profile changed successfully');
 
       cy.get('button#personal-menu-button').click();
@@ -36,7 +37,9 @@ describe('Settings - profile page', () => {
       cy.contains('Invalid credentials given.');
 
       // only new username must work
-      cy.get('input[name="username"]').click().clear().type(user1NewUsername).type('{enter}');
+      cy.get('input[name="username"]').click().clear();
+      cy.get('input[name="username"]').type(user1NewUsername).type('{enter}');
+      cy.contains('Profile').should('be.visible');
       cy.location('pathname').should('equal', '/settings/profile');
       cy.contains('Forgot password?').should('not.exist');
       cy.get('input[name=username]').should('have.value', user1NewUsername);
@@ -49,7 +52,8 @@ describe('Settings - profile page', () => {
       cy.location('pathname').should('equal', '/settings/profile');
 
       cy.contains('Profile').should('be.visible');
-      cy.get('input[name=username]').clear().type(user2username).type('{enter}');
+      cy.get('input[name=username]').should("have.value", user1username).clear();
+      cy.get('input[name=username]').type(user2username).type('{enter}');
       cy.contains('A user with that username already exists.');
 
       cy.get('button#personal-menu-button').click();

--- a/tests/cypress/support/index.d.ts
+++ b/tests/cypress/support/index.d.ts
@@ -3,5 +3,6 @@ declare namespace Cypress {
       sql(query: string): Chainable<any>
       getEmailLink(): Chainable<string>
       recreateUser(username: string, email: string, password: string): Chainable<any>
+      deleteUser(username: string): Chainable<any>
   }
 }


### PR DESCRIPTION
While running `tests/cypress/e2e/frontend/settingsProfilePage.cy.ts` it seems that username values may sometimes be typed in the input field, while another value is still present, possibly due to a race condition when loading the profile from the backend.

This PR ensures that the value has been correctly fetched before clearing the input.

Cypress documentation also recommends against chaining commands after `clear()`. So the actions have been splitted into multiple statements.