### PR TITLE
sec(infra) set HSTS max-age to 180 days (instead of 300 seconds)

### DIFF
--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -57,7 +57,15 @@ server {
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
-    add_header Strict-Transport-Security "max-age=300; includeSubDomains; preload; always;";
+
+    # HSTS set to 180 days (15552000 seconds)
+    # For information, according to Mozilla 1 year is acceptable, and 2 year
+    # is recommended.
+    #
+    #   see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+    #   see: https://hstspreload.org
+    #
+    add_header Strict-Transport-Security "max-age=15552000; includeSubDomains; preload; always;";
 
     # Content Security Policy
     #
@@ -132,7 +140,15 @@ server {
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
-    add_header Strict-Transport-Security "max-age=300; includeSubDomains; preload; always;";
+
+    # HSTS set to 180 days (15552000 seconds)
+    # For information, according to Mozilla 1 year is acceptable, and 2 year
+    # is recommended.
+    #
+    #   see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+    #   see: https://hstspreload.org
+    #
+    add_header Strict-Transport-Security "max-age=15552000; includeSubDomains; preload; always;";
 {% else %}
     listen 80;
 {% endif %}


### PR DESCRIPTION
**related to** #1439

---

(a)

I read that Mozilla recommend to set max-age to [one year](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#examples), and by doing so our website become eligible for [HTST preload](https://hstspreload.org/?domain=tournesol.app).  Curiously even with our current value of 300 seconds, it looks like we are already considered preloaded by hstspreload, but to confirm this we need to be sure we are part of the Chrome preload list (for instance, we are not part of the [Firefox preload list](https://hg.mozilla.org/mozilla-central/raw-file/tip/security/manager/ssl/nsSTSPreloadList.inc)).

There [several warnings](https://hstspreload.org/?domain=tournesol.app#opt-in) about being preloaded, so it may be a good move to first set max-age to 180 days or lower before going further.

(b)

I didn't update grafana and plausible max-age, because I'd like to see if they are automatically affected by the `includeSubDomains` options. 

See:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
- https://hstspreload.org/?domain=tournesol.app