### PR TITLE
style(front): add a welcome banner in the signup form

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -891,6 +891,7 @@
   "signup": {
     "oneLastStep": "One last step",
     "successMessage": "A verification link has been sent to <1>{{email}}</1>",
+    "ifYourEmailIsIncorrect": "If your email address is incorrect, simply <2>create a new account</2>.",
     "welcomeOnTournesol": "Welcome on Tournesol",
     "weVeBeenWaitingForYou": "We've been waiting for you 🖖",
     "title": "Account creation",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -896,7 +896,7 @@
     "weVeBeenWaitingForYou": "We've been waiting for you 🖖",
     "title": "Account creation",
     "accountCreationFailed": "Account creation failed.",
-    "anActivationEmailWillBeSent": "An activation email will be sent.",
+    "anActivationEmailWillBeSent": "An activation email will be sent to confirm the address, before you can start contributing.",
     "iAgreeWithTheTerms": "I'm at least 15 years old. I have read and I agree with the <2>Terms of Service</2> and the <6>Privacy Policy</6>."
   },
   "emailAddress": "Email address",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -889,10 +889,13 @@
   "noVideoCorrespondsToSearchCriterias": "No video corresponds to your search criteria.",
   "profile": "Profile",
   "signup": {
-    "welcome": "Welcome!",
-    "successMessage": "A verification link has been sent to <1>{{email}}</1> .",
+    "oneLastStep": "One last step",
+    "successMessage": "A verification link has been sent to <1>{{email}}</1>",
+    "welcomeOnTournesol": "Welcome on Tournesol",
+    "weVeBeenWaitingForYou": "We've been waiting for you 🖖",
     "title": "Account creation",
     "accountCreationFailed": "Account creation failed.",
+    "anActivationEmailWillBeSent": "An activation email will be sent.",
     "iAgreeWithTheTerms": "I'm at least 15 years old. I have read and I agree with the <2>Terms of Service</2> and the <6>Privacy Policy</6>."
   },
   "emailAddress": "Email address",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -892,7 +892,7 @@
     "oneLastStep": "One last step",
     "successMessage": "A verification link has been sent to <1>{{email}}</1>",
     "ifYourEmailIsIncorrect": "If your email address is incorrect, simply <2>create a new account</2>.",
-    "welcomeOnTournesol": "Welcome on Tournesol",
+    "welcomeToTournesol": "Welcome to Tournesol",
     "weVeBeenWaitingForYou": "We've been waiting for you 🖖",
     "title": "Account creation",
     "accountCreationFailed": "Account creation failed.",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -901,11 +901,11 @@
     "oneLastStep": "Une toute dernière étape",
     "successMessage": "Un lien de vérification vient d'être envoyé à <1>{{email}}</1>",
     "ifYourEmailIsIncorrect": "Si votre e-mail est incorrect, créez simplement <2>un nouveau compte</2>.",
-    "welcomeOnTournesol": "Bienvenue sur Tournesol",
+    "welcomeToTournesol": "Bienvenue sur Tournesol",
     "weVeBeenWaitingForYou": "Nous vous attendions 🖖",
     "title": "Inscription",
     "accountCreationFailed": "Création du compte échouée.",
-    "anActivationEmailWillBeSent": "Un e-mail d'activation sera envoyé.",
+    "anActivationEmailWillBeSent": "Un e-mail d'activation sera envoyé. Vous aurez besoin de confirmez votre adresse pour vous connecter.",
     "iAgreeWithTheTerms": "J'ai au moins 15 ans. J'ai lu et j'accepte les <2>Conditions Générales d'Utilisations</2> et la <6>Politique de confidentialité</6>."
   },
   "emailAddress": "Adresse e-mail",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -900,6 +900,7 @@
   "signup": {
     "oneLastStep": "Une toute dernière étape",
     "successMessage": "Un lien de vérification vient d'être envoyé à <1>{{email}}</1>",
+    "ifYourEmailIsIncorrect": "Si votre e-mail est incorrect, créez simplement <2>un nouveau compte</2>.",
     "welcomeOnTournesol": "Bienvenue sur Tournesol",
     "weVeBeenWaitingForYou": "Nous vous attendions 🖖",
     "title": "Inscription",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -898,10 +898,13 @@
   "noVideoCorrespondsToSearchCriterias": "Aucune vidéo ne correspond à vos critères de recherche.",
   "profile": "Profil",
   "signup": {
-    "welcome": "Bienvenue !",
-    "successMessage": "Un lien de vérification vient d'être envoyé à <1>{{email}}</1> .",
+    "oneLastStep": "Une toute dernière étape",
+    "successMessage": "Un lien de vérification vient d'être envoyé à <1>{{email}}</1>",
+    "welcomeOnTournesol": "Bienvenue sur Tournesol",
+    "weVeBeenWaitingForYou": "Nous vous attendions 🖖",
     "title": "Inscription",
     "accountCreationFailed": "Création du compte échouée.",
+    "anActivationEmailWillBeSent": "Un e-mail d'activation sera envoyé.",
     "iAgreeWithTheTerms": "J'ai au moins 15 ans. J'ai lu et j'accepte les <2>Conditions Générales d'Utilisations</2> et la <6>Politique de confidentialité</6>."
   },
   "emailAddress": "Adresse e-mail",

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -76,7 +76,7 @@ const WelcomePaper = () => {
     >
       <Box display="flex" flexDirection="column" gap={1}>
         <Typography variant="h3" textAlign="center">
-          {t('signup.welcomeOnTournesol')}
+          {t('signup.welcomeToTournesol')}
         </Typography>
         <Typography textAlign="center">
           {t('signup.weVeBeenWaitingForYou')}

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -11,6 +11,7 @@ import {
   AlertTitle,
   Divider,
   Box,
+  Paper,
 } from '@mui/material';
 import EmailIcon from '@mui/icons-material/Email';
 
@@ -31,11 +32,35 @@ const SignupSuccess = ({ email }: { email: string }) => {
   const { t } = useTranslation();
   return (
     <Alert severity="success">
-      <AlertTitle>{t('signup.welcome')}</AlertTitle>
+      <AlertTitle>{t('signup.oneLastStep')}</AlertTitle>
       <Trans t={t} i18nKey="signup.successMessage">
-        A verification link has been sent to <code>{{ email }}</code> .
+        A verification link has been sent to <code>{{ email }}</code>
       </Trans>
     </Alert>
+  );
+};
+
+const WelcomePaper = () => {
+  const { t } = useTranslation();
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 2,
+        mb: 4,
+        color: '#fff',
+        backgroundColor: 'background.emphatic',
+      }}
+    >
+      <Box display="flex" flexDirection="column" gap={1}>
+        <Typography variant="h3" textAlign="center">
+          {t('signup.welcomeOnTournesol')}
+        </Typography>
+        <Typography textAlign="center">
+          {t('signup.weVeBeenWaitingForYou')}
+        </Typography>
+      </Box>
+    </Paper>
   );
 };
 
@@ -98,6 +123,7 @@ const Signup = () => {
     <>
       <ContentHeader title={t('signup.title')} />
       <ContentBox maxWidth="sm">
+        <WelcomePaper />
         {successEmailAddress !== null ? (
           <SignupSuccess email={successEmailAddress} />
         ) : (
@@ -120,6 +146,7 @@ const Signup = () => {
                   label={t('emailAddress')}
                   autoComplete="email"
                   formError={formError}
+                  helperText={t('signup.anActivationEmailWillBeSent')}
                 />
               </Grid>
               <Grid item xs={12}>

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 
 import {
   Grid,
+  Link as MuiLink,
   Button,
   Typography,
   Checkbox,
@@ -31,12 +32,33 @@ import { resolvedLangToNotificationsLang } from 'src/utils/userSettings';
 const SignupSuccess = ({ email }: { email: string }) => {
   const { t } = useTranslation();
   return (
-    <Alert severity="success">
-      <AlertTitle>{t('signup.oneLastStep')}</AlertTitle>
-      <Trans t={t} i18nKey="signup.successMessage">
-        A verification link has been sent to <code>{{ email }}</code>
-      </Trans>
-    </Alert>
+    <>
+      <Alert severity="success" sx={{ mb: 8 }}>
+        <AlertTitle>
+          <strong>{t('signup.oneLastStep')}</strong>
+        </AlertTitle>
+        <Typography>
+          <Trans t={t} i18nKey="signup.successMessage">
+            A verification link has been sent to <code>{{ email }}</code>
+          </Trans>
+        </Typography>
+      </Alert>
+      <Typography paragraph px={1} textAlign="center">
+        <Trans t={t} i18nKey="signup.ifYourEmailIsIncorrect">
+          If your email address is incorrect, simply{' '}
+          <MuiLink
+            href="/signup"
+            sx={{
+              color: 'revert',
+              textDecoration: 'revert',
+            }}
+          >
+            create a new account
+          </MuiLink>
+          .
+        </Trans>
+      </Typography>
+    </>
   );
 };
 

--- a/tests/cypress/e2e/frontend/signup.cy.ts
+++ b/tests/cypress/e2e/frontend/signup.cy.ts
@@ -68,4 +68,28 @@ describe('Signup', () => {
     cy.get('[data-testid=notifications_email__research]').should('be.checked');
     cy.get('[data-testid=notifications_email__new_features]').should('not.be.checked');
   });
+
+  it('allows users to re-create an account if email is incorrect', () => {
+    cy.visit('/');
+    cy.contains('Join us').click();
+    cy.location('pathname').should('equal', '/signup');
+
+    cy.get('input[name=email]').type('user@example.com');
+    cy.get('input[name=username]').type('test-register');
+    cy.get('input[name=password]').type('tourne50l');
+    cy.get('input[name=password_confirm]').type('tourne50l');
+    cy.get('input[name=accept_terms]').check();
+
+    cy.contains('Sign up').click();
+    cy.contains('verification link').should('be.visible');
+    cy.contains('if your email address is incorrect, simply create a new account',
+      {matchCase: false});
+    cy.contains('create a new account').click();
+
+    cy.location('pathname').should('equal', '/signup');
+    cy.get('input[name=email]').should('be.visible');
+    cy.get('input[name=username]').should('be.visible');
+    cy.get('input[name=password]').should('be.visible');
+    cy.get('input[name=password_confirm]').should('be.visible');
+  });
 });


### PR DESCRIPTION
**related to** #1739 

---

This PR adds a welcome banner in the sign up form to make it more attractive.

In addition, a `helperText` has been added to the email field, to inform the users that an activation email will be sent to finalize the sign up process. For now there is no indication about the trusted / untrusted domains. I'm still trying to find the correct wording.

Finally, a security net has been added in the `SignupSuccess` component, to invite the users to check the spelling of their email address, and to create a new account in case of need (see the preview below).

### Preview

#### Desktop

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/43162439-d58c-4fca-8675-4a366a6a8330)

#### Mobile

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/e868214c-834c-4340-b58b-8f5e19bb2c2e)

#### Success

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/2c97ca54-cd07-4408-a787-efcda2b527a8)
