### PR TITLE
[back] refactor: Adapt contributor_ratings API to the new response schema

### DIFF
--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import ModelSerializer
 
-from tournesol.models import Comparison, ComparisonCriteriaScore, Entity
+from tournesol.models import Comparison, ComparisonCriteriaScore
 from tournesol.serializers.entity import RelatedEntitySerializer
 
 
@@ -77,18 +77,16 @@ class ComparisonSerializer(ComparisonSerializerMixin, ModelSerializer):
 
     @transaction.atomic
     def create(self, validated_data):
-        uid_1 = validated_data.pop("entity_1").get("uid")
-        uid_2 = validated_data.pop("entity_2").get("uid")
         # The validation performed by the `RelatedEntitySerializer` guarantees
         # that the submitted UIDs exist in the database.
-        entity_1 = Entity.objects.get(uid=uid_1)
-        entity_2 = Entity.objects.get(uid=uid_2)
+        entity_1_id = validated_data.pop("entity_1")["pk"]
+        entity_2_id = validated_data.pop("entity_2")["pk"]
         criteria_scores = validated_data.pop("criteria_scores")
 
         comparison = Comparison.objects.create(
             poll=self.context.get("poll"),
-            entity_1=entity_1,
-            entity_2=entity_2,
+            entity_1_id=entity_1_id,
+            entity_2_id=entity_2_id,
             **validated_data,
         )
 

--- a/backend/tournesol/serializers/entity.py
+++ b/backend/tournesol/serializers/entity.py
@@ -291,14 +291,16 @@ class RelatedEntitySerializer(EntitySerializer):
     def validate(self, attrs):
         uid = attrs.get("uid")
         try:
-            Entity.objects.get(uid=uid)
+            entity = Entity.objects.only("pk").get(uid=uid)
+            attrs["pk"] = entity.pk
         except ObjectDoesNotExist as error:
             created = False
             if self.context["poll"].entity_type == VideoEntity.name:
                 # A video entity can be created dynamically from a YouTube video id
                 video_id = uid.split(UID_DELIMITER)[1]
                 try:
-                    Entity.create_from_video_id(video_id)
+                    entity = Entity.create_from_video_id(video_id)
+                    attrs["pk"] = entity.pk
                     created = True
                 except VideoNotFound:
                     pass

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -53,7 +53,7 @@ class CollectiveRatingSerializer(ModelSerializer):
 
 
 class IndividualRatingSerializer(ModelSerializer):
-    n_comparisons = IntegerField(read_only=True)
+    n_comparisons = IntegerField(read_only=True, default=0)
 
     class Meta:
         model = ContributorRating

--- a/backend/tournesol/serializers/rate_later.py
+++ b/backend/tournesol/serializers/rate_later.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
 
 from tournesol.errors import ConflictError
-from tournesol.models import Entity, RateLater
+from tournesol.models import RateLater
 from tournesol.serializers.entity import RelatedEntitySerializer
 from tournesol.serializers.poll import CollectiveRatingSerializer, IndividualRatingSerializer
 

--- a/backend/tournesol/serializers/rate_later.py
+++ b/backend/tournesol/serializers/rate_later.py
@@ -41,13 +41,11 @@ class RateLaterSerializer(ModelSerializer):
         ]
 
     def create(self, validated_data):
-        uid = validated_data.pop("entity").get("uid")
-        entity = Entity.objects.get(uid=uid)
-
+        entity_id = validated_data.pop("entity")["pk"]
         try:
             rate_later = RateLater.objects.create(
                 poll=self.context.get("poll"),
-                entity=entity,
+                entity_id=entity_id,
                 **validated_data,
             )
         except IntegrityError as error:

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -25,7 +25,7 @@ class ExtendedInvididualRatingSerializer(IndividualRatingSerializer):
 
 
 @extend_schema_serializer(
-    deprecate_fields=["n_comparisons", "last_compared_at", "is_public", "criteria_scores"]
+    exclude_fields=["n_comparisons", "last_compared_at", "criteria_scores"]
 )
 class ContributorRatingSerializer(ModelSerializer):
     entity = EntityNoExtraFieldSerializer(read_only=True)
@@ -54,6 +54,7 @@ class ContributorRatingSerializer(ModelSerializer):
             "n_comparisons",
             "last_compared_at",
         ]
+        extra_kwargs = {"is_public": {"write_only": True}}
 
     def to_internal_value(self, data):
         """
@@ -79,6 +80,7 @@ class ContributorRatingCreateSerializer(ContributorRatingSerializer):
             "individual_rating",
             "collective_rating",
         ]
+        extra_kwargs = ContributorRatingSerializer.Meta.extra_kwargs
 
     def validate(self, attrs):
         uid = attrs.pop("uid")

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -1,6 +1,5 @@
-from drf_spectacular.utils import extend_schema_serializer
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import BooleanField, CharField, DateTimeField, IntegerField
+from rest_framework.fields import BooleanField, CharField, DateTimeField
 from rest_framework.serializers import ModelSerializer, Serializer
 
 from tournesol.models import ContributorRating, ContributorRatingCriteriaScore
@@ -24,9 +23,6 @@ class ExtendedInvididualRatingSerializer(IndividualRatingSerializer):
         read_only_fields = fields
 
 
-@extend_schema_serializer(
-    exclude_fields=["n_comparisons", "last_compared_at", "criteria_scores"]
-)
 class ContributorRatingSerializer(ModelSerializer):
     entity = EntityNoExtraFieldSerializer(read_only=True)
     individual_rating = ExtendedInvididualRatingSerializer(source="*", read_only=True)
@@ -35,13 +31,6 @@ class ContributorRatingSerializer(ModelSerializer):
         read_only=True,
         allow_null=True
     )
-    criteria_scores = ContributorCriteriaScore(many=True, read_only=True)
-    n_comparisons = IntegerField(
-        default=0,
-        read_only=True,
-        help_text="Number of comparisons submitted by the current user about the current video",
-    )
-    last_compared_at = DateTimeField(read_only=True, default=None, required=False)
 
     class Meta:
         model = ContributorRating
@@ -50,9 +39,6 @@ class ContributorRatingSerializer(ModelSerializer):
             "individual_rating",
             "collective_rating",
             "is_public",
-            "criteria_scores",
-            "n_comparisons",
-            "last_compared_at",
         ]
         extra_kwargs = {"is_public": {"write_only": True}}
 
@@ -74,9 +60,6 @@ class ContributorRatingCreateSerializer(ContributorRatingSerializer):
             "uid",
             "is_public",
             "entity",
-            "criteria_scores",
-            "n_comparisons",
-            "last_compared_at",
             "individual_rating",
             "collective_rating",
         ]

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -3,7 +3,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import BooleanField, CharField, DateTimeField, IntegerField
 from rest_framework.serializers import ModelSerializer, Serializer
 
-from tournesol.models import ContributorRating, ContributorRatingCriteriaScore, Entity
+from tournesol.models import ContributorRating, ContributorRatingCriteriaScore
 from tournesol.serializers.entity import EntityNoExtraFieldSerializer, RelatedEntitySerializer
 from tournesol.serializers.poll import CollectiveRatingSerializer, IndividualRatingSerializer
 

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from unittest.mock import ANY
 
 from django.db.models import ObjectDoesNotExist
 from django.test import TestCase

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -163,7 +163,6 @@ class RatingApi(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
         self.assertEqual(response.data["entity"]["uid"], self.video3.uid)
-        self.assertEqual(response.data["n_comparisons"], 0)
         self.assertEqual(response.data["individual_rating"], {
             "n_comparisons": 0,
             "is_public": True,
@@ -243,7 +242,7 @@ class RatingApi(TestCase):
         self.assertEqual(response.data["entity"]["uid"], video.uid)
         self.assertEqual(response.data["individual_rating"]["is_public"], False)
         self.assertEqual(
-            response.data["criteria_scores"],
+            response.data["individual_rating"]["criteria_scores"],
             [
                 {
                     "criteria": "test-criteria",
@@ -252,7 +251,7 @@ class RatingApi(TestCase):
                 }
             ],
         )
-        self.assertEqual(response.data["n_comparisons"], 0)
+        self.assertEqual(response.data["individual_rating"]["n_comparisons"], 0)
 
     def test_anonymous_cant_list(self):
         """
@@ -274,7 +273,6 @@ class RatingApi(TestCase):
         self.assertEqual(response.data["count"], 2)
         rating = response.data["results"][0]
         self.assertEqual(rating["entity"]["uid"], self.video2.uid)
-        self.assertEqual(rating["n_comparisons"], 1)
         self.assertEqual(
             rating["individual_rating"],
             {
@@ -327,14 +325,16 @@ class RatingApi(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            [r["n_comparisons"] for r in response.data["results"]], [1, 2, 2, 3]
+            [r["individual_rating"]["n_comparisons"] for r in response.data["results"]],
+            [1, 2, 2, 3]
         )
 
         # The most compared first.
         response = self.client.get(self.ratings_base_url + "?order_by=-n_comparisons")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            [r["n_comparisons"] for r in response.data["results"]], [3, 2, 2, 1]
+            [r["individual_rating"]["n_comparisons"] for r in response.data["results"]],
+            [3, 2, 2, 1]
         )
 
     def test_authenticated_can_list_ordered_by_last_compared_at(self):
@@ -378,7 +378,7 @@ class RatingApi(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         sorted_array = sorted(
-            response.data["results"], key=lambda x: x["last_compared_at"]
+            response.data["results"], key=lambda x: x["individual_rating"]["last_compared_at"]
         )
         self.assertEqual(
             response.data["results"], sorted_array, response.data["results"]
@@ -389,7 +389,8 @@ class RatingApi(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         sorted_array = sorted(
-            response.data["results"], key=lambda x: x["last_compared_at"], reverse=True
+            response.data["results"], key=lambda x: x["individual_rating"]["last_compared_at"],
+            reverse=True
         )
         self.assertEqual(response.data["results"], sorted_array)
 
@@ -631,7 +632,7 @@ class RatingApi(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response_data["individual_rating"]["is_public"], True)
         self.assertEqual(
-            response_data["criteria_scores"],
+            response_data["individual_rating"]["criteria_scores"],
             [
                 {
                     "criteria": "test-criteria",

--- a/backend/tournesol/tests/test_api_ratings.py
+++ b/backend/tournesol/tests/test_api_ratings.py
@@ -163,7 +163,6 @@ class RatingApi(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
         self.assertEqual(response.data["entity"]["uid"], self.video3.uid)
-        self.assertEqual(response.data["is_public"], True)
         self.assertEqual(response.data["n_comparisons"], 0)
         self.assertEqual(response.data["individual_rating"], {
             "n_comparisons": 0,
@@ -242,7 +241,7 @@ class RatingApi(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["entity"]["uid"], video.uid)
-        self.assertEqual(response.data["is_public"], False)
+        self.assertEqual(response.data["individual_rating"]["is_public"], False)
         self.assertEqual(
             response.data["criteria_scores"],
             [
@@ -275,7 +274,6 @@ class RatingApi(TestCase):
         self.assertEqual(response.data["count"], 2)
         rating = response.data["results"][0]
         self.assertEqual(rating["entity"]["uid"], self.video2.uid)
-        self.assertEqual(rating["is_public"], False)
         self.assertEqual(rating["n_comparisons"], 1)
         self.assertEqual(
             rating["individual_rating"],
@@ -631,7 +629,7 @@ class RatingApi(TestCase):
         )
         response_data = response.json()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_data["is_public"], True)
+        self.assertEqual(response_data["individual_rating"]["is_public"], True)
         self.assertEqual(
             response_data["criteria_scores"],
             [

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -82,12 +82,6 @@ class ComparisonListApi(mixins.CreateModelMixin, ComparisonListBaseApi):
     List all or a filtered list of comparisons made by the logged user, or
     create a new one.
     """
-
-    def get_serializer_context(self):
-        context = super().get_serializer_context()
-        context["poll"] = self.poll_from_url
-        return context
-
     def get(self, request, *args, **kwargs):
         """
         Retrieve all comparisons made by the logged user, in a given poll.
@@ -222,7 +216,6 @@ class ComparisonDetailApi(
     def get_serializer_context(self):
         context = super().get_serializer_context()
         context["reverse"] = self.currently_reversed
-        context["poll"] = self.poll_from_url
         return context
 
     def perform_update(self, serializer):

--- a/backend/tournesol/views/rate_later.py
+++ b/backend/tournesol/views/rate_later.py
@@ -31,7 +31,6 @@ class RateLaterQuerysetMixin(PollScopedViewMixin):
         )
 
     def prefetch_entity(self, rate_later: RateLater):
-        rate_later.refresh_from_db(fields=["entity"])
         prefetch_related_objects([rate_later], self.get_prefetch_entity_config())
 
 

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -1,14 +1,14 @@
 """
 API endpoint to interact with the contributor's ratings.
 """
-from django.shortcuts import get_object_or_404
+from django.db.models import Prefetch, prefetch_related_objects
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import generics
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from tournesol.models import ContributorRating, Poll
+from tournesol.models import ContributorRating, Entity, Poll
 from tournesol.serializers.rating import (
     ContributorRatingCreateSerializer,
     ContributorRatingSerializer,
@@ -34,22 +34,38 @@ EXTRA_ORDER_BY = "-pk"
 DEFAULT_ORDER_BY = ["-last_compared_at", EXTRA_ORDER_BY]
 
 
-def get_annotated_ratings(poll: Poll):
-    """
-    Return a `ContributorRating` queryset with additional annotations like:
-        - the number of comparisons made by the user for the entity
-        - the date of the last comparison made for this entity
-        - etc.
+class ContributorRatingQuerysetMixin(PollScopedViewMixin):
+    def get_prefetch_entity_config(self):
+        poll = self.poll_from_url
+        return Prefetch(
+            "entity",
+            queryset=(
+                Entity.objects.with_prefetched_poll_ratings(poll_name=poll.name)
+            ),
+        )
 
-    This queryset expects to be evaluated with a specific poll, user and
-    entity.
-    """
-    return (
-        ContributorRating.objects.annotate_n_comparisons()
-        .annotate_last_compared_at()
-        .annotate_collective_score()
-        .annotate_individual_score(poll=poll)
-    )
+    def get_annotated_ratings(self):
+        """
+        Return a `ContributorRating` queryset with additional annotations like:
+            - the number of comparisons made by the user for the entity
+            - the date of the last comparison made for this entity
+            - etc.
+
+        This queryset expects to be evaluated with a specific poll, user and
+        entity.
+        """
+        poll = self.poll_from_url
+        return (
+            ContributorRating.objects.annotate_n_comparisons()
+            .annotate_last_compared_at()
+            .annotate_collective_score()
+            .annotate_individual_score(poll=poll)
+            .prefetch_related(self.get_prefetch_entity_config())
+        )
+
+    def prefetch_entity(self, contributor_rating: ContributorRating):
+        prefetch_related_objects([contributor_rating], self.get_prefetch_entity_config())
+
 
 
 @extend_schema_view(
@@ -66,7 +82,7 @@ def get_annotated_ratings(poll: Poll):
         "for a specific entity."
     ),
 )
-class ContributorRatingDetail(PollScopedViewMixin, generics.RetrieveUpdateAPIView):
+class ContributorRatingDetail(ContributorRatingQuerysetMixin, generics.RetrieveUpdateAPIView):
     """
     Get or update the current user's rating for the designated entity.
     Used in particular to get or update the is_public attribute.
@@ -74,12 +90,16 @@ class ContributorRatingDetail(PollScopedViewMixin, generics.RetrieveUpdateAPIVie
 
     serializer_class = ContributorRatingSerializer
 
-    def get_object(self):
-        return get_object_or_404(
-            get_annotated_ratings(self.poll_from_url),
-            poll=self.poll_from_url,
-            user=self.request.user,
-            entity__uid=self.kwargs["uid"],
+    lookup_url_kwarg = "uid"
+    lookup_field = "entity__uid"
+
+    def get_queryset(self):
+        return (
+            self.get_annotated_ratings()
+            .filter(
+                poll=self.poll_from_url,
+                user=self.request.user
+            )
         )
 
 
@@ -109,7 +129,7 @@ class ContributorRatingDetail(PollScopedViewMixin, generics.RetrieveUpdateAPIVie
         "specific video in a given poll, with optional visibility settings."
     ),
 )
-class ContributorRatingList(PollScopedViewMixin, generics.ListCreateAPIView):
+class ContributorRatingList(ContributorRatingQuerysetMixin, generics.ListCreateAPIView):
     """List the contributor's rated entities on the given poll and their scores."""
 
     queryset = ContributorRating.objects.none()
@@ -156,15 +176,17 @@ class ContributorRatingList(PollScopedViewMixin, generics.ListCreateAPIView):
 
     def get_queryset(self):
         ratings = (
-            get_annotated_ratings(self.poll_from_url)
+            self.get_annotated_ratings()
             .filter(poll=self.poll_from_url, user=self.request.user, n_comparisons__gt=0)
-            .select_related("entity")
             .prefetch_related("criteria_scores")
         )
-
         ratings = self._filter_queryset_by_visibility(ratings)
         ratings = self._order_queryset(self.poll_from_url, ratings)
         return ratings
+
+    def perform_create(self, serializer):
+        contributor_rating = serializer.save()
+        self.prefetch_entity(contributor_rating)
 
 
 class ContributorRatingUpdateAll(PollScopedViewMixin, generics.GenericAPIView):

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -67,7 +67,6 @@ class ContributorRatingQuerysetMixin(PollScopedViewMixin):
         prefetch_related_objects([contributor_rating], self.get_prefetch_entity_config())
 
 
-
 @extend_schema_view(
     get=extend_schema(
         description="Retrieve the logged-in user's ratings for a specific entity "

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -2769,59 +2769,39 @@ components:
           allOf:
           - $ref: '#/components/schemas/EntityNoExtraField'
           readOnly: true
-        is_public:
-          type: boolean
-          description: Should the rating be public?
-        criteria_scores:
-          type: array
-          items:
-            $ref: '#/components/schemas/ContributorCriteriaScore'
+        individual_rating:
+          allOf:
+          - $ref: '#/components/schemas/ExtendedInvididualRating'
           readOnly: true
-        n_comparisons:
-          type: integer
+        collective_rating:
+          allOf:
+          - $ref: '#/components/schemas/CollectiveRating'
           readOnly: true
-          default: 0
-          description: Number of comparisons submitted by the current user about the
-            current video
-        last_compared_at:
-          type: string
-          format: date-time
-          readOnly: true
+          nullable: true
       required:
-      - criteria_scores
+      - collective_rating
       - entity
-      - last_compared_at
-      - n_comparisons
+      - individual_rating
     ContributorRatingCreate:
       type: object
       properties:
-        is_public:
-          type: boolean
-          description: Should the rating be public?
         entity:
           allOf:
           - $ref: '#/components/schemas/EntityNoExtraField'
           readOnly: true
-        criteria_scores:
-          type: array
-          items:
-            $ref: '#/components/schemas/ContributorCriteriaScore'
+        individual_rating:
+          allOf:
+          - $ref: '#/components/schemas/ExtendedInvididualRating'
           readOnly: true
-        n_comparisons:
-          type: integer
+        collective_rating:
+          allOf:
+          - $ref: '#/components/schemas/CollectiveRating'
           readOnly: true
-          default: 0
-          description: Number of comparisons submitted by the current user about the
-            current video
-        last_compared_at:
-          type: string
-          format: date-time
-          readOnly: true
+          nullable: true
       required:
-      - criteria_scores
+      - collective_rating
       - entity
-      - last_compared_at
-      - n_comparisons
+      - individual_rating
     ContributorRatingCreateRequest:
       type: object
       properties:
@@ -2832,6 +2812,7 @@ components:
           maxLength: 144
         is_public:
           type: boolean
+          writeOnly: true
           description: Should the rating be public?
       required:
       - uid
@@ -2840,6 +2821,7 @@ components:
       properties:
         is_public:
           type: boolean
+          writeOnly: true
           description: Should the rating be public?
     ContributorRatingUpdateAll:
       type: object
@@ -3137,6 +3119,32 @@ components:
       description: |-
         * `video` - Video
         * `candidate_fr_2022` - Candidate (FR 2022)
+    ExtendedInvididualRating:
+      type: object
+      properties:
+        is_public:
+          type: boolean
+          readOnly: true
+          description: Should the rating be public?
+        n_comparisons:
+          type: integer
+          readOnly: true
+          default: 0
+        criteria_scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContributorCriteriaScore'
+          readOnly: true
+        last_compared_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+      required:
+      - criteria_scores
+      - is_public
+      - last_compared_at
+      - n_comparisons
     FAQEntry:
       type: object
       description: A translated question with its translated answer.
@@ -3215,6 +3223,7 @@ components:
         n_comparisons:
           type: integer
           readOnly: true
+          default: 0
       required:
       - is_public
       - n_comparisons
@@ -3492,6 +3501,7 @@ components:
       properties:
         is_public:
           type: boolean
+          writeOnly: true
           description: Should the rating be public?
     PatchedContributorRatingUpdateAllRequest:
       type: object

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -274,7 +274,8 @@ const Comparison = ({
               uidA={uidA || ''}
               uidB={uidB || ''}
               isComparisonPublic={
-                selectorA.rating.is_public && selectorB.rating.is_public
+                selectorA.rating.individual_rating.is_public &&
+                selectorB.rating.individual_rating.is_public
               }
             />
           )

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -260,13 +260,13 @@ const EntitySelectorInnerAuth = ({
   );
 
   const toggleAction: ActionList = useMemo(() => {
-    return rating?.is_public != null
+    return rating?.individual_rating.is_public != null
       ? [
           <UserRatingPublicToggle
             key="isPublicToggle"
             uid={rating.entity.uid}
-            nComparisons={rating.n_comparisons}
-            isPublic={rating.is_public}
+            nComparisons={rating.individual_rating.n_comparisons}
+            isPublic={rating.individual_rating.is_public}
             onChange={handleRatingUpdate}
           />,
         ]

--- a/frontend/src/features/feedback/StackedCandidatesPaper.tsx
+++ b/frontend/src/features/feedback/StackedCandidatesPaper.tsx
@@ -42,7 +42,7 @@ const StackedCandidatesPaper = ({
 
   const nComparisons = Object.fromEntries(
     ratings.map((rating) => {
-      return [rating.entity.uid, rating.n_comparisons];
+      return [rating.entity.uid, rating.individual_rating.n_comparisons];
     })
   );
 

--- a/frontend/src/features/videos/PublicStatusAction.tsx
+++ b/frontend/src/features/videos/PublicStatusAction.tsx
@@ -107,13 +107,13 @@ export const RatingsContext = React.createContext<RatingsContextValue>({});
 export const PublicStatusAction = ({ uid }: { uid: string }) => {
   const { getContributorRating, onChange } = useContext(RatingsContext);
   const contributorRating = getContributorRating?.(uid);
-  if (contributorRating == null || contributorRating.is_public == null) {
+  if (contributorRating == null) {
     return null;
   }
   return (
     <UserRatingPublicToggle
-      nComparisons={contributorRating.n_comparisons}
-      isPublic={contributorRating.is_public}
+      nComparisons={contributorRating.individual_rating.n_comparisons}
+      isPublic={contributorRating.individual_rating.is_public}
       uid={uid}
       onChange={onChange}
     />

--- a/frontend/src/hooks/usePersonalCriteriaScores.tsx
+++ b/frontend/src/hooks/usePersonalCriteriaScores.tsx
@@ -92,7 +92,8 @@ export const PersonalCriteriaScoresContextProvider = ({
         setCannotActivatePersonalScores(reason);
         return;
       }
-      const { criteria_scores: personalCriteriaScores } = contributorRating;
+      const personalCriteriaScores =
+        contributorRating.individual_rating.criteria_scores;
       if (personalCriteriaScores.length === 0) {
         setCannotActivatePersonalScores('noPersonalScore');
         return;


### PR DESCRIPTION
Related to #606

---

### Description

This PR updates the response schema of routes `/users/me/contributor_ratings/...`.

Instead of flat fields `n_comparisons`, `criteria_scores`, the response now includes `individual_rating` and `collaborative_rating` object, similarly to the changes introduced in #1720

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
