### PR TITLE
refactor(front): remove an extra console.error

### DIFF
--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -138,8 +138,7 @@ const Comparison = ({
           setInitialComparison(comparison);
           setIsLoading(false);
         })
-        .catch((err) => {
-          console.error(err);
+        .catch(() => {
           setInitialComparison(null);
           setIsLoading(false);
         });


### PR DESCRIPTION
### Description

There was a console.error in the front end's code that was adding necessary noise in the browser's console.

When opening a new comparison, the console was displaying an API error. In our case, there is nothing wrong, it is expected that new comparisons don't exist in the API. Displaying an error here can be understood as "something went wrong", but it's not the case.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
