### PR TITLE
[back] fix: HTTP 500 is now 400 when unique contrainst of rating is violated

### DIFF
--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -1,6 +1,8 @@
 """
 API endpoint to interact with the contributor's ratings.
 """
+import logging
+
 from django.db import IntegrityError
 from django.db.models import Prefetch, prefetch_related_objects
 from drf_spectacular.types import OpenApiTypes
@@ -16,6 +18,8 @@ from tournesol.serializers.rating import (
     ContributorRatingUpdateAllSerializer,
 )
 from tournesol.views.mixins.poll import PollScopedViewMixin
+
+logger = logging.getLogger(__name__)
 
 # The only values accepted by the URL parameter `order_by` in the list APIs.
 ALLOWED_GENERIC_ORDER_BY_VALUES = [
@@ -190,6 +194,12 @@ class ContributorRatingList(ContributorRatingQuerysetMixin, generics.ListCreateA
         try:
             contributor_rating = serializer.save()
         except IntegrityError as err:
+            logging.warning(
+                "Got IntegrityError when creating ContributorRating\n"
+                "We suppose it's an unique constraint violation. If not, the error should be "
+                "addressed.",
+                exc_info=True
+            )
             raise ValidationError(
                 {
                     "non_field_errors": [

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -194,7 +194,7 @@ class ContributorRatingList(ContributorRatingQuerysetMixin, generics.ListCreateA
         try:
             contributor_rating = serializer.save()
         except IntegrityError as err:
-            logging.warning(
+            logger.warning(
                 "Got IntegrityError when creating ContributorRating\n"
                 "We suppose it's an unique constraint violation. If not, the error should be "
                 "addressed.",

--- a/backend/tournesol/views/ratings.py
+++ b/backend/tournesol/views/ratings.py
@@ -189,7 +189,7 @@ class ContributorRatingList(ContributorRatingQuerysetMixin, generics.ListCreateA
         # serializer's validation and cause the view to fail here.
         try:
             contributor_rating = serializer.save()
-        except IntegrityError:
+        except IntegrityError as err:
             raise ValidationError(
                 {
                     "non_field_errors": [
@@ -197,7 +197,7 @@ class ContributorRatingList(ContributorRatingQuerysetMixin, generics.ListCreateA
                     ]
                 },
                 code="unique",
-            )
+            ) from err
 
         self.prefetch_entity(contributor_rating)
 


### PR DESCRIPTION
**related issues** #1746 

---

### Description

Usually the API `POST /users/me/contributor_ratings/{poll_name}/` correctly returns HTTP 400 when an already existing rating is validated.

There is an exception to this. According to the logs, we received concurrent requests (possibly bearing the same JSON payload), passing the validation, and causing the API to fail with an error 500. This PR makes the back end fail gracefully by returning a 400 Bad Request, instead of a 500 Interval Server Error.

Nevertheless, there might still be an issue in the front end causing two requests to be sent instead of one.

---

Here is the query I used in Grafana to investigate the problem, with different time ranges:

- time range from 2023-09-05 17:12:04 to 2023-09-05 17:12:05
- time range from 2023-09-05 10:25:23 to 2023-09-05 10:25:26

Between each time range there is an ip address sending several requests very close to each other. I suppose that at least two of those requests have the same JSON payload.

```
{filename="/var/log/nginx/json_access.log"} | json | request_uri = "/users/me/contributor_ratings/videos/"
```

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
