### PR TITLE
[back] test: order the results of VoucherReceivedListAPIView

### DIFF
--- a/backend/vouch/tests/test_api_voucher.py
+++ b/backend/vouch/tests/test_api_voucher.py
@@ -286,7 +286,8 @@ class VoucherReceivedListAPIViewTestCase(TestCase):
 
     def test_auth_200_list(self):
         """
-        An authenticated user can list its received vouchers
+        An authenticated user can list its received vouchers, ordered by
+        issuer name.
         """
         self.client.force_authenticate(user=self.user3)
         response = self.client.get(self.voucher_base_url, format="json")

--- a/backend/vouch/views.py
+++ b/backend/vouch/views.py
@@ -59,4 +59,4 @@ class VoucherReceivedListAPIView(generics.ListAPIView):
         return Voucher.objects.filter(
             to=self.request.user,
             by__is_active=True,
-        )
+        ).order_by('by__username')


### PR DESCRIPTION
**related issues** #1753 

---

### Description

This PR fixes the tests of the `vouch` app that could fail because of non deterministic answers of the vouch API.

Calling several times `VoucherReceivedListAPIView` should not return different results. I ordered the queryset by issuer username so that they can easily be displayed in alphabetical order in the front end.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
