### PR TITLE
[front] adjust style of Sidebar and EntityCard with large fonts

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -222,7 +222,7 @@ export const RowEntityCard = ({
           }}
         />
       </Box>
-      <Stack gap="4px">
+      <Stack gap="4px" alignSelf="start" marginTop={1}>
         <EntityCardTitle
           uid={entity.uid}
           title={entity.metadata.name}

--- a/frontend/src/features/criteria/CriteriaSelector.tsx
+++ b/frontend/src/features/criteria/CriteriaSelector.tsx
@@ -22,6 +22,9 @@ const CriteriaSelector = ({
       size="small"
       value={criteria}
       onChange={(v) => setCriteria(v.target.value)}
+      SelectDisplayProps={{
+        style: { whiteSpace: 'normal' },
+      }}
     >
       {extraEmptyOption !== '' && (
         <MenuItem value={extraEmptyOption}>------------</MenuItem>

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -202,7 +202,7 @@ const EntityTabsBox = ({
       </Tabs>
       <LoaderWrapper
         isLoading={status === TabStatus.Loading}
-        sx={{ overflowY: 'scroll' }}
+        sx={{ overflowY: 'auto' }}
       >
         {isDescriptionVisible ? (
           <TabInfo

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { useLocation, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
-  ListItem,
+  ListItemButton,
   ListItemText,
   ListItemIcon,
   Drawer,
@@ -86,9 +86,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       // their content should not be wrapped during the drawer animation.
       minWidth: `${sideBarWidth}px`,
     },
-  },
-  listItem: {
-    height: '64px',
   },
   listItemIcon: {
     color: '#CDCABC',
@@ -218,7 +215,7 @@ const SideBar = () => {
       <List
         disablePadding
         onClick={isSmallScreen ? () => dispatch(closeDrawer()) : undefined}
-        sx={{ flexGrow: 1 }}
+        sx={{ flexGrow: 1, wordBreak: 'break-word' }}
       >
         {menuItems.map(
           ({ id, targetUrl, IconComponent, displayText, ariaLabel }) => {
@@ -230,15 +227,14 @@ const SideBar = () => {
 
             const selected = isItemSelected(targetUrl);
             return (
-              <ListItem
+              <ListItemButton
                 key={id}
                 aria-label={ariaLabel}
-                button
                 selected={selected}
-                className={classes.listItem}
                 component={Link}
                 to={targetUrl}
                 sx={{
+                  minHeight: '56px',
                   '&.Mui-selected': {
                     bgcolor: 'action.selected',
                   },
@@ -265,7 +261,7 @@ const SideBar = () => {
                   primary={displayText}
                   primaryTypographyProps={{ className: classes.listItemText }}
                 />
-              </ListItem>
+              </ListItemButton>
             );
           }
         )}

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -70,7 +70,7 @@ export const VideoAnalysis = ({ video }: { video: Recommendation }) => {
               {t('entityAnalysisPage.video.description')}
             </CollapseButton>
             <Collapse in={descriptionCollapsed} timeout="auto" unmountOnExit>
-              <Typography paragraph>
+              <Typography paragraph component="div">
                 <Box
                   style={
                     descriptionCollapsed


### PR DESCRIPTION
### Description

This is an attempt to improve the appearance of the website when a large minimal font-size is configured in the browser settings.

* Sidebar: use `min-height` instead of fixed size and wrap labels
* Align metadata of `RowEntityCard` (used in the contextual list on the analysis page and in the video selector) to the top of the card. THis is to avoid hiding the video title when the content overflow the card. Far from perfect, another redesign may be required.
* Wrap labels in `CriteriaSelector`

### Screenshots
with min font-size: 24px

|Before|After|
|--|--|
|![Capture d’écran du 2023-09-07 14-33-23](https://github.com/tournesol-app/tournesol/assets/4726554/122be51e-15fa-4382-ad38-d45b06f274a9)|![Capture d’écran du 2023-09-07 14-41-14](https://github.com/tournesol-app/tournesol/assets/4726554/54095188-ebc7-4b61-94a1-0f59a13d9bbd)



### Checklist

- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
