### PR TITLE
[ext] fix: mozilla security warnings about `innerHtml` usage

### DIFF
--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -191,7 +191,6 @@ html[dark] #tournesol_campaign_button {
 }
 
 .tournesol_simple_button {
-  fill: var(--yt-spec-text-secondary);
   width: 20px;
   height: 20px;
   border-radius: 10px;
@@ -202,7 +201,9 @@ html[dark] #tournesol_campaign_button {
   cursor: pointer;
 }
 
-.tournesol_simple_button svg {
+.tournesol_simple_button img {
+  filter: invert(38%) sepia(0%) saturate(0%) hue-rotate(66deg) brightness(96%) contrast(92%);
+
   position: absolute;
   left: 0px;
   top: 0px;
@@ -210,8 +211,14 @@ html[dark] #tournesol_campaign_button {
   height: 20px;
 }
 
-.tournesol_simple_button:hover svg {
-  fill: var(--yt-spec-text-primary);
+[darker-dark-theme] [dark] .tournesol_simple_button img,
+html[darker-dark-theme][dark] .tournesol_simple_button img {
+  filter: invert(78%) sepia(0%) saturate(0%) hue-rotate(229deg) brightness(89%) contrast(86%);
+}
+
+.tournesol_simple_button:hover img,
+.tournesol_simple_button:active img {
+  filter: invert(0%) sepia(11%) saturate(3315%) hue-rotate(338deg) brightness(79%) contrast(88%);
 
   -webkit-transition: all 0.1s ease;
   -moz-transition: all 0.1s ease;
@@ -220,32 +227,20 @@ html[dark] #tournesol_campaign_button {
   transition: all 0.1s ease;
 }
 
-.tournesol_simple_button:active svg {
-  fill: var(--yt-spec-text-primary);
-
-  -webkit-transition: all 0.1s ease;
-  -moz-transition: all 0.1s ease;
-  -o-transition: all 0.1s ease;
-  -ms-transition: all 0.1s ease;
-  transition: all 0.1s ease;
+[darker-dark-theme] [dark] .tournesol_simple_button:hover img,
+html[darker-dark-theme][dark] .tournesol_simple_button:hover img,
+[darker-dark-theme] [dark] .tournesol_simple_button:active img,
+html[darker-dark-theme][dark] .tournesol_simple_button:active img {
+  filter: invert(99%) sepia(4%) saturate(475%) hue-rotate(206deg) brightness(116%) contrast(89%);
 }
 
-.tournesol_simple_button:active {
-  background: var(--yt-spec-brand-background-solid);
-
-  -webkit-transition: all 0.1s ease;
-  -moz-transition: all 0.1s ease;
-  -o-transition: all 0.1s ease;
-  -ms-transition: all 0.1s ease;
-  transition: all 0.1s ease;
+.tournesol_simple_button:disabled img {
+  filter: invert(60%) sepia(0%) saturate(0%) hue-rotate(326deg) brightness(95%) contrast(94%);
 }
 
-.tournesol_simple_button:disabled svg {
-  fill: var(--yt-spec-text-disabled);
-}
-
-.tournesol_simple_button:disabled {
-  background: var(--yt-spec-brand-background-solid);
+[darker-dark-theme] [dark] .tournesol_simple_button:disabled img,
+html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
+  filter: invert(40%) sepia(0%) saturate(1199%) hue-rotate(174deg) brightness(107%) contrast(79%);
 }
 
 .video_card {

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -211,7 +211,6 @@ html[dark] #tournesol_campaign_button {
   height: 20px;
 }
 
-[darker-dark-theme] [dark] .tournesol_simple_button img,
 html[darker-dark-theme][dark] .tournesol_simple_button img {
   filter: invert(78%) sepia(0%) saturate(0%) hue-rotate(229deg) brightness(89%) contrast(86%);
 }
@@ -227,9 +226,7 @@ html[darker-dark-theme][dark] .tournesol_simple_button img {
   transition: all 0.1s ease;
 }
 
-[darker-dark-theme] [dark] .tournesol_simple_button:hover img,
 html[darker-dark-theme][dark] .tournesol_simple_button:hover img,
-[darker-dark-theme] [dark] .tournesol_simple_button:active img,
 html[darker-dark-theme][dark] .tournesol_simple_button:active img {
   filter: invert(99%) sepia(4%) saturate(475%) hue-rotate(206deg) brightness(116%) contrast(89%);
 }
@@ -238,7 +235,6 @@ html[darker-dark-theme][dark] .tournesol_simple_button:active img {
   filter: invert(60%) sepia(0%) saturate(0%) hue-rotate(326deg) brightness(95%) contrast(94%);
 }
 
-[darker-dark-theme] [dark] .tournesol_simple_button:disabled img,
 html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
   filter: invert(40%) sepia(0%) saturate(1199%) hue-rotate(174deg) brightness(107%) contrast(79%);
 }

--- a/browser-extension/src/displayHomeRecommendations.js
+++ b/browser-extension/src/displayHomeRecommendations.js
@@ -1,6 +1,6 @@
 (async () => {
   const { TournesolRecommendations } = await import(
-    chrome.extension.getURL(
+    chrome.runtime.getURL(
       './models/tournesolRecommendations/TournesolRecommendations.js'
     )
   );

--- a/browser-extension/src/displaySearchRecommendations.js
+++ b/browser-extension/src/displaySearchRecommendations.js
@@ -1,9 +1,9 @@
 (async () => {
-  const bannerUrl = chrome.extension.getURL('./models/banner/Banner.js'),
-    TournesolRecommendationsOptionsUrl = chrome.extension.getURL(
+  const bannerUrl = chrome.runtime.getURL('./models/banner/Banner.js'),
+    TournesolRecommendationsOptionsUrl = chrome.runtime.getURL(
       './models/tournesolRecommendations/TournesolRecommendationsOptions.js'
     ),
-    TournesolSearchRecommendationsUrl = chrome.extension.getURL(
+    TournesolSearchRecommendationsUrl = chrome.runtime.getURL(
       './models/tournesolRecommendations/TournesolSearchRecommendations.js'
     );
 

--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Open Tournesol directly from YouTube",
   "permissions": [
     "https://tournesol.app/",

--- a/browser-extension/src/models/banner/Banner.js
+++ b/browser-extension/src/models/banner/Banner.js
@@ -60,7 +60,7 @@ export class Banner {
     const bannerIconContainer = document.createElement('div');
     const icon = document.createElement('img');
     icon.id = 'tournesol_banner_icon';
-    icon.setAttribute('src', chrome.extension.getURL('images/campaign.svg'));
+    icon.setAttribute('src', chrome.runtime.getURL('images/campaign.svg'));
     icon.setAttribute('alt', 'Megaphone icon');
     bannerIconContainer.append(icon);
 
@@ -92,7 +92,7 @@ export class Banner {
     closeButtonImg.id = 'tournesol_banner_close_icon';
     closeButtonImg.setAttribute(
       'src',
-      chrome.extension.getURL('images/close.svg')
+      chrome.runtime.getURL('images/close.svg')
     );
     closeButtonImg.setAttribute('alt', 'Close icon');
     closeButton.append(closeButtonImg);

--- a/browser-extension/src/models/tournesolContainer/TournesolContainer.js
+++ b/browser-extension/src/models/tournesolContainer/TournesolContainer.js
@@ -145,9 +145,10 @@ export class TournesolContainer {
     const preferencesButton = document.createElement('button');
     preferencesButton.id = 'tournesol_preferences_buton';
     preferencesButton.title = chrome.i18n.getMessage('menuPreferences');
-    fetch(chrome.runtime.getURL('images/settings.svg'))
-      .then((r) => r.text())
-      .then((svg) => (preferencesButton.innerHTML = svg));
+
+    const preferencesImg = document.createElement('img');
+    preferencesImg.src = chrome.runtime.getURL('images/settings.svg');
+    preferencesButton.append(preferencesImg);
 
     preferencesButton.className = 'tournesol_simple_button';
     preferencesButton.onclick = () => {
@@ -159,9 +160,10 @@ export class TournesolContainer {
     const refreshButton = document.createElement('button');
     refreshButton.id = 'tournesol_refresh_button';
     refreshButton.title = chrome.i18n.getMessage('refreshRecommendations');
-    fetch(chrome.runtime.getURL('images/sync-alt.svg'))
-      .then((r) => r.text())
-      .then((svg) => (refreshButton.innerHTML = svg));
+
+    const refreshImg = document.createElement('img');
+    refreshImg.src = chrome.runtime.getURL('images/sync-alt.svg');
+    refreshButton.append(refreshImg);
 
     refreshButton.className = 'tournesol_simple_button';
     refreshButton.onclick = () => {
@@ -190,6 +192,7 @@ export class TournesolContainer {
     )
       .then((r) => r.text())
       .then((svg) => (expand_button.innerHTML = svg));
+
     expand_button.className = 'tournesol_simple_button';
     expand_button.onclick = () => {
       expand_button.disabled = true;

--- a/browser-extension/src/models/tournesolContainer/TournesolContainer.js
+++ b/browser-extension/src/models/tournesolContainer/TournesolContainer.js
@@ -98,7 +98,6 @@ export class TournesolContainer {
     tournesolIcon.setAttribute('id', 'tournesol_icon');
     tournesolIcon.setAttribute(
       'src',
-      //chrome.extension.getURL('rate_now_icon.png'),
       'https://tournesol.app/svg/tournesol.svg'
     );
     tournesolIcon.setAttribute('width', '24');
@@ -128,7 +127,7 @@ export class TournesolContainer {
       const campaignButtonImg = document.createElement('img');
       campaignButtonImg.setAttribute(
         'src',
-        chrome.extension.getURL('images/campaign.svg')
+        chrome.runtime.getURL('images/campaign.svg')
       );
       campaignButtonImg.setAttribute('alt', 'Megaphone icon');
       campaignButton.append(campaignButtonImg);

--- a/browser-extension/src/models/tournesolContainer/TournesolContainer.js
+++ b/browser-extension/src/models/tournesolContainer/TournesolContainer.js
@@ -185,13 +185,11 @@ export class TournesolContainer {
     }
 
     // A new button is created on each video loading, the image must be loaded accordingly
-    fetch(
-      chrome.runtime.getURL(
-        this.isExpanded ? 'images/chevron-up.svg' : 'images/chevron-down.svg'
-      )
-    )
-      .then((r) => r.text())
-      .then((svg) => (expand_button.innerHTML = svg));
+    const expandImg = document.createElement('img');
+    expandImg.src = chrome.runtime.getURL(
+      this.isExpanded ? 'images/chevron-up.svg' : 'images/chevron-down.svg'
+    );
+    expand_button.append(expandImg);
 
     expand_button.className = 'tournesol_simple_button';
     expand_button.onclick = () => {

--- a/browser-extension/src/models/tournesolVideoCard/TournesolVideoCard.js
+++ b/browser-extension/src/models/tournesolVideoCard/TournesolVideoCard.js
@@ -64,19 +64,23 @@ export class TournesolVideoCard {
       const highestCriteriaIconUrl = `images/criteriaIcons/${highestCriteria.criteria}.svg`;
 
       if (highestCriteria.score > 0) {
-        criteriaDiv.innerHTML += `${chrome.i18n.getMessage(
-          'ratedHigh'
-        )} <img src=${chrome.runtime.getURL(
-          highestCriteriaIconUrl
-        )} title='${highestCriteriaTitle}' />`;
+        const criteriaIcon = document.createElement("img");
+        criteriaIcon.setAttribute("src", chrome.runtime.getURL(highestCriteriaIconUrl))
+        criteriaIcon.setAttribute("title", highestCriteriaTitle)
+        criteriaDiv.append(
+          chrome.i18n.getMessage('ratedHigh') + " ",
+          criteriaIcon
+        )
       }
 
       if (lowestCriteria.score < 0) {
-        criteriaDiv.innerHTML += `${chrome.i18n.getMessage(
-          'ratedLow'
-        )} <img src=${chrome.runtime.getURL(
-          lowestCriteriaIconUrl
-        )} title='${lowestCriteriaTitle}' />`;
+        const criteriaIcon = document.createElement("img");
+        criteriaIcon.setAttribute("src", chrome.runtime.getURL(lowestCriteriaIconUrl))
+        criteriaIcon.setAttribute("title", lowestCriteriaTitle)
+        criteriaDiv.appendChild(
+          chrome.i18n.getMessage('ratedLow') + " ",
+          criteriaIcon
+        )
       }
     }
 
@@ -136,35 +140,53 @@ export class TournesolVideoCard {
     uploader.append(channelLink);
     channelDiv.append(uploader);
 
+    const dotSpan = document.createElement("span");
+    dotSpan.classList.add("dot");
+    dotSpan.textContent = "\xA0•\xA0";
+
     const viewsAndDate = document.createElement('p');
     viewsAndDate.className = 'video_text';
-    viewsAndDate.innerHTML = `${chrome.i18n.getMessage('views', [
-      TournesolVideoCard.millifyViews(video.metadata.views),
-    ])} <span class="dot">&nbsp•&nbsp</span> ${TournesolVideoCard.viewPublishedDate(
-      video.metadata.publication_date
-    )}`;
+    viewsAndDate.append(
+      chrome.i18n.getMessage('views', [
+        TournesolVideoCard.millifyViews(video.metadata.views),
+      ]),
+      dotSpan.cloneNode(true),
+      TournesolVideoCard.viewPublishedDate(video.metadata.publication_date),
+    );
+
     channelDiv.append(viewsAndDate);
     metadataDiv.append(channelDiv);
 
     const scoreAndRatings = document.createElement('p');
     scoreAndRatings.className = 'video_text video_tournesol_rating';
-    scoreAndRatings.innerHTML = `<img
-          class="tournesol_score_logo"
-          src="https://tournesol.app/svg/tournesol.svg"
-          alt="Tournesol logo"
-        />
-          <strong>
-            ${video.tournesol_score.toFixed(0)}
-            <span class="dot">&nbsp·&nbsp</span>
-          </strong>
-          <span>${chrome.i18n.getMessage('comparisonsBy', [
-            video.n_comparisons,
-          ])}</span>&nbsp
-          <span class="contributors">
-            ${chrome.i18n.getMessage('comparisonsContributors', [
-              video.n_contributors,
-            ])}
-          </span>`;
+
+    const tournesolLogo = document.createElement('img');
+    tournesolLogo.classList.add("tournesol_score_logo");
+    tournesolLogo.setAttribute("src", "https://tournesol.app/svg/tournesol.svg");
+    tournesolLogo.setAttribute("alt", "Tournesol logo")
+
+    const tournesolScore = document.createElement("strong");
+    tournesolScore.textContent = video.tournesol_score.toFixed(0);
+    tournesolScore.appendChild(dotSpan);
+
+    const nComparisons = document.createElement("span");
+    nComparisons.textContent = chrome.i18n.getMessage('comparisonsBy', [
+      video.n_comparisons,
+    ]);
+
+    const nContributors = document.createElement("span");
+    nContributors.classList.add("contributors");
+    nContributors.textContent = chrome.i18n.getMessage('comparisonsContributors', [
+      video.n_contributors,
+    ]);
+
+    scoreAndRatings.append(
+      tournesolLogo,
+      tournesolScore,
+      nComparisons,
+      "\xA0",
+      nContributors
+    );
 
     metadataDiv.append(scoreAndRatings);
     return metadataDiv;

--- a/browser-extension/src/models/tournesolVideoCard/TournesolVideoCard.js
+++ b/browser-extension/src/models/tournesolVideoCard/TournesolVideoCard.js
@@ -64,23 +64,29 @@ export class TournesolVideoCard {
       const highestCriteriaIconUrl = `images/criteriaIcons/${highestCriteria.criteria}.svg`;
 
       if (highestCriteria.score > 0) {
-        const criteriaIcon = document.createElement("img");
-        criteriaIcon.setAttribute("src", chrome.runtime.getURL(highestCriteriaIconUrl))
-        criteriaIcon.setAttribute("title", highestCriteriaTitle)
+        const criteriaIcon = document.createElement('img');
+        criteriaIcon.setAttribute(
+          'src',
+          chrome.runtime.getURL(highestCriteriaIconUrl)
+        );
+        criteriaIcon.setAttribute('title', highestCriteriaTitle);
         criteriaDiv.append(
-          chrome.i18n.getMessage('ratedHigh') + " ",
+          chrome.i18n.getMessage('ratedHigh') + ' ',
           criteriaIcon
-        )
+        );
       }
 
       if (lowestCriteria.score < 0) {
-        const criteriaIcon = document.createElement("img");
-        criteriaIcon.setAttribute("src", chrome.runtime.getURL(lowestCriteriaIconUrl))
-        criteriaIcon.setAttribute("title", lowestCriteriaTitle)
+        const criteriaIcon = document.createElement('img');
+        criteriaIcon.setAttribute(
+          'src',
+          chrome.runtime.getURL(lowestCriteriaIconUrl)
+        );
+        criteriaIcon.setAttribute('title', lowestCriteriaTitle);
         criteriaDiv.appendChild(
-          chrome.i18n.getMessage('ratedLow') + " ",
+          chrome.i18n.getMessage('ratedLow') + ' ',
           criteriaIcon
-        )
+        );
       }
     }
 
@@ -140,9 +146,9 @@ export class TournesolVideoCard {
     uploader.append(channelLink);
     channelDiv.append(uploader);
 
-    const dotSpan = document.createElement("span");
-    dotSpan.classList.add("dot");
-    dotSpan.textContent = "\xA0•\xA0";
+    const dotSpan = document.createElement('span');
+    dotSpan.classList.add('dot');
+    dotSpan.textContent = '\xA0•\xA0';
 
     const viewsAndDate = document.createElement('p');
     viewsAndDate.className = 'video_text';
@@ -151,7 +157,7 @@ export class TournesolVideoCard {
         TournesolVideoCard.millifyViews(video.metadata.views),
       ]),
       dotSpan.cloneNode(true),
-      TournesolVideoCard.viewPublishedDate(video.metadata.publication_date),
+      TournesolVideoCard.viewPublishedDate(video.metadata.publication_date)
     );
 
     channelDiv.append(viewsAndDate);
@@ -161,30 +167,34 @@ export class TournesolVideoCard {
     scoreAndRatings.className = 'video_text video_tournesol_rating';
 
     const tournesolLogo = document.createElement('img');
-    tournesolLogo.classList.add("tournesol_score_logo");
-    tournesolLogo.setAttribute("src", "https://tournesol.app/svg/tournesol.svg");
-    tournesolLogo.setAttribute("alt", "Tournesol logo")
+    tournesolLogo.classList.add('tournesol_score_logo');
+    tournesolLogo.setAttribute(
+      'src',
+      'https://tournesol.app/svg/tournesol.svg'
+    );
+    tournesolLogo.setAttribute('alt', 'Tournesol logo');
 
-    const tournesolScore = document.createElement("strong");
+    const tournesolScore = document.createElement('strong');
     tournesolScore.textContent = video.tournesol_score.toFixed(0);
     tournesolScore.appendChild(dotSpan);
 
-    const nComparisons = document.createElement("span");
+    const nComparisons = document.createElement('span');
     nComparisons.textContent = chrome.i18n.getMessage('comparisonsBy', [
       video.n_comparisons,
     ]);
 
-    const nContributors = document.createElement("span");
-    nContributors.classList.add("contributors");
-    nContributors.textContent = chrome.i18n.getMessage('comparisonsContributors', [
-      video.n_contributors,
-    ]);
+    const nContributors = document.createElement('span');
+    nContributors.classList.add('contributors');
+    nContributors.textContent = chrome.i18n.getMessage(
+      'comparisonsContributors',
+      [video.n_contributors]
+    );
 
     scoreAndRatings.append(
       tournesolLogo,
       tournesolScore,
       nComparisons,
-      "\xA0",
+      '\xA0',
       nContributors
     );
 

--- a/browser-extension/src/models/tournesolVideoCard/TournesolVideoCard.js
+++ b/browser-extension/src/models/tournesolVideoCard/TournesolVideoCard.js
@@ -192,6 +192,7 @@ export class TournesolVideoCard {
 
     scoreAndRatings.append(
       tournesolLogo,
+      '\xA0',
       tournesolScore,
       nComparisons,
       '\xA0',

--- a/browser-extension/src/models/tournesolVideoCard/TournesolVideoCard.js
+++ b/browser-extension/src/models/tournesolVideoCard/TournesolVideoCard.js
@@ -83,7 +83,7 @@ export class TournesolVideoCard {
           chrome.runtime.getURL(lowestCriteriaIconUrl)
         );
         criteriaIcon.setAttribute('title', lowestCriteriaTitle);
-        criteriaDiv.appendChild(
+        criteriaDiv.append(
           chrome.i18n.getMessage('ratedLow') + ' ',
           criteriaIcon
         );


### PR DESCRIPTION
**related to** https://github.com/tournesol-app/tournesol/issues/1548

---

### Description

This PR removes the usage of `innerHtml` from the browser extension.
In TournesolVideoCard, elements are created separately with `document.createElement`. 
In TournesolContainer, `<svg>` elements are replaced with `<img>`.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
