### PR TITLE
[back] sec: upgrade Django to 4.1.11 (from 4.1.10)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@
 
 # Full stack Web Framework used for Tournesol's backend
 # https://docs.djangoproject.com
-Django==4.1.10
+Django==4.1.11
 # Used for fields computed on save for Django models
 # See https://github.com/brechin/django-computed-property/
 django-computed-property==0.3.0


### PR DESCRIPTION
### Description

Fix:
- CVE-2023-41164

See:
- https://docs.djangoproject.com/en/4.1/releases/4.1.11/

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
