### PR TITLE
[front] refactor: increase the range of the suggested videos

### DIFF
--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -60,6 +60,10 @@ export function idFromUid(uid: string): string {
   return '';
 }
 
+function getPeudoRandomInt(max: number) {
+  return Math.floor(Math.random() * max);
+}
+
 function pick(arr: string[]): string | null {
   // Returns a random element of an array
   return arr.length > 0 ? arr[Math.floor(Math.random() * arr.length)] : null;
@@ -200,7 +204,10 @@ export async function getVideoForComparison(
   const videoResult = await PollsService.pollsRecommendationsList({
     name: 'videos',
     limit: 100,
-    offset: 0,
+    // Increase the diversity of recommended videos. Changing the `offset`
+    // allows us to not increase the `limit`, and this way limits the size of
+    // the JSON downloaded
+    offset: getPeudoRandomInt(10) * 10,
   });
 
   let newSuggestions = (videoResult?.results || []).map((v) =>

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -206,7 +206,8 @@ export async function getVideoForComparison(
     limit: 100,
     // Increase the diversity of recommended videos. Changing the `offset`
     // allows us to not increase the `limit`, and this way limits the size of
-    // the JSON downloaded
+    // the JSON downloaded. We may want to adapt/remove this `offset` the day
+    // we will filter the results according to the user preferred languages.
     offset: getPeudoRandomInt(10) * 10,
   });
 


### PR DESCRIPTION
**related issues** #1743

**this PR targets** https://github.com/tournesol-app/tournesol/pull/1758

---

### Description

This small PR is a suggestion that increases the range of suggested videos by the Auto button, to slightly increase their diversity. 

When using the Auto button, there is 5 % chance to suggest a video from the all time top 100 recommendations (all languages). Today it seems like there are good videos in the top 200 that could be safely suggested, like the following:
- https://tournesol.app/entities/yt:vKA4w2O61Xo
- https://tournesol.app/entities/yt:a_O8u0YT8T0
- https://tournesol.app/entities/yt:YMxtImOzyGw
- https://tournesol.app/entities/yt:_Jgbni6UQig

This PR pseudo-randomly selects an offset between 0 and 100 before making a request to the API /recommendations/, increasing the range of possibly recommended video (while keeping the current limit of 100 videos returned by the API). As a result some videos have slightly more chance to be recommended that others. The videos between the top 50 and 60 for instance, are part of the range [0, 100], but also the range [10, 110], [50, 150], etc. The videos between the top 0 and 10 are only part of the range [0, 100]. This shouldn't have any effect from the user perspective. Note that the top 10 videos on Tournesol are not the most entertaining and relaxing.

In the future we may want to also take the selected language(s) into account (UI language or selected languages in the preferences). This raises the following question "What should we suggest when there is no recommendation in the selected language(s)?". We can choose to not address this issue in the front end, and wait for the back end's /suggestions/ API, or we can already imagine a solution with the front end (like always adding "en" to the HTTP request, in addition to the select languages) .

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
