### PR TITLE
[front] fix: remove uploader param from URL after deleting filter

### DIFF
--- a/backend/scripts/ci/lint-fix.sh
+++ b/backend/scripts/ci/lint-fix.sh
@@ -3,4 +3,4 @@ set -euxo pipefail
 
 # Python Code Quality Fixes
 
-isort --settings-path .isort.cfg ${@:-backoffice core faq ml settings tournesol twitterbot vouch}
+isort --settings-path .isort.cfg ${@:-backoffice core ml settings tournesol twitterbot vouch}

--- a/backend/scripts/ci/lint.sh
+++ b/backend/scripts/ci/lint.sh
@@ -6,13 +6,13 @@ set -uxo pipefail
 # return 0 if all checks return 0
 # 1 instead
 
-isort --settings-path .isort.cfg --check-only ${@:-backoffice core faq ml settings tournesol twitterbot vouch}
+isort --settings-path .isort.cfg --check-only ${@:-backoffice core ml settings tournesol twitterbot vouch}
 chk1=$?
 
 flake8 --config=.flake8 ${@:-}
 chk2=$?
 
-pylint --rcfile=.pylintrc ${@:-backoffice core faq ml tournesol twitterbot vouch}
+pylint --rcfile=.pylintrc ${@:-backoffice core ml tournesol twitterbot vouch}
 chk3=$?
 
 ! (( chk1 || chk2 || chk3 ))

--- a/backend/tournesol/views/previews/recommendations.py
+++ b/backend/tournesol/views/previews/recommendations.py
@@ -58,7 +58,8 @@ def get_preview_recommendations_redirect_params(request):
 
     for (key, value) in params.items():
         if key == "uploader":
-            query["metadata[uploader]"] = params[key]
+            if value:
+                query["metadata[uploader]"] = params[key]
         elif key == "duration_lte":
             if value == "":
                 continue

--- a/backend/tournesol/views/previews/recommendations.py
+++ b/backend/tournesol/views/previews/recommendations.py
@@ -53,6 +53,7 @@ def get_preview_recommendations_redirect_params(request):
     Preview of a Recommendations page.
     Returns HTTP redirection to transform the query parameters into the format used by the backend.
     """
+    # pylint: disable=too-many-branches
     params = request.GET
     query = QueryDict("", mutable=True)
 

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -73,7 +73,7 @@ function SearchFilter({
           <Box marginBottom={1}>
             <UploaderFilter
               value={filterParams.get(recommendationFilters.uploader) ?? ''}
-              onDelete={() => setFilter(recommendationFilters.uploader, '')}
+              onDelete={() => setFilter(recommendationFilters.uploader, null)}
             />
           </Box>
         )}

--- a/frontend/src/hooks/useListFilter.ts
+++ b/frontend/src/hooks/useListFilter.ts
@@ -6,7 +6,7 @@ export const useListFilter = ({
 }: {
   defaults?: Array<{ name: string; value: string }>;
   setEmptyValues?: boolean;
-} = {}): [URLSearchParams, (key: string, value: string) => void] => {
+} = {}): [URLSearchParams, (key: string, value: string | null) => void] => {
   const location = useLocation();
   const history = useHistory();
   const searchParams = new URLSearchParams(location.search);


### PR DESCRIPTION
Fixes #1763 

---

### Description

The bug is fixed twice :)  
The frontend will remove the `uploader=` param from the URL (not relevant for UX), and the backend preview will ignore empty values to be consistent with the frontend implementation.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
