### PR TITLE
[front] style: fix the CSS of the banner button causing overflow

### DIFF
--- a/frontend/src/features/banners/WebsiteBanner.tsx
+++ b/frontend/src/features/banners/WebsiteBanner.tsx
@@ -81,22 +81,19 @@ const WebsiteBanner = ({ banner }: WebsiteBannerSingleProps) => {
                   }}
                 />
               </Box>
-
               {banner.action_link && banner.action_label && (
-                <Box minWidth="100px">
-                  <Button
-                    variant={
-                      security || (banner.priority ?? 0) >= 100
-                        ? 'contained'
-                        : 'outlined'
-                    }
-                    color={security ? 'error' : 'secondary'}
-                    component={Link}
-                    href={banner.action_link}
-                  >
-                    {banner.action_label}
-                  </Button>
-                </Box>
+                <Button
+                  variant={
+                    security || (banner.priority ?? 0) >= 100
+                      ? 'contained'
+                      : 'outlined'
+                  }
+                  color={security ? 'error' : 'secondary'}
+                  component={Link}
+                  href={banner.action_link}
+                >
+                  {banner.action_label}
+                </Button>
               )}
             </Stack>
           </Stack>

--- a/frontend/src/features/banners/WebsiteBanner.tsx
+++ b/frontend/src/features/banners/WebsiteBanner.tsx
@@ -65,39 +65,37 @@ const WebsiteBanner = ({ banner }: WebsiteBannerSingleProps) => {
               </Typography>
               {security && <Warning fontSize="large" color="error" />}
             </Stack>
-            <Stack
-              direction={{ sm: 'column', md: 'row' }}
-              spacing={{ xs: 2, sm: 2 }}
-              justifyContent="space-between"
-              alignItems="flex-end"
-            >
-              <Box>
-                <Typography
-                  paragraph
-                  mb={0}
-                  whiteSpace="pre-wrap"
-                  dangerouslySetInnerHTML={{
-                    __html: linkifyStr(banner.text, linkifyOpts),
-                  }}
-                />
-              </Box>
+            <Box>
+              <Typography
+                paragraph
+                display="inline"
+                mb={0}
+                whiteSpace="pre-wrap"
+                dangerouslySetInnerHTML={{
+                  __html: linkifyStr(banner.text, linkifyOpts),
+                }}
+              />
+
               {banner.action_link && banner.action_label && (
-                <Box>
-                  <Button
-                    variant={
-                      security || (banner.priority ?? 0) >= 100
-                        ? 'contained'
-                        : 'outlined'
-                    }
-                    color={security ? 'error' : 'secondary'}
-                    component={Link}
-                    href={banner.action_link}
-                  >
-                    {banner.action_label}
-                  </Button>
-                </Box>
+                <Button
+                  variant={
+                    security || (banner.priority ?? 0) >= 100
+                      ? 'contained'
+                      : 'outlined'
+                  }
+                  color={security ? 'error' : 'secondary'}
+                  component={Link}
+                  href={banner.action_link}
+                  sx={{
+                    mt: 1,
+                    ml: 1,
+                    float: 'right',
+                  }}
+                >
+                  {banner.action_label}
+                </Button>
               )}
-            </Stack>
+            </Box>
           </Stack>
         </Paper>
       </Grid>

--- a/frontend/src/features/banners/WebsiteBanner.tsx
+++ b/frontend/src/features/banners/WebsiteBanner.tsx
@@ -82,18 +82,20 @@ const WebsiteBanner = ({ banner }: WebsiteBannerSingleProps) => {
                 />
               </Box>
               {banner.action_link && banner.action_label && (
-                <Button
-                  variant={
-                    security || (banner.priority ?? 0) >= 100
-                      ? 'contained'
-                      : 'outlined'
-                  }
-                  color={security ? 'error' : 'secondary'}
-                  component={Link}
-                  href={banner.action_link}
-                >
-                  {banner.action_label}
-                </Button>
+                <Box>
+                  <Button
+                    variant={
+                      security || (banner.priority ?? 0) >= 100
+                        ? 'contained'
+                        : 'outlined'
+                    }
+                    color={security ? 'error' : 'secondary'}
+                    component={Link}
+                    href={banner.action_link}
+                  >
+                    {banner.action_label}
+                  </Button>
+                </Box>
               )}
             </Stack>
           </Stack>


### PR DESCRIPTION
### Description

This PR removes the CSS added by the commit https://github.com/tournesol-app/tournesol/commit/84f876a54348b967264b028d45316c73e669865a to fix the banner button displayed outside of its container, instead of inside. 

The main changes are:
- the banner's text is displayed `inline`
- the action button is now floating

| after | before |
|---|---|
| ![capture](https://github.com/tournesol-app/tournesol/assets/39056254/3e0d3066-d3f0-476a-b4bd-259355783611) | ![capture2](https://github.com/tournesol-app/tournesol/assets/39056254/801a0b07-0484-4e5a-ac03-c2d6764eef14) |


### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
