### PR TITLE
[back] fix: recommendations preview for entities without score

### DIFF
--- a/backend/tournesol/tests/factories/entity.py
+++ b/backend/tournesol/tests/factories/entity.py
@@ -65,6 +65,7 @@ class VideoMetadataFactory(factory.DictFactory):
     language = "aa"
     uploader = factory.Sequence(lambda n: "Uploader %s" % n)
     publication_date = factory.LazyFunction(lambda: datetime.date.today().isoformat())
+    views = 1000
 
 
 class VideoFactory(EntityFactory):

--- a/backend/tournesol/views/previews/recommendations.py
+++ b/backend/tournesol/views/previews/recommendations.py
@@ -233,7 +233,10 @@ class DynamicWebsitePreviewRecommendations(BasePreviewAPIView, PollsRecommendati
             else ts_logo,
             dest=(0, 0),
         )
-        score = str(round(poll_rating.tournesol_score))
+
+        score = None
+        if poll_rating.tournesol_score is not None:
+            score = str(round(poll_rating.tournesol_score))
 
         comparisons = f"{recommendation.rating_n_ratings} comparisons by "
         comparisons_width = ts_score_box_draw.textlength(
@@ -243,12 +246,13 @@ class DynamicWebsitePreviewRecommendations(BasePreviewAPIView, PollsRecommendati
         score_x_gap = ts_logo_size[0] + 2 * upscale_ratio
         comparisons_x_gap = score_x_gap + 36 * upscale_ratio
 
-        ts_score_box_draw.text(
-            (score_x_gap, -5 * upscale_ratio),
-            score,
-            font=self.fnt_config["recommendations_ts_score"],
-            fill=COLOR_BROWN_FONT,
-        )
+        if score:
+            ts_score_box_draw.text(
+                (score_x_gap, -5 * upscale_ratio),
+                score,
+                font=self.fnt_config["recommendations_ts_score"],
+                fill=COLOR_BROWN_FONT,
+            )
 
         ts_score_box_draw.text(
             (comparisons_x_gap, 2 * upscale_ratio),


### PR DESCRIPTION
**related issues** #1772

---

### Description

This PR fixes the API `/_preview/recommendations/`. Entities without computed Tournesol score will no longer cause the endpoint to fail.

Here is how entities with and without score look like:

| with score | without |
|---|---|
| ![cap2](https://github.com/tournesol-app/tournesol/assets/39056254/335ad355-767c-4933-8a40-85c2c0f269ac) | ![cap](https://github.com/tournesol-app/tournesol/assets/39056254/ab25394d-a541-4bee-94d9-927516f2f60b) |

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
