### PR TITLE
[back] feat: add `entity` and `collective_rating` fields in recommendations API

### DIFF
--- a/backend/.pylintrc
+++ b/backend/.pylintrc
@@ -165,7 +165,8 @@ disable=raw-checker-failed,
         too-many-ancestors,
         too-few-public-methods,
         use-maxsplit-arg,
-        cyclic-import
+        cyclic-import,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -52,16 +52,21 @@ class EntityQueryset(models.QuerySet):
             )
         )
 
-    def with_prefetched_contributor_ratings(self, poll, user):
+    def with_prefetched_contributor_ratings(self, poll, user, prefetch_criteria_scores=False):
         # pylint: disable=import-outside-toplevel
         from tournesol.models.ratings import ContributorRating
+
+        contributor_ratings = (
+            ContributorRating.objects.filter(poll=poll, user=user)
+            .annotate_n_comparisons()
+        )
+        if prefetch_criteria_scores:
+            contributor_ratings = contributor_ratings.prefetch_related("criteria_scores")
+
         return self.prefetch_related(
             Prefetch(
                 "contributorvideoratings",
-                queryset=ContributorRating.objects.filter(
-                    poll=poll,
-                    user=user,
-                ).annotate_n_comparisons(),
+                queryset=contributor_ratings,
                 to_attr="_prefetched_contributor_ratings",
             )
         )

--- a/backend/tournesol/serializers/contributor_recommendations.py
+++ b/backend/tournesol/serializers/contributor_recommendations.py
@@ -1,30 +1,57 @@
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from rest_framework.serializers import SerializerMethodField
 
-from tournesol.serializers.poll import RecommendationSerializer
-from tournesol.serializers.rating import ContributorCriteriaScore
+from tournesol.models.ratings import ContributorRating
+from tournesol.serializers.criteria_score import ContributorCriteriaScoreSerializer
+from tournesol.serializers.poll import (
+    CollectiveRatingSerializer,
+    IndividualRatingSerializer,
+    RecommendationSerializer,
+)
 
 
+class IndividualRatingWithScoresSerializer(IndividualRatingSerializer):
+    criteria_scores = ContributorCriteriaScoreSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = ContributorRating
+        fields = IndividualRatingSerializer.Meta.fields + ["criteria_scores"]
+        read_only_fields = fields
+
+
+@extend_schema_serializer(
+    deprecate_fields=[
+        # legacy fields have been moved to "entity", "invidual_rating", "collective_rating", etc.
+        "uid",
+        "type",
+        "n_comparisons",
+        "n_contributors",
+        "metadata",
+        "total_score",
+        "tournesol_score",
+        "criteria_scores",
+        "unsafe",
+        "is_public",
+    ]
+)
 class ContributorRecommendationsSerializer(RecommendationSerializer):
     """
     An entity recommended by a user.
-
-    In addition to the fields inherited from `RecommendationSerializer`, this
-    serializer also display the public status of the `ContributorRating`
-    related to the trio poll / entity / user.
-
-    Note that the fields `n_comparisons` and `n_contributors` contain
-    the collective values, and are not specific to the user.
     """
+
     is_public = SerializerMethodField()
     criteria_scores = SerializerMethodField()
+    individual_rating = IndividualRatingWithScoresSerializer(
+        source="single_contributor_rating",
+        read_only=True,
+    )
 
     class Meta(RecommendationSerializer.Meta):
-        fields = RecommendationSerializer.Meta.fields + ["is_public"]
+        fields = RecommendationSerializer.Meta.fields + ["is_public", "individual_rating"]
 
-    @extend_schema_field(ContributorCriteriaScore(many=True))
+    @extend_schema_field(ContributorCriteriaScoreSerializer(many=True))
     def get_criteria_scores(self, obj):
-        return ContributorCriteriaScore(
+        return ContributorCriteriaScoreSerializer(
             obj.contributorvideoratings.all()[0].criteria_scores.all(), many=True
         ).data
 

--- a/backend/tournesol/serializers/contributor_recommendations.py
+++ b/backend/tournesol/serializers/contributor_recommendations.py
@@ -48,8 +48,8 @@ class ContributorRecommendationsSerializer(RecommendationSerializer):
     @extend_schema_field(ContributorCriteriaScoreSerializer(many=True))
     def get_criteria_scores(self, obj):
         return ContributorCriteriaScoreSerializer(
-            obj.contributorvideoratings.all()[0].criteria_scores.all(), many=True
+            obj.single_contributor_rating.criteria_scores, many=True
         ).data
 
     def get_is_public(self, obj) -> bool:
-        return obj.contributorvideoratings.all()[0].is_public
+        return obj.single_contributor_rating.is_public

--- a/backend/tournesol/serializers/contributor_recommendations.py
+++ b/backend/tournesol/serializers/contributor_recommendations.py
@@ -3,11 +3,7 @@ from rest_framework.serializers import SerializerMethodField
 
 from tournesol.models.ratings import ContributorRating
 from tournesol.serializers.criteria_score import ContributorCriteriaScoreSerializer
-from tournesol.serializers.poll import (
-    CollectiveRatingSerializer,
-    IndividualRatingSerializer,
-    RecommendationSerializer,
-)
+from tournesol.serializers.poll import IndividualRatingSerializer, RecommendationSerializer
 
 
 class IndividualRatingWithScoresSerializer(IndividualRatingSerializer):

--- a/backend/tournesol/serializers/contributor_recommendations.py
+++ b/backend/tournesol/serializers/contributor_recommendations.py
@@ -16,7 +16,7 @@ class IndividualRatingWithScoresSerializer(IndividualRatingSerializer):
 
 
 @extend_schema_serializer(
-    deprecate_fields=[
+    exclude_fields=[
         # legacy fields have been moved to "entity", "invidual_rating", "collective_rating", etc.
         "uid",
         "type",

--- a/backend/tournesol/serializers/criteria_score.py
+++ b/backend/tournesol/serializers/criteria_score.py
@@ -1,0 +1,9 @@
+from rest_framework.serializers import ModelSerializer
+
+from tournesol.models import ContributorRatingCriteriaScore
+
+
+class ContributorCriteriaScoreSerializer(ModelSerializer):
+    class Meta:
+        model = ContributorRatingCriteriaScore
+        fields = ["criteria", "score", "uncertainty"]

--- a/backend/tournesol/serializers/entity.py
+++ b/backend/tournesol/serializers/entity.py
@@ -164,12 +164,7 @@ class EntitySerializer(ModelSerializer):
             "tournesol_score",
             "polls",
         ]
-        read_only_fields = [
-            # XXX: the `tournesol_score` field is available directly in the
-            # Entity model for now, but will be moved in an n-n relation
-            # between Entity and Poll
-            "tournesol_score"
-        ]
+        read_only_fields = fields
 
     @extend_schema_field(EntityPollSerializer(many=True))
     def get_polls(self, obj):

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -54,7 +54,7 @@ class CollectiveRatingSerializer(ModelSerializer):
 
 
 class ExtendedCollectiveRatingSerializer(CollectiveRatingSerializer):
-    criteria_scores = EntityCriteriaScoreSerializer(many=True)
+    criteria_scores = EntityCriteriaScoreSerializer(source="entity.criteria_scores", many=True)
 
     class Meta:
         model = CollectiveRatingSerializer.Meta.model
@@ -79,7 +79,7 @@ class RecommendationMetadataSerializer(serializers.Serializer):
 
 
 @extend_schema_serializer(
-    deprecate_fields=[
+    exclude_fields=[
         # legacy fields have been moved to "entity", "collective_rating", etc.
         "uid",
         "type",
@@ -105,7 +105,7 @@ class RecommendationSerializer(ModelSerializer):
     )
 
     entity = RelatedEntitySerializer(source="*", read_only=True)
-    collective_rating = CollectiveRatingSerializer(
+    collective_rating = ExtendedCollectiveRatingSerializer(
         source="single_poll_rating",
         read_only=True,
     )

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -75,7 +75,7 @@ class IndividualRatingSerializer(ModelSerializer):
 
 
 class RecommendationMetadataSerializer(serializers.Serializer):
-    total_score = serializers.FloatField(read_only=True)
+    total_score = serializers.FloatField(read_only=True, allow_null=True)
 
 
 @extend_schema_serializer(
@@ -108,6 +108,7 @@ class RecommendationSerializer(ModelSerializer):
     collective_rating = ExtendedCollectiveRatingSerializer(
         source="single_poll_rating",
         read_only=True,
+        allow_null=True,
     )
     recommendation_metadata = RecommendationMetadataSerializer(source="*", read_only=True)
 

--- a/backend/tournesol/serializers/rating.py
+++ b/backend/tournesol/serializers/rating.py
@@ -2,19 +2,14 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import BooleanField, CharField, DateTimeField
 from rest_framework.serializers import ModelSerializer, Serializer
 
-from tournesol.models import ContributorRating, ContributorRatingCriteriaScore
+from tournesol.models import ContributorRating
+from tournesol.serializers.criteria_score import ContributorCriteriaScoreSerializer
 from tournesol.serializers.entity import EntityNoExtraFieldSerializer, RelatedEntitySerializer
 from tournesol.serializers.poll import CollectiveRatingSerializer, IndividualRatingSerializer
 
 
-class ContributorCriteriaScore(ModelSerializer):
-    class Meta:
-        model = ContributorRatingCriteriaScore
-        fields = ["criteria", "score", "uncertainty"]
-
-
 class ExtendedInvididualRatingSerializer(IndividualRatingSerializer):
-    criteria_scores = ContributorCriteriaScore(many=True, read_only=True)
+    criteria_scores = ContributorCriteriaScoreSerializer(many=True, read_only=True)
     last_compared_at = DateTimeField(read_only=True, allow_null=True)
 
     class Meta:

--- a/backend/tournesol/tests/test_api_contributor_recommendations.py
+++ b/backend/tournesol/tests/test_api_contributor_recommendations.py
@@ -95,12 +95,12 @@ class ContributorRecommendationsApiTestCase(TestCase):
 
         results = response.data["results"]
         for entity in results:
-            self.assertEqual(entity["is_public"], True)
+            self.assertEqual(entity["individual_rating"]["is_public"], True)
 
         # The collective metadata `n_comparisons` and `n_contributors` must
         # be present in the response of the public personal reco. endpoint.
-        self.assertEqual(results[0]["n_comparisons"], 0)
-        self.assertEqual(results[0]["n_contributors"], 0)
+        self.assertEqual(results[0]["collective_rating"]["n_comparisons"], 0)
+        self.assertEqual(results[0]["collective_rating"]["n_contributors"], 0)
 
         response = self.client.get(
             f"/users/{self.user2.username}/recommendations/{self.poll.name}",
@@ -116,8 +116,8 @@ class ContributorRecommendationsApiTestCase(TestCase):
 
         # The collective metadata `n_comparisons` and `n_contributors` must
         # be present in the response of the public personal reco. endpoint.
-        self.assertEqual(results[0]["n_comparisons"], 0)
-        self.assertEqual(results[0]["n_contributors"], 0)
+        self.assertEqual(results[0]["collective_rating"]["n_comparisons"], 0)
+        self.assertEqual(results[0]["collective_rating"]["n_contributors"], 0)
 
     def test_recommendations_privacy_anon(self):
         """
@@ -133,7 +133,7 @@ class ContributorRecommendationsApiTestCase(TestCase):
         self.assertEqual(response.data["count"], 1)
 
         for entity in response.data["results"]:
-            self.assertEqual(entity["is_public"], True)
+            self.assertEqual(entity["individual_rating"]["is_public"], True)
 
         response = self.client.get(
             f"/users/{self.user2.username}/recommendations/{self.poll.name}",
@@ -144,7 +144,7 @@ class ContributorRecommendationsApiTestCase(TestCase):
         self.assertEqual(response.data["count"], 2)
 
         for entity in response.data["results"]:
-            self.assertEqual(entity["is_public"], True)
+            self.assertEqual(entity["individual_rating"]["is_public"], True)
 
     def test_recommendations_are_filtered_by_poll(self):
         new_poll = PollWithCriteriasFactory()
@@ -244,16 +244,17 @@ class ContributorRecommendationsApiTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(
-            len(response.data["results"][0]["criteria_scores"]),
+            len(response.data["results"][0]["individual_rating"]["criteria_scores"]),
             1,
         )
         self.assertEqual(
-            response.data["results"][0]["criteria_scores"][0]["score"],
+            response.data["results"][0]["individual_rating"]["criteria_scores"][0]["score"],
             criteria_score,
         )
         
         self.assertEqual(
-            response.data["results"][0]["total_score"], criteria_score * weight
+            response.data["results"][0]["recommendation_metadata"]["total_score"],
+            criteria_score * weight
         )
 
         # user2's score on this entity must not affect user1's recommendations
@@ -274,16 +275,17 @@ class ContributorRecommendationsApiTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 1)
         self.assertEqual(
-            len(response.data["results"][0]["criteria_scores"]),
+            len(response.data["results"][0]["individual_rating"]["criteria_scores"]),
             1,
         )
         # It shouldn't have changed, other users' ratings are ignored
         self.assertEqual(
-            response.data["results"][0]["criteria_scores"][0]["score"],
+            response.data["results"][0]["individual_rating"]["criteria_scores"][0]["score"],
             criteria_score,
         )
         self.assertEqual(
-            response.data["results"][0]["total_score"], criteria_score * weight
+            response.data["results"][0]["recommendation_metadata"]["total_score"],
+            criteria_score * weight
         )
 
     def test_recommendations_are_sorted_by_descending_total_score(self):
@@ -307,4 +309,10 @@ class ContributorRecommendationsApiTestCase(TestCase):
         expected_results = sorted(scores, reverse=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], len(expected_results))
-        self.assertEqual([e['criteria_scores'][0]["score"] for e in response.data["results"]], expected_results)
+        self.assertEqual(
+            [
+                e["individual_rating"]['criteria_scores'][0]["score"]
+                for e in response.data["results"]
+            ],
+            expected_results
+        )

--- a/backend/tournesol/views/contributor_recommendations.py
+++ b/backend/tournesol/views/contributor_recommendations.py
@@ -53,10 +53,14 @@ class PrivateContributorRecommendationsView(ContributorRecommendationsBaseView):
         poll = self.poll_from_url
         user = self.request.user
 
-        queryset = Entity.objects.filter(
-            contributorvideoratings__poll=poll,
-            contributorvideoratings__user=user
-        ).with_prefetched_poll_ratings(poll_name=poll.name)
+        queryset = (
+            Entity.objects.filter(
+                contributorvideoratings__poll=poll,
+                contributorvideoratings__user=user
+            )
+            .with_prefetched_poll_ratings(poll_name=poll.name)
+            .with_prefetched_contributor_ratings(poll=poll, user=user)
+        )
 
         queryset, filters = self.filter_by_parameters(self.request, queryset, poll)
         queryset = self.annotate_with_total_score(queryset, self.request, poll, user)
@@ -76,11 +80,15 @@ class PublicContributorRecommendationsView(ContributorRecommendationsBaseView):
         poll = self.poll_from_url
         user = get_object_or_404(User, username=self.kwargs["username"], is_active=True)
 
-        queryset = Entity.objects.filter(
-            contributorvideoratings__poll=poll,
-            contributorvideoratings__user=user,
-            contributorvideoratings__is_public=True,
-        ).with_prefetched_poll_ratings(poll_name=poll.name)
+        queryset = (
+            Entity.objects.filter(
+                contributorvideoratings__poll=poll,
+                contributorvideoratings__user=user,
+                contributorvideoratings__is_public=True,
+            )
+            .with_prefetched_poll_ratings(poll_name=poll.name)
+            .with_prefetched_contributor_ratings(poll=poll, user=user)
+        )
 
         queryset, filters = self.filter_by_parameters(self.request, queryset, poll)
         queryset = self.annotate_with_total_score(queryset, self.request, poll, user)

--- a/backend/tournesol/views/contributor_recommendations.py
+++ b/backend/tournesol/views/contributor_recommendations.py
@@ -1,14 +1,14 @@
 """
 Overrides the Polls API for recommendations specific to one user
 """
-from django.db.models import F, Prefetch, Sum
+from django.db.models import F, Sum
 from django.shortcuts import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 
 from core.models import User
 from tournesol.serializers.contributor_recommendations import ContributorRecommendationsSerializer
 
-from ..models import ContributorRating, Entity, Poll
+from ..models import Entity, Poll
 from ..views import PollRecommendationsBaseAPIView
 
 
@@ -21,19 +21,10 @@ class ContributorRecommendationsBaseView(PollRecommendationsBaseAPIView):
     queryset = Entity.objects.none()
     serializer_class = ContributorRecommendationsSerializer
 
-    def annotate_with_total_score(self, queryset, request, poll: Poll, user):
+    def annotate_with_total_score(self, queryset, request, poll: Poll):
         criteria_weight = self._build_criteria_weight_condition(
             request, poll, when="contributorvideoratings__criteria_scores__criteria"
         )
-
-        queryset = queryset.prefetch_related(
-            Prefetch(
-                "contributorvideoratings",
-                queryset=ContributorRating.objects.filter(poll=poll, user=user),
-            ),
-            "contributorvideoratings__criteria_scores"
-        )
-
         return queryset.annotate(
             total_score=Sum(
                 F("contributorvideoratings__criteria_scores__score") * criteria_weight,
@@ -58,12 +49,17 @@ class PrivateContributorRecommendationsView(ContributorRecommendationsBaseView):
                 contributorvideoratings__poll=poll,
                 contributorvideoratings__user=user
             )
+            .with_prefetched_scores(poll_name=poll.name)
             .with_prefetched_poll_ratings(poll_name=poll.name)
-            .with_prefetched_contributor_ratings(poll=poll, user=user)
+            .with_prefetched_contributor_ratings(
+                poll=poll,
+                user=user,
+                prefetch_criteria_scores=True
+            )
         )
 
         queryset, filters = self.filter_by_parameters(self.request, queryset, poll)
-        queryset = self.annotate_with_total_score(queryset, self.request, poll, user)
+        queryset = self.annotate_with_total_score(queryset, self.request, poll)
         queryset = self.sort_results(queryset, filters)
         return queryset
 
@@ -86,11 +82,16 @@ class PublicContributorRecommendationsView(ContributorRecommendationsBaseView):
                 contributorvideoratings__user=user,
                 contributorvideoratings__is_public=True,
             )
+            .with_prefetched_scores(poll_name=poll.name)
             .with_prefetched_poll_ratings(poll_name=poll.name)
-            .with_prefetched_contributor_ratings(poll=poll, user=user)
+            .with_prefetched_contributor_ratings(
+                poll=poll,
+                user=user,
+                prefetch_criteria_scores=True
+            )
         )
 
         queryset, filters = self.filter_by_parameters(self.request, queryset, poll)
-        queryset = self.annotate_with_total_score(queryset, self.request, poll, user)
+        queryset = self.annotate_with_total_score(queryset, self.request, poll)
         queryset = self.sort_results(queryset, filters)
         return queryset

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -2842,6 +2842,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/ExtendedCollectiveRating'
           readOnly: true
+          nullable: true
         recommendation_metadata:
           allOf:
           - $ref: '#/components/schemas/RecommendationMetadata'
@@ -3704,6 +3705,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/ExtendedCollectiveRating'
           readOnly: true
+          nullable: true
         recommendation_metadata:
           allOf:
           - $ref: '#/components/schemas/RecommendationMetadata'
@@ -3719,6 +3721,7 @@ components:
           type: number
           format: double
           readOnly: true
+          nullable: true
       required:
       - total_score
     Recommendations_defaultDateEnum:

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -2832,67 +2832,29 @@ components:
       - is_public
     ContributorRecommendations:
       type: object
-      description: |-
-        An entity recommended by a user.
-
-        In addition to the fields inherited from `RecommendationSerializer`, this
-        serializer also display the public status of the `ContributorRating`
-        related to the trio poll / entity / user.
-
-        Note that the fields `n_comparisons` and `n_contributors` contain
-        the collective values, and are not specific to the user.
+      description: An entity recommended by a user.
       properties:
-        uid:
-          type: string
-          readOnly: true
-          description: A unique identifier, build with a namespace and an external
-            id.
-        type:
+        entity:
           allOf:
-          - $ref: '#/components/schemas/TypeEnum'
+          - $ref: '#/components/schemas/RelatedEntity'
           readOnly: true
-        n_comparisons:
-          type: integer
-        n_contributors:
-          type: integer
-        metadata:
-          type: object
-          additionalProperties: {}
-          readOnly: true
-        total_score:
-          type: number
-          format: double
-        tournesol_score:
-          type: number
-          format: double
-          readOnly: true
-          nullable: true
-          description: The aggregated of all criteria for all users in a specific
-            poll.
-        criteria_scores:
-          type: array
-          items:
-            $ref: '#/components/schemas/ContributorCriteriaScore'
-          readOnly: true
-        unsafe:
+        collective_rating:
           allOf:
-          - $ref: '#/components/schemas/UnsafeStatus'
+          - $ref: '#/components/schemas/ExtendedCollectiveRating'
           readOnly: true
-          nullable: true
-        is_public:
-          type: boolean
+        recommendation_metadata:
+          allOf:
+          - $ref: '#/components/schemas/RecommendationMetadata'
+          readOnly: true
+        individual_rating:
+          allOf:
+          - $ref: '#/components/schemas/IndividualRatingWithScores'
           readOnly: true
       required:
-      - criteria_scores
-      - is_public
-      - metadata
-      - n_comparisons
-      - n_contributors
-      - total_score
-      - tournesol_score
-      - type
-      - uid
-      - unsafe
+      - collective_rating
+      - entity
+      - individual_rating
+      - recommendation_metadata
     CriteriaDistributionScore:
       type: object
       properties:
@@ -2999,14 +2961,17 @@ components:
       properties:
         uid:
           type: string
+          readOnly: true
           description: A unique identifier, build with a namespace and an external
             id.
-          maxLength: 144
         type:
-          $ref: '#/components/schemas/TypeEnum'
+          allOf:
+          - $ref: '#/components/schemas/TypeEnum'
+          readOnly: true
         metadata:
           type: object
           additionalProperties: {}
+          readOnly: true
         tournesol_score:
           type: number
           format: double
@@ -3020,6 +2985,7 @@ components:
             $ref: '#/components/schemas/EntityPoll'
           readOnly: true
       required:
+      - metadata
       - polls
       - tournesol_score
       - type
@@ -3119,6 +3085,39 @@ components:
       description: |-
         * `video` - Video
         * `candidate_fr_2022` - Candidate (FR 2022)
+    ExtendedCollectiveRating:
+      type: object
+      properties:
+        n_comparisons:
+          type: integer
+          readOnly: true
+          description: Total number of pairwise comparisons for this entityfrom certified
+            contributors
+        n_contributors:
+          type: integer
+          readOnly: true
+          description: Total number of certified contributors who rated the entity
+        tournesol_score:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+          description: The aggregated score of the main criterion for all users, in
+            a specific poll.
+        unsafe:
+          allOf:
+          - $ref: '#/components/schemas/UnsafeStatus'
+          readOnly: true
+        criteria_scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityCriteriaScore'
+      required:
+      - criteria_scores
+      - n_comparisons
+      - n_contributors
+      - tournesol_score
+      - unsafe
     ExtendedInvididualRating:
       type: object
       properties:
@@ -3225,6 +3224,26 @@ components:
           readOnly: true
           default: 0
       required:
+      - is_public
+      - n_comparisons
+    IndividualRatingWithScores:
+      type: object
+      properties:
+        is_public:
+          type: boolean
+          readOnly: true
+          description: Should the rating be public?
+        n_comparisons:
+          type: integer
+          readOnly: true
+          default: 0
+        criteria_scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContributorCriteriaScore'
+          readOnly: true
+      required:
+      - criteria_scores
       - is_public
       - n_comparisons
     Length3Cycles:
@@ -3677,52 +3696,31 @@ components:
     Recommendation:
       type: object
       properties:
-        uid:
-          type: string
-          readOnly: true
-          description: A unique identifier, build with a namespace and an external
-            id.
-        type:
+        entity:
           allOf:
-          - $ref: '#/components/schemas/TypeEnum'
+          - $ref: '#/components/schemas/RelatedEntity'
           readOnly: true
-        n_comparisons:
-          type: integer
-        n_contributors:
-          type: integer
-        metadata:
-          type: object
-          additionalProperties: {}
+        collective_rating:
+          allOf:
+          - $ref: '#/components/schemas/ExtendedCollectiveRating'
           readOnly: true
+        recommendation_metadata:
+          allOf:
+          - $ref: '#/components/schemas/RecommendationMetadata'
+          readOnly: true
+      required:
+      - collective_rating
+      - entity
+      - recommendation_metadata
+    RecommendationMetadata:
+      type: object
+      properties:
         total_score:
           type: number
           format: double
-        tournesol_score:
-          type: number
-          format: double
           readOnly: true
-          nullable: true
-          description: The aggregated of all criteria for all users in a specific
-            poll.
-        criteria_scores:
-          type: array
-          items:
-            $ref: '#/components/schemas/EntityCriteriaScore'
-        unsafe:
-          allOf:
-          - $ref: '#/components/schemas/UnsafeStatus'
-          readOnly: true
-          nullable: true
       required:
-      - criteria_scores
-      - metadata
-      - n_comparisons
-      - n_contributors
       - total_score
-      - tournesol_score
-      - type
-      - uid
-      - unsafe
     Recommendations_defaultDateEnum:
       enum:
       - TODAY

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -422,12 +422,12 @@ const SizedBarChart = ({
 };
 
 interface Props {
-  entity: Recommendation;
+  reco: Recommendation;
 }
 
-const CriteriaBarChart = ({ entity }: Props) => {
+const CriteriaBarChart = ({ reco }: Props) => {
   const { shouldDisplayChart, data, personalScoresActivated, domain } =
-    useCriteriaChartData({ entity });
+    useCriteriaChartData({ reco });
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState<number | undefined>(undefined);

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -18,7 +18,11 @@ import {
 } from '@mui/icons-material';
 
 import { TypeEnum } from 'src/services/openapi';
-import { ActionList, JSONValue, RelatedEntityObject } from 'src/utils/types';
+import {
+  ActionList,
+  EntityResult as EntityResult,
+  JSONValue,
+} from 'src/utils/types';
 
 import EntityCardTitle from './EntityCardTitle';
 import EntityCardScores from './EntityCardScores';
@@ -27,14 +31,14 @@ import EntityMetadata, { VideoMetadata } from './EntityMetadata';
 import { entityCardMainSx } from './style';
 
 const EntityCard = ({
-  entity,
+  result,
   actions = [],
   settings = [],
   compact = false,
   entityTypeConfig,
   isAvailable = true,
 }: {
-  entity: RelatedEntityObject;
+  result: EntityResult;
   actions?: ActionList;
   settings?: ActionList;
   compact?: boolean;
@@ -44,6 +48,7 @@ const EntityCard = ({
 }) => {
   const { t } = useTranslation();
   const theme = useTheme();
+  const entity = result.entity;
 
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'), {
     noSsr: true,
@@ -57,10 +62,10 @@ const EntityCard = ({
   }, [isAvailable]);
 
   const displayEntityCardScores = () => {
-    if ('tournesol_score' in entity && !compact) {
+    if ('collective_rating' in result && !compact) {
       return (
         <EntityCardScores
-          entity={entity}
+          result={result}
           showTournesolScore={entity.type !== TypeEnum.CANDIDATE_FR_2022}
           showTotalScore={entity.type === TypeEnum.CANDIDATE_FR_2022}
         />
@@ -196,12 +201,13 @@ const EntityCard = ({
 };
 
 export const RowEntityCard = ({
-  entity,
+  result,
   withLink = false,
 }: {
-  entity: RelatedEntityObject;
+  result: EntityResult;
   withLink?: boolean;
 }) => {
+  const entity = result.entity;
   return (
     <Box
       display="flex"

--- a/frontend/src/components/entity/EntityCardScores.tsx
+++ b/frontend/src/components/entity/EntityCardScores.tsx
@@ -111,15 +111,17 @@ const EntityCardScores = ({
       ''
     );
 
+  const totalScore =
+    'recommendation_metadata' in result
+      ? result.recommendation_metadata.total_score
+      : null;
+
   return (
     <>
-      {showTotalScore && 'recommendation_metadata' in result && (
+      {showTotalScore && totalScore != null && (
         <Box display="flex" alignItems="center" columnGap={1}>
           <Typography color="text.secondary">
-            Score :{' '}
-            <strong>
-              {result.recommendation_metadata.total_score.toFixed(2)}
-            </strong>
+            Score : <strong>{totalScore.toFixed(2)}</strong>
             {''}
           </Typography>
           <Tooltip

--- a/frontend/src/components/entity/EntityCardScores.tsx
+++ b/frontend/src/components/entity/EntityCardScores.tsx
@@ -7,11 +7,11 @@ import {
 } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { Recommendation } from 'src/services/openapi';
 import CriteriaIcon from '../CriteriaIcon';
+import { EntityResult } from 'src/utils/types';
 
 interface Props {
-  entity: Recommendation;
+  result: EntityResult;
   showTournesolScore?: boolean;
   showTotalScore?: boolean;
 }
@@ -42,7 +42,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 const EntityCardScores = ({
-  entity,
+  result,
   showTournesolScore = true,
   showTotalScore = false,
 }: Props) => {
@@ -51,16 +51,20 @@ const EntityCardScores = ({
   const { getCriteriaLabel, options } = useCurrentPoll();
   const mainCriterionName = options?.mainCriterionName ?? '';
 
-  const nbRatings = entity.n_comparisons;
-  const nbContributors = entity.n_contributors;
+  if (!('collective_rating' in result) || result.collective_rating == null) {
+    return null;
+  }
+
+  const nbRatings = result.collective_rating.n_comparisons;
+  const nbContributors = result.collective_rating.n_contributors;
 
   let max_score = -Infinity;
   let min_score = Infinity;
   let max_criteria = '';
   let min_criteria = '';
 
-  const isUnsafe = entity.unsafe?.status === true;
-  const unsafeReasons = (entity.unsafe?.reasons ?? [])
+  const isUnsafe = result.collective_rating.unsafe.status;
+  const unsafeReasons = result.collective_rating.unsafe.reasons
     .map((reason) => {
       if (reason === 'insufficient_tournesol_score') {
         return t('video.insufficientScore');
@@ -72,8 +76,8 @@ const EntityCardScores = ({
     })
     .filter((str) => str !== '');
 
-  if ('criteria_scores' in entity) {
-    entity.criteria_scores?.forEach((criteria) => {
+  if ('criteria_scores' in result.collective_rating) {
+    result.collective_rating.criteria_scores.forEach((criteria) => {
       if (
         criteria.score != undefined &&
         criteria.score > max_score &&
@@ -109,10 +113,13 @@ const EntityCardScores = ({
 
   return (
     <>
-      {showTotalScore && (
+      {showTotalScore && 'recommendation_metadata' in result && (
         <Box display="flex" alignItems="center" columnGap={1}>
           <Typography color="text.secondary">
-            Score : <strong>{entity.total_score.toFixed(2)}</strong>
+            Score :{' '}
+            <strong>
+              {result.recommendation_metadata.total_score.toFixed(2)}
+            </strong>
             {''}
           </Typography>
           <Tooltip
@@ -131,8 +138,7 @@ const EntityCardScores = ({
         py={1}
       >
         {showTournesolScore &&
-          'tournesol_score' in entity &&
-          entity.tournesol_score != null && (
+          result.collective_rating?.tournesol_score != null && (
             <Tooltip title={tournesolScoreTitle} placement="right">
               <Box
                 display="flex"
@@ -153,7 +159,7 @@ const EntityCardScores = ({
                   width={32}
                 />
                 <span className={classes.nb_tournesol}>
-                  {entity.tournesol_score.toFixed(0)}
+                  {result.collective_rating.tournesol_score.toFixed(0)}
                 </span>
               </Box>
             </Tooltip>

--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -6,7 +6,7 @@ import { Avatar, Box, useTheme } from '@mui/material';
 
 import { useCurrentPoll } from 'src/hooks';
 import { TypeEnum } from 'src/services/openapi';
-import { JSONValue, RelatedEntityObject } from 'src/utils/types';
+import { JSONValue, EntityObject } from 'src/utils/types';
 import { convertDurationToClockDuration, idFromUid } from 'src/utils/video';
 
 export const DurationWrapper = React.forwardRef(function DurationWrapper(
@@ -86,7 +86,7 @@ const EntityImagery = ({
   compact = false,
   config = {},
 }: {
-  entity: RelatedEntityObject;
+  entity: EntityObject;
   compact?: boolean;
   config?: { [k in TypeEnum]?: { [k: string]: JSONValue } };
 }) => {

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 import { Box, Tooltip, Link } from '@mui/material';
 import { TypeEnum } from 'src/services/openapi';
-import { RelatedEntityObject } from 'src/utils/types';
+import { EntityObject } from 'src/utils/types';
 
 const toPaddedString = (num: number): string => {
   return num.toString().padStart(2, '0');
@@ -83,7 +83,7 @@ export const VideoMetadata = ({
   );
 };
 
-const EntityMetadata = ({ entity }: { entity: RelatedEntityObject }) => {
+const EntityMetadata = ({ entity }: { entity: EntityObject }) => {
   if (entity.type === TypeEnum.VIDEO) {
     return (
       <VideoMetadata

--- a/frontend/src/features/charts/CriteriaScoresDistribution.tsx
+++ b/frontend/src/features/charts/CriteriaScoresDistribution.tsx
@@ -134,21 +134,22 @@ const CriteriaScoresDistributionChart = ({
 };
 
 interface CriteriaScoresDistributionProps {
-  entity: Recommendation;
+  reco: Recommendation;
 }
 
 const CriteriaScoresDistribution = ({
-  entity,
+  reco,
 }: CriteriaScoresDistributionProps) => {
   const { name: pollName } = useCurrentPoll();
   const { selectedCriterion, setSelectedCriterion } = useSelectedCriterion();
+  const entity = reco.entity;
 
   const [criteriaScoresDistribution, setCriteriaScoresDistribution] = useState<
     CriteriaDistributionScore[]
   >([]);
 
   const { data, personalScoresActivated, domain } = useCriteriaChartData({
-    entity,
+    reco,
   });
 
   const contextValue = useMemo<ChartContextValue>(

--- a/frontend/src/features/comparisons/ComparisonHelperPresidentielle2022.tsx
+++ b/frontend/src/features/comparisons/ComparisonHelperPresidentielle2022.tsx
@@ -2,13 +2,14 @@ import React, { useState, useEffect } from 'react';
 
 import { Typography, Link, Box, Grid } from '@mui/material';
 import { getAllCandidates } from 'src/utils/polls/presidentielle2022';
-import { Entity } from 'src/services/openapi';
+import { EntityObject } from 'src/utils/types';
 
 const ComparisonHelperPresidentielle2022 = () => {
-  const [candidates, setCandidates] = useState<Entity[]>([]);
+  const [candidates, setCandidates] = useState<EntityObject[]>([]);
 
   useEffect(() => {
-    getAllCandidates().then((candidates) => {
+    getAllCandidates().then((results) => {
+      const candidates = results.map((res) => res.entity);
       const sortedCandidates = [...candidates].sort((a, b) => {
         // Sort by last name
         const aName: string = a?.metadata?.name.split(' ').slice(1).join(' ');

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -26,7 +26,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
     >
       <EntityCard
         compact
-        entity={entity_a}
+        result={{ entity: entity_a }}
         entityTypeConfig={{ video: { displayPlayer: false } }}
       />
       <Box
@@ -58,7 +58,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
       </Box>
       <EntityCard
         compact
-        entity={entity_b}
+        result={{ entity: entity_b }}
         entityTypeConfig={{ video: { displayPlayer: false } }}
       />
     </Box>

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -6,11 +6,10 @@ import EntityCard from 'src/components/entity/EntityCard';
 import AvailableEntity from '../../components/entity/AvailableEntity';
 
 import { useCurrentPoll, useLoginState } from 'src/hooks';
-import { Recommendation } from 'src/services/openapi/models/Recommendation';
-import { ActionList, RelatedEntityObject } from 'src/utils/types';
+import { ActionList, EntityResult } from 'src/utils/types';
 
 interface Props {
-  entities: RelatedEntityObject[] | Recommendation[] | undefined;
+  entities: EntityResult[] | undefined;
   actions?: ActionList;
   settings?: ActionList;
   emptyMessage?: React.ReactNode;
@@ -46,14 +45,14 @@ function EntityList({
   return (
     <>
       {entities && entities.length ? (
-        entities.map((entity: Recommendation | RelatedEntityObject) => (
-          <Box key={entity.uid} mx={1} my={2}>
+        entities.map((res: EntityResult) => (
+          <Box key={res.entity.uid} mx={1} my={2}>
             <AvailableEntity
-              uid={entity.uid}
+              uid={res.entity.uid}
               actionsIfUnavailable={actionsIfUnavailable}
             >
               <EntityCard
-                entity={entity}
+                result={res}
                 actions={actions ?? defaultEntityActions}
                 settings={settings}
                 compact={false}

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -14,13 +14,14 @@ import {
   PRESIDENTIELLE_2022_POLL_NAME,
   YOUTUBE_POLL_NAME,
 } from 'src/utils/constants';
-import { Entity, UsersService } from 'src/services/openapi';
+import { UsersService } from 'src/services/openapi';
 import { getRecommendations } from 'src/utils/api/recommendations';
 import { getAllCandidates } from 'src/utils/polls/presidentielle2022';
 import SelectorListBox, { EntitiesTab } from './EntityTabsBox';
 import SelectorPopper from './SelectorPopper';
 import { useLoginState } from 'src/hooks';
 import { ComparisonsCountContext } from 'src/pages/comparisons/Comparison';
+import { EntityObject } from 'src/utils/types';
 
 // in milliseconds
 const TYPING_DELAY = 50;
@@ -99,7 +100,7 @@ const VideoInput = ({
             pollName,
             limit: 20,
           });
-          return (response.results ?? []).map((rl) => rl.entity);
+          return response.results ?? [];
         },
         disabled: !isLoggedIn,
       },
@@ -111,7 +112,7 @@ const VideoInput = ({
             pollName: YOUTUBE_POLL_NAME,
             limit: 20,
           });
-          return (response.results ?? []).map((rating) => rating.entity);
+          return response.results ?? [];
         },
         disabled: !isLoggedIn,
       },
@@ -138,7 +139,7 @@ const VideoInput = ({
             limit: 20,
             strict: false,
           });
-          return response.results ?? [];
+          return (response.results ?? []).map((entity) => ({ entity }));
         },
         disabled: !isLoggedIn || !otherUid,
       },
@@ -199,10 +200,11 @@ const VideoInput = ({
 };
 
 const CandidateInput = ({ onChange, value }: Props) => {
-  const [options, setOptions] = useState<Entity[]>([]);
+  const [options, setOptions] = useState<EntityObject[]>([]);
 
   useEffect(() => {
-    getAllCandidates().then((candidates) => {
+    getAllCandidates().then((results) => {
+      const candidates = results.map((res) => res.entity);
       const sortedCandidates = [...candidates].sort((a, b) => {
         // Sort by last name
         const aName: string = a?.metadata?.name.split(' ').slice(1).join(' ');

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -121,7 +121,7 @@ const EntitySelectorInnerAnonymous = ({ value }: { value: SelectorValue }) => {
   }, [isLoggedIn, pollName, uid]);
 
   return entityFallback ? (
-    <EntityCard compact entity={entityFallback} settings={undefined} />
+    <EntityCard compact result={entityFallback} settings={undefined} />
   ) : (
     <EmptyEntityCard compact loading={loading} />
   );
@@ -333,7 +333,7 @@ const EntitySelectorInnerAuth = ({
         {rating ? (
           <EntityCard
             compact
-            entity={rating.entity}
+            result={rating}
             settings={showRatingControl ? toggleAction : undefined}
           ></EntityCard>
         ) : (

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -10,7 +10,7 @@ import {
   IconButton,
 } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
-import { RelatedEntityObject } from 'src/utils/types';
+import { EntityResult } from 'src/utils/types';
 import { RowEntityCard } from 'src/components/entity/EntityCard';
 import LoaderWrapper from 'src/components/LoaderWrapper';
 import EntityTextInput from './EntityTextInput';
@@ -31,7 +31,7 @@ interface Props {
 export interface EntitiesTab {
   name: string;
   label: string;
-  fetch: () => Promise<RelatedEntityObject[]>;
+  fetch: () => Promise<EntityResult[]>;
   disabled?: boolean;
 }
 
@@ -106,7 +106,7 @@ const EntityTabsBox = ({
 
   const [tabValue, setTabValue] = useState(tabs[0]?.name);
   const [status, setStatus] = useState<TabStatus>(TabStatus.Ok);
-  const [options, setOptions] = useState<RelatedEntityObject[]>([]);
+  const [options, setOptions] = useState<EntityResult[]>([]);
   const [isDescriptionVisible, setIsDescriptionVisible] =
     useState(displayDescription);
 
@@ -226,12 +226,14 @@ const EntityTabsBox = ({
           <TabError message={t('tabsBox.errorOnLoading')} />
         ) : options.length > 0 ? (
           <ul>
-            {options.map((entity) => (
+            {options.map((res) => (
               <li
-                key={entity.uid}
-                onClick={onSelectEntity && (() => onSelectEntity(entity.uid))}
+                key={res.entity.uid}
+                onClick={
+                  onSelectEntity && (() => onSelectEntity(res.entity.uid))
+                }
               >
-                <RowEntityCard entity={entity} withLink={withLink} />
+                <RowEntityCard result={res} withLink={withLink} />
               </li>
             ))}
           </ul>

--- a/frontend/src/features/feedback/StackedCandidatesPaper.tsx
+++ b/frontend/src/features/feedback/StackedCandidatesPaper.tsx
@@ -49,17 +49,17 @@ const StackedCandidatesPaper = ({
   const sortedRecommendations = recommendations
     .filter(
       (entityWithScores) =>
-        entityWithScores.criteria_scores.find(
+        entityWithScores.individual_rating.criteria_scores.find(
           ({ criteria }) => criteria == sortingCriteria
         )?.score != null
     )
     .map((entityWithScores) => ({
-      entity: entityWithScores,
-      score: entityWithScores.criteria_scores.find(
+      reco: entityWithScores,
+      score: entityWithScores.individual_rating.criteria_scores.find(
         ({ criteria }) => criteria == sortingCriteria
       )?.score,
     }))
-    .map(({ entity, score }) => ({ entity, score: 10 * (score as number) }))
+    .map(({ reco, score }) => ({ reco, score: 10 * (score as number) }))
     .sort((a, b) => (a.score < b.score ? 1 : -1));
 
   return (
@@ -76,7 +76,8 @@ const StackedCandidatesPaper = ({
           </Trans>
         </Typography>
       }
-      items={sortedRecommendations.map(({ entity, score }) => {
+      items={sortedRecommendations.map(({ reco, score }) => {
+        const entity = reco.entity;
         const nComp = nComparisons[entity.uid] || 0;
         return (
           <ListItem key={entity.uid} alignItems="flex-start">

--- a/frontend/src/features/recommendation/ContextualRecommendations.tsx
+++ b/frontend/src/features/recommendation/ContextualRecommendations.tsx
@@ -32,7 +32,7 @@ const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
             },
           });
           const results = response.results ?? [];
-          return results.filter((entity) => entity.uid !== contextUid);
+          return results.filter((reco) => reco.entity.uid !== contextUid);
         },
       });
     tabs.push({
@@ -46,7 +46,9 @@ const ContextualRecommendations = ({ contextUid, uploader }: Props) => {
         });
         const results = response.results ?? [];
         return results.map(({ entity_a, entity_b }) =>
-          entity_a.uid === contextUid ? entity_b : entity_a
+          entity_a.uid === contextUid
+            ? { entity: entity_b }
+            : { entity: entity_a }
         );
       },
       disabled: !isLoggedIn,

--- a/frontend/src/features/recommendation/subset/RecommendationsSubset.tsx
+++ b/frontend/src/features/recommendation/subset/RecommendationsSubset.tsx
@@ -87,16 +87,16 @@ const RecommendationsSubset = ({
         ) : (
           <Paper sx={{ p: 1, bgcolor: 'background.primary' }}>
             <Grid container gap={1} flexDirection="column">
-              {entities.map((entity) => (
+              {entities.map((reco) => (
                 <Grid
                   item
-                  key={entity.uid}
+                  key={reco.entity.uid}
                   // Allow the RecommendationsSubset's parent to overwrite the
                   // text color without impacting the EntityCard.
                   sx={{ color: theme.palette.text.primary }}
                 >
                   <EntityCard
-                    entity={entity}
+                    result={reco}
                     compact={false}
                     entityTypeConfig={{ video: { displayPlayer: false } }}
                   />

--- a/frontend/src/features/videos/VideoCard.spec.tsx
+++ b/frontend/src/features/videos/VideoCard.spec.tsx
@@ -19,24 +19,33 @@ const renderVideoCard = (video: Recommendation) =>
 describe('VideoCard content', () => {
   it('shows video metadata without criterias', () => {
     const video: Recommendation = {
-      uid: 'yt:xSqqXN0D4fY',
-      type: TypeEnum.VIDEO,
-      metadata: {
-        name: 'Video title',
-        description: 'Video description',
-        views: 154988,
-        uploader: 'Channel name',
-        duration: 120,
-        publication_date: '2021-03-21',
-        language: 'fr',
-        video_id: 'xSqqXN0D4fY',
+      entity: {
+        uid: 'yt:xSqqXN0D4fY',
+        type: TypeEnum.VIDEO,
+        metadata: {
+          name: 'Video title',
+          description: 'Video description',
+          views: 154988,
+          uploader: 'Channel name',
+          duration: 120,
+          publication_date: '2021-03-21',
+          language: 'fr',
+          video_id: 'xSqqXN0D4fY',
+        },
       },
-      n_contributors: 4,
-      n_comparisons: 9,
-      tournesol_score: 0.0,
-      total_score: 0.0,
-      criteria_scores: [],
-      unsafe: null,
+      collective_rating: {
+        n_contributors: 4,
+        n_comparisons: 9,
+        tournesol_score: 0.0,
+        criteria_scores: [],
+        unsafe: {
+          status: false,
+          reasons: [],
+        },
+      },
+      recommendation_metadata: {
+        total_score: 0.0,
+      },
     };
     renderVideoCard(video);
 
@@ -56,29 +65,38 @@ describe('VideoCard content', () => {
 
   it('shows video card with single criteria', () => {
     const video: Recommendation = {
-      uid: 'yt:xSqqXN0D4fY',
-      type: TypeEnum.VIDEO,
-      metadata: {
-        name: 'Video title',
-        description: 'Video description',
-        views: 154988,
-        uploader: 'Channel name',
-        duration: 4200,
-        video_id: 'xSqqXN0D4fY',
-        publication_date: '2021-03-21',
-        language: 'fr',
-      },
-      n_contributors: 4,
-      n_comparisons: 9,
-      tournesol_score: 4,
-      total_score: 4,
-      criteria_scores: [
-        {
-          criteria: 'largely_recommended',
-          score: 0.4,
+      entity: {
+        uid: 'yt:xSqqXN0D4fY',
+        type: TypeEnum.VIDEO,
+        metadata: {
+          name: 'Video title',
+          description: 'Video description',
+          views: 154988,
+          uploader: 'Channel name',
+          duration: 4200,
+          video_id: 'xSqqXN0D4fY',
+          publication_date: '2021-03-21',
+          language: 'fr',
         },
-      ],
-      unsafe: null,
+      },
+      collective_rating: {
+        n_contributors: 4,
+        n_comparisons: 9,
+        tournesol_score: 4,
+        criteria_scores: [
+          {
+            criteria: 'largely_recommended',
+            score: 0.4,
+          },
+        ],
+        unsafe: {
+          status: false,
+          reasons: [],
+        },
+      },
+      recommendation_metadata: {
+        total_score: 4,
+      },
     };
     renderVideoCard(video);
 
@@ -101,33 +119,42 @@ describe('VideoCard content', () => {
 
   it('shows video card with multiple criteria', () => {
     const video: Recommendation = {
-      uid: 'yt:xSqqXN0D4fY',
-      type: TypeEnum.VIDEO,
-      metadata: {
-        name: 'Video title',
-        description: 'Video description',
-        views: 154988,
-        uploader: 'Channel name',
-        duration: 120,
-        video_id: 'xSqqXN0D4fY',
-        publication_date: '2021-03-21',
-        language: 'fr',
+      entity: {
+        uid: 'yt:xSqqXN0D4fY',
+        type: TypeEnum.VIDEO,
+        metadata: {
+          name: 'Video title',
+          description: 'Video description',
+          views: 154988,
+          uploader: 'Channel name',
+          duration: 120,
+          video_id: 'xSqqXN0D4fY',
+          publication_date: '2021-03-21',
+          language: 'fr',
+        },
       },
-      n_contributors: 4,
-      n_comparisons: 9,
-      tournesol_score: 17,
-      total_score: 17,
-      criteria_scores: [
-        {
-          criteria: 'engaging',
-          score: 0.9,
+      collective_rating: {
+        n_contributors: 4,
+        n_comparisons: 9,
+        tournesol_score: 17,
+        criteria_scores: [
+          {
+            criteria: 'engaging',
+            score: 0.9,
+          },
+          {
+            criteria: 'pedagogy',
+            score: 0.8,
+          },
+        ],
+        unsafe: {
+          status: false,
+          reasons: [],
         },
-        {
-          criteria: 'pedagogy',
-          score: 0.8,
-        },
-      ],
-      unsafe: null,
+      },
+      recommendation_metadata: {
+        total_score: 17,
+      },
     };
     renderVideoCard(video);
 
@@ -142,24 +169,33 @@ describe('VideoCard content', () => {
 
   it('shows video metadata with null Tournesol score', () => {
     const video: Recommendation = {
-      uid: 'yt:xSqqXN0D4fY',
-      type: TypeEnum.VIDEO,
-      metadata: {
-        name: 'Video title',
-        description: 'Video description',
-        views: 154988,
-        uploader: 'Channel name',
-        duration: 120,
-        publication_date: '2021-03-21',
-        language: 'fr',
-        video_id: 'xSqqXN0D4fY',
+      entity: {
+        uid: 'yt:xSqqXN0D4fY',
+        type: TypeEnum.VIDEO,
+        metadata: {
+          name: 'Video title',
+          description: 'Video description',
+          views: 154988,
+          uploader: 'Channel name',
+          duration: 120,
+          publication_date: '2021-03-21',
+          language: 'fr',
+          video_id: 'xSqqXN0D4fY',
+        },
       },
-      n_contributors: 4,
-      n_comparisons: 9,
-      tournesol_score: null,
-      total_score: 0,
-      criteria_scores: [],
-      unsafe: null,
+      collective_rating: {
+        n_contributors: 4,
+        n_comparisons: 9,
+        tournesol_score: null,
+        criteria_scores: [],
+        unsafe: {
+          status: false,
+          reasons: [],
+        },
+      },
+      recommendation_metadata: {
+        total_score: 0,
+      },
     };
     renderVideoCard(video);
 

--- a/frontend/src/features/videos/VideoCard.tsx
+++ b/frontend/src/features/videos/VideoCard.tsx
@@ -72,7 +72,8 @@ function VideoCard({
   const { t } = useTranslation();
   const { baseUrl } = useCurrentPoll();
 
-  const videoId = video.metadata.video_id;
+  const entity = video.entity;
+  const videoId = entity.metadata.video_id;
 
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'), {
     noSsr: true,
@@ -111,11 +112,11 @@ function VideoCard({
               to={`${baseUrl}/entities/${UID_YT_NAMESPACE}${videoId}`}
               className="full-width"
             >
-              <DurationWrapper duration={video.metadata.duration || undefined}>
+              <DurationWrapper duration={entity.metadata.duration || undefined}>
                 <img
                   className="full-width entity-thumbnail"
                   src={`https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`}
-                  alt={video.metadata.name}
+                  alt={entity.metadata.name}
                 />
               </DurationWrapper>
             </RouterLink>
@@ -134,16 +135,16 @@ function VideoCard({
         direction="column"
       >
         <EntityCardTitle
-          uid={video.uid}
-          title={video.metadata.name}
+          uid={entity.uid}
+          title={entity.metadata.name}
           compact={compact}
         />
         <VideoMetadata
-          views={video.metadata.views}
-          publicationDate={video.metadata.publication_date}
-          uploader={video.metadata.uploader}
+          views={entity.metadata.views}
+          publicationDate={entity.metadata.publication_date}
+          uploader={entity.metadata.uploader}
         />
-        {!compact && <EntityCardScores entity={video} />}
+        {!compact && <EntityCardScores result={video} />}
         {personalScore !== undefined &&
           t('video.personalScore', { score: personalScore.toFixed(0) })}
       </Grid>
@@ -163,7 +164,7 @@ function VideoCard({
       >
         {actions.map((Action, index) =>
           typeof Action === 'function' ? (
-            <Action key={index} uid={video.uid} />
+            <Action key={index} uid={entity.uid} />
           ) : (
             Action
           )
@@ -193,7 +194,7 @@ function VideoCard({
             >
               {settings.map((Action, index) =>
                 typeof Action === 'function' ? (
-                  <Action key={index} uid={video.uid} />
+                  <Action key={index} uid={entity.uid} />
                 ) : (
                   Action
                 )

--- a/frontend/src/hooks/useCriteriaChartData.ts
+++ b/frontend/src/hooks/useCriteriaChartData.ts
@@ -41,14 +41,15 @@ interface ScoreByCriterion {
 
 const useCriteriaChartData = ({
   video,
-  entity,
+  reco,
 }: {
   video?: VideoSerializerWithCriteria;
-  entity?: Recommendation;
+  reco?: Recommendation;
 }): UseCriteriaChartDataValue => {
   const criteriaScores: Array<EntityCriteriaScore> = useMemo(
-    () => video?.criteria_scores || entity?.criteria_scores || [],
-    [video, entity]
+    () =>
+      video?.criteria_scores || reco?.collective_rating?.criteria_scores || [],
+    [video, reco]
   );
   const shouldDisplayChart = criteriaScores && criteriaScores.length > 0;
 

--- a/frontend/src/pages/entities/CandidateAnalysisPage.tsx
+++ b/frontend/src/pages/entities/CandidateAnalysisPage.tsx
@@ -15,9 +15,10 @@ interface Props {
   entity: Recommendation;
 }
 
-const CandidateAnalysisPage = ({ entity }: Props) => {
+const CandidateAnalysisPage = ({ entity: reco }: Props) => {
   const { t } = useTranslation();
   const { baseUrl } = useCurrentPoll();
+  const entity = reco.entity;
 
   return (
     <Container sx={{ maxWidth: '1000px !important' }}>
@@ -48,7 +49,7 @@ const CandidateAnalysisPage = ({ entity }: Props) => {
                   compact={false}
                 />
                 <EntityCardScores
-                  entity={entity}
+                  result={reco}
                   showTournesolScore={
                     entity.type !== TypeEnum.CANDIDATE_FR_2022
                   }
@@ -72,7 +73,7 @@ const CandidateAnalysisPage = ({ entity }: Props) => {
                 </Typography>
               </Box>
               <Box p={1}>
-                <CriteriaBarChart entity={entity} />
+                <CriteriaBarChart reco={reco} />
               </Box>
             </Paper>
           </Grid>

--- a/frontend/src/pages/home/videos/sections/HomeComparison.tsx
+++ b/frontend/src/pages/home/videos/sections/HomeComparison.tsx
@@ -95,24 +95,24 @@ const HomeComparison = () => {
       .then(([comparisons, entities]) => {
         // Build the comparison.
         if (entities.length > 0) {
-          const entityA = selectRandomEntity(entities, []);
+          const recoA = selectRandomEntity(entities, []);
           let alreadyComparedWithA: string[] = [];
 
           // Exlude entities already compared with A.
           if (isLoggedIn) {
             alreadyComparedWithA = alreadyComparedWith(
-              entityA.uid,
+              recoA.entity.uid,
               comparisons[1]
             );
           }
 
-          const entityB = selectRandomEntity(
+          const recoB = selectRandomEntity(
             entities,
-            alreadyComparedWithA.concat([entityA.uid])
+            alreadyComparedWithA.concat([recoA.entity.uid])
           );
-          setComparison([entityA.uid, entityB.uid]);
-          setSelectorA({ uid: entityA.uid, rating: null });
-          setSelectorB({ uid: entityB.uid, rating: null });
+          setComparison([recoA.entity.uid, recoB.entity.uid]);
+          setSelectorA({ uid: recoA.entity.uid, rating: null });
+          setSelectorB({ uid: recoB.entity.uid, rating: null });
         }
 
         setIsLoading(false);

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -162,7 +162,6 @@ const RateLaterPage = () => {
     loadList();
   }, [loadList]);
 
-  const entities = rateLaterList.map((r) => r.entity);
   const rateLaterPageActions = [
     CompareNowAction,
     RemoveFromRateLater(loadList),
@@ -276,7 +275,7 @@ const RateLaterPage = () => {
           <Box width="100%" textAlign="center">
             <LoaderWrapper isLoading={isLoading}>
               <EntityList
-                entities={entities}
+                entities={rateLaterList}
                 actions={rateLaterPageActions}
                 actionsIfUnavailable={[RemoveFromRateLater(loadList)]}
               />

--- a/frontend/src/pages/videos/VideoAnalysisActionBar.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisActionBar.tsx
@@ -32,7 +32,7 @@ const VideoAnalysisActionBar = ({ video }: { video: Recommendation }) => {
     setRateLaterInProgress(true);
 
     try {
-      await addToRateLaterList(pollName, video.uid);
+      await addToRateLaterList(pollName, video.entity.uid);
       showSuccessAlert(t('actions.videoAddedToRateLaterList'));
     } catch (error) {
       showInfoAlert(t('actions.videoAlreadyInRateLaterList'));
@@ -81,7 +81,7 @@ const VideoAnalysisActionBar = ({ video }: { video: Recommendation }) => {
         variant="contained"
         startIcon={<Compare />}
         component={RouterLink}
-        to={`${baseUrl}/comparison?uidA=${video.uid}`}
+        to={`${baseUrl}/comparison?uidA=${video.entity.uid}`}
       >
         {t('entityAnalysisPage.generic.compare')}
       </Button>

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -26,12 +26,13 @@ export const VideoAnalysis = ({ video }: { video: Recommendation }) => {
 
   const actions = useLoginState() ? [CompareNowAction, AddToRateLaterList] : [];
 
-  const { criteria_scores: criteriaScores } = video;
+  const entity = video.entity;
+  const criteriaScores = video.collective_rating.criteria_scores;
   const shouldDisplayCharts = criteriaScores && criteriaScores.length > 0;
 
   const linkifyOpts = { defaultProtocol: 'https', target: '_blank' };
   const linkifiedDescription = linkifyStr(
-    video.metadata.description || '',
+    entity.metadata.description || '',
     linkifyOpts
   );
 
@@ -49,8 +50,8 @@ export const VideoAnalysis = ({ video }: { video: Recommendation }) => {
         <Grid container spacing={2} justifyContent="center">
           <Grid item xs={12} sx={{ aspectRatio: '16 / 9' }}>
             <VideoPlayer
-              videoId={video.metadata.video_id}
-              duration={video.metadata.duration}
+              videoId={entity.metadata.video_id}
+              duration={entity.metadata.duration}
               controls
             />
           </Grid>
@@ -88,7 +89,7 @@ export const VideoAnalysis = ({ video }: { video: Recommendation }) => {
           {/* Data visualization. */}
           {shouldDisplayCharts && (
             <SelectedCriterionProvider>
-              <PersonalCriteriaScoresContextProvider uid={video.uid}>
+              <PersonalCriteriaScoresContextProvider uid={entity.uid}>
                 <Grid item xs={12} sm={12} md={6}>
                   <Paper>
                     <Box
@@ -105,7 +106,7 @@ export const VideoAnalysis = ({ video }: { video: Recommendation }) => {
                       <PersonalScoreCheckbox />
                     </Box>
                     <Box p={1}>
-                      <CriteriaBarChart entity={video} />
+                      <CriteriaBarChart reco={video} />
                     </Box>
                   </Paper>
                 </Grid>
@@ -122,7 +123,7 @@ export const VideoAnalysis = ({ video }: { video: Recommendation }) => {
                       </Typography>
                     </Box>
                     <Box p={1}>
-                      <CriteriaScoresDistribution entity={video} />
+                      <CriteriaScoresDistribution reco={video} />
                     </Box>
                   </Paper>
                 </Grid>
@@ -133,8 +134,8 @@ export const VideoAnalysis = ({ video }: { video: Recommendation }) => {
       </Box>
       <Box flex={1}>
         <ContextualRecommendations
-          contextUid={video.uid}
-          uploader={video.metadata.uploader || undefined}
+          contextUid={entity.uid}
+          uploader={entity.metadata.uploader || undefined}
         />
       </Box>
     </Box>

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -27,8 +27,8 @@ export const VideoAnalysis = ({ video }: { video: Recommendation }) => {
   const actions = useLoginState() ? [CompareNowAction, AddToRateLaterList] : [];
 
   const entity = video.entity;
-  const criteriaScores = video.collective_rating.criteria_scores;
-  const shouldDisplayCharts = criteriaScores && criteriaScores.length > 0;
+  const criteriaScores = video.collective_rating?.criteria_scores ?? [];
+  const shouldDisplayCharts = criteriaScores.length > 0;
 
   const linkifyOpts = { defaultProtocol: 'https', target: '_blank' };
   const linkifiedDescription = linkifyStr(

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -92,9 +92,6 @@ const VideoRatingsPage = () => {
     loadData();
   }, [loadData]);
 
-  const entities = (ratings.results || []).map(
-    (rating: ContributorRating) => rating.entity
-  );
   const uidToRating = Object.fromEntries(
     (ratings.results || []).map((rating) => [rating.entity.uid, rating])
   );
@@ -141,7 +138,7 @@ const VideoRatingsPage = () => {
         )}
         <LoaderWrapper isLoading={isLoading}>
           <EntityList
-            entities={entities}
+            entities={ratings.results}
             settings={[PublicStatusAction]}
             emptyMessage={<NoRatingMessage hasFilter={hasFilter} />}
           />

--- a/frontend/src/utils/entity.ts
+++ b/frontend/src/utils/entity.ts
@@ -1,30 +1,15 @@
-import { RelatedEntityObject } from './types';
-import { Entity, Recommendation, Video } from 'src/services/openapi';
-
-export const videoFromRelatedEntity = (entity: RelatedEntityObject): Video => {
-  return {
-    uid: entity.uid,
-    name: entity.metadata.name,
-    description: entity.metadata.description,
-    publication_date: entity.metadata.publication_date,
-    views: entity.metadata.views,
-    uploader: entity.metadata.uploader,
-    language: entity.metadata.language,
-    rating_n_ratings: 0,
-    rating_n_contributors: 0,
-    duration: entity.metadata.duration,
-    video_id: entity.metadata.video_id,
-  };
-};
+import { EntityResult } from './types';
 
 /**
  * Return a random entity with uid not included in the `exclude` array.
  */
 export const selectRandomEntity = (
-  entities: Array<Entity | Recommendation>,
+  entities: Array<EntityResult>,
   exclude: string[]
-): Entity | Recommendation => {
-  const filtered = entities.filter((entity) => !exclude.includes(entity.uid));
+): EntityResult => {
+  const filtered = entities.filter(
+    (reco) => !exclude.includes(reco.entity.uid)
+  );
 
   return filtered[Math.floor(Math.random() * filtered.length)];
 };

--- a/frontend/src/utils/polls/presidentielle2022.ts
+++ b/frontend/src/utils/polls/presidentielle2022.ts
@@ -1,16 +1,16 @@
 import { TFunction } from 'react-i18next';
-import { EntitiesService, Entity, TypeEnum } from 'src/services/openapi';
-import { OrderedDialogs } from 'src/utils/types';
+import { EntitiesService, TypeEnum } from 'src/services/openapi';
+import { EntityResult, OrderedDialogs } from 'src/utils/types';
 
-let CANDIDATES: Promise<Entity[]> | null = null;
+let CANDIDATES: Promise<EntityResult[]> | null = null;
 
-export function getAllCandidates(): Promise<Entity[]> {
+export function getAllCandidates(): Promise<EntityResult[]> {
   if (CANDIDATES != null) {
     return CANDIDATES;
   }
   CANDIDATES = EntitiesService.entitiesList({
     type: TypeEnum.CANDIDATE_FR_2022,
-  }).then((data) => data.results ?? []);
+  }).then((data) => (data.results ?? []).map((entity) => ({ entity })));
   return CANDIDATES;
 }
 

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -2,13 +2,14 @@ import React from 'react';
 import { TFunction } from 'react-i18next';
 import { SvgIconComponent } from '@mui/icons-material';
 import {
-  Entity,
-  EntityNoExtraField,
+  ContributorRating,
+  RateLater,
   Recommendation,
   RelatedEntity,
   TournesolUserSettings,
   Video,
   VideoSerializerWithCriteria,
+  EntityNoExtraField,
 } from 'src/services/openapi';
 
 export type JSONValue =
@@ -29,10 +30,16 @@ export type ActionList = Array<
 
 export type CriteriaValuesType = { [s: string]: number | undefined };
 
-export type RelatedEntityObject =
-  | EntityNoExtraField
-  | RelatedEntity
-  | Recommendation;
+interface SimpleEntityResult {
+  entity: RelatedEntity;
+}
+
+export type EntityResult =
+  | ContributorRating
+  | RateLater
+  | Recommendation
+  | SimpleEntityResult;
+export type EntityObject = RelatedEntity | EntityNoExtraField;
 export type VideoObject = Video | VideoSerializerWithCriteria;
 
 /**
@@ -112,7 +119,7 @@ export type SelectablePoll = {
   tutorialLength?: number;
   // can be used by comparison series to limit the pool of entities
   // that are suggested after each comparison
-  tutorialAlternatives?: () => Promise<Array<Entity | Recommendation>>;
+  tutorialAlternatives?: () => Promise<Array<EntityResult>>;
   tutorialDialogs?: (t: TFunction) => OrderedDialogs;
   // a set of actions that will be displayed within the configured
   // `tutorialDialogs`, at the configured indexes, next to the main button

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -1,6 +1,6 @@
-import { UsersService, TypeEnum, PollsService } from 'src/services/openapi';
+import { UsersService, PollsService } from 'src/services/openapi';
 import { YOUTUBE_POLL_NAME } from './constants';
-import { RelatedEntityObject, VideoObject } from './types';
+import { VideoObject } from './types';
 
 export function extractVideoId(idOrUrl: string) {
   const host = process.env.PUBLIC_URL || location.host;
@@ -173,7 +173,9 @@ export async function getVideoForComparison(
     limit: 100,
     offset: 0,
   });
-  const videoList = (videoResult?.results || []).map((v) => idFromUid(v.uid));
+  const videoList = (videoResult?.results || []).map((v) =>
+    idFromUid(v.entity.uid)
+  );
   const videoId = await retryRandomPick(5, otherVideo, currentVideo, videoList);
   if (videoId) return videoId;
   return videoList ? pick(videoList) : null;
@@ -188,18 +190,3 @@ export const convertDurationToClockDuration = (duration: number) => {
   const seconds = roundToTwoDigits(duration % 60);
   return hours > 0 ? `${hours}:${minutes}:${seconds}` : `${minutes}:${seconds}`;
 };
-
-export const videoToEntity = (video: VideoObject): RelatedEntityObject => ({
-  uid: video.uid,
-  type: TypeEnum.VIDEO,
-  metadata: {
-    name: video.name,
-    description: video.description,
-    publication_date: video.publication_date,
-    uploader: video.uploader,
-    language: video.language,
-    duration: video.duration,
-    video_id: video.video_id,
-    views: video.views,
-  },
-});


### PR DESCRIPTION
Related to https://github.com/tournesol-app/tournesol/issues/606

---

### Description

#### New fields 
* Entity metadata are moved to `entity`
* Collective criteria scores, number of comparisons, unsafe status etc are moved to `collective_rating`
* 'total_score" computed based on the current criteria weights is moved to `recommendation_metadata`

#### Legacy fields
All legacy fields are preserved for backwards compatibility with the browser extension that relies on the API `/polls/<name>/recommendations ` 


### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
