### PR TITLE
[front] fix: `isLive()` value was not correctly computed based on talk date

### DIFF
--- a/frontend/src/pages/talks/TalkSingleEntry.tsx
+++ b/frontend/src/pages/talks/TalkSingleEntry.tsx
@@ -36,10 +36,10 @@ function isLive(talk: TalkEntry) {
     return false;
   }
 
+  const talkDate = new Date(talk.date);
   const now = new Date();
   return (
-    !isPast(talk) &&
-    new Date(talk.date) < new Date(now.getTime() + TOLERANCE_PERIOD)
+    talkDate < now && now < new Date(talkDate.getTime() + TOLERANCE_PERIOD)
   );
 }
 


### PR DESCRIPTION
### Description

"live" is present only when a talk has just started, since less than 2 hours

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
