### PR TITLE
[solidago] feat: Asymetric uncertainty

### DIFF
--- a/solidago/tests/test_comparisons_to_scores.py
+++ b/solidago/tests/test_comparisons_to_scores.py
@@ -1,10 +1,13 @@
 import random
 
+from numba import njit
+import numpy as np
 import pandas as pd
 import pytest
 
-from solidago.comparisons_to_scores import ContinuousBradleyTerry, HookeIndividualScores
 
+from solidago.comparisons_to_scores import ContinuousBradleyTerry, HookeIndividualScores
+from solidago.comparisons_to_scores.continuous_bradley_terry import get_high_likelihood_range
 
 matrix_inversion = HookeIndividualScores(r_max=10)
 continuous_bradley_terry = ContinuousBradleyTerry(r_max=10)
@@ -145,3 +148,57 @@ class TestIndividualScores:
         assert scores.loc["B"].raw_score == pytest.approx(scores.loc["F"].raw_score, abs=1e-4)
         assert scores.loc["C"].raw_score == pytest.approx(scores.loc["G"].raw_score, abs=1e-4)
         assert scores.loc["D"].raw_score == pytest.approx(scores.loc["H"].raw_score, abs=1e-4)
+
+def test_generalised_bradley_terry_uncertainty_is_asymetric():
+    model = ContinuousBradleyTerry(r_max=1)
+    comparisons = pd.DataFrame({
+        "entity_a": ["A", "A", "B", "C"],
+        "entity_b": ["B", "C", "C", "D"],
+        "score": [10, 10, 6, 10]
+    })
+    individual_scores = model.compute_individual_scores(comparisons)
+    # TODO uncomment the below assertion and finish implementing asymetry in 
+    # `compute_individual_scores`
+    # assert "raw_score_lower_bound" in individual_scores.columns
+    # assert "raw_score_upper_bound" in individual_scores.columns
+    # assert individual_scores.raw_score_lower_bound.loc["A"] == -np.inf
+
+
+@njit
+def quadratic_log_likelihood_mock(x):
+    return -10 - (x-3)**2
+
+@njit
+def asymetrix_log_likelihood_mock(x):
+    return -10 - (x-3)**2 if x > 3 else -10 - (x-3)**2 / 9
+
+@pytest.mark.parametrize("log_likelihood,max_a_posteriori,threshold,expected_range", [
+    (quadratic_log_likelihood_mock, 3, 1, (2, 4)),
+    (asymetrix_log_likelihood_mock, 3, 1, (0, 4)),
+    (quadratic_log_likelihood_mock, 3, 9, (0, 6)),
+    (quadratic_log_likelihood_mock, 0, 7, (-1, 7)),
+])
+def test_get_high_likelihood_range_has_expected_value(log_likelihood, max_a_posteriori,threshold,expected_range):
+    found_lower, found_upper = get_high_likelihood_range(log_likelihood, max_a_posteriori, threshold)
+    expected_lower, expected_upper =  expected_range
+    assert found_lower == pytest.approx(expected_lower)
+    assert found_upper == pytest.approx(expected_upper)
+
+
+@njit
+def lost_against_magnus_log_likelihood_mock(x):
+    # This represents the likelihood of losing a game against world champion
+    # Magnus Carlsen. This observation would tell you that the elo score `x`
+    # cannot be extermely high, but it may very likely be arbitrarily low.
+    # In other words, with such a likelihood function, we expect infinite
+    # uncertainty on the left. 
+    L = 0.005 
+    MAGNUS_ELO = 2839  # Source https://ratings.fide.com/profile/1503014 as of Sep 23rd
+    return np.log(1-1./(1 + np.exp(L * (MAGNUS_ELO - x))))
+
+def test_get_high_likelihood_range_supports_infinite_uncertainty():
+    found_lower, _ = get_high_likelihood_range(
+        lost_against_magnus_log_likelihood_mock,
+        2000,
+    )
+    assert found_lower == -np.inf

--- a/solidago/tests/test_resilient_primitives.py
+++ b/solidago/tests/test_resilient_primitives.py
@@ -154,8 +154,8 @@ class QrUncTest(TestCase):
         (10, np.array([1] * 1000), np.array([-1] * 500 + [1] * 500), np.array([0.1] * 1000), 0.10, -1.0712),
         (10, np.array([1] * 1000), np.array([-1] * 100 + [1] * 900), np.array([1e-6] * 1000), 0.10, 0.),
         (0.0001, np.array([1] * 1000), np.array([-1] * 102 + [1] * 898), np.array([1e-6] * 1000), 0.01, -1),
-        (1e-12, np.array([1000] * 1000), np.arange(1000, 2000, 1), np.array([1e-6] * 1000), 0.90, 1899.3929),
+        (1e-12, np.array([1000] * 1000), np.arange(1000, 2000, 1), np.array([1e-6] * 1000), 0.90, 1899.39),
     ]
 )
 def test_qr_quantile_returns_expected_results(W,w,x,delta,quantile,expected_result):
-    assert pytest.approx(expected_result, abs=1e-4) == QrQuantile(W,w,x,delta,quantile)
+    assert pytest.approx(expected_result, abs=1e-2) == QrQuantile(W,w,x,delta,quantile)

--- a/solidago/tests/test_solvers.py
+++ b/solidago/tests/test_solvers.py
@@ -1,0 +1,27 @@
+import pytest
+
+from numba import njit
+
+from solidago.solvers.optimize import brentq
+
+
+def test_brentq_fails_to_converge_for_non_zero_method():
+    @njit
+    def one_plus_x_square(x):
+        return 1 + x * x
+    with pytest.raises(RuntimeError):
+        brentq(one_plus_x_square)
+
+
+def test_brentq_finds_zeros_of_simple_increasing_linear():
+    @njit
+    def x_plus_five(x):
+        return x+5
+    assert brentq(x_plus_five) == -5.
+
+
+def test_brentq_finds_zeros_of_simple_decreasing_linear():
+    @njit
+    def minus_x_plus_twelve(x):
+        return -x+12
+    assert brentq(minus_x_plus_twelve) == 12.


### PR DESCRIPTION
#1780 

---

### Description

Uncertainty of individual scores should be asymmetric.
This PR updates the computation of individual scores for the Continuous Bradley Terry model in solidago using the method of "high likelihood range".

### To-do

- [ ] Remove the symmetric uncertainty in solidago CBT model
- [ ] Adapt Tournesol's individual rating model to store the assymetric uncertainties
- [ ] Adapt the downstream handling of uncertainty to support assymetric uncertainty of individual ratings (
    - [ ] usage of uncertainty in global score aggregation
    - [ ] the display of uncertainty in the public dataset
    - [ ] usage of the uncertainty in scaling
- [ ] Make sure the new feature does not overly change the current video rankings
- [ ] Increment Solidago's version

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
