### PR TITLE
[front] refactor: use UIDs instead of video ids in getUidForComparison

### DIFF
--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -9,8 +9,8 @@ import {
   dontSuggestAnymore,
 } from 'src/features/rateLater/alreadySuggested';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import { YOUTUBE_POLL_NAME, UID_YT_NAMESPACE } from 'src/utils/constants';
-import { getVideoForComparison, idFromUid } from 'src/utils/video';
+import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { getUidForComparison } from 'src/utils/video';
 
 interface Props {
   currentUid: string | null;
@@ -44,27 +44,26 @@ const AutoEntityButton = ({
     async ({ fromAutoFill = false } = {}) => {
       onClick();
 
-      const newVideoId: string | null = await getVideoForComparison(
-        otherUid ? idFromUid(otherUid) : null,
-        idFromUid(currentUid || ''),
+      const newUid: string | null = await getUidForComparison(
+        currentUid || '',
+        otherUid ? otherUid : null,
         ALREADY_SUGGESTED[pollName]
       );
 
       if (!mountedRef.current) return;
 
-      if (newVideoId) {
-        const newVideoUid = `${UID_YT_NAMESPACE}${newVideoId}`;
-        dontSuggestAnymore(pollName, newVideoUid);
+      if (newUid) {
+        dontSuggestAnymore(pollName, newUid);
 
         // When both videos are auto filled it's common to receive the same video twice.
         // When it happens we ask for another one.
-        if (fromAutoFill && newVideoUid === otherUidRef.current) {
+        if (fromAutoFill && newUid === otherUidRef.current) {
           onResponse(null);
           askNewVideo({ fromAutoFill: true });
           return;
         }
 
-        onResponse(newVideoUid);
+        onResponse(newUid);
       } else {
         onResponse(null);
       }


### PR DESCRIPTION
**related issues** #1743

---

### Description

This PR replaces the usage of video ids by UIDs in the `getUidForComparison` function.

This avoid having unnecessary id to UID and UID to id conversions between the `AutoEntityButton` component and the `getUidForComparison` function.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
