### PR TITLE
[ext] fix: remove unecessary browser alerts

### DIFF
--- a/browser-extension/src/manifest.json
+++ b/browser-extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Tournesol Extension",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Open Tournesol directly from YouTube",
   "permissions": [
     "https://tournesol.app/",

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -36,7 +36,6 @@ export const fetchTournesolApi = async (url, method, data) => {
     body['body'] = JSON.stringify(data);
   }
   return fetch(`https://api.tournesol.app/${url}`, body)
-    .then((r) => r)
     .catch(console.error);
 };
 

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -16,13 +16,6 @@ export const alertUseOnLinkToYoutube = () => {
   alertOnCurrentTab('This must be used on a link to a youtube video');
 };
 
-export const alertInvalidAccessToken = () => {
-  alertOnCurrentTab(
-    'Your connection to Tournesol needs to be refreshed.\\n\\n' +
-      'Please log in using the form below.'
-  );
-};
-
 export const fetchTournesolApi = async (url, method, data) => {
   const headers = {
     Accept: 'application/json',
@@ -43,17 +36,7 @@ export const fetchTournesolApi = async (url, method, data) => {
     body['body'] = JSON.stringify(data);
   }
   return fetch(`https://api.tournesol.app/${url}`, body)
-    .then((r) => {
-      if (r.status === 401 || r.status === 403) {
-        // 401 Unauthorized with an access token means either
-        // - the token has expired
-        // - the token has been crafted
-        if (r.status === 401 && access_token) {
-          alertInvalidAccessToken();
-        }
-      }
-      return r;
-    })
+    .then((r) => r)
     .catch(console.error);
 };
 

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -35,8 +35,7 @@ export const fetchTournesolApi = async (url, method, data) => {
   if (data) {
     body['body'] = JSON.stringify(data);
   }
-  return fetch(`https://api.tournesol.app/${url}`, body)
-    .catch(console.error);
+  return fetch(`https://api.tournesol.app/${url}`, body).catch(console.error);
 };
 
 export const addRateLater = async (video_id) => {


### PR DESCRIPTION
**related issues** #1779

---

### Description

This PR aims to improve the UX of the browser extension, and addresses the issue **(a)** described in this comment https://github.com/tournesol-app/tournesol/issues/1779#issuecomment-1742648000. The other points require more investigation.

The browser alert telling the users to refresh their connection to Tournesol has been deleted. We consider that an outdated access token should be refreshed automatically in the background, without noticing the users. Some cases still trigger the display of the log in iframe: when the refresh token present in the front end is "expired" (automatically deleted in the API database by a scheduled task when its life time exceed 1 week), the users have to log in again.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
