### PR TITLE
[front] fix: gap between video cards in RecommendationsSubset was inconsistent

### DIFF
--- a/frontend/src/features/recommendation/subset/RecommendationsSubset.tsx
+++ b/frontend/src/features/recommendation/subset/RecommendationsSubset.tsx
@@ -86,7 +86,7 @@ const RecommendationsSubset = ({
           </Typography>
         ) : (
           <Paper sx={{ p: 1, bgcolor: 'background.primary' }}>
-            <Grid container gap={1} flexDirection="column">
+            <Grid container gap={1} direction="column" wrap="nowrap">
               {entities.map((reco) => (
                 <Grid
                   item


### PR DESCRIPTION
### Description

MUI `grid` uses `flex-wrap: "wrap"` by default, which is not suitable when stacking cards in a column. 

### Checklist
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
