### PR TITLE
[tests] trigger less input events when pasting values in video input

### DIFF
--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -99,6 +99,9 @@ describe('Comparison page', () => {
     cy.get("[data-testid=paste-video-url] input")
       .focus()
       .invoke("val", value)
+      // For some reason typing an additional character is needed for all event handlers
+      // to get the change. But a whitespace would be trimmed and ignored by the EntitySelector,
+      // so we put an arbitrary character and delete it right away.
       .type("_{backspace}", {delay: 0});
   }
 

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -95,6 +95,13 @@ describe('Comparison page', () => {
       .should('have.length', 2);
   }
 
+  const pasteInVideoInput = (value: string) => {
+    cy.get("[data-testid=paste-video-url] input")
+      .focus()
+      .invoke("val", value)
+      .type("_{backspace}", {delay: 0});
+  }
+
   describe('authorization', () => {
     it('is not accessible by anonymous users', () => {
       cy.visit('/comparison');
@@ -133,7 +140,8 @@ describe('Comparison page', () => {
   });
 
   describe('video selectors', () => {
-    const videoAUrl = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
+    const videoAId = "lYXQvHhfKuM";
+    const videoAUrl = `https://www.youtube.com/watch?v=${videoAId}`;
 
     it('support pasting YouTube URLs', () => {
       cy.visit('/comparison');
@@ -145,8 +153,7 @@ describe('Comparison page', () => {
       waitForAutoFill();
 
       cy.get("[data-testid=entity-select-button-compact]").first().click();
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoAUrl, {delay: 0});
+      pasteInVideoInput(videoAUrl);
 
       // wait for the auto filled video to be replaced
       cy.contains('5 IA surpuissantes');
@@ -163,7 +170,7 @@ describe('Comparison page', () => {
 
       cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url] input[type=text]")
-        .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
+        .should('have.attr', 'value', `yt:${videoAId}`);
     });
 
     it('support pasting YouTube video ID', () => {
@@ -179,8 +186,7 @@ describe('Comparison page', () => {
       waitForAutoFill();
 
       cy.get("[data-testid=entity-select-button-compact]").first().click();
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoAUrl.split('?v=')[1], {delay: 0});
+      pasteInVideoInput(videoAId);
 
       // wait for the auto filled video to be replaced
       cy.contains('5 IA surpuissantes');
@@ -197,7 +203,7 @@ describe('Comparison page', () => {
 
       cy.get("[data-testid=entity-select-button-compact]").first().click();
       cy.get("[data-testid=paste-video-url] input[type=text]")
-        .should('have.attr', 'value', `yt:${videoAUrl.split('?v=')[1]}`);
+        .should('have.attr', 'value', `yt:${videoAId}`);
     });
   });
 
@@ -244,12 +250,10 @@ describe('Comparison page', () => {
 
       // add one video, and ask for a second one
       cy.get("[data-testid=entity-select-button-compact]").first().click();
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoAId, {delay: 0});
+      pasteInVideoInput(videoAId);
 
       cy.get("[data-testid=entity-select-button-compact]").last().click();
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoBId, {delay: 0});
+      pasteInVideoInput(videoBId);
 
       // only one criteria must be visible by default
       cy.contains('add optional criteria', {matchCase: false})
@@ -281,11 +285,9 @@ describe('Comparison page', () => {
       waitForAutoFill();
 
       cy.get("[data-testid=entity-select-button-compact]").first().click();
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoAId, {delay: 0});
+      pasteInVideoInput(videoAId);
       cy.get("[data-testid=entity-select-button-compact]").last().click();
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoBId, {delay: 0});
+      pasteInVideoInput(videoBId);
 
       cy.contains('add optional criteria', {matchCase: false}).click();
 
@@ -318,11 +320,9 @@ describe('Comparison page', () => {
       waitForAutoFill();
 
       cy.get("[data-testid=entity-select-button-compact]").first().click();
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoAId, {delay: 0});
+      pasteInVideoInput(videoAId);
       cy.get("[data-testid=entity-select-button-compact]").last().click();
-      cy.get("[data-testid=paste-video-url]")
-        .type(videoAId, {delay: 0});
+      pasteInVideoInput(videoAId);
 
       cy.contains('These two items are very similar', {matchCase: false})
           .should('be.visible');


### PR DESCRIPTION
### Description

Tests in "comparisonPage.cy.ts" have been flaky recently. This PR tried to solve this issue by setting the input value in a single event. But Cypress make things a bit more complicated, ans additional ".type()" is required to make sure that React will behave properly once the value has changed.

### Checklist

- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass



[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
