### PR TITLE
[front] fix: typo in association details (fr)

### DIFF
--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -605,7 +605,7 @@
     "tournesolTransparency": "Tournesol se veut être un projet extrêmement transparent. Toutes les contributions au code source de la plateforme sont visibles sur GitHub\u00a0; la description des concepts importants et la vision du projet sont consultables sur ce site\u00a0; enfin les discussions relatives au développement de Tournesol se déroulent ouvertement sur Discord.",
     "considerHelpingWithDonation": "Si vous en avez la possibilité, n'hésitez pas à nous aider <2>en faisant un don</2>.",
     "tournesolAssociation": "L'association Tournesol",
-    "tournesolAssociationDetail": "Le projet est porté par l'association à but not lucratif « Association Tournesol » basée à Lausanne en Suisse.",
+    "tournesolAssociationDetail": "Le projet est porté par l'association à but non lucratif « Association Tournesol » basée à Lausanne en Suisse.",
     "rolePresident": "Président",
     "roleTreasurer": "Trésorier",
     "roleSecretary": "Secrétaire",


### PR DESCRIPTION
### Description

use "non lucratif" instead of "not lucratif"

This PR was created from directly from github
Run `yarn i18n:parse` is probably needed to update the translation catalogs accordingly in public/locales (or maybe it's only needed for a local usage ?)

### Checklist

- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] Run [yarn i18n:parse](https://github.com/tournesol-app/tournesol/blob/main/frontend/README.md#yarn-i18nparse)

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
