### PR TITLE
[front] Adapt rate-later page to display RatingControlon (with nb of comparisons) on cards

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -36,7 +36,7 @@ export interface EntityCardProps {
   actions?: ActionList;
   compact?: boolean;
   isAvailable?: boolean;
-  withRatingStatus?: boolean;
+  showRatingControl?: boolean;
   onRatingChange?: (rating: ContributorRating) => void;
   // Configuration specific to the entity type.
   entityTypeConfig?: { [k in TypeEnum]?: { [k: string]: JSONValue } };
@@ -48,7 +48,7 @@ const EntityCard = ({
   compact = false,
   entityTypeConfig,
   isAvailable = true,
-  withRatingStatus = false,
+  showRatingControl = false,
   onRatingChange,
 }: EntityCardProps) => {
   const { t } = useTranslation();
@@ -60,7 +60,9 @@ const EntityCard = ({
   });
 
   const [contentDisplayed, setContentDisplayed] = useState(true);
-  const [ratingVisible, setSettingsVisible] = useState(!isSmallScreen);
+  const [ratingVisible, setSettingsVisible] = useState(
+    !isSmallScreen && showRatingControl
+  );
 
   useEffect(() => {
     setContentDisplayed(isAvailable);
@@ -165,7 +167,7 @@ const EntityCard = ({
                 Action
               )
             )}
-            {isSmallScreen && withRatingStatus && (
+            {isSmallScreen && showRatingControl && (
               <>
                 <Box flexGrow={1} />
                 <IconButton
@@ -178,7 +180,7 @@ const EntityCard = ({
               </>
             )}
           </Grid>
-          {withRatingStatus && (
+          {showRatingControl && (
             <Grid item xs={12}>
               <Collapse in={ratingVisible || !isSmallScreen}>
                 <Box
@@ -188,26 +190,17 @@ const EntityCard = ({
                   gap="16px"
                   color="text.secondary"
                 >
-                  <>
-                    {/* {settings.map((Action, index) =>
-                      typeof Action === 'function' ? (
-                        <Action key={index} uid={entity.uid} />
-                      ) : (
-                        Action
-                      )
-                    )} */}
-                    {'individual_rating' in result &&
-                      result.individual_rating && (
-                        <UserRatingPublicToggle
-                          // Custom key to make sure the state is reset after rating has been updated by another component
-                          key={`${entity.uid}__${result.individual_rating.is_public}`}
-                          uid={entity.uid}
-                          nComparisons={result.individual_rating.n_comparisons}
-                          initialIsPublic={result.individual_rating.is_public}
-                          onChange={onRatingChange}
-                        />
-                      )}
-                  </>
+                  {'individual_rating' in result &&
+                    result.individual_rating && (
+                      <UserRatingPublicToggle
+                        // Custom key to make sure the state is reset after rating has been updated by another component
+                        key={`${entity.uid}__${result.individual_rating.is_public}`}
+                        uid={entity.uid}
+                        nComparisons={result.individual_rating.n_comparisons}
+                        initialIsPublic={result.individual_rating.is_public}
+                        onChange={onRatingChange}
+                      />
+                    )}
                 </Box>
               </Collapse>
             </Grid>

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -23,7 +23,7 @@ import {
   EntityResult as EntityResult,
   JSONValue,
 } from 'src/utils/types';
-import { UserRatingPublicToggle } from 'src/features/videos/PublicStatusAction';
+import { RatingControl } from 'src/features/ratings/RatingControl';
 
 import EntityCardTitle from './EntityCardTitle';
 import EntityCardScores from './EntityCardScores';
@@ -190,17 +190,15 @@ const EntityCard = ({
                   gap="16px"
                   color="text.secondary"
                 >
-                  {'individual_rating' in result &&
-                    result.individual_rating && (
-                      <UserRatingPublicToggle
-                        // Custom key to make sure the state is reset after rating has been updated by another component
-                        key={`${entity.uid}__${result.individual_rating.is_public}`}
-                        uid={entity.uid}
-                        nComparisons={result.individual_rating.n_comparisons}
-                        initialIsPublic={result.individual_rating.is_public}
-                        onChange={onRatingChange}
-                      />
-                    )}
+                  {'individual_rating' in result && (
+                    <RatingControl
+                      // Custom key to make sure the state is reset after rating has been updated by another component
+                      key={`${entity.uid}__${result.individual_rating?.is_public}`}
+                      uid={entity.uid}
+                      individualRating={result.individual_rating}
+                      onChange={onRatingChange}
+                    />
+                  )}
                 </Box>
               </Collapse>
             </Grid>

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -13,7 +13,6 @@ interface Props {
   actions?: ActionList;
   settings?: ActionList;
   emptyMessage?: React.ReactNode;
-  personalScores?: { [uid: string]: number };
   actionsIfUnavailable?: ActionList;
   cardProps?: Partial<EntityCardProps>;
 }
@@ -31,8 +30,6 @@ interface Props {
 function EntityList({
   entities,
   actions,
-  // settings = [],
-  // personalScores,
   emptyMessage,
   actionsIfUnavailable,
   cardProps = {},

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import EntityCard from 'src/components/entity/EntityCard';
+import EntityCard, { EntityCardProps } from 'src/components/entity/EntityCard';
 import AvailableEntity from '../../components/entity/AvailableEntity';
 
 import { useCurrentPoll, useLoginState } from 'src/hooks';
@@ -15,6 +15,7 @@ interface Props {
   emptyMessage?: React.ReactNode;
   personalScores?: { [uid: string]: number };
   actionsIfUnavailable?: ActionList;
+  cardProps?: Partial<EntityCardProps>;
 }
 
 /**
@@ -30,10 +31,11 @@ interface Props {
 function EntityList({
   entities,
   actions,
-  settings = [],
+  // settings = [],
   // personalScores,
   emptyMessage,
   actionsIfUnavailable,
+  cardProps = {},
 }: Props) {
   const { isLoggedIn } = useLoginState();
   const { options } = useCurrentPoll();
@@ -54,9 +56,9 @@ function EntityList({
               <EntityCard
                 result={res}
                 actions={actions ?? defaultEntityActions}
-                settings={settings}
                 compact={false}
                 entityTypeConfig={{ video: { displayPlayer: false } }}
+                {...cardProps}
               />
             </AvailableEntity>
           </Box>

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useCallback, useState } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Theme, useTheme } from '@mui/material/styles';
@@ -7,11 +7,9 @@ import { Box, Grid, Typography } from '@mui/material';
 
 import { useCurrentPoll, useEntityAvailable, useLoginState } from 'src/hooks';
 import { ENTITY_AVAILABILITY } from 'src/hooks/useEntityAvailable';
-import { UserRatingPublicToggle } from 'src/features/videos/PublicStatusAction';
 import EntityCard from 'src/components/entity/EntityCard';
 import EmptyEntityCard from 'src/components/entity/EmptyEntityCard';
 
-import { ActionList } from 'src/utils/types';
 import {
   UsersService,
   ContributorRating,
@@ -259,20 +257,6 @@ const EntitySelectorInnerAuth = ({
     [onChange]
   );
 
-  const toggleAction: ActionList = useMemo(() => {
-    return rating?.individual_rating.is_public != null
-      ? [
-          <UserRatingPublicToggle
-            key="isPublicToggle"
-            uid={rating.entity.uid}
-            nComparisons={rating.individual_rating.n_comparisons}
-            initialIsPublic={rating.individual_rating.is_public}
-            onChange={handleRatingUpdate}
-          />,
-        ]
-      : [];
-  }, [handleRatingUpdate, rating]);
-
   return (
     <>
       {showEntityInput && (
@@ -334,8 +318,7 @@ const EntitySelectorInnerAuth = ({
           <EntityCard
             compact
             result={rating}
-            // settings={showRatingControl ? toggleAction : undefined}
-            withRatingStatus={showRatingControl}
+            showRatingControl={showRatingControl}
             onRatingChange={handleRatingUpdate}
           ></EntityCard>
         ) : (

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -121,7 +121,7 @@ const EntitySelectorInnerAnonymous = ({ value }: { value: SelectorValue }) => {
   }, [isLoggedIn, pollName, uid]);
 
   return entityFallback ? (
-    <EntityCard compact result={entityFallback} settings={undefined} />
+    <EntityCard compact result={entityFallback} />
   ) : (
     <EmptyEntityCard compact loading={loading} />
   );
@@ -266,7 +266,7 @@ const EntitySelectorInnerAuth = ({
             key="isPublicToggle"
             uid={rating.entity.uid}
             nComparisons={rating.individual_rating.n_comparisons}
-            isPublic={rating.individual_rating.is_public}
+            initialIsPublic={rating.individual_rating.is_public}
             onChange={handleRatingUpdate}
           />,
         ]
@@ -334,7 +334,9 @@ const EntitySelectorInnerAuth = ({
           <EntityCard
             compact
             result={rating}
-            settings={showRatingControl ? toggleAction : undefined}
+            // settings={showRatingControl ? toggleAction : undefined}
+            withRatingStatus={showRatingControl}
+            onRatingChange={handleRatingUpdate}
           ></EntityCard>
         ) : (
           <>

--- a/frontend/src/features/ratings/MarkAllRatings.tsx
+++ b/frontend/src/features/ratings/MarkAllRatings.tsx
@@ -1,17 +1,15 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { Button, Box } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 import { TitledSection } from 'src/components';
 import { UsersService } from 'src/services/openapi';
-import { RatingsContext } from 'src/features/videos/PublicStatusAction';
 import { useNotifications } from 'src/hooks';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
-function MarkAllRatings() {
+function MarkAllRatings({ onChange }: { onChange: () => void }) {
   const { t } = useTranslation();
-  const { onChange: onRatingChange } = useContext(RatingsContext);
   const { showErrorAlert, showInfoAlert } = useNotifications();
   const { name: pollName } = useCurrentPoll();
 
@@ -25,9 +23,7 @@ function MarkAllRatings() {
       showErrorAlert(err?.message || 'Server error');
       return;
     }
-    if (onRatingChange) {
-      onRatingChange();
-    }
+    onChange();
     showInfoAlert(
       isPublic
         ? t('ratings.allRatingsMarkedPublic')

--- a/frontend/src/features/ratings/RatingControl.tsx
+++ b/frontend/src/features/ratings/RatingControl.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { Tooltip, Typography, Box, Switch, Link } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
-import { UsersService, ContributorRating } from 'src/services/openapi';
+import {
+  UsersService,
+  ContributorRating,
+  IndividualRating,
+} from 'src/services/openapi';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
 const setPublicStatus = async (
@@ -19,20 +23,19 @@ const setPublicStatus = async (
   });
 };
 
-export const UserRatingPublicToggle = ({
+export const RatingControl = ({
   uid,
-  nComparisons,
-  initialIsPublic,
+  individualRating,
   onChange,
 }: {
   uid: string;
-  nComparisons: number;
-  initialIsPublic: boolean;
+  individualRating: IndividualRating | null;
   onChange?: (rating: ContributorRating) => void;
 }) => {
   const { t } = useTranslation();
   const { name: pollName, baseUrl, options } = useCurrentPoll();
-  const [isPublic, setIsPublic] = useState(initialIsPublic);
+  const [isPublic, setIsPublic] = useState(individualRating?.is_public ?? true);
+  const nComparisons = individualRating?.n_comparisons ?? 0;
 
   const handleChange = React.useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -64,7 +67,7 @@ export const UserRatingPublicToggle = ({
         )}
       </Typography>
       <Box flexGrow={1} minWidth="12px" />
-      {options?.comparisonsCanBePublic === true && (
+      {individualRating && options?.comparisonsCanBePublic === true && (
         <Tooltip
           title={
             <Typography variant="caption">

--- a/frontend/src/features/ratings/RatingsFilter.tsx
+++ b/frontend/src/features/ratings/RatingsFilter.tsx
@@ -11,9 +11,11 @@ import RatingOrderByInput from './RatingOrderByInput';
 
 function RatingsFilter({
   defaultFilters = [],
+  onAllRatingsChange,
 }: {
   // A list of default values used to initialize the filters.
   defaultFilters: Array<{ name: string; value: string }>;
+  onAllRatingsChange: () => void;
 }) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
@@ -43,7 +45,7 @@ function RatingsFilter({
             />
           </Grid>
           <Grid item xs={12} sm={6} md={4}>
-            <MarkAllRatingsMenu />
+            <MarkAllRatingsMenu onChange={onAllRatingsChange} />
           </Grid>
         </Grid>
       </Collapse>

--- a/frontend/src/features/videos/PublicStatusAction.tsx
+++ b/frontend/src/features/videos/PublicStatusAction.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { Tooltip, Typography, Box, Switch, Link } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
@@ -22,26 +22,28 @@ const setPublicStatus = async (
 export const UserRatingPublicToggle = ({
   uid,
   nComparisons,
-  isPublic,
+  initialIsPublic,
   onChange,
 }: {
   uid: string;
   nComparisons: number;
-  isPublic: boolean;
+  initialIsPublic: boolean;
   onChange?: (rating: ContributorRating) => void;
 }) => {
   const { t } = useTranslation();
   const { name: pollName, baseUrl, options } = useCurrentPoll();
+  const [isPublic, setIsPublic] = useState(initialIsPublic);
 
   const handleChange = React.useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const newStatus = e.target.checked;
-      const rating = await setPublicStatus(pollName, uid, newStatus);
+      const result = await setPublicStatus(pollName, uid, newStatus);
+      setIsPublic(result.individual_rating.is_public);
       if (onChange) {
-        onChange(rating);
+        onChange(result);
       }
     },
-    [onChange, pollName, uid]
+    [onChange, setIsPublic, pollName, uid]
   );
 
   return (
@@ -104,18 +106,18 @@ interface RatingsContextValue {
 
 export const RatingsContext = React.createContext<RatingsContextValue>({});
 
-export const PublicStatusAction = ({ uid }: { uid: string }) => {
-  const { getContributorRating, onChange } = useContext(RatingsContext);
-  const contributorRating = getContributorRating?.(uid);
-  if (contributorRating == null) {
-    return null;
-  }
-  return (
-    <UserRatingPublicToggle
-      nComparisons={contributorRating.individual_rating.n_comparisons}
-      isPublic={contributorRating.individual_rating.is_public}
-      uid={uid}
-      onChange={onChange}
-    />
-  );
-};
+// export const PublicStatusAction = ({ uid }: { uid: string }) => {
+//   const { getContributorRating, onChange } = useContext(RatingsContext);
+//   const contributorRating = getContributorRating?.(uid);
+//   if (contributorRating == null) {
+//     return null;
+//   }
+//   return (
+//     <UserRatingPublicToggle
+//       nComparisons={contributorRating.individual_rating.n_comparisons}
+//       initialIsPublic={contributorRating.individual_rating.is_public}
+//       uid={uid}
+//       onChange={onChange}
+//     />
+//   );
+// };

--- a/frontend/src/features/videos/PublicStatusAction.tsx
+++ b/frontend/src/features/videos/PublicStatusAction.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { Tooltip, Typography, Box, Switch, Link } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
@@ -98,26 +98,3 @@ export const UserRatingPublicToggle = ({
     </Box>
   );
 };
-
-interface RatingsContextValue {
-  getContributorRating?: (uid: string) => ContributorRating;
-  onChange?: (rating?: ContributorRating) => void;
-}
-
-export const RatingsContext = React.createContext<RatingsContextValue>({});
-
-// export const PublicStatusAction = ({ uid }: { uid: string }) => {
-//   const { getContributorRating, onChange } = useContext(RatingsContext);
-//   const contributorRating = getContributorRating?.(uid);
-//   if (contributorRating == null) {
-//     return null;
-//   }
-//   return (
-//     <UserRatingPublicToggle
-//       nComparisons={contributorRating.individual_rating.n_comparisons}
-//       initialIsPublic={contributorRating.individual_rating.is_public}
-//       uid={uid}
-//       onChange={onChange}
-//     />
-//   );
-// };

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -278,6 +278,7 @@ const RateLaterPage = () => {
                 entities={rateLaterList}
                 actions={rateLaterPageActions}
                 actionsIfUnavailable={[RemoveFromRateLater(loadList)]}
+                cardProps={{ showRatingControl: true }}
               />
             </LoaderWrapper>
           </Box>

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -10,10 +10,7 @@ import type {
 import Pagination from 'src/components/Pagination';
 import { UsersService } from 'src/services/openapi';
 import { ContentBox, ContentHeader, LoaderWrapper } from 'src/components';
-import {
-  PublicStatusAction,
-  RatingsContext,
-} from 'src/features/videos/PublicStatusAction';
+import { RatingsContext } from 'src/features/videos/PublicStatusAction';
 import RatingsFilter from 'src/features/ratings/RatingsFilter';
 import { scrollToTop } from 'src/utils/ui';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
@@ -139,8 +136,8 @@ const VideoRatingsPage = () => {
         <LoaderWrapper isLoading={isLoading}>
           <EntityList
             entities={ratings.results}
-            settings={[PublicStatusAction]}
             emptyMessage={<NoRatingMessage hasFilter={hasFilter} />}
+            cardProps={{ withRatingStatus: true }}
           />
         </LoaderWrapper>
         {!isLoading && videoCount > 0 && videoCount > limit && (

--- a/frontend/src/pages/videos/VideoRatings.tsx
+++ b/frontend/src/pages/videos/VideoRatings.tsx
@@ -3,14 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useHistory, Link } from 'react-router-dom';
 import { Box, Button, Divider } from '@mui/material';
 
-import type {
-  ContributorRating,
-  PaginatedContributorRatingList,
-} from 'src/services/openapi';
+import type { PaginatedContributorRatingList } from 'src/services/openapi';
 import Pagination from 'src/components/Pagination';
 import { UsersService } from 'src/services/openapi';
 import { ContentBox, ContentHeader, LoaderWrapper } from 'src/components';
-import { RatingsContext } from 'src/features/videos/PublicStatusAction';
 import RatingsFilter from 'src/features/ratings/RatingsFilter';
 import { scrollToTop } from 'src/utils/ui';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
@@ -89,39 +85,19 @@ const VideoRatingsPage = () => {
     loadData();
   }, [loadData]);
 
-  const uidToRating = Object.fromEntries(
-    (ratings.results || []).map((rating) => [rating.entity.uid, rating])
-  );
-  const getRating = (uid: string) => uidToRating[uid];
-
-  const onRatingChange = (newRating: ContributorRating | undefined) => {
-    if (newRating) {
-      setRatings((prevRatings) => {
-        const updatedResults = (prevRatings.results || []).map((rating) =>
-          rating.entity.uid === newRating.entity.uid ? newRating : rating
-        );
-        return { ...prevRatings, results: updatedResults };
-      });
+  const onAllRatingsChange = () => {
+    if (hasFilter) {
+      // A filter had been selected. Let's reset the filter to reload the list.
+      searchParams.delete('isPublic');
+      history.push({ search: searchParams.toString() });
     } else {
-      // All ratings have been updated.
-      if (hasFilter) {
-        // A filter had been selected. Let's reset the filter to reload the list.
-        searchParams.delete('isPublic');
-        history.push({ search: searchParams.toString() });
-      } else {
-        // No filter is selected. Let's simply refresh the list.
-        loadData();
-      }
+      // No filter is selected. Let's simply refresh the list.
+      loadData();
     }
   };
 
   return (
-    <RatingsContext.Provider
-      value={{
-        getContributorRating: getRating,
-        onChange: onRatingChange,
-      }}
-    >
+    <>
       <ContentHeader title={t('myRatedVideosPage.title')} />
       <ContentBox noMinPaddingX maxWidth="lg">
         {options?.comparisonsCanBePublic === true && (
@@ -130,6 +106,7 @@ const VideoRatingsPage = () => {
               defaultFilters={[
                 { name: 'orderBy', value: DEFAULT_FILTER_ORDER_BY },
               ]}
+              onAllRatingsChange={onAllRatingsChange}
             />
           </Box>
         )}
@@ -137,7 +114,7 @@ const VideoRatingsPage = () => {
           <EntityList
             entities={ratings.results}
             emptyMessage={<NoRatingMessage hasFilter={hasFilter} />}
-            cardProps={{ withRatingStatus: true }}
+            cardProps={{ showRatingControl: true }}
           />
         </LoaderWrapper>
         {!isLoading && videoCount > 0 && videoCount > limit && (
@@ -149,7 +126,7 @@ const VideoRatingsPage = () => {
           />
         )}
       </ContentBox>
-    </RatingsContext.Provider>
+    </>
   );
 };
 


### PR DESCRIPTION
### Description

Related to https://github.com/tournesol-app/tournesol/issues/606  
>  Adapt front rate-later page video cards to display the number of comparisons

This also removes the `RatingsContext` now that the rating object is usually accessible in the API response.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
