### PR TITLE
[back] fix: server error on subsample when user has no rating

### DIFF
--- a/backend/tournesol/tests/test_api_subsamples.py
+++ b/backend/tournesol/tests/test_api_subsamples.py
@@ -200,3 +200,12 @@ class SubSamplesListTestCase(TestCase):
                 item["entity"]["uid"], [video.uid for video in self.poll1_videos1[from_:to]]
             )
             self.assertEqual(item["subsample_metadata"]["bucket"], offset + idx)
+
+    def test_with_no_rating(self):
+        new_user = UserFactory()
+        self.client.force_authenticate(new_user)
+        response = self.client.get(self.base_subsamples_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 0)

--- a/backend/tournesol/views/subsamples.py
+++ b/backend/tournesol/views/subsamples.py
@@ -42,6 +42,9 @@ class SubSamplesQuerysetMixin(ContributorRatingQuerysetMixin):
             .values_list("entity_id", flat=True)
         )
 
+        if len(all_ratings) == 0:
+            return ContributorRating.objects.none()
+
         sub_sample_size = min(sub_sample_size, len(all_ratings))
         selected = [random.choice(bucket)  # nosec
                     for bucket in np.array_split(all_ratings, sub_sample_size)]


### PR DESCRIPTION
### Description

Calling `array_split()` would fail when `len(all_ratings)` is 0

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
