### PR TITLE
[front] fix: avoid multiple initializations of `Comparison` component in `ComparisonSeries`

### DIFF
--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -190,7 +190,6 @@ const ComparisonPage = () => {
                   length={tutorialLength}
                   initComparisonsMade={userComparisons ?? []}
                   isTutorial={true}
-                  generateInitial={true}
                   dialogs={dialogs}
                   dialogAdditionalActions={dialogActions}
                   getAlternatives={tutorialAlternatives}


### PR DESCRIPTION
### Description

In some cases, it could cause several concurrent attempts to create the same `ContributorRating` on the backend.

I also tried to simplify a bit the logic in `ComparisonSeries` by removing the `isLoading` state: the initialization ref is enough.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
