### PR TITLE
[infra] define blocklist for register and password reset in nginx config

### DIFF
--- a/infra/ansible/roles/django/files/gunicorn_proxy.conf
+++ b/infra/ansible/roles/django/files/gunicorn_proxy.conf
@@ -1,0 +1,8 @@
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header Host $host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $connection_upgrade;
+proxy_redirect off;
+proxy_buffering off;
+proxy_pass http://unix:/run/gunicorn.sock;

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -171,6 +171,28 @@
     state: started
     daemon_reload: true
 
+- name: Copy gunicorn snippet
+  copy:
+    src: gunicorn_proxy.conf
+    dest: /etc/nginx/snippets/
+
+- name: Create block_tor snippet
+  block:
+  - find:
+      paths: /etc/nginx/snippets
+      patterns: block_tor.conf
+      age: -30d
+    register: find_snippet
+
+  - name: Generate block_tor snippet
+    shell: >
+      wget -qO- https://check.torproject.org/exit-addresses
+      | grep ExitAddress
+      | cut -d ' ' -f 2
+      | sed "s/^/deny /g; s/$/;/g"
+      > /etc/nginx/snippets/block_tor.conf
+    when: find_snippet.matched == 0
+
 - name: Copy Nginx configuration
   template:
     src: tournesol.j2

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -189,6 +189,7 @@
       wget -qO- https://check.torproject.org/exit-addresses
       | grep ExitAddress
       | cut -d ' ' -f 2
+      | sort -u
       | sed "s/^/deny /g; s/$/;/g"
       > /etc/nginx/snippets/block_tor.conf
     when: find_snippet.matched == 0

--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -116,7 +116,7 @@ server {
         proxy_pass http://unix:/run/gunicorn.sock;
     }
 
-    location ~ /accounts/(register-email|send-reset-password-link) {
+    location ~* /accounts/(register|send-reset-password-link)/ {
         {% if maintenance %}
             return 503;
         {% else %}

--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -116,18 +116,20 @@ server {
         proxy_pass http://unix:/run/gunicorn.sock;
     }
 
+    location ~ /accounts/(register-email|send-reset-password-link) {
+        {% if maintenance %}
+            return 503;
+        {% else %}
+            include /etc/nginx/snippets/block_tor.conf;
+            include /etc/nginx/snippets/gunicorn_proxy.conf;
+        {% endif %}
+    }
+
     location / {
         {% if maintenance %}
             return 503;
         {% else %}
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Host $host;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            proxy_redirect off;
-            proxy_buffering off;
-            proxy_pass http://unix:/run/gunicorn.sock;
+            include /etc/nginx/snippets/gunicorn_proxy.conf;
         {% endif %}
     }
 


### PR DESCRIPTION
The "snippets" folder in /etc/nginx is used to refactor the configuration for the API. A snippet is specifically used for blocking IPs on URLs about account registration and password reset.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
