### PR TITLE
Fix dev-env api setup

### DIFF
--- a/backend/dev-env/Dockerfile
+++ b/backend/dev-env/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.9-slim-bullseye
+FROM python:3.9-slim-bookworm
 ENV PYTHONUNBUFFERED=1
 WORKDIR /backend
 

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |
+        set -eux
         pip install -r tests/requirements.txt -r requirements.txt
         python manage.py migrate
         python manage.py createcachetable

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -1,5 +1,5 @@
 version: "3.3"
-   
+
 services:
   db:
     container_name: tournesol-dev-db


### PR DESCRIPTION
The installation of the python packages in the dev-env api container failed with this error:

```
ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode: /solidago
(A "pyproject.toml" file was found, but editable mode currently requires a setuptools-based build.)
WARNING: You are using pip version 21.2.4; however, version 23.3.1 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
```

It looks like using `pyproject.toml` requires a newer version of `setuptools`. Upgrading to a newer Debian worked.

I also made the container stop immediately when the setup fails.