### PR TITLE
[dev-env] fix: django migrations were partially applied when using the default db

### DIFF
--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.3"
 services:
   db:
     container_name: tournesol-dev-db
-    image: ${DB_IMAGE:-ghcr.io/tournesol-app/postgres-dev-env:2023-07-16}
+    image: ${DB_IMAGE:-ghcr.io/tournesol-app/postgres-dev-env:2023-10-27}
     user: ${DB_UID}:${DB_GID}
     volumes:
       - ./db-data:/var/lib/postgresql/data
@@ -28,7 +28,7 @@ services:
     container_name: tournesol-dev-api
     environment:
       - SETTINGS_FILE=/backend/dev-env/settings-tournesol.yaml
-    entrypoint: ["/bin/bash", "-c"]
+    entrypoint: ["/bin/bash", "-eux", "-c"]
     command:
       - |
         pip install -r tests/requirements.txt -r requirements.txt


### PR DESCRIPTION
Fixes #1818 

### Description

In #1735 we assumed it was safe to remove references to the obsolete "faq" entry from the migrations. But we forgot about the dev-env database that was created before the migration from "faq" to "backoffice" was finalized. And as the error went unnoticed as the script used to start the  "tournesol-dev-api" container would not block on error :confused:  and the last few migrations related to "backoffice" does not affect the application.

This PR updates the database with recent data, and all migrations applied correctly from scratch, and makes sure that the container will now fail on the first error.

Thanks @sigmike for catching this!

---

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
