### PR TITLE
[infra] fix: maintenance page could not load static assets

### DIFF
--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -24,7 +24,7 @@ server {
 
     keepalive_timeout 5;
 
-    error_page 503 @503;
+    error_page 503 /maintenance;
 
     location / {
         {% if maintenance %}
@@ -36,16 +36,16 @@ server {
         {% endif %}
     }
 
+    location /maintenance {
+        root /srv/maintenance;
+        try_files $uri /index.html =404;
+    }
+
     location @index {
         root /srv/tournesol-frontend;
         sub_filter '__META_OG_IMAGE__' '$scheme://{{api_domain_name}}/preview$request_uri';
         sub_filter '__META_OG_URL__' '$scheme://$server_name$request_uri';
         try_files /index.html =404;
-    }
-
-    location @503 {
-        root /srv/maintenance;
-        try_files $uri /index.html =404;
     }
 
 {% if letsencrypt_email is defined %}

--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -24,7 +24,7 @@ server {
 
     keepalive_timeout 5;
 
-    error_page 503 /maintenance;
+    error_page 503 /maintenance/index.html;
 
     location / {
         {% if maintenance %}
@@ -37,8 +37,8 @@ server {
     }
 
     location /maintenance {
-        root /srv/maintenance;
-        try_files $uri /index.html =404;
+        alias /srv/maintenance;
+        try_files $uri =404;
     }
 
     location @index {

--- a/infra/ansible/roles/nginx/files/maintenance/index.html
+++ b/infra/ansible/roles/nginx/files/maintenance/index.html
@@ -12,7 +12,7 @@
     body {
       margin: 0;
       min-height: 100vh;
-      background-image: url('/chandelier.svg');
+      background-image: url('/maintenance/chandelier.svg');
       background-repeat: repeat-x;
       background-position: center top;
     }
@@ -37,11 +37,11 @@
 <body>
   <div id="root">
     <header>
-      <img src="/Logo.svg" />
+      <img src="/maintenance/Logo.svg" />
     </header>
     <main>
       <h2 style="text-align: center; font-family: system-ui, sans-serif">Tournesol is currently under maintenance</h2>
-      <img src="/Watering.svg" width="280px"/>
+      <img src="/maintenance/Watering.svg" width="280px"/>
     </main>
   </div>
 </body>


### PR DESCRIPTION
### Description

The maintenance mode was not defined properly in Nginx configuration: all assets would redirect return a response code 503, causing the browser to not display them.

This PR defines a separate `location /maintenance` section to serve the static page as expected.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
