### PR TITLE
[dev-env] feat: stop recreating the containers on restart

### DIFF
--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -60,12 +60,19 @@ Then, the application is accessible on http://localhost:3000.
 The created database includes video metadata, users and comparisons derived from a subset of Tournesol public dataset.
 An additional non-admin user is also created: `user1` with password `tournesol`.
 
-## Rebuild the containers while preserving the database
+## Restart the containers
 
-By default, the database content is initialized with test data.
-To recreate the containers (e.g to update the backend dependencies) while preserving the data, use:
+When you need to start or restart the existing containers, use:
 ```bash
 ./run-docker-compose.sh restart
+```
+
+## Rebuild the containers while preserving the database
+
+When you run `init`, the database content is initialized with test data.
+To recreate the containers (e.g to update the backend dependencies) while preserving the data, use:
+```bash
+./run-docker-compose.sh recreate
 ```
 
 ## See all available commands

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -23,36 +23,25 @@ function is_front_ready() {
   curl -s localhost:3000 --max-time 1 -o /dev/null
 }
 
-function compose_up(){
+function compose(){
   if docker compose version 2>/dev/null; then
-      echo "compose_up : docker-compose-plugin found"
-      docker compose up --build --force-recreate -d "$@"
+      docker compose "$@"
   else
-    echo "compose_up : docker-compose-plugin not found, trying to find docker-compose command"
     if command -v docker-compose ; then
-      echo "compose_up : docker-compose found"
-      docker-compose up --build --force-recreate -d "$@"
+      docker-compose "$@"
     else
-      echo "please install either docker-compose or docker-compose-plugin "
+      echo "Please install either docker-compose or docker-compose-plugin"
       exit 1
     fi
   fi
 }
 
+function compose_up(){
+  compose up --build --force-recreate -d "$@"
+}
+
 function compose_stop(){
-  if docker compose version 2>/dev/null; then
-      echo "compose_stop: docker-compose-plugin found"
-      docker compose stop
-  else
-    echo "compose_stop : docker-compose-plugin not found, trying to find docker-compose command"
-    if command -v docker-compose ; then
-      echo "compose_stop : docker-compose found"
-      docker-compose stop
-    else
-      echo "please install either docker-compose or docker-compose-plugin "
-      exit 1
-    fi
-  fi
+  compose stop
 }
 
 function wait_for() {

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -61,6 +61,14 @@ function wait_for() {
 }
 
 function dev_env_restart() {
+  echo "Restarting dev containers..."
+  compose restart
+  wait_for is_front_ready "front"
+  wait_for is_api_ready "api"
+  echo "You can now access Tournesol on http://localhost:3000"
+}
+
+function dev_env_recreate() {
   echo "Recreating dev containers..."
   compose_up
   wait_for is_front_ready "front"
@@ -153,8 +161,12 @@ Commands:
     ./run-docker-compose.sh download --user-sampling 0.1
 
   restart
-  Recreate containers and restart all dev_env services using the existing database. Containers will be rebuilt if necessary.
+  Restart all dev_env services using the existing database and containers.
     ./run-docker-compose.sh restart
+
+  recreate
+  Recreate containers and restart all dev_env services using the existing database. Containers will be rebuilt if necessary.
+    ./run-docker-compose.sh recreate
 
   stop
   Stop dev containers. The database will be persisted in "$DB_DIR" folder.
@@ -170,6 +182,8 @@ case ${1:-""} in
     dev_env_init "${@:2}" ;;
   restart)
     dev_env_restart ;;
+  recreate)
+    dev_env_recreate ;;
   stop)
     dev_env_stop ;;
 	*)

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -36,12 +36,8 @@ function compose(){
   fi
 }
 
-function compose_up(){
+function compose_up_recreate(){
   compose up --build --force-recreate -d "$@"
-}
-
-function compose_stop(){
-  compose stop
 }
 
 function wait_for() {
@@ -70,7 +66,7 @@ function dev_env_restart() {
 
 function dev_env_recreate() {
   echo "Recreating dev containers..."
-  compose_up
+  compose_up_recreate
   wait_for is_front_ready "front"
   wait_for is_api_ready "api"
   echo "You can now access Tournesol on http://localhost:3000"
@@ -78,7 +74,7 @@ function dev_env_recreate() {
 
 function dev_env_stop() {
   echo "Stopping dev containers..."
-  compose_stop
+  compose stop
   echo "Docker containers are stopped."
 }
 
@@ -102,10 +98,10 @@ function dev_env_init() {
     export DB_IMAGE="postgres:13-bullseye"
   fi
 
-  compose_up db
+  compose_up_recreate db
   wait_for is_db_ready "db"
 
-  compose_up
+  compose_up_recreate
   wait_for is_api_ready "api"
 
   if [ "$DOWNLOAD_PUBLIC_DATASET" = true ] ; then


### PR DESCRIPTION
### Description

The `./run-docker-compose.sh restart` command recreated the containers, and that required downloading again all the backend packages.

With these changes (7d4d1b45f2379a6215ae0b77a87334ed82099bd1) the command only restarts the existing containers, and a new command `recreate` does what the previous `restart` did.

I also refactored the code a bit (c06acfcc627062e8bb16f296e5b0f2b254616621 and 801159fec72d60cb5f057bc918c437ba6b919caa).

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass
