### PR TITLE
[infra] sec: set a default timeout for all zsh shells

### DIFF
--- a/infra/ansible/roles/zsh/tasks/main.yml
+++ b/infra/ansible/roles/zsh/tasks/main.yml
@@ -7,6 +7,14 @@
     install_recommends: no
     update_cache: yes
 
+- name: Set a default timeout for all zsh shells
+  blockinfile:
+    path: /etc/zsh/zshrc
+    block: |
+    
+      # Automatically log out after an inactivity period (in seconds)
+      export TMOUT=480
+
 - name: Create fonts directory
   file:
     path: /usr/local/share/fonts


### PR DESCRIPTION
**related issues** #1832 

---

### Description

The default timeout is set to 8 minutes.

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
