### PR TITLE
feat: Add id='publications' on publication home page box

### DIFF
--- a/frontend/src/pages/home/videos/sections/research/ScientificLiteratureBox.tsx
+++ b/frontend/src/pages/home/videos/sections/research/ScientificLiteratureBox.tsx
@@ -237,6 +237,7 @@ const ScientificLiteratureBox = () => {
   return (
     <TitledPaper
       title={t('scientificLiteratureBox.publications')}
+      titleId="publications"
       contentBoxPadding={0}
     >
       <>


### PR DESCRIPTION
### Description

When sharing links to our publications, one good way is to share the link to https://tournesol.app/#research. This PR makes it even better by adding the option to share the link https://tournesol.app/#publications. This is motivated by recently wanting to add a link to our publications in a few administrative documents.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
