### PR TITLE
 [front] attempt to reduce memory usage during build 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,8 +36,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "start:e2e": "cp .env.development .env.production.local && react-scripts build && sirv build --host --single -p 3000",
-    "build": "react-scripts build && precompress -t gz -i json,js,css,xml,svg,ttf build",
+    "start:e2e": "cp .env.development .env.production.local && react-scripts --max-old-space-size=1200 build && sirv build --host --single -p 3000",
+    "build": "react-scripts --max-old-space-size=1200 build && precompress -t gz -i json,js,css,xml,svg,ttf build",
     "test": "react-scripts test --testURL=http://localhost:3000",
     "eject": "react-scripts eject",
     "update-schema": "wget -O scripts/openapi.yaml \"${REACT_APP_API_URL:-http://localhost:8000}/schema/\"",


### PR DESCRIPTION
### Description

Node `max_old_space_size` (also called "heap size limit") is set at 2GB by default, and may be too high when deploying to the staging environment.

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
