### PR TITLE
[back][front] fix: incorrect schema for suggestions/tocompare API

### DIFF
--- a/backend/tournesol/lib/suggestions/strategies/base.py
+++ b/backend/tournesol/lib/suggestions/strategies/base.py
@@ -19,11 +19,3 @@ class ContributionSuggestionStrategy(ABC):
     @abstractmethod
     def get_results(self):
         raise NotImplementedError
-
-    @abstractmethod
-    def get_serializer_class(self):
-        """
-        Return a DRF serializer class that should be used to serialize the
-        results returned by `get_results()`.
-        """
-        raise NotImplementedError

--- a/backend/tournesol/lib/suggestions/strategies/tocompare/classic.py
+++ b/backend/tournesol/lib/suggestions/strategies/tocompare/classic.py
@@ -197,9 +197,6 @@ class ClassicEntitySuggestionStrategy(ContributionSuggestionStrategy):
 
         return sample1 + sample2 + sample3
 
-    def get_serializer_class(self):
-        return EntityToCompare
-
     def get_results(self):
         return self.get_results_for_user_intermediate()
 

--- a/backend/tournesol/lib/suggestions/strategies/tocompare/classic.py
+++ b/backend/tournesol/lib/suggestions/strategies/tocompare/classic.py
@@ -5,7 +5,6 @@ from core.utils.time import time_ago
 from tournesol.lib.suggestions.strategies.base import ContributionSuggestionStrategy
 from tournesol.models import ContributorRating, Entity, RateLater
 from tournesol.models.rate_later import RATE_LATER_AUTO_REMOVE_DEFAULT
-from tournesol.serializers.suggestion import EntityToCompare
 
 
 @dataclass

--- a/backend/tournesol/tests/test_api_suggestions_tocompare.py
+++ b/backend/tournesol/tests/test_api_suggestions_tocompare.py
@@ -148,7 +148,7 @@ class SuggestionsToCompareTestCase(TestCase):
 
         self.client.force_authenticate(self.user1)
         response = self.client.get(self.base_url)
-        results = response.data["results"]
+        results = response.data
 
         uids_compared = [ent.uid for ent in compared_videos_user1_poll1]
         uids_rate_later = [ent.uid for ent in rate_later_videos_user1_poll1]

--- a/backend/tournesol/views/suggestions/to_compare.py
+++ b/backend/tournesol/views/suggestions/to_compare.py
@@ -48,8 +48,5 @@ class SuggestionsToCompare(PollScopedViewMixin, generics.ListAPIView):
             # Fallback to the classic strategy if an unknown strategy is provided.
             self.strategy = ClassicEntitySuggestionStrategy(self.poll_from_url, request.user)
 
-    def get_serializer_class(self):
-        return self.strategy.get_serializer_class()
-
     def get_queryset(self):
         return self.strategy.get_results()

--- a/backend/tournesol/views/suggestions/to_compare.py
+++ b/backend/tournesol/views/suggestions/to_compare.py
@@ -32,6 +32,7 @@ class SuggestionsToCompare(PollScopedViewMixin, generics.ListAPIView):
     The suggestion strategy is determined by the `strategy` query parameter.
     """
 
+    pagination_class = None
     permission_classes = [IsAuthenticated]
     serializer_class = EntityToCompare
 

--- a/backend/vouch/views.py
+++ b/backend/vouch/views.py
@@ -25,6 +25,8 @@ class VoucherCreateAPIView(generics.CreateAPIView):
     ),
 )
 class VoucherGivenDestroyAPIView(generics.DestroyAPIView):
+    serializer_class = GivenVoucherSerializer
+
     def get_object(self):
         target = get_object_or_404(User, username=self.kwargs["username"])
         return get_object_or_404(Voucher, by=self.request.user, to=target)

--- a/backend/vouch/views.py
+++ b/backend/vouch/views.py
@@ -22,11 +22,10 @@ class VoucherCreateAPIView(generics.CreateAPIView):
 @extend_schema_view(
     delete=extend_schema(
         description="Delete a voucher given to a target user by the logged-in user.",
+        responses=None,
     ),
 )
 class VoucherGivenDestroyAPIView(generics.DestroyAPIView):
-    serializer_class = GivenVoucherSerializer
-
     def get_object(self):
         target = get_object_or_404(User, username=self.kwargs["username"])
         return get_object_or_404(Voucher, by=self.request.user, to=target)

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -2151,7 +2151,7 @@ paths:
           description: ''
   /users/me/suggestions/{poll_name}/tocompare/:
     get:
-      operationId: users_me_suggestions_tocompare_retrieve
+      operationId: users_me_suggestions_tocompare_list
       description: |-
         Suggest a list of entities to compare to the logged-in user.
 
@@ -2162,6 +2162,18 @@ paths:
         schema:
           type: string
         required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       - in: query
         name: strategy
         schema:
@@ -2177,7 +2189,11 @@ paths:
         - read write groups
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedEntityToCompareList'
+          description: ''
   /users/me/unconnected_entities/{poll_name}/{uid}/:
     get:
       operationId: users_me_unconnected_entities_list
@@ -3153,6 +3169,18 @@ components:
       required:
       - criteria_scores
       - name
+    EntityToCompare:
+      type: object
+      properties:
+        entity:
+          $ref: '#/components/schemas/RelatedEntity'
+        collective_rating:
+          allOf:
+          - $ref: '#/components/schemas/CollectiveRating'
+          readOnly: true
+      required:
+      - collective_rating
+      - entity
     EntityTypeEnum:
       enum:
       - video
@@ -3491,6 +3519,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EntityNoExtraField'
+    PaginatedEntityToCompareList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityToCompare'
     PaginatedFAQEntryList:
       type: object
       properties:
@@ -3785,10 +3833,12 @@ components:
       enum:
       - insufficient_trust
       - insufficient_tournesol_score
+      - moderation_by_association
       type: string
       description: |-
         * `insufficient_trust` - insufficient_trust
         * `insufficient_tournesol_score` - insufficient_tournesol_score
+        * `moderation_by_association` - moderation_by_association
     Recommendation:
       type: object
       properties:

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -2162,18 +2162,6 @@ paths:
         schema:
           type: string
         required: true
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
       - in: query
         name: strategy
         schema:
@@ -2192,7 +2180,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedEntityToCompareList'
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntityToCompare'
           description: ''
   /users/me/unconnected_entities/{poll_name}/{uid}/:
     get:
@@ -3519,26 +3509,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EntityNoExtraField'
-    PaginatedEntityToCompareList:
-      type: object
-      properties:
-        count:
-          type: integer
-          example: 123
-        next:
-          type: string
-          nullable: true
-          format: uri
-          example: http://api.example.org/accounts/?offset=400&limit=100
-        previous:
-          type: string
-          nullable: true
-          format: uri
-          example: http://api.example.org/accounts/?offset=200&limit=100
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/EntityToCompare'
     PaginatedFAQEntryList:
       type: object
       properties:

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -1,4 +1,4 @@
-import { UsersService, RelatedEntity } from 'src/services/openapi';
+import { UsersService } from 'src/services/openapi';
 import { VideoObject } from './types';
 import {
   autoSuggestionsRandom,
@@ -82,16 +82,12 @@ export async function getUidForComparison(
       pollName: poll,
     });
 
-    if (suggestions['count'] && suggestions['count'] > 0) {
-      if (suggestions['results']) {
-        fillAutoSuggestions(
-          poll,
-          suggestions['results'].map(
-            (item: { entity: RelatedEntity }) => item.entity.uid
-          ),
-          exclude
-        );
-      }
+    if (suggestions && suggestions.length > 0) {
+      fillAutoSuggestions(
+        poll,
+        suggestions.map((item) => item.entity.uid),
+        exclude
+      );
     }
   }
 

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -78,18 +78,20 @@ export async function getUidForComparison(
   });
 
   if (isAutoSuggestionsEmpty(poll)) {
-    const suggestions = await UsersService.usersMeSuggestionsTocompareRetrieve({
+    const suggestions = await UsersService.usersMeSuggestionsTocompareList({
       pollName: poll,
     });
 
-    if (suggestions['count'] > 0) {
-      fillAutoSuggestions(
-        poll,
-        suggestions['results'].map(
-          (item: { entity: RelatedEntity }) => item.entity.uid
-        ),
-        exclude
-      );
+    if (suggestions['count'] && suggestions['count'] > 0) {
+      if (suggestions['results']) {
+        fillAutoSuggestions(
+          poll,
+          suggestions['results'].map(
+            (item: { entity: RelatedEntity }) => item.entity.uid
+          ),
+          exclude
+        );
+      }
     }
   }
 


### PR DESCRIPTION
### Description

This PR fixes several OpenAPI schema generation errors.

**(1) error related to the API `suggestions/tocompare`**

If found the error when running the command `yarn update-schema`

```
/home/.../tournesol/backend/tournesol/views/suggestions/to_compare.py:
Error [SuggestionsToCompare]: exception raised while getting serializer.
Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'NoneType' object has no attribute 'get_serializer_class')
```

This was caused by the method `get_serializer_class()`. Before, the method was depending on a request object to return the correct serializer. The code has been simplified, and all suggestion strategies of a view should now conform with the  serializer defined by the view. The schema of `EntityToCompare` is now correctly generated.

**(2) error related to the API `vouch`**

```
/home/.../tournesol/backend/vouch/views.py:
Error [VoucherGivenDestroyAPIView]: exception raised while getting serializer.
Hint: Is get_serializer_class() returning None or is get_queryset() not working without a request? Ignoring the view for now. (Exception: 'VoucherGivenDestroyAPIView' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.)
```

The view `VoucherGivenDestroyAPIView` didn't define any serializer, and the schema generation command was displaying an error. The fix shouldn't have any impact, except on the command output.

**(3) error related to the legacy video API**

I didn't fix this issue. This API is now obsolete and could be fully replaced by the API `/entities/`.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
