### PR TITLE
[front] feat: display unsafe context in rate-later list

### DIFF
--- a/backend/tournesol/serializers/rate_later.py
+++ b/backend/tournesol/serializers/rate_later.py
@@ -19,6 +19,11 @@ class RateLaterMetadataSerializer(ModelSerializer):
 class RateLaterSerializer(ModelSerializer):
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
     entity = RelatedEntitySerializer()
+    entity_contexts = EntityContextSerializer(
+        source="entity.single_poll_entity_contexts",
+        read_only=True,
+        many=True
+    )
     collective_rating = CollectiveRatingSerializer(
         source="entity.single_poll_rating",
         read_only=True,
@@ -28,11 +33,6 @@ class RateLaterSerializer(ModelSerializer):
         source="entity.single_contributor_rating",
         read_only=True,
         allow_null=True,
-    )
-    entity_contexts = EntityContextSerializer(
-        source="entity.single_poll_entity_contexts",
-        read_only=True,
-        many=True
     )
     rate_later_metadata = RateLaterMetadataSerializer(source="*", read_only=True)
 

--- a/backend/tournesol/serializers/rate_later.py
+++ b/backend/tournesol/serializers/rate_later.py
@@ -6,6 +6,7 @@ from rest_framework.serializers import ModelSerializer
 from tournesol.errors import ConflictError
 from tournesol.models import RateLater
 from tournesol.serializers.entity import RelatedEntitySerializer
+from tournesol.serializers.entity_context import EntityContextSerializer
 from tournesol.serializers.poll import CollectiveRatingSerializer, IndividualRatingSerializer
 
 
@@ -28,6 +29,11 @@ class RateLaterSerializer(ModelSerializer):
         read_only=True,
         allow_null=True,
     )
+    entity_contexts = EntityContextSerializer(
+        source="entity.single_poll_entity_contexts",
+        read_only=True,
+        many=True
+    )
     rate_later_metadata = RateLaterMetadataSerializer(source="*", read_only=True)
 
     class Meta:
@@ -37,6 +43,7 @@ class RateLaterSerializer(ModelSerializer):
             "entity",
             "collective_rating",
             "individual_rating",
+            "entity_contexts",
             "rate_later_metadata",
         ]
 

--- a/backend/tournesol/tests/test_api_rate_later.py
+++ b/backend/tournesol/tests/test_api_rate_later.py
@@ -105,6 +105,7 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
                         "reasons": ANY,
                     }
                 },
+                "entity_contexts": [],
                 "rate_later_metadata": {
                     "created_at": str(
                         self.to_rate_later.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -195,6 +196,7 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
             },
             "collective_rating": None,
             "individual_rating": None,
+            "entity_contexts": [],
             "rate_later_metadata": {
                 "created_at": ANY
             }
@@ -305,6 +307,7 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
                         "reasons": ANY,
                     }
                 },
+                "entity_contexts": [],
             },
         )
 
@@ -349,6 +352,7 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
                         "reasons": ANY,
                     }
                 },
+                "entity_contexts": [],
             },
         )
 

--- a/backend/tournesol/tests/test_api_rate_later.py
+++ b/backend/tournesol/tests/test_api_rate_later.py
@@ -113,16 +113,6 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
                     "type": "video",
                     "metadata": ANY,
                 },
-                "individual_rating": None,
-                "collective_rating": {
-                    "n_comparisons": 2,
-                    "n_contributors": 1,
-                    "tournesol_score": 3.0,
-                    "unsafe": {
-                        "status": True,
-                        "reasons": ANY,
-                    },
-                },
                 "entity_contexts": [
                     {
                         "origin": "ASSOCIATION",
@@ -133,6 +123,16 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
                         ),
                     }
                 ],
+                "individual_rating": None,
+                "collective_rating": {
+                    "n_comparisons": 2,
+                    "n_contributors": 1,
+                    "tournesol_score": 3.0,
+                    "unsafe": {
+                        "status": True,
+                        "reasons": ANY,
+                    },
+                },
                 "rate_later_metadata": {
                     "created_at": str(
                         self.to_rate_later.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -223,9 +223,9 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
                     "type": "video",
                     "metadata": ANY,
                 },
+                "entity_contexts": [],
                 "collective_rating": None,
                 "individual_rating": None,
-                "entity_contexts": [],
                 "rate_later_metadata": {"created_at": ANY},
             },
         )
@@ -317,19 +317,6 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
                     "type": "video",
                     "metadata": ANY,
                 },
-                "rate_later_metadata": {
-                    "created_at": self.to_rate_later.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                },
-                "individual_rating": None,
-                "collective_rating": {
-                    "n_comparisons": 2,
-                    "n_contributors": 1,
-                    "tournesol_score": 3.0,
-                    "unsafe": {
-                        "status": True,
-                        "reasons": ANY,
-                    },
-                },
                 "entity_contexts": [
                     {
                         "origin": "ASSOCIATION",
@@ -340,6 +327,19 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
                         ),
                     }
                 ],
+                "individual_rating": None,
+                "collective_rating": {
+                    "n_comparisons": 2,
+                    "n_contributors": 1,
+                    "tournesol_score": 3.0,
+                    "unsafe": {
+                        "status": True,
+                        "reasons": ANY,
+                    },
+                },
+                "rate_later_metadata": {
+                    "created_at": self.to_rate_later.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                },
             },
         )
 
@@ -366,9 +366,16 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
                     "type": "video",
                     "metadata": ANY,
                 },
-                "rate_later_metadata": {
-                    "created_at": self.to_rate_later.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                },
+                "entity_contexts": [
+                    {
+                        "origin": "ASSOCIATION",
+                        "unsafe": False,
+                        "text": self.entity_in_rl_context_text.text,
+                        "created_at": self.entity_in_rl_context.created_at.strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        ),
+                    }
+                ],
                 "individual_rating": {
                     "is_public": True,
                     "n_comparisons": 0,
@@ -382,16 +389,9 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
                         "reasons": ANY,
                     },
                 },
-                "entity_contexts": [
-                    {
-                        "origin": "ASSOCIATION",
-                        "unsafe": False,
-                        "text": self.entity_in_rl_context_text.text,
-                        "created_at": self.entity_in_rl_context.created_at.strftime(
-                            "%Y-%m-%dT%H:%M:%S.%fZ"
-                        ),
-                    }
-                ],
+                "rate_later_metadata": {
+                    "created_at": self.to_rate_later.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                },
             },
         )
 

--- a/backend/tournesol/tests/test_api_rate_later.py
+++ b/backend/tournesol/tests/test_api_rate_later.py
@@ -8,6 +8,7 @@ from rest_framework.test import APIClient
 
 from core.tests.factories.user import UserFactory
 from tournesol.models import RateLater
+from tournesol.models.entity_context import EntityContext, EntityContextLocale
 from tournesol.tests.factories.comparison import ComparisonFactory
 from tournesol.tests.factories.entity import VideoFactory
 from tournesol.tests.factories.entity_poll_rating import EntityPollRatingFactory
@@ -36,12 +37,28 @@ class RateLaterCommonMixinTestCase:
         self.rate_later_base_url = f"/users/me/rate_later/{self.poll.name}/"
 
         self.entity_in_ratelater = VideoFactory()
+
         EntityPollRatingFactory(
             entity=self.entity_in_ratelater,
             poll=self.poll,
             tournesol_score=3,
             n_contributors=1,
             n_comparisons=2,
+        )
+
+        self.entity_in_rl_context = EntityContext.objects.create(
+            name="context_safe",
+            origin=EntityContext.ASSOCIATION,
+            predicate={"video_id": self.entity_in_ratelater.metadata["video_id"]},
+            unsafe=False,
+            enabled=True,
+            poll=self.poll,
+        )
+
+        self.entity_in_rl_context_text = EntityContextLocale.objects.create(
+            context=self.entity_in_rl_context,
+            language="en",
+            text="Hello context",
         )
 
         self.entity_not_in_ratelater = VideoFactory()
@@ -59,6 +76,7 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
 
     The `RateLaterList` API provides the endpoints list and create.
     """
+
     def test_anon_401_list(self) -> None:
         """
         An anonymous user cannot list its rate-later items, even if the poll
@@ -103,9 +121,18 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
                     "unsafe": {
                         "status": True,
                         "reasons": ANY,
-                    }
+                    },
                 },
-                "entity_contexts": [],
+                "entity_contexts": [
+                    {
+                        "origin": "ASSOCIATION",
+                        "unsafe": False,
+                        "text": self.entity_in_rl_context_text.text,
+                        "created_at": self.entity_in_rl_context.created_at.strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        ),
+                    }
+                ],
                 "rate_later_metadata": {
                     "created_at": str(
                         self.to_rate_later.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -188,19 +215,20 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
         response = self.client.post(self.rate_later_base_url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertDictEqual(response.data, {
-            "entity": {
-                "uid": self._uid_not_in_db,
-                "type": "video",
-                "metadata": ANY,
+        self.assertDictEqual(
+            response.data,
+            {
+                "entity": {
+                    "uid": self._uid_not_in_db,
+                    "type": "video",
+                    "metadata": ANY,
+                },
+                "collective_rating": None,
+                "individual_rating": None,
+                "entity_contexts": [],
+                "rate_later_metadata": {"created_at": ANY},
             },
-            "collective_rating": None,
-            "individual_rating": None,
-            "entity_contexts": [],
-            "rate_later_metadata": {
-                "created_at": ANY
-            }
-        })
+        )
 
         self.assertEqual(
             RateLater.objects.filter(poll=self.poll, user=self.user).count(),
@@ -208,9 +236,7 @@ class RateLaterListTestCase(RateLaterCommonMixinTestCase, TestCase):
         )
 
         # Rate-later items are saved per poll.
-        self.assertEqual(
-            RateLater.objects.filter(poll=other_poll, user=self.user).count(), 0
-        )
+        self.assertEqual(RateLater.objects.filter(poll=other_poll, user=self.user).count(), 0)
 
     @override_settings(YOUTUBE_API_KEY=None)
     def test_auth_409_create_two_times(self) -> None:
@@ -253,14 +279,13 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
 
     The `RateLaterList` API provides the endpoints get and delete.
     """
+
     def test_anon_401_get(self) -> None:
         """
         An anonymous user cannot get a rate-later item, even if the poll
         exists.
         """
-        response = self.client.get(
-            f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/"
-        )
+        response = self.client.get(f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         response = self.client.get(f"{self.rate_later_base_url}invalid/")
@@ -281,9 +306,7 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
         An authenticated user can get a rate-later item from a specific poll.
         """
         self.client.force_authenticate(self.user)
-        response = self.client.get(
-            f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/"
-        )
+        response = self.client.get(f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertDictEqual(
@@ -305,9 +328,18 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
                     "unsafe": {
                         "status": True,
                         "reasons": ANY,
-                    }
+                    },
                 },
-                "entity_contexts": [],
+                "entity_contexts": [
+                    {
+                        "origin": "ASSOCIATION",
+                        "unsafe": False,
+                        "text": self.entity_in_rl_context_text.text,
+                        "created_at": self.entity_in_rl_context.created_at.strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        ),
+                    }
+                ],
             },
         )
 
@@ -323,9 +355,7 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
         )
 
         self.client.force_authenticate(self.user)
-        response = self.client.get(
-            f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/"
-        )
+        response = self.client.get(f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertDictEqual(
@@ -350,9 +380,18 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
                     "unsafe": {
                         "status": True,
                         "reasons": ANY,
-                    }
+                    },
                 },
-                "entity_contexts": [],
+                "entity_contexts": [
+                    {
+                        "origin": "ASSOCIATION",
+                        "unsafe": False,
+                        "text": self.entity_in_rl_context_text.text,
+                        "created_at": self.entity_in_rl_context.created_at.strftime(
+                            "%Y-%m-%dT%H:%M:%S.%fZ"
+                        ),
+                    }
+                ],
             },
         )
 
@@ -368,9 +407,7 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
         )
 
         self.client.force_authenticate(self.user)
-        response = self.client.get(
-            f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/"
-        )
+        response = self.client.get(f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.client.get(
@@ -394,9 +431,7 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
         An anonymous user cannot delete an item from its rate-later list, even
         if the poll exists.
         """
-        response = self.client.delete(
-            f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/"
-        )
+        response = self.client.delete(f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         response = self.client.delete(f"{self.rate_later_base_url}invalid/")
@@ -418,16 +453,12 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
         """
         # A second poll ensures the delete operation is poll specific.
         other_poll = PollFactory()
-        RateLater.objects.create(
-            entity=self.entity_in_ratelater, user=self.user, poll=other_poll
-        )
+        RateLater.objects.create(entity=self.entity_in_ratelater, user=self.user, poll=other_poll)
 
         initial_nbr = RateLater.objects.filter(poll=self.poll, user=self.user).count()
 
         self.client.force_authenticate(self.user)
-        response = self.client.delete(
-            f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/"
-        )
+        response = self.client.delete(f"{self.rate_later_base_url}{self.entity_in_ratelater.uid}/")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(
             RateLater.objects.filter(poll=self.poll, user=self.user).count(),
@@ -435,9 +466,7 @@ class RateLaterDetailTestCase(RateLaterCommonMixinTestCase, TestCase):
         )
 
         # Rate-later items are saved per poll.
-        self.assertEqual(
-            RateLater.objects.filter(poll=other_poll, user=self.user).count(), 1
-        )
+        self.assertEqual(RateLater.objects.filter(poll=other_poll, user=self.user).count(), 1)
 
     def test_auth_404_delete_invalid_poll(self) -> None:
         """
@@ -458,6 +487,7 @@ class RateLaterFeaturesTestCase(RateLaterCommonMixinTestCase, TestCase):
     Note: the tests related to `Entity.auto_remove_from_rate_later` could be
     moved in an Entity specific test case.
     """
+
     def test_auto_remove(self) -> None:
         """
         Test of the `auto_remove_from_rate_later` method of the Entity model.
@@ -527,7 +557,7 @@ class RateLaterFeaturesTestCase(RateLaterCommonMixinTestCase, TestCase):
             {
                 "is_public": False,
                 "n_comparisons": 4,
-            }
+            },
         )
         self.assertEqual(
             RateLater.objects.filter(poll=poll, user=user, entity=entity).count(),

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -102,6 +102,10 @@
   "comparisonSeries": {
     "skipTheSeries": "Skip the series"
   },
+  "entityCardContextAlert": {
+    "contextHasBeenAddedToThisElement": "Context has been added to this element.",
+    "see": "See"
+  },
   "contextsFromOrigin": {
     "theAssociationWouldLikeToGiveYouContext": "The Tournesol association would like to give you some context on this element."
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -106,6 +106,10 @@
   "comparisonSeries": {
     "skipTheSeries": "Passer la série"
   },
+  "entityCardContextAlert": {
+    "contextHasBeenAddedToThisElement": "Du contexte a été ajouté à cet élément.",
+    "see": "Voir"
+  },
   "contextsFromOrigin": {
     "theAssociationWouldLikeToGiveYouContext": "L'association Tournesol souhaite vous apporter du contexte sur cet élément."
   },

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -3101,6 +3101,25 @@ components:
       required:
       - created_at
       - text
+    EntityContextRequest:
+      type: object
+      properties:
+        origin:
+          allOf:
+          - $ref: '#/components/schemas/OriginEnum'
+          description: |-
+            The persons who want to share this context with the rest of the community.
+
+            * `ASSOCIATION` - Association
+            * `CONTRIBUTORS` - Contributors
+        unsafe:
+          type: boolean
+          description: If True, this context will make the targeted entities unsafe.
+        text:
+          type: string
+          minLength: 1
+      required:
+      - text
     EntityCriteriaDistribution:
       type: object
       description: An Entity serializer that show distribution of score for a given
@@ -3790,6 +3809,11 @@ components:
           - $ref: '#/components/schemas/IndividualRating'
           readOnly: true
           nullable: true
+        entity_contexts:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityContext'
+          readOnly: true
         rate_later_metadata:
           allOf:
           - $ref: '#/components/schemas/RateLaterMetadata'
@@ -3797,6 +3821,7 @@ components:
       required:
       - collective_rating
       - entity
+      - entity_contexts
       - individual_rating
       - rate_later_metadata
     RateLaterMetadata:

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -20,6 +20,8 @@ import {
 import {
   ContributorRating,
   ContributorCriteriaScore,
+  EntityContext,
+  OriginEnum,
   TypeEnum,
 } from 'src/services/openapi';
 import {
@@ -27,6 +29,7 @@ import {
   EntityResult as EntityResult,
   JSONValue,
 } from 'src/utils/types';
+import EntityCardContextAlert from 'src/features/entity_context/EntityCardContextAlert';
 import { RatingControl } from 'src/features/ratings/RatingControl';
 
 import EntityCardTitle from './EntityCardTitle';
@@ -45,6 +48,7 @@ export interface EntityCardProps {
   onRatingChange?: (rating: ContributorRating) => void;
   // Configuration specific to the entity type.
   entityTypeConfig?: { [k in TypeEnum]?: { [k: string]: JSONValue } };
+  displayContextAlert?: boolean;
 }
 
 const EntityCard = ({
@@ -55,10 +59,21 @@ const EntityCard = ({
   isAvailable = true,
   showRatingControl = false,
   onRatingChange,
+  displayContextAlert = false,
 }: EntityCardProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
+
   const entity = result.entity;
+  let unsafeContext: EntityContext | undefined;
+
+  if ('entity_contexts' in result) {
+    // TODO: when context from contribors are implemented, remove the
+    // context.origin condition
+    unsafeContext = result.entity_contexts.find(
+      (context) => context.unsafe && context.origin === OriginEnum.ASSOCIATION
+    );
+  }
 
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'), {
     noSsr: true,
@@ -185,6 +200,13 @@ const EntityCard = ({
               </>
             )}
           </Grid>
+
+          {displayContextAlert && unsafeContext && (
+            <Grid item xs={12}>
+              <EntityCardContextAlert uid={entity.uid} />
+            </Grid>
+          )}
+
           {showRatingControl && (
             <Grid item xs={12}>
               <Collapse in={ratingVisible || !isSmallScreen}>

--- a/frontend/src/features/entities/EntityList.tsx
+++ b/frontend/src/features/entities/EntityList.tsx
@@ -15,6 +15,7 @@ interface Props {
   emptyMessage?: React.ReactNode;
   actionsIfUnavailable?: ActionList;
   cardProps?: Partial<EntityCardProps>;
+  displayContextAlert?: boolean;
 }
 
 /**
@@ -33,6 +34,7 @@ function EntityList({
   emptyMessage,
   actionsIfUnavailable,
   cardProps = {},
+  displayContextAlert = false,
 }: Props) {
   const { isLoggedIn } = useLoginState();
   const { options } = useCurrentPoll();
@@ -55,6 +57,7 @@ function EntityList({
                 actions={actions ?? defaultEntityActions}
                 compact={false}
                 entityTypeConfig={{ video: { displayPlayer: false } }}
+                displayContextAlert={displayContextAlert}
                 {...cardProps}
               />
             </AvailableEntity>

--- a/frontend/src/features/entity_context/EntityCardContextAlert.tsx
+++ b/frontend/src/features/entity_context/EntityCardContextAlert.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+import { Alert, Box, Chip, Grid, Typography } from '@mui/material';
+
+interface EntityCardContextAlertProps {
+  uid: string;
+}
+
+const EntityCardContextAlert = ({ uid }: EntityCardContextAlertProps) => {
+  const { t } = useTranslation();
+  const history = useHistory();
+
+  const handleClick = () => {
+    history.push(`/entities/${uid}#entity-context`);
+  };
+
+  return (
+    <Grid item xs={12}>
+      <Alert
+        icon={false}
+        severity="warning"
+        sx={{
+          py: '4px',
+          borderRadius: 0,
+          '& .MuiAlert-message': {
+            width: '100%',
+            py: '4px',
+          },
+        }}
+      >
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Typography variant="body2">
+            {t('entityCardContextAlert.contextHasBeenAddedToThisElement')}
+          </Typography>
+          <Chip
+            variant="outlined"
+            size="small"
+            label={t('entityCardContextAlert.see')}
+            onClick={handleClick}
+          />
+        </Box>
+      </Alert>
+    </Grid>
+  );
+};
+
+export default EntityCardContextAlert;

--- a/frontend/src/features/entity_context/EntityContextBox.tsx
+++ b/frontend/src/features/entity_context/EntityContextBox.tsx
@@ -78,7 +78,11 @@ const EntityContextList = ({
   }
 
   return (
-    <Alert severity={entityHasWarnings ? 'warning' : 'info'} sx={alertSx}>
+    <Alert
+      id="entity-context"
+      severity={entityHasWarnings ? 'warning' : 'info'}
+      sx={alertSx}
+    >
       <AlertTitle>
         <strong>
           {origin_ === OriginEnum.ASSOCIATION &&

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -279,6 +279,7 @@ const RateLaterPage = () => {
                 actions={rateLaterPageActions}
                 actionsIfUnavailable={[RemoveFromRateLater(loadList)]}
                 cardProps={{ showRatingControl: true }}
+                displayContextAlert={true}
               />
             </LoaderWrapper>
           </Box>

--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -10,7 +10,7 @@ import { VideoPlayer } from 'src/components/entity/EntityImagery';
 import CriteriaScoresDistribution from 'src/features/charts/CriteriaScoresDistribution';
 import EntityContextBox from 'src/features/entity_context/EntityContextBox';
 import VideoCard from 'src/features/videos/VideoCard';
-import { useLoginState } from 'src/hooks';
+import { useLoginState, useScrollToLocation } from 'src/hooks';
 import { Recommendation } from 'src/services/openapi';
 import { PersonalCriteriaScoresContextProvider } from 'src/hooks/usePersonalCriteriaScores';
 import PersonalScoreCheckbox from 'src/components/PersonalScoreCheckbox';
@@ -26,6 +26,8 @@ export const VideoAnalysis = ({ video }: { video: Recommendation }) => {
   const [descriptionCollapsed, setDescriptionCollapsed] = React.useState(false);
 
   const actions = useLoginState() ? [CompareNowAction, AddToRateLaterList] : [];
+
+  useScrollToLocation();
 
   const entity = video.entity;
   const criteriaScores = video.collective_rating?.criteria_scores ?? [];


### PR DESCRIPTION
**related to** #1852

---

### Description

This PR adds entity context notices in the rate-later list and ensures the notices don't appear in the recommendations.

Only unsafe contexts can display the notice for now.

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/d036969e-827b-4ad1-bb91-57d60f46a810)

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/a249be9b-2839-400b-81d6-ceae058d5f8a)

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
