### PR TITLE
[back] chore: remove deprecated fields from API responses

### DIFF
--- a/backend/tournesol/serializers/contributor_recommendations.py
+++ b/backend/tournesol/serializers/contributor_recommendations.py
@@ -1,6 +1,3 @@
-from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
-from rest_framework.serializers import SerializerMethodField
-
 from tournesol.models.ratings import ContributorRating
 from tournesol.serializers.criteria_score import ContributorCriteriaScoreSerializer
 from tournesol.serializers.poll import IndividualRatingSerializer, RecommendationSerializer
@@ -15,41 +12,14 @@ class IndividualRatingWithScoresSerializer(IndividualRatingSerializer):
         read_only_fields = fields
 
 
-@extend_schema_serializer(
-    exclude_fields=[
-        # legacy fields have been moved to "entity", "invidual_rating", "collective_rating", etc.
-        "uid",
-        "type",
-        "n_comparisons",
-        "n_contributors",
-        "metadata",
-        "total_score",
-        "tournesol_score",
-        "criteria_scores",
-        "unsafe",
-        "is_public",
-    ]
-)
 class ContributorRecommendationsSerializer(RecommendationSerializer):
     """
     An entity recommended by a user.
     """
-
-    is_public = SerializerMethodField()
-    criteria_scores = SerializerMethodField()
     individual_rating = IndividualRatingWithScoresSerializer(
         source="single_contributor_rating",
         read_only=True,
     )
 
     class Meta(RecommendationSerializer.Meta):
-        fields = RecommendationSerializer.Meta.fields + ["is_public", "individual_rating"]
-
-    @extend_schema_field(ContributorCriteriaScoreSerializer(many=True))
-    def get_criteria_scores(self, obj):
-        return ContributorCriteriaScoreSerializer(
-            obj.single_contributor_rating.criteria_scores, many=True
-        ).data
-
-    def get_is_public(self, obj) -> bool:
-        return obj.single_contributor_rating.is_public
+        fields = RecommendationSerializer.Meta.fields + ["individual_rating"]

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -1,4 +1,3 @@
-from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 from rest_framework.serializers import IntegerField, ModelSerializer
 
@@ -79,32 +78,7 @@ class RecommendationMetadataSerializer(serializers.Serializer):
     total_score = serializers.FloatField(read_only=True, allow_null=True)
 
 
-@extend_schema_serializer(
-    exclude_fields=[
-        # legacy fields have been moved to "entity", "collective_rating", etc.
-        "uid",
-        "type",
-        "n_comparisons",
-        "n_contributors",
-        "metadata",
-        "total_score",
-        "tournesol_score",
-        "criteria_scores",
-        "unsafe",
-    ]
-)
 class RecommendationSerializer(ModelSerializer):
-    # pylint: disable=duplicate-code
-    n_comparisons = serializers.IntegerField(source="rating_n_ratings")
-    n_contributors = serializers.IntegerField(source="rating_n_contributors")
-    criteria_scores = EntityCriteriaScoreSerializer(many=True)
-    # TODO: the field total_score is the only field in this serializer that
-    # on the parameters of an api request. Should it be treated differently?
-    total_score = serializers.FloatField()
-    unsafe = UnsafeStatusSerializer(
-        source="single_poll_rating", allow_null=True, default=None, read_only=True
-    )
-
     entity = RelatedEntitySerializer(source="*", read_only=True)
     collective_rating = ExtendedCollectiveRatingSerializer(
         source="single_poll_rating",
@@ -121,15 +95,6 @@ class RecommendationSerializer(ModelSerializer):
     class Meta:
         model = Entity
         fields = [
-            "uid",
-            "type",
-            "n_comparisons",
-            "n_contributors",
-            "metadata",
-            "total_score",
-            "tournesol_score",
-            "criteria_scores",
-            "unsafe",
             "entity",
             "collective_rating",
             "entity_contexts",

--- a/backend/tournesol/tests/test_api_contributor_recommendations.py
+++ b/backend/tournesol/tests/test_api_contributor_recommendations.py
@@ -112,7 +112,7 @@ class ContributorRecommendationsApiTestCase(TestCase):
 
         results = response.data["results"]
         for entity in results:
-            self.assertEqual(entity["is_public"], True)
+            self.assertEqual(entity["individual_rating"]["is_public"], True)
 
         # The collective metadata `n_comparisons` and `n_contributors` must
         # be present in the response of the public personal reco. endpoint.

--- a/backend/tournesol/tests/test_text_search.py
+++ b/backend/tournesol/tests/test_text_search.py
@@ -414,9 +414,10 @@ class TextSearchTestCase(TestCase):
         self.assertEqual(len(response.data["results"]), response.data["count"])
 
         sorted_scores = sorted(scores, reverse=True)
+        results = response.data["results"]
         for index, score in enumerate(sorted_scores):
             entity = entities[scores.index(score)]
-            self.assertEqual(response.data["results"][index]["uid"], entity.uid)
+            self.assertEqual(results[index]["entity"]["uid"], entity.uid)
 
     def test_public_contributor_recommendations_sorting_depends_on_total_score(self):
         """
@@ -442,9 +443,10 @@ class TextSearchTestCase(TestCase):
         self.assertEqual(len(response.data["results"]), response.data["count"])
 
         sorted_scores = sorted(scores, reverse=True)
+        results = response.data["results"]
         for index, score in enumerate(sorted_scores):
             entity = entities[scores.index(score)]
-            self.assertEqual(response.data["results"][index]["uid"], entity.uid)
+            self.assertEqual(results[index]["entity"]["uid"], entity.uid)
 
     def test_private_contributor_recommendations_sorting_depends_on_total_score(self):
         """
@@ -471,9 +473,10 @@ class TextSearchTestCase(TestCase):
         self.assertEqual(len(response.data["results"]), response.data["count"])
 
         sorted_scores = sorted(scores, reverse=True)
+        results = response.data["results"]
         for index, score in enumerate(sorted_scores):
             entity = entities[scores.index(score)]
-            self.assertEqual(response.data["results"][index]["uid"], entity.uid)
+            self.assertEqual(results[index]["entity"]["uid"], entity.uid)
 
     def test_videos_fields_weights(self):
         """
@@ -503,8 +506,8 @@ class TextSearchTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["uid"], self.setup_entity.uid)
-        self.assertEqual(response.data["results"][1]["uid"], other_entity.uid)
+        self.assertEqual(response.data["results"][0]["entity"]["uid"], self.setup_entity.uid)
+        self.assertEqual(response.data["results"][1]["entity"]["uid"], other_entity.uid)
 
     def test_query_weights(self):
         """
@@ -542,8 +545,8 @@ class TextSearchTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["uid"], entity_2.uid)
-        self.assertEqual(response.data["results"][1]["uid"], entity_1.uid)
+        self.assertEqual(response.data["results"][0]["entity"]["uid"], entity_2.uid)
+        self.assertEqual(response.data["results"][1]["entity"]["uid"], entity_1.uid)
 
         response = self.client.get(
             self._make_url(query) + f"&weights[{criteria_1}]=10&weights[{criteria_2}]=50",
@@ -552,8 +555,8 @@ class TextSearchTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["uid"], entity_1.uid)
-        self.assertEqual(response.data["results"][1]["uid"], entity_2.uid)
+        self.assertEqual(response.data["results"][0]["entity"]["uid"], entity_1.uid)
+        self.assertEqual(response.data["results"][1]["entity"]["uid"], entity_2.uid)
 
     def test_multiple_matches(self):
         """
@@ -580,8 +583,8 @@ class TextSearchTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["uid"], relevant_entity.uid)
-        self.assertEqual(response.data["results"][1]["uid"], less_relevant_entity.uid)
+        self.assertEqual(response.data["results"][0]["entity"]["uid"], relevant_entity.uid)
+        self.assertEqual(response.data["results"][1]["entity"]["uid"], less_relevant_entity.uid)
 
     def test_public_contributor_recommendations_multiple_matches(self):
         """
@@ -609,8 +612,8 @@ class TextSearchTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["uid"], relevant_entity.uid)
-        self.assertEqual(response.data["results"][1]["uid"], less_relevant_entity.uid)
+        self.assertEqual(response.data["results"][0]["entity"]["uid"], relevant_entity.uid)
+        self.assertEqual(response.data["results"][1]["entity"]["uid"], less_relevant_entity.uid)
 
     def test_private_contributor_recommendations_multiple_matches(self):
         """
@@ -639,8 +642,8 @@ class TextSearchTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["uid"], relevant_entity.uid)
-        self.assertEqual(response.data["results"][1]["uid"], less_relevant_entity.uid)
+        self.assertEqual(response.data["results"][0]["entity"]["uid"], relevant_entity.uid)
+        self.assertEqual(response.data["results"][1]["entity"]["uid"], less_relevant_entity.uid)
 
     def test_multiple_words(self):
         """
@@ -666,7 +669,7 @@ class TextSearchTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["uid"], relevant_entity.uid)
+        self.assertEqual(response.data["results"][0]["entity"]["uid"], relevant_entity.uid)
 
     def test_case_insensitive(self):
 


### PR DESCRIPTION
Closes #606 

---

### Description

Removes the deprecated fields (already excluded from the docs and API schema) in `RecommendationSerializer` and `ContributorRecommendationsSerializer`

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass



[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
