### PR TITLE
[infra] fix: update firewall rules to initialize networking properly

### DIFF
--- a/infra/ansible/roles/base/tasks/main.yml
+++ b/infra/ansible/roles/base/tasks/main.yml
@@ -4,10 +4,14 @@
 
 - name: Configure hosts file
   blockinfile:
-    path: /etc/hosts
+    path: "{{ item }}"
+    create: true
     block: |
     
       127.0.1.1    {{machine_name}} {{domain_name}} {{api_domain_name}}
+  loop:
+    - /etc/hosts
+    - /etc/cloud/templates/hosts.debian.tmpl  # Template used by cloud-init on startup
 
 - name: Install minimal set of packages
   apt:

--- a/infra/ansible/roles/nftables/templates/nftables.conf.j2
+++ b/infra/ansible/roles/nftables/templates/nftables.conf.j2
@@ -42,6 +42,9 @@ table inet filter {
 
     ip protocol igmp accept
 
+    # accept DHCPv6: necessary to initialize networking.service on Infomaniak cloud
+    ip6 daddr fe80::/10 udp sport 547 udp dport 546 accept
+
     # accept SSH, HTTP, HTTPS
     tcp dport { 22, 80, 443 } accept
   }


### PR DESCRIPTION
### Description

Following the migration of our virtual machines to a new provider, we observed networking issues post-provisioning. Specifically, the `networking.service` fails to initialize correctly upon reboot, resulting in slow startup and eventual loss of network connectivity.

It seems that the firewall configuration defined in Ansible tasks is blocking packets essential for the networking service to establish the IPv6 connection with DHCPv6. That's why the service times out and fails to start. Notably, this service is also responsible for renewing the IPv4 DHCP lease, leading to server inaccessibility.

This PR introduces a rule to accept connections related to DHCPv6, addressing the networking issue.

Following #1862, it also applies the same `/etc/hosts` configuration in the template used by cloud-init at startup time.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
