### PR TITLE
[back] refactor: set the nbr of CPU not used during the ML run

### DIFF
--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import pandas as pd
 from django import db
+from django.conf import settings
 from solidago.collaborative_scaling import estimate_positive_score_shift, estimate_score_deviation
 from solidago.comparisons_to_scores import ContinuousBradleyTerry
 
@@ -272,7 +273,9 @@ def run_mehestan(
 
     # compute each criterion in parallel
     cpu_count = os.cpu_count() or 1
-    with Pool(processes=max(1, cpu_count - 1)) as pool:
+    cpu_count -= settings.MEHESTAN_KEEP_N_FREE_CPU
+
+    with Pool(processes=max(1, cpu_count)) as pool:
         for _ in pool.imap_unordered(
             partial(
                 run_mehestan_for_criterion,

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -419,7 +419,7 @@ RECOMMENDATIONS_MIN_TOURNESOL_SCORE = 20.0
 RECOMMENDATIONS_MIN_TRUST_SCORES = 1.5
 
 UPDATE_MEHESTAN_SCORES_ON_COMPARISON = False
-MEHESTAN_KEEP_N_FREE_CPU = server_settings.get("MEHESTAN_KEEP_N_FREE_CPU", 3)
+MEHESTAN_KEEP_N_FREE_CPU = server_settings.get("MEHESTAN_KEEP_N_FREE_CPU", 2)
 
 # Configuration of the app `core`
 # See the documentation for the complete description.

--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -419,6 +419,7 @@ RECOMMENDATIONS_MIN_TOURNESOL_SCORE = 20.0
 RECOMMENDATIONS_MIN_TRUST_SCORES = 1.5
 
 UPDATE_MEHESTAN_SCORES_ON_COMPARISON = False
+MEHESTAN_KEEP_N_FREE_CPU = server_settings.get("MEHESTAN_KEEP_N_FREE_CPU", 3)
 
 # Configuration of the app `core`
 # See the documentation for the complete description.


### PR DESCRIPTION
### Description

This PR allows to define per server the number of CPU that won't be used by the ML, leaving more resources for other processes. This may improve the performance of SQL queries made by the API during a ML run.

By default 3 CPU will be kept free. Let me know if this number is too high.

|  | CPU | used by ML (before) | used by ML (after) |
|---|---|---|---|
| staging | 2 | 1 | **1** |
| production | 8 | 7 | **6** |

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
