### PR TITLE
[front] feat: display entity context Chip in the entity selector

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -44,6 +44,9 @@
   "score": {
     "totalScoreBasedOnRankingChoice": "Score based on selected ranking parameters"
   },
+  "entityContextChip": {
+    "context": "context"
+  },
   "entityIndividualScores": {
     "inYourOpinion": "your score <1></1>"
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -47,6 +47,9 @@
   "score": {
     "totalScoreBasedOnRankingChoice": "Score basé sur les critères de classement sélectionnés"
   },
+  "entityContextChip": {
+    "context": "contexte"
+  },
   "entityIndividualScores": {
     "inYourOpinion": "selon vous <1></1>"
   },

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -34,6 +34,7 @@ import { RatingControl } from 'src/features/ratings/RatingControl';
 
 import EntityCardTitle from './EntityCardTitle';
 import EntityCardScores from './EntityCardScores';
+import EntityContextChip from './EntityContextChip';
 import EntityImagery from './EntityImagery';
 import EntityMetadata, { VideoMetadata } from './EntityMetadata';
 import EntityIndividualScores from './EntityIndividualScores';
@@ -240,10 +241,12 @@ export const RowEntityCard = ({
   result,
   withLink = false,
   individualScores,
+  displayEntityContextChip = true,
 }: {
   result: EntityResult;
   withLink?: boolean;
   individualScores?: ContributorCriteriaScore[];
+  displayEntityContextChip?: boolean;
 }) => {
   const entity = result.entity;
   return (
@@ -280,6 +283,12 @@ export const RowEntityCard = ({
             uploader={entity.metadata.uploader}
             publicationDate={entity.metadata.publication_date}
             withLinks={false}
+          />
+        )}
+        {displayEntityContextChip && 'entity_contexts' in result && (
+          <EntityContextChip
+            uid={result.entity.uid}
+            entityContexts={result.entity_contexts}
           />
         )}
         {individualScores && (

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -285,15 +285,18 @@ export const RowEntityCard = ({
             withLinks={false}
           />
         )}
-        {displayEntityContextChip && 'entity_contexts' in result && (
-          <EntityContextChip
-            uid={result.entity.uid}
-            entityContexts={result.entity_contexts}
-          />
-        )}
-        {individualScores && (
-          <EntityIndividualScores scores={individualScores} />
-        )}
+
+        <Box pr={1} display="flex" justifyContent="flex-end" gap={1}>
+          {displayEntityContextChip && 'entity_contexts' in result && (
+            <EntityContextChip
+              uid={result.entity.uid}
+              entityContexts={result.entity_contexts}
+            />
+          )}
+          {individualScores && (
+            <EntityIndividualScores scores={individualScores} />
+          )}
+        </Box>
       </Stack>
     </Box>
   );

--- a/frontend/src/components/entity/EntityContextChip.tsx
+++ b/frontend/src/components/entity/EntityContextChip.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+
+import { Box, Chip } from '@mui/material';
+
+import { EntityContext, OriginEnum } from 'src/services/openapi';
+
+export const EntityContextChip = ({
+  uid,
+  entityContexts,
+}: {
+  uid: string;
+  entityContexts: EntityContext[];
+}) => {
+  const history = useHistory();
+  const { t } = useTranslation();
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    history.push(`/entities/${uid}#entity-context`);
+  };
+
+  const unsafeContext = entityContexts.find(
+    (context) => context.unsafe && context.origin === OriginEnum.ASSOCIATION
+  );
+
+  if (!unsafeContext) {
+    return <></>;
+  }
+
+  return (
+    <Box pr={1} display="flex" justifyContent="flex-end">
+      <Chip
+        size="small"
+        color="warning"
+        variant="outlined"
+        label={t('entityContextChip.context')}
+        onClick={handleClick}
+      />
+    </Box>
+  );
+};
+
+export default EntityContextChip;

--- a/frontend/src/components/entity/EntityContextChip.tsx
+++ b/frontend/src/components/entity/EntityContextChip.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 
-import { Box, Chip } from '@mui/material';
+import { Chip } from '@mui/material';
 
 import { EntityContext, OriginEnum } from 'src/services/openapi';
 
@@ -25,20 +25,18 @@ export const EntityContextChip = ({
     (context) => context.unsafe && context.origin === OriginEnum.ASSOCIATION
   );
 
-  if (!unsafeContext) {
+  if (unsafeContext == undefined) {
     return <></>;
   }
 
   return (
-    <Box pr={1} display="flex" justifyContent="flex-end">
-      <Chip
-        size="small"
-        color="warning"
-        variant="outlined"
-        label={t('entityContextChip.context')}
-        onClick={handleClick}
-      />
-    </Box>
+    <Chip
+      size="small"
+      color="warning"
+      variant="outlined"
+      label={t('entityContextChip.context')}
+      onClick={handleClick}
+    />
   );
 };
 

--- a/frontend/src/components/entity/EntityContextChip.tsx
+++ b/frontend/src/components/entity/EntityContextChip.tsx
@@ -36,6 +36,9 @@ export const EntityContextChip = ({
       variant="outlined"
       label={t('entityContextChip.context')}
       onClick={handleClick}
+      sx={{
+        fontSize: '0.8125em',
+      }}
     />
   );
 };

--- a/frontend/src/components/entity/EntityIndividualScores.tsx
+++ b/frontend/src/components/entity/EntityIndividualScores.tsx
@@ -28,26 +28,26 @@ export const EntityIndividualScores = ({
     )?.score;
   }
 
+  if (mainCriterionScore == undefined) {
+    return <></>;
+  }
+
   return (
-    <Box pr={1} display="flex" justifyContent="flex-end">
-      {mainCriterionScore != null && (
-        <Chip
-          size="small"
-          variant="outlined"
-          label={
-            <Box display="flex" columnGap="2px">
-              <Trans t={t} i18nKey="entityIndividualScores.inYourOpinion">
-                in your opinion
-                <TournesolScore
-                  score={mainCriterionScore}
-                  tooltip={getCriteriaLabel(mainCriterionName)}
-                />
-              </Trans>
-            </Box>
-          }
-        />
-      )}
-    </Box>
+    <Chip
+      size="small"
+      variant="outlined"
+      label={
+        <Box display="flex" columnGap="2px">
+          <Trans t={t} i18nKey="entityIndividualScores.inYourOpinion">
+            in your opinion
+            <TournesolScore
+              score={mainCriterionScore}
+              tooltip={getCriteriaLabel(mainCriterionName)}
+            />
+          </Trans>
+        </Box>
+      }
+    />
   );
 };
 

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Location } from 'history';


### PR DESCRIPTION
**related issues** #1852

---

### Description

This PR adds clickable `<Chip />` in the raw entity card, allowing the users to visualise the existence of entity contexts. A click on this new element redirects the users to the entity analysis page.

Note that the API /unconnected_entities/ and /subsamples/ don't return the entity contexts for now. 

### Preview

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/600fc9ac-a173-418e-81bf-e13c668685ab)

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
