### PR TITLE
[front] style: adapt flex style of compact EntityCard to make 'card-i…

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next';
 import {
   Box,
   Collapse,
-  Grid,
   IconButton,
   useTheme,
   useMediaQuery,
   Stack,
   Typography,
 } from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
 import {
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
@@ -106,17 +106,26 @@ const EntityCard = ({
   };
 
   return (
-    <Grid container sx={entityCardMainSx}>
+    <Grid
+      container
+      sx={entityCardMainSx}
+      direction={compact ? 'column' : 'row'}
+    >
       {!isAvailable && (
-        <Grid container justifyContent="space-between" alignItems="center">
-          <Grid item pl={1} py={2}>
+        <Grid
+          xs={12}
+          container
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Grid pl={1} py={2}>
             <Typography>
               {entity.type == TypeEnum.VIDEO
                 ? t('video.notAvailableAnymore')
                 : t('entityCard.thisElementIsNotAvailable')}
             </Typography>
           </Grid>
-          <Grid item>
+          <Grid>
             <IconButton onClick={toggleEntityVisibility}>
               {contentDisplayed ? (
                 <ArrowDropUp sx={{ color: 'rgba(0, 0, 0, 0.42)' }} />
@@ -130,15 +139,12 @@ const EntityCard = ({
       {contentDisplayed && (
         <>
           <Grid
-            item
             xs={12}
             sm={compact ? 12 : 'auto'}
             sx={{
               display: 'flex',
               justifyContent: 'center',
-              ...(compact
-                ? {}
-                : { minWidth: '240px', maxWidth: { sm: '240px' } }),
+              ...(compact ? {} : { maxWidth: { sm: '240px' } }),
             }}
           >
             <EntityImagery
@@ -148,12 +154,8 @@ const EntityCard = ({
             />
           </Grid>
           <Grid
-            item
-            xs={12}
-            sm={compact ? 12 : true}
-            sx={{
-              padding: 1,
-            }}
+            xs={true} // Grow and fill the container height when two cards are side by side
+            p={1}
             data-testid="video-card-info"
             container
             direction="column"
@@ -167,7 +169,6 @@ const EntityCard = ({
             {displayEntityCardScores()}
           </Grid>
           <Grid
-            item
             xs={12}
             sm={compact ? 12 : 1}
             sx={{
@@ -202,13 +203,13 @@ const EntityCard = ({
           </Grid>
 
           {displayContextAlert && unsafeContext && (
-            <Grid item xs={12}>
+            <Grid xs={12}>
               <EntityCardContextAlert uid={entity.uid} />
             </Grid>
           )}
 
           {showRatingControl && (
-            <Grid item xs={12}>
+            <Grid xs={12}>
               <Collapse in={ratingVisible || !isSmallScreen}>
                 <Box
                   paddingY={1}

--- a/frontend/src/components/entity/style.ts
+++ b/frontend/src/components/entity/style.ts
@@ -7,7 +7,7 @@ export const entityCardMainSx: SxProps = {
   border: '1px solid #DCD8CB',
   boxShadow: '0px 0px 8px rgba(0, 0, 0, 0.02), 0px 2px 4px rgba(0, 0, 0, 0.05)',
   borderRadius: '4px',
-  alignContent: 'space-between',
+  alignContent: 'flex-start',
   overflow: 'hidden',
   fontSize: {
     xs: '14px',


### PR DESCRIPTION
Targets #1865 

---

### Description

An attempt to adapt the style issue discussed in https://github.com/tournesol-app/tournesol/pull/1865/files#r1433850019

For some reason I had to use `Grid2` to make that work.

![image](https://github.com/tournesol-app/tournesol/assets/4726554/f9c38d39-0dc3-4686-9b96-c01d16530b0a)

@GresilleSiffle Is that the behaviour you had in mind?

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
