### PR TITLE
[ext] fix: avoid repeated calls to initialize Home and Search Recommendations

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/displayHomeRecommendations.js
+++ b/browser-extension/src/displayHomeRecommendations.js
@@ -23,22 +23,21 @@
       parentComponentQuery: '#primary > ytd-rich-grid-renderer',
       displayCriteria: false,
     });
-    homeRecommendations = new TournesolRecommendations(options);
+    return new TournesolRecommendations(options);
   };
 
   const processHomeRecommendations = async () => {
     if (homeRecommendations === undefined) {
-      await initializeHomeRecommendations();
+      homeRecommendations = initializeHomeRecommendations();
     }
-
-    homeRecommendations.process();
+    (await homeRecommendations).process();
   };
 
-  const clearHomeRecommendations = () => {
+  const clearHomeRecommendations = async () => {
     if (homeRecommendations === undefined) {
       return;
     }
-    homeRecommendations.clear();
+    (await homeRecommendations).clear();
   };
 
   const process = () => {

--- a/browser-extension/src/displaySearchRecommendations.js
+++ b/browser-extension/src/displaySearchRecommendations.js
@@ -26,23 +26,21 @@
       displayCriteria: true,
     });
 
-    searchRecommendations = new TournesolSearchRecommendations(options);
+    return new TournesolSearchRecommendations(options);
   };
 
   const processSearchRecommendations = async () => {
     if (searchRecommendations === undefined) {
-      await initializeSearchRecommendations();
+      searchRecommendations = initializeSearchRecommendations();
     }
-
-    searchRecommendations.process();
+    (await searchRecommendations).process();
   };
 
-  const clearSearchRecommendations = () => {
+  const clearSearchRecommendations = async () => {
     if (searchRecommendations === undefined) {
       return;
     }
-
-    searchRecommendations.clear();
+    (await searchRecommendations).clear();
   };
 
   // Allow to display the Tournesol search results without modifying the


### PR DESCRIPTION
### Description

This avoid to repeat API requests to fetch banners and recommendations when initializing the extension.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
