### PR TITLE
[back][ext] feat: recommendations API can now return random entities

### DIFF
--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -123,3 +123,9 @@ class RecommendationsFilterSerializer(serializers.Serializer):
         help_text="If true and a user is authenticated, then entities compared by the"
         " user will be removed from the response",
     )
+
+
+class RecommendationsRandomFilterSerializer(serializers.Serializer):
+    random = serializers.IntegerField(default=None)
+    date_lte = serializers.DateTimeField(default=None)
+    date_gte = serializers.DateTimeField(default=None)

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -139,7 +139,7 @@ class RecommendationsFilterSerializer(serializers.Serializer):
 
 
 class RecommendationsRandomFilterSerializer(serializers.Serializer):
-    random = serializers.IntegerField(
+    bundle = serializers.IntegerField(
         default=None,
         help_text="Successive calls can return the same cached results. Vary"
         " this parameter to request new results."

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -145,7 +145,7 @@ class RecommendationsFilterSerializer(serializers.Serializer):
 class RecommendationsRandomFilterSerializer(serializers.Serializer):
     random = serializers.IntegerField(
         default=None,
-        help_text="Successive calls will produce the same cached results. Vary"
+        help_text="Successive calls can return the same cached results. Vary"
         " this parameter to request new results."
     )
     date_lte = serializers.DateTimeField(default=None)

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -104,6 +104,12 @@ class RecommendationSerializer(ModelSerializer):
 
 
 class RecommendationsFilterSerializer(serializers.Serializer):
+    random = serializers.IntegerField(
+        default=None,
+        help_text="If defined, the entities will be randomized instead of sorted by score."
+        " Because the API results are cached, using the same digit will return the same set of"
+        " entities. To get new entities, use a different digit."
+    )
     date_lte = serializers.DateTimeField(default=None)
     date_gte = serializers.DateTimeField(default=None)
     search = serializers.CharField(default=None, help_text="A search query to filter entities")

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -103,6 +103,29 @@ class RecommendationSerializer(ModelSerializer):
         read_only_fields = fields
 
 
+class RecommendationRandomSerializer(serializers.Serializer):
+    entity = RelatedEntitySerializer(source="*", read_only=True)
+    collective_rating = ExtendedCollectiveRatingSerializer(
+        source="single_poll_rating",
+        read_only=True,
+        allow_null=True,
+    )
+    entity_contexts = EntityContextSerializer(
+        source="single_poll_entity_contexts",
+        read_only=True,
+        many=True
+    )
+
+    class Meta:
+        model = Entity
+        fields = [
+            "entity",
+            "collective_rating",
+            "entity_contexts",
+        ]
+        read_only_fields = fields
+
+
 class RecommendationsFilterSerializer(serializers.Serializer):
     random = serializers.IntegerField(
         default=None,

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -105,23 +105,23 @@ class RecommendationSerializer(ModelSerializer):
 
 class RecommendationRandomSerializer(serializers.Serializer):
     entity = RelatedEntitySerializer(source="*", read_only=True)
-    collective_rating = ExtendedCollectiveRatingSerializer(
-        source="single_poll_rating",
-        read_only=True,
-        allow_null=True,
-    )
     entity_contexts = EntityContextSerializer(
         source="single_poll_entity_contexts",
         read_only=True,
         many=True
+    )
+    collective_rating = ExtendedCollectiveRatingSerializer(
+        source="single_poll_rating",
+        read_only=True,
+        allow_null=True,
     )
 
     class Meta:
         model = Entity
         fields = [
             "entity",
-            "collective_rating",
             "entity_contexts",
+            "collective_rating",
         ]
         read_only_fields = fields
 

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -127,12 +127,6 @@ class RecommendationRandomSerializer(serializers.Serializer):
 
 
 class RecommendationsFilterSerializer(serializers.Serializer):
-    random = serializers.IntegerField(
-        default=None,
-        help_text="If defined, the entities will be randomized instead of sorted by score."
-        " Because the API results are cached, using the same digit will return the same set of"
-        " entities. To get new entities, use a different digit."
-    )
     date_lte = serializers.DateTimeField(default=None)
     date_gte = serializers.DateTimeField(default=None)
     search = serializers.CharField(default=None, help_text="A search query to filter entities")
@@ -149,6 +143,10 @@ class RecommendationsFilterSerializer(serializers.Serializer):
 
 
 class RecommendationsRandomFilterSerializer(serializers.Serializer):
-    random = serializers.IntegerField(default=None)
+    random = serializers.IntegerField(
+        default=None,
+        help_text="Successive calls will produce the same cached results. Vary"
+        " this parameter to request new results."
+    )
     date_lte = serializers.DateTimeField(default=None)
     date_gte = serializers.DateTimeField(default=None)

--- a/backend/tournesol/serializers/poll.py
+++ b/backend/tournesol/serializers/poll.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from rest_framework.serializers import IntegerField, ModelSerializer
 
-from tournesol.models import ContributorRating, CriteriaRank, Entity, EntityPollRating, Poll
+from tournesol.models import ContributorRating, CriteriaRank, EntityPollRating, Poll
 from tournesol.models.entity_poll_rating import UNSAFE_REASONS
 from tournesol.serializers.entity import EntityCriteriaScoreSerializer, RelatedEntitySerializer
 from tournesol.serializers.entity_context import EntityContextSerializer
@@ -74,54 +74,50 @@ class IndividualRatingSerializer(ModelSerializer):
         read_only_fields = fields
 
 
-class RecommendationMetadataSerializer(serializers.Serializer):
-    total_score = serializers.FloatField(read_only=True, allow_null=True)
+class RecommendationBaseSerializer(serializers.Serializer):
+    """
+    A base serializer for all recommendations.
 
-
-class RecommendationSerializer(ModelSerializer):
+    The recommendations of a poll should always be provided with
+    the fields defined in this serializer.
+    """
     entity = RelatedEntitySerializer(source="*", read_only=True)
-    collective_rating = ExtendedCollectiveRatingSerializer(
-        source="single_poll_rating",
-        read_only=True,
-        allow_null=True,
-    )
     entity_contexts = EntityContextSerializer(
         source="single_poll_entity_contexts",
         read_only=True,
         many=True
     )
-    recommendation_metadata = RecommendationMetadataSerializer(source="*", read_only=True)
+    collective_rating = ExtendedCollectiveRatingSerializer(
+        source="single_poll_rating",
+        read_only=True,
+        allow_null=True,
+    )
 
     class Meta:
-        model = Entity
         fields = [
             "entity",
-            "collective_rating",
             "entity_contexts",
-            "recommendation_metadata",
+            "collective_rating",
         ]
         read_only_fields = fields
 
 
-class RecommendationRandomSerializer(serializers.Serializer):
-    entity = RelatedEntitySerializer(source="*", read_only=True)
-    entity_contexts = EntityContextSerializer(
-        source="single_poll_entity_contexts",
-        read_only=True,
-        many=True
-    )
-    collective_rating = ExtendedCollectiveRatingSerializer(
-        source="single_poll_rating",
-        read_only=True,
-        allow_null=True,
-    )
+class RecommendationMetadataSerializer(serializers.Serializer):
+    total_score = serializers.FloatField(read_only=True, allow_null=True)
+
+
+class RecommendationSerializer(RecommendationBaseSerializer):
+    """
+    An entity recommended in a poll.
+    """
+    recommendation_metadata = RecommendationMetadataSerializer(source="*", read_only=True)
 
     class Meta:
-        model = Entity
         fields = [
             "entity",
             "entity_contexts",
             "collective_rating",
+            "recommendation_metadata",
         ]
         read_only_fields = fields
 

--- a/backend/tournesol/tests/test_api_polls_reco_random.py
+++ b/backend/tournesol/tests/test_api_polls_reco_random.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -95,8 +96,8 @@ class RandomRecommendationTestCase(TestCase):
 
         for i in range(100):
             VideoFactory(
-                metadata__name=f"tmpsafe__{i}",
-                tournesol_score=88,
+                metadata__name=f"other_safe__{i}",
+                tournesol_score=settings.RECOMMENDATIONS_MIN_TOURNESOL_SCORE + 1 + i,
                 make_safe_for_poll=other_poll,
             )
 
@@ -121,7 +122,7 @@ class RandomRecommendationTestCase(TestCase):
         for i in range(db_size):
             VideoFactory(
                 metadata__name=f"other_safe__{i}",
-                tournesol_score=88,
+                tournesol_score=settings.RECOMMENDATIONS_MIN_TOURNESOL_SCORE + 1 + i,
                 make_safe_for_poll=other_poll,
             )
 

--- a/backend/tournesol/tests/test_api_polls_reco_random.py
+++ b/backend/tournesol/tests/test_api_polls_reco_random.py
@@ -68,14 +68,14 @@ class RandomRecommendationTestCase(TestCase):
             self.assertEqual(result["entity_contexts"], [])
 
     def test_list_is_poll_specific(self):
-        resp = self.client.get(f"{self.url_path}?random=1")
+        resp = self.client.get(f"{self.url_path}?bundle=1")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(len(resp.data["results"]), 3)
 
         other_poll = Poll.objects.create(name="other")
         video_5 = VideoFactory.create(make_safe_for_poll=other_poll)
 
-        resp = self.client.get(f"{self.url_path}?random=2")
+        resp = self.client.get(f"{self.url_path}?bundle=2")
         results = resp.data["results"]
         uids = [res["entity"]["uid"] for res in results]
 
@@ -85,7 +85,7 @@ class RandomRecommendationTestCase(TestCase):
 
     def test_list_is_random(self):
         """
-        Two consecutive requests with different `random` query parameter
+        Two consecutive requests with different `bundle` query parameter
         should return two bundles of different videos.
 
         Still, it's possible for the bundles to share some videos. In very
@@ -101,16 +101,16 @@ class RandomRecommendationTestCase(TestCase):
                 make_safe_for_poll=other_poll,
             )
 
-        resp = self.client.get(f"{other_path}?random=1")
+        resp = self.client.get(f"{other_path}?bundle=1")
         bundle1 = [res["entity"]["uid"] for res in resp.data["results"]]
 
-        resp = self.client.get(f"{other_path}?random=2")
+        resp = self.client.get(f"{other_path}?bundle=2")
         bundle2 = [res["entity"]["uid"] for res in resp.data["results"]]
         self.assertNotEqual(set(bundle1), set(bundle2))
 
     def test_list_is_not_ordered(self):
         """
-        Two consecutive requests with different `random` query parameter
+        Two consecutive requests with different `bundle` query parameter
         should return randomly ordered bundles of videos, even when the
         bundles contain exactly the same videos.
         """
@@ -126,10 +126,10 @@ class RandomRecommendationTestCase(TestCase):
                 make_safe_for_poll=other_poll,
             )
 
-        resp = self.client.get(f"{other_path}?random=1&limit={db_size}")
+        resp = self.client.get(f"{other_path}?bundle=1&limit={db_size}")
         bundle1 = [res["entity"]["uid"] for res in resp.data["results"]]
 
-        resp = self.client.get(f"{other_path}?random=2&limit={db_size}")
+        resp = self.client.get(f"{other_path}?bundle=2&limit={db_size}")
         bundle2 = [res["entity"]["uid"] for res in resp.data["results"]]
 
         self.assertSetEqual(set(bundle1), set(bundle2))

--- a/backend/tournesol/tests/test_api_polls_reco_random.py
+++ b/backend/tournesol/tests/test_api_polls_reco_random.py
@@ -1,0 +1,141 @@
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from tournesol.models import Poll
+from tournesol.tests.factories.entity import VideoFactory
+
+
+class RandomRecommendationTestCase(TestCase):
+    """
+    TestCase of the RandomRecommendationList view.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.poll = Poll.default_poll()
+        self.url_path = "/polls/videos/recommendations/random/"
+
+        self.video_1 = VideoFactory(
+            metadata__name="unsafe",
+            metadata__publication_date="2021-01-01",
+            metadata__uploader="_test_uploader_1",
+            metadata__language="es",
+            tournesol_score=-1,
+            make_safe_for_poll=False,
+        )
+        self.video_2 = VideoFactory(
+            metadata__name="safe__22",
+            metadata__publication_date="2021-01-02",
+            metadata__uploader="_test_uploader_2",
+            metadata__language="fr",
+            metadata__duration=10,
+            tournesol_score=22,
+            make_safe_for_poll=False,
+        )
+        self.video_3 = VideoFactory(
+            metadata__name="safe__33",
+            metadata__publication_date="2021-01-03",
+            metadata__uploader="_test_uploader_2",
+            metadata__language="pt",
+            metadata__duration=120,
+            tournesol_score=33,
+            make_safe_for_poll=False,
+        )
+        self.video_4 = VideoFactory(
+            metadata__name="safe__44",
+            metadata__publication_date="2021-01-04",
+            metadata__uploader="_test_uploader_3",
+            metadata__language="it",
+            metadata__duration=240,
+            tournesol_score=44,
+            make_safe_for_poll=False,
+        )
+
+    def test_anon_can_list(self):
+        resp = self.client.get(self.url_path)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        results = resp.data["results"]
+        self.assertEqual(len(results), 3)
+
+        uids = [res["entity"]["uid"] for res in results]
+
+        self.assertNotIn(self.video_1.uid, uids)
+        self.assertIn(self.video_2.uid, uids)
+        self.assertIn(self.video_3.uid, uids)
+        self.assertIn(self.video_4.uid, uids)
+
+        for result in results:
+            self.assertEqual(result["entity_contexts"], [])
+
+    def test_list_is_poll_specific(self):
+        resp = self.client.get(f"{self.url_path}?random=1")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(resp.data["results"]), 3)
+
+        other_poll = Poll.objects.create(name="other")
+        video_5 = VideoFactory.create(make_safe_for_poll=other_poll)
+
+        resp = self.client.get(f"{self.url_path}?random=2")
+        results = resp.data["results"]
+        uids = [res["entity"]["uid"] for res in results]
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 3)
+        self.assertNotIn(video_5.uid, uids)
+
+    def test_anon_can_list_with_limit(self):
+        """
+        An anonymous user can limit the size of the results by using the
+        `limit` query parameter.
+        """
+        resp = self.client.get(f"{self.url_path}?limit=1")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(resp.data["results"]), 1)
+
+    def test_anon_can_list_videos_filtered_by_metadata(self):
+        """
+        Anonymous users can filter the recommended videos using a single
+        value filter.
+        """
+        resp = self.client.get(f"{self.url_path}?metadata[uploader]=_test_uploader_3")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(resp.data["results"]), 1)
+        self.assertEqual(resp.data["results"][0]["entity"]["uid"], self.video_4.uid)
+
+        # filtering by an unknown upload must return an empty list
+        resp = self.client.get(f"{self.url_path}?metadata[uploader]=unknown_uploader")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["count"], 0)
+        self.assertEqual(resp.data["results"], [])
+
+    def test_anon_can_list_videos_filtered_by_pub_date(self):
+        """
+        Anonymous users can filter the recommended videos using a single
+        value filter.
+        """
+        resp = self.client.get(f"{self.url_path}?date_lte=2021-01-02")
+        results = resp.data["results"]
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["entity"]["uid"], self.video_2.uid)
+
+        resp = self.client.get(f"{self.url_path}?date_lte=2021-01-03")
+        results = resp.data["results"]
+        uids = [res["entity"]["uid"] for res in results]
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 2)
+        self.assertIn(self.video_2.uid, uids)
+        self.assertIn(self.video_3.uid, uids)
+
+        resp = self.client.get(f"{self.url_path}?date_gte=2021-01-01")
+        results = resp.data["results"]
+        uids = [res["entity"]["uid"] for res in results]
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(results), 3)
+        self.assertIn(self.video_2.uid, uids)
+        self.assertIn(self.video_3.uid, uids)
+        self.assertIn(self.video_4.uid, uids)

--- a/backend/tournesol/urls.py
+++ b/backend/tournesol/urls.py
@@ -28,6 +28,7 @@ from .views.polls import (
     PollsRecommendationsView,
     PollsView,
 )
+from .views.polls_reco_random import RandomRecommendationList
 from .views.previews import (
     DynamicWebsitePreviewComparison,
     DynamicWebsitePreviewDefault,
@@ -195,6 +196,11 @@ urlpatterns = [
         "polls/<str:name>/recommendations/",
         PollsRecommendationsView.as_view(),
         name="polls_recommendations",
+    ),
+    path(
+        "polls/<str:name>/recommendations/random/",
+        RandomRecommendationList.as_view(),
+        name="polls_recommendations_random",
     ),
     path(
         "polls/<str:name>/entities/<str:uid>",

--- a/backend/tournesol/utils/constants.py
+++ b/backend/tournesol/utils/constants.py
@@ -18,4 +18,5 @@ MEHESTAN_MAX_SCALED_SCORE = 100.0
 COMPARISON_MAX = 10.0
 
 # Default weight for a criteria in the recommendations
+# FIXME: the default weight used by the front end is 50, not 10
 CRITERIA_DEFAULT_WEIGHT = 10

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -183,6 +183,9 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
             If set to 0, total_score is ignored.
             Set it to a higher value to take more into account the total score.
         """
+        if filters["random"]:
+            return queryset.order_by("?")
+
         if filters["search"] and self.poll_from_url.algorithm == ALGORITHM_MEHESTAN:
             max_absolute_score = MEHESTAN_MAX_SCALED_SCORE * self._weights_sum
             if max_absolute_score > 0:

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -298,6 +298,13 @@ class PollsRecommendationsView(PollRecommendationsBaseAPIView):
         criteria_weight = self._build_criteria_weight_condition(
             request, poll, when="all_criteria_scores__criteria"
         )
+
+        # FIXME: we can significantly improve the performance of the queryset
+        # by filtering the criteria on their names, to remove those that are
+        # not present in the request.
+        #
+        #   ex:
+        #       all_criteria_scores__criteria__in=[...]
         queryset = queryset.filter(
             all_criteria_scores__poll=poll,
             all_criteria_scores__score_mode=score_mode,

--- a/backend/tournesol/views/polls.py
+++ b/backend/tournesol/views/polls.py
@@ -183,9 +183,6 @@ class PollRecommendationsBaseAPIView(PollScopedViewMixin, ListAPIView):
             If set to 0, total_score is ignored.
             Set it to a higher value to take more into account the total score.
         """
-        if filters["random"]:
-            return queryset.order_by("?")
-
         if filters["search"] and self.poll_from_url.algorithm == ALGORITHM_MEHESTAN:
             max_absolute_score = MEHESTAN_MAX_SCALED_SCORE * self._weights_sum
             if max_absolute_score > 0:

--- a/backend/tournesol/views/polls_reco_random.py
+++ b/backend/tournesol/views/polls_reco_random.py
@@ -10,7 +10,7 @@ from drf_spectacular.utils import (
 
 from tournesol.models import Entity
 from tournesol.serializers.poll import (
-    RecommendationRandomSerializer,
+    RecommendationBaseSerializer,
     RecommendationsRandomFilterSerializer,
 )
 from tournesol.utils.cache import cache_page_no_i18n
@@ -77,7 +77,7 @@ class RandomRecommendationList(RandomRecommendationBaseAPIView):
     """
 
     permission_classes = []
-    serializer_class = RecommendationRandomSerializer
+    serializer_class = RecommendationBaseSerializer
     poll_parameter = "name"
 
     @method_decorator(cache_page_no_i18n(60 * 10))

--- a/backend/tournesol/views/polls_reco_random.py
+++ b/backend/tournesol/views/polls_reco_random.py
@@ -1,0 +1,81 @@
+from django.utils.decorators import method_decorator
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    extend_schema,
+    extend_schema_view,
+)
+
+from tournesol.models import Entity
+from tournesol.serializers.entity import EntityNoExtraFieldSerializer
+from tournesol.serializers.poll import RecommendationsRandomFilterSerializer
+from tournesol.utils.cache import cache_page_no_i18n
+from tournesol.views import PollRecommendationsBaseAPIView
+
+
+class RandomRecommendationBaseAPIView(PollRecommendationsBaseAPIView):
+    def get_queryset(self):
+        """
+        Return a queryset of random recommended entities.
+
+        This queryset is designed to be more performant than the queryset
+        of the regular recommendations view. For this reason, it doesn't allow
+        to:
+            - filter entities by text
+            - filter entities by weighted criteria score
+            - or anything involving a SQL JOIN on EntityCriteriaScore
+        """
+        poll = self.poll_from_url
+        queryset = Entity.objects.all()
+        queryset, _ = self.filter_by_parameters(self.request, queryset, poll)
+        queryset = queryset.with_prefetched_poll_ratings(poll_name=poll.name)
+        queryset = queryset.filter_safe_for_poll(poll)
+        queryset = queryset.order_by("?")
+        return queryset
+
+
+@extend_schema_view(
+    get=extend_schema(
+        parameters=[
+            RecommendationsRandomFilterSerializer,
+            OpenApiParameter(
+                "metadata",
+                OpenApiTypes.OBJECT,
+                style="deepObject",
+                description="Filter by one or more metadata.",
+                examples=[
+                    OpenApiExample(
+                        name="No metadata filter",
+                    ),
+                    OpenApiExample(
+                        name="Videos - some examples",
+                        value={"language": ["en", "pt"], "uploader": "Kurzgesagt – In a Nutshell"},
+                    ),
+                    OpenApiExample(
+                        name="Videos - videos of 8 minutes or less (480 sec)",
+                        value={"duration:lte:int": "480"},
+                    ),
+                    OpenApiExample(
+                        name="Candidates - some examples",
+                        value={
+                            "name": "A candidate full name",
+                            "youtube_channel_id": "channel ID",
+                        },
+                    ),
+                ],
+            ),
+        ],
+    )
+)
+class RandomRecommendationList(RandomRecommendationBaseAPIView):
+    """
+    Return a random list of recommended entities.
+    """
+    permission_classes = []
+    serializer_class = EntityNoExtraFieldSerializer
+    poll_parameter = "name"
+
+    @method_decorator(cache_page_no_i18n(60 * 10))  # 10 minutes cache
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)

--- a/backend/tournesol/views/polls_reco_random.py
+++ b/backend/tournesol/views/polls_reco_random.py
@@ -1,4 +1,3 @@
-from django.utils.cache import patch_vary_headers
 from django.utils.decorators import method_decorator
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (

--- a/backend/tournesol/views/polls_reco_random.py
+++ b/backend/tournesol/views/polls_reco_random.py
@@ -18,6 +18,8 @@ from tournesol.views import PollRecommendationsBaseAPIView
 
 
 class RandomRecommendationBaseAPIView(PollRecommendationsBaseAPIView):
+    query_params_serializer = RecommendationsRandomFilterSerializer
+
     def get_queryset(self):
         """
         Return a queryset of random recommended entities.
@@ -82,7 +84,4 @@ class RandomRecommendationList(RandomRecommendationBaseAPIView):
 
     @method_decorator(cache_page_no_i18n(60 * 10))
     def get(self, request, *args, **kwargs):
-        response = self.list(self, request, *args, **kwargs)
-        if request.query_params.get("exclude_compared_entities") == "true":
-            patch_vary_headers(response, ["Authorization"])
-        return response
+        return self.list(self, request, *args, **kwargs)

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -14,7 +14,7 @@ import { frontendHost } from './config.js';
 
 const RECENT_VIDEOS_RATIO = 0.75;
 const RECENT_VIDEOS_EXTRA_RATIO = 0.5;
-const BUNDLE_SIZE_F = 3;
+const BUNDLE_OVERFETCH_FACTOR = 3;
 
 /**
  * Build the extension context menu.
@@ -208,14 +208,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
         const recentParams = new URLSearchParams([
           ['date_gte', threeWeeksAgo],
-          ['limit', (recentToLoadRow1 + recentToLoadExtra) * BUNDLE_SIZE_F],
-          ['random', request.queryParamRandom],
+          [
+            'limit',
+            (recentToLoadRow1 + recentToLoadExtra) * BUNDLE_OVERFETCH_FACTOR,
+          ],
+          ['bundle', request.queryParamBundle],
         ]);
 
         const oldParams = new URLSearchParams([
           ['date_lte', threeWeeksAgo],
-          ['limit', (oldToLoadRow1 + oldToLoadExtra) * BUNDLE_SIZE_F],
-          ['random', request.queryParamRandom],
+          ['limit', (oldToLoadRow1 + oldToLoadExtra) * BUNDLE_OVERFETCH_FACTOR],
+          ['bundle', request.queryParamBundle],
         ]);
 
         recommendationsLangs.forEach((lang) => {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -174,9 +174,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   ) {
     const poll_name = 'videos';
 
-    const api_path = `polls/${poll_name}/recommendations/`;
-
-    const request_recommendations = async (options) => {
+    const request_recommendations = async (api_path, options) => {
       const resp = await fetchTournesolApi(
         `${api_path}${options ? '?' : ''}${options}`
       );
@@ -188,6 +186,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     };
 
     if (request.message === 'getTournesolRecommendations') {
+      const api_path = `polls/${poll_name}/recommendations/random/`;
+
       const nbrPerRow = request.videosNumber;
       const extraNbr = request.additionalVideosNumber;
 
@@ -226,8 +226,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         });
 
         const [poolRecent, poolOld] = await Promise.all([
-          request_recommendations(recentParams),
-          request_recommendations(oldParams),
+          request_recommendations(api_path, recentParams),
+          request_recommendations(api_path, oldParams),
         ]);
 
         const videosRecent = poolRecent.slice(0, recentToLoadRow1);
@@ -286,6 +286,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       return true;
     } else if (request.message === 'getTournesolSearchRecommendations') {
       const process = async () => {
+        const api_path = `polls/${poll_name}/recommendations/`;
+
         const videosNumber = request.videosNumber;
         const recommendationsLangs =
           await getRecommendationsLanguagesAuthenticated();
@@ -305,7 +307,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         });
 
         const [videosList] = await Promise.all([
-          request_recommendations(params),
+          request_recommendations(api_path, params),
         ]);
 
         return {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -204,13 +204,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         const recentParams = new URLSearchParams([
           ['date_gte', threeWeeksAgo],
           ['limit', recentToLoadRow1 + recentToLoadExtra],
-          ['random', 1],
+          ['random', request.queryParamRandom],
         ]);
 
         const oldParams = new URLSearchParams([
           ['date_lte', threeWeeksAgo],
           ['limit', oldToLoadRow1 + oldToLoadExtra],
-          ['random', 1],
+          ['random', request.queryParamRandom],
         ]);
 
         recommendationsLangs.forEach((lang) => {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -12,8 +12,9 @@ import {
 
 import { frontendHost } from './config.js';
 
-const recentVideoRatio = 0.75;
-const recentVideoExtraRatio = 0.5;
+const RECENT_VIDEOS_RATIO = 0.75;
+const RECENT_VIDEOS_EXTRA_RATIO = 0.5;
+const BUNDLE_SIZE_F = 3;
 
 /**
  * Build the extension context menu.
@@ -190,11 +191,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       const nbrPerRow = request.videosNumber;
       const extraNbr = request.additionalVideosNumber;
 
-      const recentToLoadRow1 = Math.round(nbrPerRow * recentVideoRatio);
-      const oldToLoadRow1 = Math.round(nbrPerRow * (1 - recentVideoRatio));
+      const recentToLoadRow1 = Math.round(nbrPerRow * RECENT_VIDEOS_RATIO);
+      const oldToLoadRow1 = Math.round(nbrPerRow * (1 - RECENT_VIDEOS_RATIO));
 
-      const recentToLoadExtra = Math.round(extraNbr * recentVideoExtraRatio);
-      const oldToLoadExtra = Math.round(extraNbr * (1 - recentVideoExtraRatio));
+      const recentToLoadExtra = Math.round(
+        extraNbr * RECENT_VIDEOS_EXTRA_RATIO
+      );
+      const oldToLoadExtra = Math.round(
+        extraNbr * (1 - RECENT_VIDEOS_EXTRA_RATIO)
+      );
 
       const process = async () => {
         const threeWeeksAgo = getDateThreeWeeksAgo();
@@ -203,13 +208,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
         const recentParams = new URLSearchParams([
           ['date_gte', threeWeeksAgo],
-          ['limit', recentToLoadRow1 + recentToLoadExtra],
+          ['limit', (recentToLoadRow1 + recentToLoadExtra) * BUNDLE_SIZE_F],
           ['random', request.queryParamRandom],
         ]);
 
         const oldParams = new URLSearchParams([
           ['date_lte', threeWeeksAgo],
-          ['limit', oldToLoadRow1 + oldToLoadExtra],
+          ['limit', (oldToLoadRow1 + oldToLoadExtra) * BUNDLE_SIZE_F],
           ['random', request.queryParamRandom],
         ]);
 
@@ -232,14 +237,14 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
         // Compute the actual number of videos from each category that will appear in the feed.
         // If there is not enough recent videos, use old ones of the same category instead.
-        let recentRow1Nbr = Math.round(nbrPerRow * recentVideoRatio);
+        let recentRow1Nbr = Math.round(nbrPerRow * RECENT_VIDEOS_RATIO);
         if (recentRow1Nbr > videosRecent.length) {
           recentRow1Nbr = videosRecent.length;
         }
 
         const oldRow1Nbr = nbrPerRow - recentRow1Nbr;
 
-        let recentExtraNbr = Math.round(extraNbr * recentVideoExtraRatio);
+        let recentExtraNbr = Math.round(extraNbr * RECENT_VIDEOS_EXTRA_RATIO);
         if (recentExtraNbr > videosRecentExtra.length) {
           recentExtraNbr = videosRecentExtra.length;
         }

--- a/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
+++ b/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
@@ -35,18 +35,18 @@ export class TournesolRecommendations {
    *
    * A random number prevents the users from seeing the same cached
    * recommendation results each time they refresh the YT page. Be careful,
-   * increasing the range of generated numbers will also increase the number
-   * of cached results by the API.
+   * increasing the range of generated numbers will also increase the
+   * theoretical maximum number of cached results by the API.
    *
-   * 20 means if 1000 users press F5 at the same time, at most 20 results will
-   * be cached.
+   * 20 means if 1000 users press F5 at the same time, at most 40 results will
+   * be cached (20 for recent reco. and 20 for older reco.).
    */
   initializeQueryParamRandom() {
     return this.getRandomInt(20);
   }
 
   varyQueryParamRandom() {
-    this.queryParamRandom += 1 + this.getRandomInt(3);
+    this.queryParamRandom += 1 + this.getRandomInt(2);
     return this.queryParamRandom;
   }
 

--- a/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
+++ b/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
@@ -20,10 +20,10 @@ export class TournesolRecommendations {
     this.handleResponse = this.handleResponse.bind(this);
     this.displayRecommendations = this.displayRecommendations.bind(this);
 
-    // The value of the query parameter `random` of the API /recommendations/.
+    // The value of the query parameter `bundle` of the API /recommendations/.
     // Vary this paramater from a request to another to avoid fetching the
     // same cached recommendation results.
-    this.queryParamRandom = this.initializeQueryParamRandom();
+    this.queryParamBundle = this.initializeQueryParamBundle();
   }
 
   getRandomInt(max) {
@@ -31,7 +31,7 @@ export class TournesolRecommendations {
   }
 
   /**
-   * Initialize `queryParamRandom` with a random number.
+   * Initialize `queryParamBundle` with a random number.
    *
    * A random number prevents the users from seeing the same cached
    * recommendation results each time they refresh the YT page. Be careful,
@@ -41,13 +41,13 @@ export class TournesolRecommendations {
    * 20 means if 1000 users press F5 at the same time, at most 40 results will
    * be cached (20 for recent reco. and 20 for older reco.).
    */
-  initializeQueryParamRandom() {
+  initializeQueryParamBundle() {
     return this.getRandomInt(20);
   }
 
-  varyQueryParamRandom() {
-    this.queryParamRandom += 1 + this.getRandomInt(2);
-    return this.queryParamRandom;
+  varyQueryParamBundle() {
+    this.queryParamBundle += 1 + this.getRandomInt(2);
+    return this.queryParamBundle;
   }
 
   /**
@@ -132,7 +132,7 @@ export class TournesolRecommendations {
         message: 'getTournesolRecommendations',
         videosNumber: this.videosPerRow,
         additionalVideosNumber: this.videosPerRow * (this.rowsWhenExpanded - 1),
-        queryParamRandom: this.varyQueryParamRandom(),
+        queryParamBundle: this.varyQueryParamBundle(),
       },
       this.handleResponse
     );

--- a/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
+++ b/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
@@ -20,7 +20,7 @@ export class TournesolRecommendations {
     this.handleResponse = this.handleResponse.bind(this);
     this.displayRecommendations = this.displayRecommendations.bind(this);
 
-    // The value of the query parameter `random` of the /recommendations/ API.
+    // The value of the query parameter `random` of the API /recommendations/.
     // Vary this paramater from a request to another to avoid fetching the
     // same cached recommendation results.
     this.queryParamRandom = this.initializeQueryParamRandom();

--- a/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
+++ b/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
@@ -19,6 +19,35 @@ export class TournesolRecommendations {
 
     this.handleResponse = this.handleResponse.bind(this);
     this.displayRecommendations = this.displayRecommendations.bind(this);
+
+    // The value of the query parameter `random` of the /recommendations/ API.
+    // Vary this paramater from a request to another to avoid fetching the
+    // same cached recommendation results.
+    this.queryParamRandom = this.initializeQueryParamRandom();
+  }
+
+  getRandomInt(max) {
+    return Math.floor(Math.random() * max);
+  }
+
+  /**
+   * Initialize `queryParamRandom` with a random number.
+   *
+   * A random number prevents the users from seeing the same cached
+   * recommendation results each time they refresh the YT page. Be careful,
+   * increasing the range of generated numbers will also increase the number
+   * of cached results by the API.
+   *
+   * 20 means if 1000 users press F5 at the same time, at most 20 results will
+   * be cached.
+   */
+  initializeQueryParamRandom() {
+    return this.getRandomInt(20);
+  }
+
+  varyQueryParamRandom() {
+    this.queryParamRandom += 1 + this.getRandomInt(3);
+    return this.queryParamRandom;
   }
 
   /**
@@ -103,6 +132,7 @@ export class TournesolRecommendations {
         message: 'getTournesolRecommendations',
         videosNumber: this.videosPerRow,
         additionalVideosNumber: this.videosPerRow * (this.rowsWhenExpanded - 1),
+        queryParamRandom: this.varyQueryParamRandom(),
       },
       this.handleResponse
     );

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -749,6 +749,82 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedRecommendationList'
           description: ''
+  /polls/{name}/recommendations/random/:
+    get:
+      operationId: polls_recommendations_random_list
+      description: Return a random list of recommended entities.
+      parameters:
+      - in: path
+        name: name
+        schema:
+          type: string
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: random
+        schema:
+          type: integer
+        description: Successive calls can return the same cached results. Vary this
+          parameter to request new results.
+      - in: query
+        name: date_lte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: date_gte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: metadata
+        schema:
+          type: object
+          additionalProperties: {}
+        description: Filter by one or more metadata.
+        style: deepObject
+        examples:
+          NoMetadataFilter:
+            summary: No metadata filter
+          Videos-SomeExamples:
+            value:
+              language:
+              - en
+              - pt
+              uploader: Kurzgesagt – In a Nutshell
+            summary: Videos - some examples
+          Videos-VideosOf8MinutesOrLess(480Sec):
+            value:
+              duration:lte:int: '480'
+            summary: Videos - videos of 8 minutes or less (480 sec)
+          Candidates-SomeExamples:
+            value:
+              name: A candidate full name
+              youtube_channel_id: channel ID
+            summary: Candidates - some examples
+      tags:
+      - polls
+      security:
+      - oauth2:
+        - read write groups
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRecommendationBaseList'
+          description: ''
   /preview/.:
     get:
       operationId: preview_._retrieve
@@ -2955,16 +3031,16 @@ components:
           allOf:
           - $ref: '#/components/schemas/RelatedEntity'
           readOnly: true
-        collective_rating:
-          allOf:
-          - $ref: '#/components/schemas/ExtendedCollectiveRating'
-          readOnly: true
-          nullable: true
         entity_contexts:
           type: array
           items:
             $ref: '#/components/schemas/EntityContext'
           readOnly: true
+        collective_rating:
+          allOf:
+          - $ref: '#/components/schemas/ExtendedCollectiveRating'
+          readOnly: true
+          nullable: true
         recommendation_metadata:
           allOf:
           - $ref: '#/components/schemas/RecommendationMetadata'
@@ -3620,6 +3696,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RateLater'
+    PaginatedRecommendationBaseList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecommendationBase'
     PaginatedRecommendationList:
       type: object
       properties:
@@ -3890,21 +3986,22 @@ components:
         * `moderation_by_contributors` - moderation_by_contributors
     Recommendation:
       type: object
+      description: An entity recommended in a poll.
       properties:
         entity:
           allOf:
           - $ref: '#/components/schemas/RelatedEntity'
+          readOnly: true
+        entity_contexts:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityContext'
           readOnly: true
         collective_rating:
           allOf:
           - $ref: '#/components/schemas/ExtendedCollectiveRating'
           readOnly: true
           nullable: true
-        entity_contexts:
-          type: array
-          items:
-            $ref: '#/components/schemas/EntityContext'
-          readOnly: true
         recommendation_metadata:
           allOf:
           - $ref: '#/components/schemas/RecommendationMetadata'
@@ -3914,6 +4011,32 @@ components:
       - entity
       - entity_contexts
       - recommendation_metadata
+    RecommendationBase:
+      type: object
+      description: |-
+        A base serializer for all recommendations.
+
+        The recommendations of a poll should always be provided with
+        the fields defined in this serializer.
+      properties:
+        entity:
+          allOf:
+          - $ref: '#/components/schemas/RelatedEntity'
+          readOnly: true
+        entity_contexts:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityContext'
+          readOnly: true
+        collective_rating:
+          allOf:
+          - $ref: '#/components/schemas/ExtendedCollectiveRating'
+          readOnly: true
+          nullable: true
+      required:
+      - collective_rating
+      - entity
+      - entity_contexts
     RecommendationMetadata:
       type: object
       properties:

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -772,7 +772,7 @@ paths:
         schema:
           type: integer
       - in: query
-        name: random
+        name: bundle
         schema:
           type: integer
         description: Successive calls can return the same cached results. Vary this


### PR DESCRIPTION
### Description

This PR adds two features:

**(1)** A new API `polls/{name}/recommendations/random/` that returns random recommendations, designed to be more efficient than the regular recommendations route.

**(2)** The browser extension now uses this new API to improve the loading time of recommendations and their diversity.

**context**

This PR aims to reduce the number of latency alerts triggered by the API recommendations, by providing API clients, such as the browser extension, an alternative and efficient way to request random recommended entities.

Those latency alerts are currently triggered by the browser extension, when fetching the top 250 of all time recommendations to perform a random selection. Thanks to the new API, the extension doesn't need to fetch a big amount of entities to display a diverse bundle of entities.

Note that the new API is more efficient because it uses a simple SQL query that provides less features than the regular recommendations route:
- no search by text
- no search by weighted criteria score
- not possible to return unsafe recommendations

ℹ️ **consequences and important changes**

This PR significantly changes the strategy used by browser extension to display diverse entities.

(a) Before, only the top 250 of all time recommendations could be displayed. Now all recommended videos have a chance to be displayed, even those with a Tournesol score of 20.1, like on the web site.

(b) The number of cached recommendation results requested by the extension will increase from 2 every 10 minutes (for a given set of languages) to ~ 40, up to a lot more depending on how many time the users refresh their recommendations with the extension refresh button. This may impact our infrastructure.

**to-do**

*back end - /recommendations/*
- [x] remove the random logic

*back end - /recommendations/random/*
- [x] add a /recommendations/random/ view
- [x] create a new serializer
  - and the `random` parameter in the metadata?
- [x] document the view
- [x] test the view

*extension*
- [x] request random recommendations
  - should the recommendation be in the top X ?
- [x] randomly initialize the query parameter `random` for each instance of `TournesolRecommendations`
- [x] make the query parameter `random` vary for each refresh
- [x] increase the `limit` parameters for more randomness
  - actually 5 for old videos
  - actually 7 for new videos
- [x] connect the extension to the new route

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
