### PR TITLE
[back] fix: API /reco./random/ now prefetches criteria scores

### DIFF
--- a/backend/tournesol/views/polls_reco_random.py
+++ b/backend/tournesol/views/polls_reco_random.py
@@ -33,6 +33,7 @@ class RandomRecommendationBaseAPIView(PollRecommendationsBaseAPIView):
         poll = self.poll_from_url
         queryset = Entity.objects.all()
         queryset, _ = self.filter_by_parameters(self.request, queryset, poll)
+        queryset = queryset.with_prefetched_scores(poll_name=poll.name)
         queryset = queryset.with_prefetched_poll_ratings(poll_name=poll.name)
         queryset = queryset.filter_safe_for_poll(poll)
         queryset = queryset.order_by("?")


### PR DESCRIPTION
### Description

The API /recommendations/random/ was triggering one SQL query per entity to retrieve the related criteria scores. This was caused by the field `criteria_scores` of the serializer `ExtendedCollectiveRatingSerializer`.

Now only one request is made to retrieve all criteria scores.

Note that if the extension doesn't use the criteria scores to display the recommendations, we could remove the criteria scores from the request. This will save one SQL query (nevertheless this request seems to be extremely fast on production). 

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
