### PR TITLE
[front] fix: video metadata not wrapped correctly in EntityCard on Safari

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -160,6 +160,7 @@ const EntityCard = ({
             data-testid="video-card-info"
             container
             direction="column"
+            flexWrap="nowrap"
           >
             <EntityCardTitle
               uid={entity.uid}

--- a/frontend/src/features/goals/CollectiveGoalWeeklyProgress.tsx
+++ b/frontend/src/features/goals/CollectiveGoalWeeklyProgress.tsx
@@ -33,7 +33,7 @@ const CollectiveGoalWeeklyProgress = () => {
       gap={1}
       mb={4}
     >
-      <Typography variant="h6">
+      <Typography variant="h6" textAlign="center">
         <Trans
           t={t}
           i18nKey="collectiveGoalWeeklyProgress.weeklyCollectiveGoal"
@@ -45,7 +45,8 @@ const CollectiveGoalWeeklyProgress = () => {
           }}
           %
         </Trans>
-        {` ${getWeeklyProgressionEmoji(collectiveComparisonsPercent)}`}
+        &nbsp;
+        {`${getWeeklyProgressionEmoji(collectiveComparisonsPercent)}`}
       </Typography>
       <Box
         width="100%"


### PR DESCRIPTION
### Description

Two small changes visible on Safari and/or on small screens

|Before|After|
|--|--|
|![IMG_0034](https://github.com/tournesol-app/tournesol/assets/4726554/10711616-8e2b-4b66-8da1-1bd1a105c0c7)|![IMG_0033](https://github.com/tournesol-app/tournesol/assets/4726554/e24b4a95-2c22-4477-9696-6091c278f994)



### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
