### PR TITLE
[front] feat: add menu item and banner to trigger pwa installation prompt

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -300,6 +300,7 @@
     "FAQAriaLabel": "Link to the FAQ page",
     "about": "About",
     "aboutAriaLabel": "Link to the about page",
+    "installTheApp": "Install the app",
     "donate": "Donate"
   },
   "frame": {
@@ -320,6 +321,11 @@
     "vouching": "Vouch for other users"
   },
   "logoutButton": "Logout",
+  "pwaBanner": {
+    "message": "By installing the Tournesol app, you can effortlessly compare the videos you watch and share them seamlessly from other applications like YouTube.",
+    "ignore": "Ignore",
+    "install": "Install"
+  },
   "topbar": {
     "search": "Search"
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -306,6 +306,7 @@
     "FAQAriaLabel": "Lien vers la page FAQ",
     "about": "À propos",
     "aboutAriaLabel": "Lien vers la page à propos",
+    "installTheApp": "Installer l'appli",
     "donate": "Faire un don"
   },
   "frame": {
@@ -326,6 +327,11 @@
     "vouching": "Me porter garant"
   },
   "logoutButton": "Se déconnecter",
+  "pwaBanner": {
+    "message": "En installant l'appli Tournesol, vous pourrez plus facilement comparer les vidéos que vous regardez, en les partageant depuis d'autres applications telles que YouTube.",
+    "ignore": "Ignorer",
+    "install": "Installer"
+  },
   "topbar": {
     "search": "Rechercher"
   },

--- a/frontend/src/features/frame/Frame.tsx
+++ b/frontend/src/features/frame/Frame.tsx
@@ -90,6 +90,11 @@ const Frame = ({ children }: Props) => {
   useEffect(() => {
     const handler = (event: BeforeInstallPromptEvent) => {
       setBeforePromptEvent(event);
+      event.userChoice?.then(({ outcome }) => {
+        if (outcome === 'accepted') {
+          setBeforePromptEvent(undefined);
+        }
+      });
     };
     window.addEventListener('beforeinstallprompt', handler);
     return () => {

--- a/frontend/src/features/frame/Frame.tsx
+++ b/frontend/src/features/frame/Frame.tsx
@@ -6,6 +6,7 @@ import TopBar, { topBarHeight } from './components/topbar/TopBar';
 import Footer from './components/footer/Footer';
 import SideBar from './components/sidebar/SideBar';
 import StorageError from './components/StorageError';
+import { BeforeInstallPromptEvent } from './pwaPrompt';
 
 const isEmbedded = Boolean(new URLSearchParams(location.search).get('embed'));
 
@@ -70,6 +71,9 @@ interface Props {
 const Frame = ({ children }: Props) => {
   const classes = useStyles();
   const [hasStorageError, setHasStorageError] = useState(false);
+  const [beforePromptEvent, setBeforePromptEvent] = useState<
+    BeforeInstallPromptEvent | undefined
+  >(undefined);
 
   useEffect(() => {
     const checkStorage = async () => {
@@ -83,11 +87,27 @@ const Frame = ({ children }: Props) => {
     }
   }, []);
 
+  useEffect(() => {
+    const handler = (event: BeforeInstallPromptEvent) => {
+      setBeforePromptEvent(event);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handler);
+    };
+  }, []);
+
   return (
     <>
-      {isEmbedded ? <EmbeddedTopBar /> : <TopBar />}
+      {isEmbedded ? (
+        <EmbeddedTopBar />
+      ) : (
+        <TopBar beforeInstallPromptEvent={beforePromptEvent} />
+      )}
       <div className={clsx({ [classes.sideBarContainer]: !isEmbedded })}>
-        {!isEmbedded && <SideBar />}
+        {!isEmbedded && (
+          <SideBar beforeInstallPromptEvent={beforePromptEvent} />
+        )}
         <main className={classes.main}>
           {hasStorageError ? <StorageError /> : children}
           {!isEmbedded && <Footer />}

--- a/frontend/src/features/frame/components/sidebar/SideBar.tsx
+++ b/frontend/src/features/frame/components/sidebar/SideBar.tsx
@@ -12,6 +12,7 @@ import {
   Theme,
   Divider,
   Tooltip,
+  Avatar,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
@@ -44,6 +45,7 @@ import { RouteID } from 'src/utils/types';
 import { getDefaultRecommendationsSearchParams } from 'src/utils/userSettings';
 
 import { closeDrawer } from '../../drawerOpenSlice';
+import { BeforeInstallPromptEvent } from '../../pwaPrompt';
 
 export const sideBarWidth = 264;
 
@@ -87,21 +89,16 @@ const useStyles = makeStyles((theme: Theme) => ({
       minWidth: `${sideBarWidth}px`,
     },
   },
-  listItemIcon: {
-    color: '#CDCABC',
-  },
   listItemIconSelected: {
     color: theme.palette.neutral.dark,
   },
-  listItemText: {
-    fontWeight: 'bold',
-    '&:first-letter': {
-      textTransform: 'capitalize',
-    },
-  },
 }));
 
-const SideBar = () => {
+interface Props {
+  beforeInstallPromptEvent?: BeforeInstallPromptEvent;
+}
+
+const SideBar = ({ beforeInstallPromptEvent }: Props) => {
   const classes = useStyles();
   const theme = useTheme();
 
@@ -215,7 +212,23 @@ const SideBar = () => {
       <List
         disablePadding
         onClick={isSmallScreen ? () => dispatch(closeDrawer()) : undefined}
-        sx={{ flexGrow: 1, wordBreak: 'break-word' }}
+        sx={{
+          flexGrow: 1,
+          wordBreak: 'break-word',
+          '& > .MuiListItemButton-root': {
+            minHeight: '56px',
+          },
+          '& .MuiListItemIcon-root': {
+            color: theme.palette.grey[400],
+            minWidth: '40px',
+          },
+          '& .MuiListItemText-primary': {
+            fontWeight: 'bold',
+            '&:first-letter': {
+              textTransform: 'capitalize',
+            },
+          },
+        }}
       >
         {menuItems.map(
           ({ id, targetUrl, IconComponent, displayText, ariaLabel }) => {
@@ -234,7 +247,6 @@ const SideBar = () => {
                 component={Link}
                 to={targetUrl}
                 sx={{
-                  minHeight: '56px',
                   '&.Mui-selected': {
                     bgcolor: 'action.selected',
                   },
@@ -248,22 +260,35 @@ const SideBar = () => {
                   placement="right"
                   arrow
                 >
-                  <ListItemIcon sx={{ minWidth: '40px' }}>
+                  <ListItemIcon>
                     <IconComponent
                       className={clsx({
-                        [classes.listItemIcon]: !selected,
                         [classes.listItemIconSelected]: selected,
                       })}
                     />
                   </ListItemIcon>
                 </Tooltip>
-                <ListItemText
-                  primary={displayText}
-                  primaryTypographyProps={{ className: classes.listItemText }}
-                />
+                <ListItemText primary={displayText} />
               </ListItemButton>
             );
           }
+        )}
+        {beforeInstallPromptEvent && (
+          <>
+            <Divider />
+            <ListItemButton onClick={() => beforeInstallPromptEvent.prompt()}>
+              <ListItemIcon>
+                <Avatar
+                  src="/icons/maskable-icon-512x512.png"
+                  sx={{ width: '24px', height: '24px' }}
+                />
+              </ListItemIcon>
+              <ListItemText
+                primary={t('menu.installTheApp')}
+                primaryTypographyProps={{ color: theme.palette.neutral.dark }}
+              />
+            </ListItemButton>
+          </>
         )}
       </List>
       <Divider />

--- a/frontend/src/features/frame/components/topbar/PwaBanner.tsx
+++ b/frontend/src/features/frame/components/topbar/PwaBanner.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { BeforeInstallPromptEvent } from '../../pwaPrompt';
+import { Avatar, Button, Grid, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+const pwaBannerIgnoredKey = 'pwaBannerIgnoredAt';
+
+const hasPwaBannerBeenIgnored = () => {
+  try {
+    const value = localStorage.getItem(pwaBannerIgnoredKey);
+    return value != null;
+  } catch {
+    return true;
+  }
+};
+
+interface Props {
+  beforeInstallPromptEvent?: BeforeInstallPromptEvent;
+}
+
+const PwaBanner = ({ beforeInstallPromptEvent }: Props) => {
+  const { t } = useTranslation();
+  const [pwaBannerIgnored, setPwaBannerIgnored] = useState(
+    hasPwaBannerBeenIgnored
+  );
+
+  if (!beforeInstallPromptEvent || pwaBannerIgnored) {
+    return null;
+  }
+
+  return (
+    <Grid
+      container
+      p={2}
+      sx={(theme) => ({
+        backgroundColor: theme.palette.neutral.light,
+        color: theme.palette.text.primary,
+      })}
+      gap={2}
+      alignItems="center"
+    >
+      <Typography fontWeight="bold" display="flex" gap={1}>
+        <Avatar
+          component="span"
+          src="/icons/maskable-icon-512x512.png"
+          sx={{ width: '48px', height: '48px' }}
+        />
+        {t('pwaBanner.message')}
+      </Typography>
+      <Grid item container justifyContent="right" columnGap={1}>
+        <Button
+          variant="text"
+          color="inherit"
+          onClick={() => {
+            setPwaBannerIgnored(true);
+            localStorage.setItem(pwaBannerIgnoredKey, new Date().toISOString());
+          }}
+        >
+          {t('pwaBanner.ignore')}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => beforeInstallPromptEvent.prompt()}
+        >
+          {t('pwaBanner.install')}
+        </Button>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default PwaBanner;

--- a/frontend/src/features/frame/components/topbar/PwaBanner.tsx
+++ b/frontend/src/features/frame/components/topbar/PwaBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { BeforeInstallPromptEvent } from '../../pwaPrompt';
 import { Avatar, Button, Grid, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
@@ -20,11 +20,19 @@ interface Props {
 
 const PwaBanner = ({ beforeInstallPromptEvent }: Props) => {
   const { t } = useTranslation();
-  const [pwaBannerIgnored, setPwaBannerIgnored] = useState(
-    hasPwaBannerBeenIgnored
+  const [pwaBannerVisible, setPwaBannerVisible] = useState(
+    () => !hasPwaBannerBeenIgnored()
   );
 
-  if (!beforeInstallPromptEvent || pwaBannerIgnored) {
+  useEffect(() => {
+    beforeInstallPromptEvent?.userChoice?.then(({ outcome }) => {
+      if (outcome === 'accepted') {
+        setPwaBannerVisible(false);
+      }
+    });
+  }, [beforeInstallPromptEvent]);
+
+  if (!beforeInstallPromptEvent || !pwaBannerVisible) {
     return null;
   }
 
@@ -52,7 +60,7 @@ const PwaBanner = ({ beforeInstallPromptEvent }: Props) => {
           variant="text"
           color="inherit"
           onClick={() => {
-            setPwaBannerIgnored(true);
+            setPwaBannerVisible(false);
             localStorage.setItem(pwaBannerIgnoredKey, new Date().toISOString());
           }}
         >

--- a/frontend/src/features/frame/components/topbar/PwaBanner.tsx
+++ b/frontend/src/features/frame/components/topbar/PwaBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { BeforeInstallPromptEvent } from '../../pwaPrompt';
 import { Avatar, Button, Grid, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
@@ -23,14 +23,6 @@ const PwaBanner = ({ beforeInstallPromptEvent }: Props) => {
   const [pwaBannerVisible, setPwaBannerVisible] = useState(
     () => !hasPwaBannerBeenIgnored()
   );
-
-  useEffect(() => {
-    beforeInstallPromptEvent?.userChoice?.then(({ outcome }) => {
-      if (outcome === 'accepted') {
-        setPwaBannerVisible(false);
-      }
-    });
-  }, [beforeInstallPromptEvent]);
 
   if (!beforeInstallPromptEvent || !pwaBannerVisible) {
     return null;

--- a/frontend/src/features/frame/components/topbar/TopBar.tsx
+++ b/frontend/src/features/frame/components/topbar/TopBar.tsx
@@ -10,12 +10,18 @@ import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 
 import TopBarDesktop from './TopBarDesktop';
 import TopBarMobile from './TopBarMobile';
+import PwaBanner from './PwaBanner';
+import { BeforeInstallPromptEvent } from '../../pwaPrompt';
 
 // Allow to position contents like the footer relatively to the top of the
 // page.
 export const topBarHeight = 80;
 
-const TopBar = () => {
+interface Props {
+  beforeInstallPromptEvent?: BeforeInstallPromptEvent;
+}
+
+const TopBar = ({ beforeInstallPromptEvent }: Props) => {
   const theme = useTheme();
   const { options } = useCurrentPoll();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
@@ -43,6 +49,9 @@ const TopBar = () => {
           {isSmallScreen ? <TopBarMobile /> : <TopBarDesktop />}
         </Grid>
       </Toolbar>
+      {isSmallScreen && (
+        <PwaBanner beforeInstallPromptEvent={beforeInstallPromptEvent} />
+      )}
     </AppBar>
   );
 };

--- a/frontend/src/features/frame/pwaPrompt.ts
+++ b/frontend/src/features/frame/pwaPrompt.ts
@@ -1,0 +1,14 @@
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{
+    outcome: 'accepted' | 'dismissed';
+    platform: string;
+  }>;
+  prompt(): Promise<void>;
+}
+
+declare global {
+  interface WindowEventMap {
+    beforeinstallprompt: BeforeInstallPromptEvent;
+  }
+}

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -30,6 +30,7 @@ export const theme = responsiveFontSizes(
         main: '#506AD4',
       },
       neutral: {
+        light: '#C6BFA5',
         main: '#A09B87',
         dark: '#806300',
       },


### PR DESCRIPTION
…when the browser supports it. 

---

### Description

When the event `beforeinstallprompt` is triggered, the item "Install the app" is added to the menu, and a banner invites the user to install the app. Clicking on "Install" will display the native installation prompt (with screenshot + app description).

The event `beforeinstallprompt` is triggered by the browser when the app is ready to be installed (based on the [engagement heuristics](https://web.dev/articles/install-criteria#criteria)  implemented by the browser, typically after some activity on the website when the app is not already installed).

If the banner is closed with the button "Ignore", the current date is stored in local storage and the banner will never appear again (unless we want to update that implementation later). The menu item remains visible.

|Sidebar|Banner|
|-|-|
|![screenshot1](https://github.com/tournesol-app/tournesol/assets/4726554/194f7c02-4db1-4658-b9d4-d7c96f92a66d)|![screenshot2](https://github.com/tournesol-app/tournesol/assets/4726554/987ea2b8-9c4b-43e6-89eb-e504300962e4)|


### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
