### PR TITLE
[infra] sec: update tor exits more often (4d instead of 30d)

### DIFF
--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -181,7 +181,7 @@
   - find:
       paths: /etc/nginx/snippets
       patterns: block_tor.conf
-      age: -30d
+      age: -4d
     register: find_snippet
 
   - name: Generate block_tor snippet


### PR DESCRIPTION
### Description

The list of Tor exits can now be updated at least one time per week, every 4 days. 

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
