### PR TITLE
[ext] fix: hide Watch on Tournesol button for anonymous users

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -160,16 +160,24 @@ function addVideoButtons() {
       },
     });
 
-    addVideoButton({
-      id: 'tournseol-watch-button',
-      label: 'Watch on Tournesol',
-      iconSrc: chrome.runtime.getURL('images/watch.svg'),
-      onClick: () => {
-        window.open(
-          `${frontendUrl}/entities/yt:${videoId}?utm_source=extension&utm_medium=video_button`,
-          '_blank'
-        );
-      },
+    // This button doesn't work when: the user is not authenticated, and the
+    // video is not in the database.
+    // See: https://github.com/tournesol-app/tournesol/issues/1904
+    chrome.storage.local.get(['access_token'], (items) => {
+      if (items.access_token) {
+
+        addVideoButton({
+          id: 'tournseol-watch-button',
+          label: 'Watch on Tournesol',
+          iconSrc: chrome.runtime.getURL('images/watch.svg'),
+          onClick: () => {
+            window.open(
+              `${frontendUrl}/entities/yt:${videoId}?utm_source=extension&utm_medium=video_button`,
+              '_blank'
+            );
+          },
+        });
+      }
     });
   }
 }

--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -108,60 +108,11 @@ function addVideoButtons() {
       return { button, setLabel, setIcon };
     };
 
-    addVideoButton({
-      id: 'tournesol-rate-now-button',
-      label: 'Rate Now',
-      iconSrc: chrome.runtime.getURL('images/compare.svg'),
-      onClick: () => {
-        chrome.runtime.sendMessage({
-          message: 'displayModal',
-          modalOptions: {
-            src: `${frontendUrl}/comparison?embed=1&utm_source=extension&utm_medium=frame&uidA=yt%3A${videoId}`,
-            height: '90vh',
-          },
-        });
-      },
-    });
-
-    const {
-      button: rateLaterButton,
-      setLabel: setRateLaterButtonLabel,
-      setIcon: setRateLaterButtonIcon,
-    } = addVideoButton({
-      id: 'tournesol-rate-later-button',
-      label: 'Rate Later',
-      iconSrc: chrome.runtime.getURL('images/add.svg'),
-      iconClass: 'tournesol-rate-later',
-      onClick: () => {
-        rateLaterButton.disabled = true;
-
-        new Promise((resolve, reject) => {
-          chrome.runtime.sendMessage(
-            {
-              message: 'addRateLater',
-              video_id: videoId,
-            },
-            (data) => {
-              if (data.success) {
-                setRateLaterButtonLabel('Done!');
-                setRateLaterButtonIcon(
-                  chrome.runtime.getURL('images/checkmark.svg')
-                );
-                resolve();
-              } else {
-                rateLaterButton.disabled = false;
-                reject();
-              }
-            }
-          );
-        }).catch(() => {
-          chrome.runtime.sendMessage({ message: 'displayModal' });
-        });
-      },
-    });
-
     // This button doesn't work when: the user is not authenticated, and the
     // video is not in the database.
+    //
+    // For now, it is displayed only for authenticated users.
+    //
     // See: https://github.com/tournesol-app/tournesol/issues/1904
     chrome.storage.local.get(['access_token'], (items) => {
       if (items.access_token) {
@@ -177,6 +128,58 @@ function addVideoButtons() {
           },
         });
       }
+
+      addVideoButton({
+        id: 'tournesol-rate-now-button',
+        label: 'Rate Now',
+        iconSrc: chrome.runtime.getURL('images/compare.svg'),
+        onClick: () => {
+          chrome.runtime.sendMessage({
+            message: 'displayModal',
+            modalOptions: {
+              src: `${frontendUrl}/comparison?embed=1&utm_source=extension&utm_medium=frame&uidA=yt%3A${videoId}`,
+              height: '90vh',
+            },
+          });
+        },
+      });
+
+      const {
+        button: rateLaterButton,
+        setLabel: setRateLaterButtonLabel,
+        setIcon: setRateLaterButtonIcon,
+      } = addVideoButton({
+        id: 'tournesol-rate-later-button',
+        label: 'Rate Later',
+        iconSrc: chrome.runtime.getURL('images/add.svg'),
+        iconClass: 'tournesol-rate-later',
+        onClick: () => {
+          rateLaterButton.disabled = true;
+
+          new Promise((resolve, reject) => {
+            chrome.runtime.sendMessage(
+              {
+                message: 'addRateLater',
+                video_id: videoId,
+              },
+              (data) => {
+                if (data.success) {
+                  setRateLaterButtonLabel('Done!');
+                  setRateLaterButtonIcon(
+                    chrome.runtime.getURL('images/checkmark.svg')
+                  );
+                  resolve();
+                } else {
+                  rateLaterButton.disabled = false;
+                  reject();
+                }
+              }
+            );
+          }).catch(() => {
+            chrome.runtime.sendMessage({ message: 'displayModal' });
+          });
+        },
+      });
     });
   }
 }

--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -165,7 +165,6 @@ function addVideoButtons() {
     // See: https://github.com/tournesol-app/tournesol/issues/1904
     chrome.storage.local.get(['access_token'], (items) => {
       if (items.access_token) {
-
         addVideoButton({
           id: 'tournseol-watch-button',
           label: 'Watch on Tournesol',


### PR DESCRIPTION
**related issues** #1904

---

### Description

This PR removes the button Watch on Tournesol from the browser extension for anonymous users.

This is/may be a temporary fix. For now, only authenticated users are allowed to add new videos in the database (and use the YouTube API).

See: https://github.com/tournesol-app/tournesol/issues/1904

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
