### PR TITLE
[ext] style: align banner title style with front end style

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.5.0",
+  "version": "3.5.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -58,6 +58,12 @@
   display: flex;
 }
 
+#tournesol_banner_title {
+  margin-bottom: 8px;
+
+  font-size: 1.06em;
+}
+
 #tournesol_banner p {
   letter-spacing: 0.2px;
 }

--- a/browser-extension/src/models/banner/Banner.js
+++ b/browser-extension/src/models/banner/Banner.js
@@ -98,8 +98,10 @@ export class Banner {
     // The second flex item is the text.
     const bannerTextContainer = document.createElement('div');
     const bannerTitle = document.createElement('h2');
+    bannerTitle.id = 'tournesol_banner_title';
     bannerTitle.textContent = this.title;
     bannerTextContainer.append(bannerTitle);
+
     const bannerText = document.createElement('p');
     bannerText.textContent = this.text;
     bannerTextContainer.append(bannerText);


### PR DESCRIPTION
### Description

The banner title displayed in the browser extension was bigger than the title displayed in the front end. This PR adds a bit of CSS to harmonize the styles.

| before | after |
|---|---|
| ![capture2](https://github.com/tournesol-app/tournesol/assets/39056254/70cb38f2-6e75-4182-94ad-11be492dce60) | ![capture](https://github.com/tournesol-app/tournesol/assets/39056254/8d8bac30-fb4c-446c-bbbd-a1744e585253) |

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
