### PR TITLE
[infra] fix: nginx is now restarted when block_tor snippet is updated

### DIFF
--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -184,15 +184,15 @@
       age: -4d
     register: find_snippet
 
-- name: Generate block_tor snippet
-  shell: >
-    wget -qO- https://check.torproject.org/exit-addresses
-    | grep ExitAddress
-    | cut -d ' ' -f 2
-    | sort -u
-    | sed "s/^/deny /g; s/$/;/g"
-    > /etc/nginx/snippets/block_tor.conf
-  when: find_snippet.matched == 0
+  - name: Generate block_tor snippet
+    shell: >
+      wget -qO- https://check.torproject.org/exit-addresses
+      | grep ExitAddress
+      | cut -d ' ' -f 2
+      | sort -u
+      | sed "s/^/deny /g; s/$/;/g"
+      > /etc/nginx/snippets/block_tor.conf
+    when: find_snippet.matched == 0
   notify:
     - Reload Nginx
 

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -184,15 +184,17 @@
       age: -4d
     register: find_snippet
 
-  - name: Generate block_tor snippet
-    shell: >
-      wget -qO- https://check.torproject.org/exit-addresses
-      | grep ExitAddress
-      | cut -d ' ' -f 2
-      | sort -u
-      | sed "s/^/deny /g; s/$/;/g"
-      > /etc/nginx/snippets/block_tor.conf
-    when: find_snippet.matched == 0
+- name: Generate block_tor snippet
+  shell: >
+    wget -qO- https://check.torproject.org/exit-addresses
+    | grep ExitAddress
+    | cut -d ' ' -f 2
+    | sort -u
+    | sed "s/^/deny /g; s/$/;/g"
+    > /etc/nginx/snippets/block_tor.conf
+  when: find_snippet.matched == 0
+  notify:
+    - Reload Nginx
 
 - name: Copy Nginx configuration
   template:


### PR DESCRIPTION
### Description

I found in our logs one registration request that was accepted despite the fact that its ip address should have been blocked by our nginx snippet. I think it's because the nginx daemon is not restarted when the Tor configuration is updated. 

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
