### PR TITLE
[front] fix: search returning video id when there is no video id

### DIFF
--- a/frontend/src/features/frame/components/topbar/Search.tsx
+++ b/frontend/src/features/frame/components/topbar/Search.tsx
@@ -67,7 +67,7 @@ const Search = () => {
     searchParams.append('search', search);
     searchParams.delete('offset');
 
-    const videoId = extractVideoId(search, true);
+    const videoId = extractVideoId(search, { ignoreVideoId: true });
 
     if (videoId) {
       history.push('/entities/yt:' + videoId.toString());

--- a/frontend/src/features/frame/components/topbar/Search.tsx
+++ b/frontend/src/features/frame/components/topbar/Search.tsx
@@ -67,11 +67,9 @@ const Search = () => {
     searchParams.append('search', search);
     searchParams.delete('offset');
 
-    const videoId = extractVideoId(search);
+    const videoId = extractVideoId(search, true);
 
-    // TODO: we should pass an argument to `extractVideoId` so that raw YouTube
-    // ids are ignored.
-    if (videoId && search.length !== 11) {
+    if (videoId) {
       history.push('/entities/yt:' + videoId.toString());
     } else {
       history.push('/recommendations?' + searchParams.toString());

--- a/frontend/src/utils/video.spec.ts
+++ b/frontend/src/utils/video.spec.ts
@@ -15,7 +15,7 @@ describe('video module', () => {
       expect(id1).toEqual(videoId);
 
       // When ignoreVideoId is true, raw video id should not be extracted.
-      const id2 = extractVideoId(videoId, true);
+      const id2 = extractVideoId(videoId, { ignoreVideoId: true });
       expect(id2).toEqual(null);
     });
 
@@ -23,7 +23,7 @@ describe('video module', () => {
       const id1 = extractVideoId(`yt:${videoId}`);
       expect(id1).toEqual(videoId);
 
-      const id2 = extractVideoId(`yt:${videoId}`, true);
+      const id2 = extractVideoId(`yt:${videoId}`, { ignoreVideoId: true });
       expect(id2).toEqual(videoId);
     });
 
@@ -34,7 +34,7 @@ describe('video module', () => {
       const id2 = extractVideoId(ytUrlPatternLive.replace('://www.', '://'));
       expect(id2).toEqual(videoId);
 
-      const id3 = extractVideoId(ytUrlPatternLive, true);
+      const id3 = extractVideoId(ytUrlPatternLive, { ignoreVideoId: true });
       expect(id3).toEqual(videoId);
     });
 
@@ -42,7 +42,7 @@ describe('video module', () => {
       const id = extractVideoId(ytUrlPatternMobile);
       expect(id).toEqual(videoId);
 
-      const id2 = extractVideoId(ytUrlPatternMobile, true);
+      const id2 = extractVideoId(ytUrlPatternMobile, { ignoreVideoId: true });
       expect(id2).toEqual(videoId);
     });
 
@@ -53,7 +53,7 @@ describe('video module', () => {
       const id2 = extractVideoId(ytUrlPatternWatch.replace('://www.', '://'));
       expect(id2).toEqual(videoId);
 
-      const id3 = extractVideoId(ytUrlPatternWatch, true);
+      const id3 = extractVideoId(ytUrlPatternWatch, { ignoreVideoId: true });
       expect(id3).toEqual(videoId);
     });
 
@@ -61,7 +61,7 @@ describe('video module', () => {
       const id = extractVideoId(ytUrlPatternShort);
       expect(id).toEqual(videoId);
 
-      const id2 = extractVideoId(ytUrlPatternShort, true);
+      const id2 = extractVideoId(ytUrlPatternShort, { ignoreVideoId: true });
       expect(id2).toEqual(videoId);
     });
   });

--- a/frontend/src/utils/video.spec.ts
+++ b/frontend/src/utils/video.spec.ts
@@ -11,13 +11,20 @@ describe('video module', () => {
     const ytUrlPatternWatch = 'https://www.youtube.com/watch?v=lYXQvHhfKuM';
 
     it('handles video id', () => {
-      const id = extractVideoId(videoId);
-      expect(id).toEqual(videoId);
+      const id1 = extractVideoId(videoId);
+      expect(id1).toEqual(videoId);
+
+      // When ignoreVideoId is true, raw video id should not be extracted.
+      const id2 = extractVideoId(videoId, true);
+      expect(id2).toEqual(null);
     });
 
     it('handles Tournesol UID', () => {
-      const id = extractVideoId(`yt:${videoId}`);
-      expect(id).toEqual(videoId);
+      const id1 = extractVideoId(`yt:${videoId}`);
+      expect(id1).toEqual(videoId);
+
+      const id2 = extractVideoId(`yt:${videoId}`, true);
+      expect(id2).toEqual(videoId);
     });
 
     it("handles the pattern 'live'", () => {
@@ -26,11 +33,17 @@ describe('video module', () => {
 
       const id2 = extractVideoId(ytUrlPatternLive.replace('://www.', '://'));
       expect(id2).toEqual(videoId);
+
+      const id3 = extractVideoId(ytUrlPatternLive, true);
+      expect(id3).toEqual(videoId);
     });
 
     it("handles the pattern 'mobile'", () => {
       const id = extractVideoId(ytUrlPatternMobile);
       expect(id).toEqual(videoId);
+
+      const id2 = extractVideoId(ytUrlPatternMobile, true);
+      expect(id2).toEqual(videoId);
     });
 
     it("handles the pattern 'watch'", () => {
@@ -39,11 +52,17 @@ describe('video module', () => {
 
       const id2 = extractVideoId(ytUrlPatternWatch.replace('://www.', '://'));
       expect(id2).toEqual(videoId);
+
+      const id3 = extractVideoId(ytUrlPatternWatch, true);
+      expect(id3).toEqual(videoId);
     });
 
     it("handles the pattern 'youtu.be'", () => {
       const id = extractVideoId(ytUrlPatternShort);
       expect(id).toEqual(videoId);
+
+      const id2 = extractVideoId(ytUrlPatternShort, true);
+      expect(id2).toEqual(videoId);
     });
   });
 });

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -14,7 +14,7 @@ export function extractVideoId(idOrUrl: string, ignoreVideoId = false) {
   const tournesolEntityUrl = /(?:[.\w]+\/entities\/)/;
 
   const videoId = /([A-Za-z0-9-_]{11})/;
-  const youtubeId = /(?:yt:)?([A-Za-z0-9-_]{11})/;
+  const videoIdOrUid = new RegExp(`(?:yt:)?${videoId.source}`);
 
   if (ignoreVideoId) {
     const matchVideoId = idOrUrl.match(new RegExp(`^${videoId.source}`));
@@ -27,7 +27,7 @@ export function extractVideoId(idOrUrl: string, ignoreVideoId = false) {
     new RegExp(
       `^${protocol.source}${subdomain.source}` +
         `(?:${youtubeWatchUrl.source}|${youtubeShortUrl.source}|${tournesolEntityUrl.source})?` +
-        `${youtubeId.source}`
+        `${videoIdOrUid.source}`
     )
   );
   const id = matchUrl ? matchUrl[1] : idOrUrl.trim();

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -6,13 +6,23 @@ import {
   isAutoSuggestionsEmpty,
 } from 'src/features/rateLater/autoSuggestions';
 
-export function extractVideoId(idOrUrl: string) {
+export function extractVideoId(idOrUrl: string, ignoreVideoId = false) {
   const protocol = /(?:https?:\/\/)?/;
   const subdomain = /(?:www\.|m\.)?/;
   const youtubeWatchUrl = /(?:youtube\.com\/(?:watch\?v=|live\/))/;
   const youtubeShortUrl = /(?:youtu\.be\/)/;
   const tournesolEntityUrl = /(?:[.\w]+\/entities\/)/;
+
+  const videoId = /([A-Za-z0-9-_]{11})/;
   const youtubeId = /(?:yt:)?([A-Za-z0-9-_]{11})/;
+
+  if (ignoreVideoId) {
+    const matchVideoId = idOrUrl.match(new RegExp(`^${videoId.source}`));
+    if (matchVideoId != null) {
+      return null;
+    }
+  }
+
   const matchUrl = idOrUrl.match(
     new RegExp(
       `^${protocol.source}${subdomain.source}` +

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -6,7 +6,10 @@ import {
   isAutoSuggestionsEmpty,
 } from 'src/features/rateLater/autoSuggestions';
 
-export function extractVideoId(idOrUrl: string, ignoreVideoId = false) {
+export function extractVideoId(
+  idOrUrl: string,
+  { ignoreVideoId = false } = {}
+) {
   const protocol = /(?:https?:\/\/)?/;
   const subdomain = /(?:www\.|m\.)?/;
   const youtubeWatchUrl = /(?:youtube\.com\/(?:watch\?v=|live\/))/;


### PR DESCRIPTION
### Description

Regular strings and "ambiguous" video id redirect the users to the search results. If a string was actually a real YouTube video id, the video will appear in the search result if it is "safe".
- s0KQHmVR40c 
- algorithmes
- horizon-gul
- horizon-gull
- horizon-gulll

Explicit UIDs and URLs redirect the users to the analysis page:
- yt:s0KQHmVR40c
- https://tournesol.app/entities/yt:s0KQHmVR40c
- https://youtu.be/s0KQHmVR40c
- https://youtu.be/s0KQHmVR40c?feature=shared
- https://www.youtube.com/watch?v=s0KQHmVR40c
- https://www.youtube.com/watch?v=s0KQHmVR40c&feature=shared
- etc

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
