### PR TITLE
[front] fix: ajust entity card style to fix alignment on RateLater and Comparison pages

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -161,6 +161,7 @@ const EntityCard = ({
             container
             direction="column"
             flexWrap="nowrap"
+            lineHeight="1.2"
           >
             <EntityCardTitle
               uid={entity.uid}

--- a/frontend/src/components/entity/EntityCardScores.tsx
+++ b/frontend/src/components/entity/EntityCardScores.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 const useStyles = makeStyles((theme: Theme) => ({
   ratings: {
-    color: theme.palette.neutral.main,
+    color: theme.palette.text.secondary,
   },
   contributors: {
     color: theme.palette.neutral.dark,
@@ -176,7 +176,7 @@ const EntityCardScores = ({
               borderColor: 'divider',
               paddingLeft: 1,
               fontSize: '0.9rem',
-              color: 'text.secondary',
+              color: 'neutral.main',
             }}
           >
             {max_score > 0 && (

--- a/frontend/src/components/entity/EntityCardScores.tsx
+++ b/frontend/src/components/entity/EntityCardScores.tsx
@@ -19,12 +19,9 @@ interface Props {
 
 const useStyles = makeStyles((theme: Theme) => ({
   ratings: {
-    marginRight: '4px',
-    fontSize: '0.9rem',
     color: theme.palette.neutral.main,
   },
   contributors: {
-    fontSize: '0.9rem',
     color: theme.palette.neutral.dark,
   },
 }));
@@ -130,17 +127,15 @@ const EntityCardScores = ({
         display="flex"
         flexWrap="wrap"
         alignItems="center"
-        columnGap="12px"
-        lineHeight="1.3"
-        py={1}
-        marginTop={1}
+        columnGap="10px"
+        paddingTop={1.5}
       >
         {showTournesolScore &&
           result.collective_rating?.tournesol_score != null && (
             <TournesolScore
               score={result.collective_rating.tournesol_score}
               tooltip={tournesolScoreTitle}
-              fontSize={32}
+              fontSize="2rem"
               unsafe={isUnsafe}
               data-testid="video-card-overall-score"
             />
@@ -151,6 +146,7 @@ const EntityCardScores = ({
             data-testid="video-card-ratings"
             display="flex"
             flexDirection="column"
+            fontSize="0.9rem"
           >
             <span className={classes.ratings}>
               <Trans t={t} i18nKey="video.nbComparisonsBy" count={nbRatings}>
@@ -174,6 +170,7 @@ const EntityCardScores = ({
             data-testid="video-card-minmax-criterias"
             display="flex"
             flexDirection="column"
+            rowGap="2px"
             sx={{
               borderLeft: '1px solid',
               borderColor: 'divider',
@@ -187,8 +184,8 @@ const EntityCardScores = ({
                 {t('video.criteriaRatedHigh')}
                 <CriteriaIcon
                   criteriaName={max_criteria}
-                  emojiSize="12px"
-                  imgWidth="18px"
+                  emojiSize="14px"
+                  imgWidth="16px"
                   tooltip={`${getCriteriaLabel(
                     max_criteria
                   )}: ${max_score.toFixed(0)}`}
@@ -201,8 +198,8 @@ const EntityCardScores = ({
                 {t('video.criteriaRatedLow')}
                 <CriteriaIcon
                   criteriaName={min_criteria}
-                  emojiSize="12px"
-                  imgWidth="18px"
+                  emojiSize="14px"
+                  imgWidth="16px"
                   tooltip={`${getCriteriaLabel(
                     min_criteria
                   )}: ${min_score.toFixed(0)}`}

--- a/frontend/src/components/entity/EntityCardTitle.tsx
+++ b/frontend/src/components/entity/EntityCardTitle.tsx
@@ -25,6 +25,7 @@ const EntityCardTitle = ({
   const titleNode = (
     <Typography
       color="text.primary"
+      lineHeight="1.3"
       sx={{
         fontSize: compact ? '1em !important' : undefined,
         // Limit text to 3 lines and show ellipsis

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -41,11 +41,10 @@ export const VideoMetadata = ({
         display: 'flex',
         flexWrap: 'wrap',
         alignContent: 'space-between',
-        fontFamily: 'Poppins',
         fontSize: '0.8rem',
         color: 'neutral.main',
         columnGap: '12px',
-        lineHeight: '1.3',
+        marginTop: '4px',
       }}
     >
       {views && (

--- a/frontend/src/components/entity/style.ts
+++ b/frontend/src/components/entity/style.ts
@@ -1,16 +1,15 @@
 import { SxProps } from '@mui/material';
 
 export const entityCardMainSx: SxProps = {
-  margin: 0,
-  width: '100%',
   bgcolor: '#FFFFFF',
   border: '1px solid #DCD8CB',
   boxShadow: '0px 0px 8px rgba(0, 0, 0, 0.02), 0px 2px 4px rgba(0, 0, 0, 0.05)',
   borderRadius: '4px',
   alignContent: 'flex-start',
   overflow: 'hidden',
-  fontSize: {
-    xs: '14px',
-    md: '16px',
-  },
+  /*
+    Allow the card to grow on the comparison page
+    to match the height of the second entity card
+  */
+  flexGrow: 1,
 };

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -226,9 +226,9 @@ const Comparison = ({
         item
         xs
         component={Card}
-        sx={{
-          alignSelf: 'start',
-        }}
+        display="flex"
+        flexDirection="column"
+        alignSelf="stretch"
       >
         <EntitySelector
           title="A"
@@ -243,9 +243,9 @@ const Comparison = ({
         item
         xs
         component={Card}
-        sx={{
-          alignSelf: 'start',
-        }}
+        display="flex"
+        flexDirection="column"
+        alignSelf="stretch"
       >
         <EntitySelector
           title="B"

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Theme, useTheme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
+import { useTheme } from '@mui/material/styles';
 import { Box, Grid, Typography } from '@mui/material';
 
 import { useCurrentPoll, useEntityAvailable, useLoginState } from 'src/hooks';
@@ -22,23 +21,6 @@ import AutoEntityButton from './AutoEntityButton';
 import EntitySelectButton from './EntitySelectButton';
 import { extractVideoId } from 'src/utils/video';
 import { entityCardMainSx } from 'src/components/entity/style';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    margin: 0,
-  },
-  controls: {
-    margin: 4,
-    display: 'flex',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-  },
-  input: {
-    [theme.breakpoints.down('sm')]: {
-      fontSize: '0.7rem',
-    },
-  },
-}));
 
 interface Props {
   title: string;
@@ -68,11 +50,10 @@ const EntitySelector = ({
   variant = 'regular',
   autoFill = false,
 }: Props) => {
-  const classes = useStyles();
   const { isLoggedIn } = useLoginState();
 
   return (
-    <div className={classes.root}>
+    <>
       {isLoggedIn ? (
         <EntitySelectorInnerAuth
           title={title}
@@ -86,7 +67,7 @@ const EntitySelector = ({
       ) : (
         <EntitySelectorInnerAnonymous value={value} />
       )}
-    </div>
+    </>
   );
 };
 
@@ -314,7 +295,7 @@ const EntitySelectorInnerAuth = ({
           </Typography>
         </Box>
       )}
-      <Box position="relative">
+      <>
         {rating ? (
           <EntityCard
             compact
@@ -408,7 +389,7 @@ const EntitySelectorInnerAuth = ({
             </Grid>
           </>
         )}
-      </Box>
+      </>
     </>
   );
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,12 @@ html, body, #root {
   background-color: #fafafa;
 }
 
+@media not (min-width: 600px) {
+  html {
+    font-size: 95%;
+  }
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;

--- a/frontend/src/pages/home/videos/sections/HomeComparison.tsx
+++ b/frontend/src/pages/home/videos/sections/HomeComparison.tsx
@@ -141,9 +141,9 @@ const HomeComparison = () => {
         item
         xs
         component={Card}
-        sx={{
-          alignSelf: 'start',
-        }}
+        display="flex"
+        flexDirection="column"
+        alignSelf="stretch"
       >
         <EntitySelector
           variant="noControl"
@@ -157,9 +157,9 @@ const HomeComparison = () => {
         item
         xs
         component={Card}
-        sx={{
-          alignSelf: 'start',
-        }}
+        display="flex"
+        flexDirection="column"
+        alignSelf="stretch"
       >
         <EntitySelector
           variant="noControl"

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -252,7 +252,9 @@ const RateLaterPage = () => {
           {entityCount !== null && (
             <Typography
               variant="subtitle1"
-              mb={0}
+              m={2}
+              textAlign="center"
+              lineHeight="1.5em"
               sx={{
                 '& strong': {
                   color: 'secondary.main',
@@ -272,7 +274,7 @@ const RateLaterPage = () => {
             </Typography>
           )}
 
-          <Box width="100%" textAlign="center">
+          <Box width="100%">
             <LoaderWrapper isLoading={isLoading}>
               <EntityList
                 entities={rateLaterList}
@@ -283,6 +285,7 @@ const RateLaterPage = () => {
               />
             </LoaderWrapper>
           </Box>
+
           {!!entityCount && entityCount > limit && (
             <Pagination
               offset={offset}


### PR DESCRIPTION
### Description

|Before|After|
|-|-|
|![Capture d’écran 2024-02-01 à 15 33 30](https://github.com/tournesol-app/tournesol/assets/4726554/c3d2360f-214e-4961-9e38-5cc20bd303be)|![Capture d’écran 2024-02-01 à 15 34 49](https://github.com/tournesol-app/tournesol/assets/4726554/6c79e7f1-fbf7-4037-b9c3-ca4f2097a0c6)
|![Capture d’écran 2024-02-01 à 15 34 04](https://github.com/tournesol-app/tournesol/assets/4726554/81c80c7a-133a-4ff9-b682-d8943e73b254)|![Capture d’écran 2024-02-01 à 15 35 17](https://github.com/tournesol-app/tournesol/assets/4726554/b5950fc3-5d8e-40d7-87b7-b9c8b2b7da0a)




### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [x] The code quality check pass



[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
