### PR TITLE
[front] fix: update entity card flex style to maintain equal size on comparisons list

### DIFF
--- a/frontend/src/components/entity/style.ts
+++ b/frontend/src/components/entity/style.ts
@@ -8,8 +8,9 @@ export const entityCardMainSx: SxProps = {
   alignContent: 'flex-start',
   overflow: 'hidden',
   /*
-    Allow the card to grow on the comparison page
-    to match the height of the second entity card
+    Set flex property to 1 to allow the card to expand as a flex item
+    when placed side-by-side with another card, ensuring they remain
+    equal in size.
   */
-  flexGrow: 1,
+  flex: 1,
 };

--- a/frontend/src/features/comparisons/ComparisonList.tsx
+++ b/frontend/src/features/comparisons/ComparisonList.tsx
@@ -19,7 +19,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
       display="flex"
       justifyContent="space-between"
       alignItems="stretch"
-      gap={2}
+      gap={1}
     >
       <EntityCard
         compact
@@ -51,7 +51,7 @@ const ComparisonThumbnail = ({ comparison }: { comparison: Comparison }) => {
             sx={{ backgroundColor: '#F1EFE7' }}
             size="small"
           >
-            <CompareIcon sx={{ color: '#B6B1A1' }} />
+            <CompareIcon sx={{ color: 'neutral.main' }} />
           </Fab>
         </Tooltip>
       </Box>


### PR DESCRIPTION
### Description

Fix bug introduced by #1910 causing video cards to have different widths on /comparisons list.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass



[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
