### PR TITLE
[ext] trans: replace rate later confirmation with "Added!" instead of "Done!"

### DIFF
--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -164,7 +164,7 @@ function addVideoButtons() {
               },
               (data) => {
                 if (data.success) {
-                  setRateLaterButtonLabel('Done!');
+                  setRateLaterButtonLabel('Added!');
                   setRateLaterButtonIcon(
                     chrome.runtime.getURL('images/checkmark.svg')
                   );


### PR DESCRIPTION
### Description

This replaces the generic "Done!" confirmation message by "Added!". Especially useful since this message replaces the button text, so even with the "Rate Later" button text gone we can still see what the grayed button was standing for ^^

Before this commit:
<img width="329" alt="image" src="https://github.com/tournesol-app/tournesol/assets/52411229/e5391e20-dff2-42b1-8198-5e96bdafc5af">
<img width="329" alt="image" src="https://github.com/tournesol-app/tournesol/assets/52411229/498ceaca-8dc0-4002-8ec1-7803ea10dcaf">

After this commit:
<img width="329" alt="image" src="https://github.com/tournesol-app/tournesol/assets/52411229/e5391e20-dff2-42b1-8198-5e96bdafc5af">
<img width="329" alt="image" src="https://github.com/tournesol-app/tournesol/assets/52411229/3ff06240-01b3-4e0c-8e3f-9a344351b9ec">

Please note that I couldn't find how to update the translation to French (actually, I'm not even sure if a translation to French existed in the first place for those buttons).

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
