### PR TITLE
[front] feat: add the page /feed/recommendations

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -31,7 +31,7 @@
     }
   ],
   "id": "/",
-  "start_url": "/?utm_source=pwa",
+  "start_url": "/feed/recommendations?utm_source=pwa",
   "display": "standalone",
   "theme_color": "#ffc800",
   "background_color": "#a09b87",

--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -13,6 +13,7 @@ import ProofByKeywordPage from 'src/pages/me/proof/ProofByKeywordPage';
 import RecommendationPage from 'src/pages/recommendations/RecommendationPage';
 import VideoRatingsPage from 'src/pages/videos/VideoRatings';
 import ComparisonPage from 'src/pages/comparisons/Comparison';
+import FeedCollectiveRecommendations from 'src/pages/feed/FeedCollectiveRecommendations';
 import RateLaterPage from 'src/pages/rateLater/RateLater';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import { RouteID } from 'src/utils/types';
@@ -54,6 +55,12 @@ const PollRoutes = ({ pollName }: Props) => {
       id: RouteID.Home,
       url: '',
       page: HomePage,
+      type: PublicRoute,
+    },
+    {
+      id: RouteID.FeedCollectiveRecommendations,
+      url: 'feed/recommendations',
+      page: FeedCollectiveRecommendations,
       type: PublicRoute,
     },
     {

--- a/frontend/src/pages/feed/FeedCollectiveRecommendations.tsx
+++ b/frontend/src/pages/feed/FeedCollectiveRecommendations.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+
+import { selectSettings } from 'src/features/settings/userSettingsSlice';
+import { useCurrentPoll } from 'src/hooks';
+import { getDefaultRecommendationsSearchParams } from 'src/utils/userSettings';
+
+const FeedCollectiveRecommendations = () => {
+  const { name: pollName, options } = useCurrentPoll();
+  const userSettings = useSelector(selectSettings).settings;
+
+  const searchParams = getDefaultRecommendationsSearchParams(
+    pollName,
+    options,
+    userSettings
+  );
+
+  return <Redirect to={`/recommendations${searchParams.toString()}`} />;
+};
+
+export default FeedCollectiveRecommendations;

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -49,6 +49,7 @@ export type VideoObject = Video | VideoSerializerWithCriteria;
 export enum RouteID {
   // public and collective routes
   Home = 'home',
+  FeedCollectiveRecommendations = 'feedCollectiveRecommendations',
   CollectiveRecommendations = 'collectiveRecommendations',
   EntityAnalysis = 'entityAnalysis',
   FAQ = 'FAQ',

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -301,7 +301,7 @@ describe('Comparison page', () => {
       optionalCriteriaSliders.forEach((slider) => {
         cy.get('#' + slider).within(() => {
           cy.get('span[data-index=12]').click();
-        })
+        });
       });
 
       cy.contains('submit', {matchCase: false})

--- a/tests/cypress/e2e/frontend/feedRecommendationsPage.cy.ts
+++ b/tests/cypress/e2e/frontend/feedRecommendationsPage.cy.ts
@@ -1,0 +1,36 @@
+describe('Feed - collective recommendations', () => {
+  const username = "test-feed-reco-page";
+
+  beforeEach(() => {
+    cy.recreateUser(username, "test-feed-reco-page@example.com", "tournesol");
+  });
+
+  const login = () => {
+    cy.focused().type(username);
+    cy.get('input[name="password"]').click().type("tournesol").type('{enter}');
+  }
+
+  describe('redirection', () => {
+    it('anonymous users are redirected with default filters', () => {
+      cy.visit('/feed/recommendations');
+      cy.location('pathname').should('equal', '/recommendations');
+      cy.location('search').should('contain', '?date=Month');
+    });
+
+    it('authenticated users are redirected with their preferences', () => {
+      cy.visit('/settings/preferences');
+      login();
+
+      cy.get('#videos_recommendations__default_date').click();
+      cy.contains('A day ago').click();
+      cy.get('[data-testid=videos_recommendations__default_unsafe]').click();
+      cy.get('[data-testid=videos_recommendations__default_exclude_compared_entities]').click();
+      cy.contains('Update preferences').click();
+
+      cy.visit('/feed/recommendations');
+      cy.location('pathname').should('equal', '/recommendations');
+      cy.location('search')
+        .should('contain', '?date=Today&advanced=unsafe%2Cexclude_compared&language=en');
+    });
+  });
+});


### PR DESCRIPTION
**related issues** #1895

---

### Description

The start page of the PWA is now the collective recommendations.

If the user is logged, his/her preferences are used to initialize the filters. Anonymous users see the recommendations with the default poll filters.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
