### PR TITLE
[front] fix: remove word "By" to introduce a talk author

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -759,7 +759,6 @@
   "eventsPage": {
     "title": "Events",
     "live": "Live",
-    "by": "By\u00a0{{speaker}}",
     "replay": "Replay",
     "join": "Join",
     "upcomingEvents": "Upcoming event(s)",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -767,7 +767,6 @@
   "eventsPage": {
     "title": "Évènements",
     "live": "En direct",
-    "by": "Par\u00a0{{speaker}}",
     "replay": "Revoir",
     "join": "Rejoindre",
     "upcomingEvents": "Évènement(s) à venir",

--- a/frontend/src/pages/events/EventSingleEntry.tsx
+++ b/frontend/src/pages/events/EventSingleEntry.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import {
   Box,
@@ -226,13 +226,11 @@ const EventSingleEntry = ({ event }: { event: TournesolEvent }) => {
       <EventHeading event={event} />
       <Box p={2} sx={{ overflow: 'auto' }}>
         <EventImagery event={event} />
-        <Typography variant="h6" color="secondary" gutterBottom>
-          {event.speakers && (
-            <Trans t={t} i18nKey="eventsPage.by">
-              By {{ speaker: event.speakers }}
-            </Trans>
-          )}
-        </Typography>
+        {event.speakers && (
+          <Typography variant="h6" color="secondary" gutterBottom>
+            {event.speakers}
+          </Typography>
+        )}
         {abstractParagraphs.map((abstractParagraph, index) => (
           <Typography
             key={`${event.title}_p${index}`}


### PR DESCRIPTION
### Description

In the events pages, I removed the word "By" automatically added by the front end because it was not appropriate for events like Tournesol Live. Now the back end has a full control how the speakers are introduced.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
