### PR TITLE
[front] feat: add pagination in all event pages

### DIFF
--- a/frontend/src/pages/events/GenericEventsPage.tsx
+++ b/frontend/src/pages/events/GenericEventsPage.tsx
@@ -46,7 +46,7 @@ const GenericEventsPage = ({
 
   const searchParams = new URLSearchParams(location.search);
   const offset = Number(searchParams.get('offset') || 0);
-  const limit = 2;
+  const limit = 20;
 
   const handleOffsetChange = (newOffset: number) => {
     searchParams.set('offset', newOffset.toString());

--- a/frontend/src/pages/events/GenericEventsPage.tsx
+++ b/frontend/src/pages/events/GenericEventsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { Alert, Box, Typography } from '@mui/material';
 
@@ -14,7 +15,6 @@ import {
 } from 'src/services/openapi';
 
 import EventsMenu from './EventsMenu';
-import { useHistory, useLocation } from 'react-router-dom';
 
 interface SortedEventAccumulator {
   past: TournesolEvent[];

--- a/frontend/src/pages/events/GenericEventsPage.tsx
+++ b/frontend/src/pages/events/GenericEventsPage.tsx
@@ -53,11 +53,7 @@ const GenericEventsPage = ({
     history.push({ search: searchParams.toString() });
   };
 
-  const displayFutureEvents = () => {
-    return offset === 0 || futureEvents.length > 0;
-  };
-
-  console.log(offset);
+  const displayFutureEvents = offset === 0 || futureEvents.length > 0;
 
   useEffect(() => {
     async function getEventsEntries() {
@@ -112,7 +108,7 @@ const GenericEventsPage = ({
           <EventsMenu selected={selectedMenuItem} />
         </Box>
         {header && header}
-        {displayFutureEvents() && (
+        {displayFutureEvents && (
           <Box mb={4}>
             <Typography
               variant="h6"


### PR DESCRIPTION
**related issues** #1923

---

### Description

The three pages Events, Tournesol Live and Tournesol Talks now display the pagination component.

The limit is set to `20` like in the recommendations page.

### Preview

![screencapture-localhost-3000-events-2024-03-04-11_29_51](https://github.com/tournesol-app/tournesol/assets/39056254/416e8026-5546-4ec9-8617-d488e054a31b)

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
