### PR TITLE
[front] feat: add a link to page Events in the footer

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -174,6 +174,7 @@
     "youtubePlaylistEn": "YouTube Playlist EN",
     "youtubePlaylistFr": "YouTube Playlist FR",
     "followUs": "Follow Us",
+    "events": "Events",
     "supportUs": "Support Us",
     "directTransfer": "Direct transfer",
     "compareVideos": "Compare videos 🌻",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -180,6 +180,7 @@
     "youtubePlaylistEn": "Playlist YouTube EN",
     "youtubePlaylistFr": "Playlist YouTube FR",
     "followUs": "Suivez-nous",
+    "events": "Évènements",
     "supportUs": "Nous soutenir",
     "directTransfer": "Virement direct",
     "compareVideos": "Comparez des videos 🌻",

--- a/frontend/src/features/frame/components/footer/Footer.tsx
+++ b/frontend/src/features/frame/components/footer/Footer.tsx
@@ -22,6 +22,7 @@ import {
   tournesolTalksMailingListUrl,
   whitePaperUrl,
   tournesolTalksYTPlaylist,
+  youtubeTournesolUrl,
 } from 'src/utils/url';
 import { theme } from 'src/theme';
 
@@ -54,9 +55,11 @@ const Footer = () => {
       id: 'follow-us',
       title: t('footer.followUs'),
       items: [
+        { name: t('footer.events'), to: '/events' },
         { name: 'Twitter', to: twitterTournesolUrl },
-        { name: 'Discord', to: discordTournesolInviteUrl },
+        { name: 'YouTube', to: youtubeTournesolUrl },
         { name: 'Twitch', to: twitchTournesolUrl },
+        { name: 'Discord', to: discordTournesolInviteUrl },
         { name: 'LinkedIn', to: linkedInTournesolUrl },
         { name: 'GitHub', to: githubTournesolUrl },
       ],

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -31,6 +31,7 @@ export const linkedInTournesolUrl =
   'https://www.linkedin.com/company/tournesol-app';
 
 // YouTube
+export const youtubeTournesolUrl = 'https://www.youtube.com/@TournesolApp';
 export const youtubePlaylistEnUrl =
   'https://youtube.com/playlist?list=PLXX93NlSmUpayYeaNvKaeftX_QwEei3fU';
 export const youtubePlaylistFrUrl =


### PR DESCRIPTION
### Description

The section Follow Us now contains a link to the page `/events`.

I also added the missing YouTube link.

| before | after |
|---|---|
| ![capture1](https://github.com/tournesol-app/tournesol/assets/39056254/387a9f0c-109c-47d2-9ec0-b9c099ec4810) | ![capture](https://github.com/tournesol-app/tournesol/assets/39056254/5330f0db-cc4b-4106-80c8-a55b425910a0) |

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
