### PR TITLE
[front] ui: smaller entity selector on mobile

### DIFF
--- a/frontend/src/components/entity/EntityCardTitle.tsx
+++ b/frontend/src/components/entity/EntityCardTitle.tsx
@@ -27,6 +27,7 @@ const EntityCardTitle = ({
       color="text.primary"
       lineHeight="1.3"
       sx={{
+        overflowWrap: 'anywhere',
         fontSize: compact ? '1em !important' : undefined,
         // Limit text to 3 lines and show ellipsis
         display: '-webkit-box',

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -215,13 +215,7 @@ const Comparison = ({
   };
 
   return (
-    <Grid
-      container
-      sx={{
-        maxWidth: '880px',
-        gap: '8px',
-      }}
-    >
+    <Grid container maxWidth="880px" gap={1}>
       <Grid item xs display="flex" flexDirection="column" alignSelf="stretch">
         <EntitySelector
           alignment="left"

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -231,7 +231,6 @@ const Comparison = ({
         alignSelf="stretch"
       >
         <EntitySelector
-          title="A"
           alignment="left"
           value={selectorA}
           onChange={onChangeA}
@@ -248,7 +247,6 @@ const Comparison = ({
         alignSelf="stretch"
       >
         <EntitySelector
-          title="B"
           alignment="right"
           value={selectorB}
           onChange={onChangeB}

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -222,14 +222,7 @@ const Comparison = ({
         gap: '8px',
       }}
     >
-      <Grid
-        item
-        xs
-        component={Card}
-        display="flex"
-        flexDirection="column"
-        alignSelf="stretch"
-      >
+      <Grid item xs display="flex" flexDirection="column" alignSelf="stretch">
         <EntitySelector
           alignment="left"
           value={selectorA}
@@ -238,14 +231,7 @@ const Comparison = ({
           autoFill={autoFillSelectorA}
         />
       </Grid>
-      <Grid
-        item
-        xs
-        component={Card}
-        display="flex"
-        flexDirection="column"
-        alignSelf="stretch"
-      >
+      <Grid item xs display="flex" flexDirection="column" alignSelf="stretch">
         <EntitySelector
           alignment="right"
           value={selectorB}

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Tooltip, Button } from '@mui/material';
+import { Tooltip, Button, useMediaQuery, IconButton } from '@mui/material';
 import { Autorenew } from '@mui/icons-material';
 
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import { theme } from 'src/theme';
 import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
 import { getUidForComparison } from 'src/utils/video';
 
@@ -29,6 +30,8 @@ const AutoEntityButton = ({
 }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
+  const smallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
   const mountedRef = useRef(false);
 
   // askNewVideo needs to compare the received UID with the current `otherUid`
@@ -88,31 +91,49 @@ const AutoEntityButton = ({
   }
 
   return (
-    <Tooltip title={`${t('entitySelector.newVideo')}`} aria-label="new_video">
-      {/* A non-disabled element, such as <span>, is required by the Tooltip
-          component to properly listen to fired events. */}
-      <span>
-        <Button
-          fullWidth={variant === 'full' ? true : false}
+    <>
+      {smallScreen && variant === 'compact' ? (
+        <IconButton
           disabled={disabled}
           color="secondary"
-          variant="outlined"
           size="small"
           onClick={askNewVideo}
-          startIcon={variant === 'full' ? undefined : <Autorenew />}
-          sx={
-            variant === 'full'
-              ? { minHeight: '100px', fontSize: '1rem' }
-              : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
-          }
+          sx={{ fontSize: { xs: '0.7rem', sm: '0.8rem' } }}
           data-testid={`auto-entity-button-${variant}`}
         >
-          {variant === 'full'
-            ? t('entitySelector.letTournesolSelectAVideo')
-            : t('entitySelector.auto')}
-        </Button>
-      </span>
-    </Tooltip>
+          <Autorenew />
+        </IconButton>
+      ) : (
+        <Tooltip
+          title={`${t('entitySelector.newVideo')}`}
+          aria-label="new_video"
+        >
+          {/* A non-disabled element, such as <span>, is required by the Tooltip
+            component to properly listen to fired events. */}
+          <span>
+            <Button
+              fullWidth={variant === 'full' ? true : false}
+              disabled={disabled}
+              color="secondary"
+              variant="outlined"
+              size="small"
+              onClick={askNewVideo}
+              startIcon={variant === 'full' ? undefined : <Autorenew />}
+              sx={
+                variant === 'full'
+                  ? { minHeight: '100px', fontSize: '1rem' }
+                  : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
+              }
+              data-testid={`auto-entity-button-${variant}`}
+            >
+              {variant === 'full'
+                ? t('entitySelector.letTournesolSelectAVideo')
+                : t('entitySelector.auto')}
+            </Button>
+          </span>
+        </Tooltip>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+
 import {
   Autocomplete,
   Box,
@@ -7,7 +8,10 @@ import {
   useMediaQuery,
   Theme,
   Button,
+  IconButton,
 } from '@mui/material';
+import { Search } from '@mui/icons-material';
+
 import { useTranslation } from 'react-i18next';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import {
@@ -49,7 +53,7 @@ const VideoInput = ({
   const [suggestionsOpen, setSuggestionsOpen] = useState(false);
 
   const { isLoggedIn } = useLoginState();
-  const fullScreenModal = useMediaQuery(
+  const smallScreen = useMediaQuery(
     (theme: Theme) => `${theme.breakpoints.down('sm')}, (pointer: coarse)`,
     { noSsr: true }
   );
@@ -180,29 +184,44 @@ const VideoInput = ({
           width: variant === 'full' ? '100%' : 'auto',
         }}
       >
-        <Button
-          fullWidth={variant === 'full' ? true : false}
-          onClick={toggleSuggestions}
-          size="small"
-          variant="contained"
-          color="secondary"
-          disabled={disabled}
-          sx={
-            variant === 'full'
-              ? { minHeight: '100px', fontSize: '1rem' }
-              : { minWidth: '80px', fontSize: { xs: '0.7rem', sm: '0.8rem' } }
-          }
-          disableElevation
-          data-testid={`entity-select-button-${variant}`}
-        >
-          {variant === 'full'
-            ? t('entitySelector.selectAVideo')
-            : t('entitySelector.select')}
-        </Button>
+        {smallScreen && variant === 'compact' ? (
+          <IconButton
+            onClick={toggleSuggestions}
+            size="small"
+            color="secondary"
+            disabled={disabled}
+            sx={{ fontSize: { xs: '0.7rem', sm: '0.8rem' } }}
+            data-testid={`entity-select-button-${variant}`}
+          >
+            <Search />
+          </IconButton>
+        ) : (
+          <Button
+            fullWidth={variant === 'full' ? true : false}
+            onClick={toggleSuggestions}
+            size="small"
+            variant="contained"
+            color="secondary"
+            disabled={disabled}
+            startIcon={variant === 'full' ? undefined : <Search />}
+            sx={
+              variant === 'full'
+                ? { minHeight: '100px', fontSize: '1rem' }
+                : { fontSize: { xs: '0.7rem', sm: '0.8rem' } }
+            }
+            disableElevation
+            data-testid={`entity-select-button-${variant}`}
+          >
+            {variant === 'full'
+              ? t('entitySelector.selectAVideo')
+              : t('entitySelector.select')}
+          </Button>
+        )}
+
         {selectorAnchor.current &&
           selectorAnchor.current.offsetParent != null && (
             <SelectorPopper
-              modal={fullScreenModal}
+              modal={smallScreen}
               open={suggestionsOpen}
               anchorEl={selectorAnchor.current}
               onClose={() => setSuggestionsOpen(false)}

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -238,7 +238,7 @@ const EntitySelectorInnerAuth = ({
     <>
       {showEntityInput && (
         <Box
-          m={1}
+          mb={1}
           display="flex"
           flexDirection={
             uid

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -344,6 +344,7 @@ const EntitySelectorInnerAuth = ({
                   aspectRatio: '16 / 9',
                   backgroundColor: '#fafafa',
                 }}
+                height="100%"
                 spacing={1}
                 alignItems="center"
                 justifyContent="space-around"

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -23,7 +23,6 @@ import { extractVideoId } from 'src/utils/video';
 import { entityCardMainSx } from 'src/components/entity/style';
 
 interface Props {
-  title: string;
   alignment?: 'left' | 'right';
   value: SelectorValue;
   onChange: (newValue: SelectorValue) => void;
@@ -42,7 +41,6 @@ const isUidValid = (uid: string | null) =>
   uid === null ? false : uid.match(/\w+:.+/);
 
 const EntitySelector = ({
-  title,
   alignment = 'left',
   value,
   onChange,
@@ -56,7 +54,6 @@ const EntitySelector = ({
     <>
       {isLoggedIn ? (
         <EntitySelectorInnerAuth
-          title={title}
           value={value}
           onChange={onChange}
           otherUid={otherUid}
@@ -107,7 +104,6 @@ const EntitySelectorInnerAnonymous = ({ value }: { value: SelectorValue }) => {
 };
 
 const EntitySelectorInnerAuth = ({
-  title,
   value,
   onChange,
   otherUid,
@@ -285,14 +281,6 @@ const EntitySelectorInnerAuth = ({
               />
             </Grid>
           </Grid>
-          <Typography
-            variant="h6"
-            color="secondary"
-            fontWeight="bold"
-            sx={{ '&:first-letter': { textTransform: 'capitalize' } }}
-          >
-            {title}
-          </Typography>
         </Box>
       )}
       <>

--- a/frontend/src/pages/home/videos/sections/HomeComparison.tsx
+++ b/frontend/src/pages/home/videos/sections/HomeComparison.tsx
@@ -134,14 +134,7 @@ const HomeComparison = () => {
         gap: '8px',
       }}
     >
-      <Grid
-        item
-        xs
-        component={Card}
-        display="flex"
-        flexDirection="column"
-        alignSelf="stretch"
-      >
+      <Grid item xs display="flex" flexDirection="column" alignSelf="stretch">
         <EntitySelector
           variant="noControl"
           value={selectorA}
@@ -149,14 +142,7 @@ const HomeComparison = () => {
           otherUid={uidB}
         />
       </Grid>
-      <Grid
-        item
-        xs
-        component={Card}
-        display="flex"
-        flexDirection="column"
-        alignSelf="stretch"
-      >
+      <Grid item xs display="flex" flexDirection="column" alignSelf="stretch">
         <EntitySelector
           variant="noControl"
           value={selectorB}

--- a/frontend/src/pages/home/videos/sections/HomeComparison.tsx
+++ b/frontend/src/pages/home/videos/sections/HomeComparison.tsx
@@ -17,7 +17,6 @@ import EntitySelector, {
 import CriteriaSlider from 'src/features/comparisons/CriteriaSlider';
 import { useLoginState, useCurrentPoll } from 'src/hooks';
 import { getUserComparisonsRaw } from 'src/utils/api/comparisons';
-import { getEntityName } from 'src/utils/constants';
 import { setPendingRating } from 'src/utils/comparison/pending';
 import { alreadyComparedWith, selectRandomEntity } from 'src/utils/entity';
 import { getTutorialVideos } from 'src/utils/polls/videos';
@@ -56,8 +55,6 @@ const HomeComparison = () => {
     uid: uidB,
     rating: null,
   });
-
-  const entityName = getEntityName(t, pollName);
 
   /**
    * This effect determines if the user should be redirected to the tutorial
@@ -147,7 +144,6 @@ const HomeComparison = () => {
       >
         <EntitySelector
           variant="noControl"
-          title={`${entityName} 1`}
           value={selectorA}
           onChange={setSelectorA}
           otherUid={uidB}
@@ -163,7 +159,6 @@ const HomeComparison = () => {
       >
         <EntitySelector
           variant="noControl"
-          title={`${entityName} 2`}
           value={selectorB}
           onChange={setSelectorB}
           otherUid={uidA}


### PR DESCRIPTION
### Description

This PR reduces the size of the entity selector on mobile, making it fit on a single line on a larger variety of small screens.

It also removes the Paper surface on top of which the entity cards were displayed. The objective is to delimit the card surface and to mark clear a distinction between the controls and the card itself, so that it will be easier for users to identify the "swipe-able" surface of the card in the future.

The titles A and B have been removed as suggested, to make to simplify the UI.

**to-do**
- [x] remove the titles A and B

| before | after |
|---|---|
| ![capture](https://github.com/tournesol-app/tournesol/assets/39056254/d03d8fb2-4f1f-4417-9f65-fc2072802c4a) | ![capture](https://github.com/tournesol-app/tournesol/assets/39056254/05a6ae2f-b04a-4b86-b177-4f9128705090) |

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
