### PR TITLE
[front] fix: manifest scope should cover all URLs

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -31,6 +31,7 @@
     }
   ],
   "id": "/",
+  "scope": "/",
   "start_url": "/feed/recommendations?utm_source=pwa",
   "display": "standalone",
   "theme_color": "#ffc800",


### PR DESCRIPTION
### Description

Following #1920, the scope of the PWA was restricted to the new start URL.  
This PR defines an explicit scope, in order to keep the session on Tournesol inside the app.

See https://web.dev/articles/add-manifest#scope


### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
