### PR TITLE
[front] feat: add missing authors + 1 book in /actions

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -716,8 +716,6 @@
     },
     "beEducated": {
       "readAndOfferMoreBooksLike": "Read and offer more books like:",
-      "inEnglish": "in english",
-      "inFrench": "in french",
       "watchAndShareVideosFrom": "Watch and share videos from:",
       "andMore": "and more...",
       "beTrainedAndTrainOthers": "Be trained and train others on the fundamentals of digital democracy",
@@ -726,6 +724,8 @@
       "listenAndSharePodcastsLike": "Listen and share podcasts like",
       "discoverAndShareEducationalGamesLike": "Discover and share educational games like <2>Nicky Case's</2>."
     },
+    "inEnglish": "in english",
+    "inFrench": "in french",
     "beWellSurrounded": {
       "beWellSurrounded": "Be well surrounded",
       "joinDiscord": "Join <2>Tournesol Discord</2> (say hi and present yourself 👋).",
@@ -745,11 +745,11 @@
       "hereIsAlist": "Here is a non-exhaustive list of projects and organizations that, through their actions and philosophy, are fighting for information quality, and highlight the related democratic and digital issues."
     },
     "qualityInformation": {
+      "readAndOfferBooksLike": "Read and offer books like:",
       "increaseYourExposureToQualityInformation": "Increase your exposure to quality information",
       "installTournesol": "Install the <2>Tournesol browser extension</2> and the <6>Tournesol mobile app</6> (can be installed from your browser on Android).",
       "improveUnderstandingOfPsychology": "Improve your understanding of your psychology",
       "watchShareVideos": "Watch and share videos on this topic, like <2>Dissatisfaction</2>.",
-      "readOfferBooks": "Read and offer books, like <2>The Righteous Mind</2>, <5>Feeling Good</5>, <8>The Scout Mindset</8>.",
       "readAboutProcrastination": "Read the blog posts <2>Why procrastinators procrastinate?</2>, or watch the author's <5>TED talk</5>."
     },
     "helpResearch": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -724,8 +724,6 @@
     },
     "beEducated": {
       "readAndOfferMoreBooksLike": "Lire et offrir d'autres livres comme :",
-      "inEnglish": "en anglais",
-      "inFrench": "en français",
       "watchAndShareVideosFrom": "Visionner et partager les vidéos de :",
       "andMore": "et d'autres...",
       "beTrainedAndTrainOthers": "Être formé et former les autres aux fondamentaux de la démocratie numérique",
@@ -734,6 +732,8 @@
       "listenAndSharePodcastsLike": "Écouter et partager des podcasts comme",
       "discoverAndShareEducationalGamesLike": "Découvrir et partager des jeux éducatifs, comme ceux de <2>Nicky Case</2>."
     },
+    "inEnglish": "en anglais",
+    "inFrench": "en français",
     "beWellSurrounded": {
       "beWellSurrounded": "Être bien entouré",
       "joinDiscord": "Rejoindre le <2>Discord de Tournesol</2> (venez dire bonjour et vous présenter 👋).",
@@ -753,11 +753,11 @@
       "hereIsAlist": "Voici une liste non exhaustive de projets et d'organisations qui, par leurs actions et leur philosophie, luttent pour la qualité de l'information, et mettent en lumière les grands enjeux démocratiques et numériques associés."
     },
     "qualityInformation": {
+      "readAndOfferBooksLike": "Lire et offir des livres comme :",
       "increaseYourExposureToQualityInformation": "Augmenter votre exposition à des informations de qualité",
       "installTournesol": "Installer <2>l'extension Tournesol</2> sur votre navigateur et installer <6>l'application mobile Tournesol</6> (installable depuis votre navigateur sur Android).",
       "improveUnderstandingOfPsychology": "Améliorer la compréhension de notre psychologie",
       "watchShareVideos": "Regarder et partager des vidéos sur ce sujet, comme <2>Dissatisfaction</2>.",
-      "readOfferBooks": "Lire et offrir les ouvrages <2>The Righteous Mind</2>, <5>Feeling Good</5>, <8>The Scout Mindset</8>.",
       "readAboutProcrastination": "Lire cette série d'articles sur la procrastination : <2>Why procrastinators procrastinate?</2>, ou visionner la <5>conférence TED</5> de leur auteur."
     },
     "helpResearch": {

--- a/frontend/src/pages/actions/sections/BeEducated.tsx
+++ b/frontend/src/pages/actions/sections/BeEducated.tsx
@@ -26,7 +26,7 @@ const booksToReadAndOfferEn = [
   {
     text: 'Weapons of Math Destruction',
     href: 'https://www.penguinrandomhouse.com/books/241363/weapons-of-math-destruction-by-cathy-oneil/',
-    authors: "Cathy O'Neil",
+    authors: "Cathy O'NEIL",
   },
 ];
 
@@ -39,7 +39,7 @@ const booksToReadAndOfferFr = [
   {
     text: 'Algorithmes : la bombe à retardement',
     href: 'https://arenes.fr/livre/algorithmes-la-bombe-a-retardement/',
-    authors: "Cathy O'Neil",
+    authors: "Cathy O'NEIL",
   },
   {
     text: 'Le Fabuleux Chantier',

--- a/frontend/src/pages/actions/sections/BeEducated.tsx
+++ b/frontend/src/pages/actions/sections/BeEducated.tsx
@@ -23,6 +23,11 @@ const booksToReadAndOfferEn = [
     href: 'https://www.twitterandteargas.org/downloads/twitter-and-tear-gas-by-zeynep-tufekci.pdf',
     authors: 'Zeynep TÜFEKÇI',
   },
+  {
+    text: 'Weapons of Math Destruction',
+    href: 'https://www.penguinrandomhouse.com/books/241363/weapons-of-math-destruction-by-cathy-oneil/',
+    authors: "Cathy O'Neil",
+  },
 ];
 
 const booksToReadAndOfferFr = [
@@ -30,6 +35,11 @@ const booksToReadAndOfferFr = [
     text: 'Algocratie',
     href: 'https://www.actes-sud.fr/algocratie',
     authors: 'Arthur GRIMONPONT',
+  },
+  {
+    text: 'Algorithmes : la bombe à retardement',
+    href: 'https://arenes.fr/livre/algorithmes-la-bombe-a-retardement/',
+    authors: "Cathy O'Neil",
   },
   {
     text: 'Le Fabuleux Chantier',
@@ -77,7 +87,7 @@ const BooksToReadAndOffer = () => {
       </Box>
       <ul>
         <li>
-          <Typography>{t('actionsPage.beEducated.inEnglish')}</Typography>
+          <Typography>{t('actionsPage.inEnglish')}</Typography>
           <ul>
             {booksToReadAndOfferEn.map((book, idx) => (
               <li key={`book_en_${idx}`}>
@@ -90,7 +100,7 @@ const BooksToReadAndOffer = () => {
           </ul>
         </li>
         <li>
-          <Typography>{t('actionsPage.beEducated.inFrench')}</Typography>
+          <Typography>{t('actionsPage.inFrench')}</Typography>
           <ul>
             {booksToReadAndOfferFr.map((book, idx) => (
               <li key={`book_fr_${idx}`}>
@@ -119,7 +129,7 @@ const VideosToWatchAndShare = () => {
       </Box>
       <ul>
         <li>
-          <Typography>{t('actionsPage.beEducated.inEnglish')}</Typography>
+          <Typography>{t('actionsPage.inEnglish')}</Typography>
           <ul>
             {videosToWatchAndShareEn.map((videos, idx) => (
               <li key={`videos_en_${idx}`}>
@@ -132,7 +142,7 @@ const VideosToWatchAndShare = () => {
           </ul>
         </li>
         <li>
-          <Typography>{t('actionsPage.beEducated.inFrench')}</Typography>
+          <Typography>{t('actionsPage.inFrench')}</Typography>
           <ul>
             {videosToWatchAndShareFr.map((videos, idx) => (
               <li key={`videos_fr_${idx}`}>

--- a/frontend/src/pages/actions/sections/ExposureToQualityInformation.tsx
+++ b/frontend/src/pages/actions/sections/ExposureToQualityInformation.tsx
@@ -6,6 +6,50 @@ import { Box, Typography } from '@mui/material';
 import { ExternalLink } from 'src/components';
 import { getWebExtensionUrl } from 'src/utils/extension';
 
+const booksToReadAndOfferEn = [
+  {
+    text: 'Feeling Good',
+    href: 'https://feelinggood.com/books/',
+    authors: 'David D. BURNS',
+  },
+  {
+    text: 'The Righteous Mind',
+    href: 'https://www.penguinrandomhouse.com/books/73535/the-righteous-mind-by-jonathan-haidt/',
+    authors: 'Jonathan HAIDT',
+  },
+  {
+    text: 'The Scout Mindset',
+    href: 'https://www.penguinrandomhouse.com/books/555240/the-scout-mindset-by-julia-galef/',
+    authors: 'Julia GALEF',
+  },
+];
+
+const BooksToReadAndOffer = () => {
+  const { t } = useTranslation();
+  return (
+    <Box>
+      <Typography>
+        {t('actionsPage.qualityInformation.readAndOfferBooksLike')}
+      </Typography>
+      <ul>
+        <li>
+          <Typography>{t('actionsPage.inEnglish')}</Typography>
+          <ul>
+            {booksToReadAndOfferEn.map((book, idx) => (
+              <li key={`book_en_${idx}`}>
+                <Box display="flex" flexWrap="wrap" columnGap={1}>
+                  <ExternalLink href={book.href}>{book.text}</ExternalLink>
+                  <Typography variant="body2">- {book.authors}</Typography>
+                </Box>
+              </li>
+            ))}
+          </ul>
+        </li>
+      </ul>
+    </Box>
+  );
+};
+
 const ExposureToQualityInformation = () => {
   const { t } = useTranslation();
   const browserExtensionUrl =
@@ -62,26 +106,7 @@ const ExposureToQualityInformation = () => {
           </Typography>
         </li>
         <li>
-          <Typography>
-            <Trans
-              t={t}
-              i18nKey="actionsPage.qualityInformation.readOfferBooks"
-            >
-              Read and offer books, like{' '}
-              <ExternalLink href="https://www.penguinrandomhouse.com/books/73535/the-righteous-mind-by-jonathan-haidt/">
-                The Righteous Mind
-              </ExternalLink>
-              ,{' '}
-              <ExternalLink href="https://feelinggood.com/books/">
-                Feeling Good
-              </ExternalLink>
-              ,{' '}
-              <ExternalLink href="https://www.penguinrandomhouse.com/books/555240/the-scout-mindset-by-julia-galef/">
-                The Scout Mindset
-              </ExternalLink>
-              .
-            </Trans>
-          </Typography>
+          <BooksToReadAndOffer />
         </li>
         <li>
           <Typography>

--- a/frontend/src/pages/actions/sections/Volition.tsx
+++ b/frontend/src/pages/actions/sections/Volition.tsx
@@ -66,7 +66,7 @@ const BooksToReadAndOffer = () => {
       </Typography>
       <ul>
         <li>
-          <Typography>{t('actionsPage.beEducated.inEnglish')}</Typography>
+          <Typography>{t('actionsPage.inEnglish')}</Typography>
           <ul>
             {booksToReadAndOfferEn.map((book, idx) => (
               <li key={`book_en_${idx}`}>


### PR DESCRIPTION
### Description

This PR adds the authors of the books displayed in the section "Increase your exposure to quality information", and add one more book in the section "Be trained" (as discussed with @lenhoanglnh and @aidanjungo).

The authors:

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/dbeccaf9-7d16-4e79-a066-8b7198fb9580)

The book from Cathy O'Neil:

![capture2](https://github.com/tournesol-app/tournesol/assets/39056254/5d14b87e-27e9-4d2c-af52-f77d624b5e39)


### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
