### PR TITLE
proto / [front] feat: replace sliders by buttons on mobile

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -301,10 +301,10 @@ REST_FRAMEWORK = {
         "tournesol.throttling.SustainedUserRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": {
-        "anon_burst": "120/min",
-        "user_burst": server_settings.get("THROTTLE_USER_BURST", "120/min"),
-        "anon_sustained": "3600/hour",
-        "user_sustained": "3600/hour",
+        "anon_burst": "99999/min",
+        "user_burst": server_settings.get("THROTTLE_USER_BURST", "99999/min"),
+        "anon_sustained": "999999999/hour",
+        "user_sustained": "999999999/hour",
         # specific rates for specific parts of the API
         "api_video_post": "50/min",
         "api_users_me_export": "10/min",

--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -47,9 +47,6 @@ class ComparisonSerializerMixin:
             if missing_criterias:
                 raise ValidationError(f"Missing required criteria: {','.join(missing_criterias)}")
 
-        # XXX missing check: if the main criterion has not been rated, the
-        # submitted value should contain the main criterion.
-
         return value
 
 

--- a/backend/tournesol/views/comparison.py
+++ b/backend/tournesol/views/comparison.py
@@ -230,7 +230,6 @@ class ComparisonDetailApi(
             raise InactivePollError
         return self.partial_update(request, *args, **kwargs)
 
-
     def put(self, request, *args, **kwargs):
         """Update a comparison made by the logged user, in the given poll"""
         if not self.poll_from_url.active:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "^17.0.11",
     "@types/react-redux": "^7.1.7",
     "@types/react-router-dom": "^5.1.8",
+    "@use-gesture/react": "^10.3.0",
     "i18next": "^22.4.0",
     "i18next-browser-languagedetector": "^7.0.1",
     "i18next-http-backend": "^2.1.1",

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1383,6 +1383,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/ComparisonUpdate'
           description: ''
+    patch:
+      operationId: users_me_comparisons_partial_update
+      description: Partially update a comparison made by the logged user, in the given
+        poll.
+      parameters:
+      - in: path
+        name: poll_name
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: uid_a
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: uid_b
+        schema:
+          type: string
+        required: true
+      tags:
+      - users
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedComparisonUpdateRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedComparisonUpdateRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedComparisonUpdateRequest'
+      security:
+      - oauth2:
+        - read write groups
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComparisonUpdate'
+          description: ''
     delete:
       operationId: users_me_comparisons_destroy
       description: Delete a comparison made by the logged user, in the given poll
@@ -3338,12 +3381,12 @@ components:
         * `candidate_fr_2022` - Candidate (FR 2022)
     EventTypeEnum:
       enum:
-      - live
       - talk
+      - live
       type: string
       description: |-
-        * `live` - Tournesol Live
         * `talk` - Tournesol Talk
+        * `live` - Tournesol Live
     ExtendedCollectiveRating:
       type: object
       properties:
@@ -3842,6 +3885,25 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VideoSerializerWithCriteria'
+    PatchedComparisonUpdateRequest:
+      type: object
+      description: |-
+        A comparison serializer used only for updates.
+
+        Given the context determined by the view, it will represent or save the
+        comparison in the reverse order.
+
+        Use `ComparisonSerializer` for all other operations.
+      properties:
+        criteria_scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComparisonCriteriaScoreRequest'
+        duration_ms:
+          type: number
+          format: double
+          nullable: true
+          description: Time it took to rate the videos (in milliseconds)
     PatchedContributorRatingRequest:
       type: object
       properties:

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -219,9 +219,7 @@ const Comparison = ({
   const selectorHasContextA = selectorHasContext(selectorA);
   const selectorHasContextB = selectorHasContext(selectorB);
 
-  const displayContexts = () => {
-    return selectorHasContextA || selectorHasContextB;
-  };
+  const displayContexts = selectorHasContextA || selectorHasContextB;
 
   return (
     <Grid container maxWidth="880px" gap={1}>
@@ -260,7 +258,7 @@ const Comparison = ({
       >
         <ComparisonHelper />
       </Grid>
-      {displayContexts() && (
+      {displayContexts && (
         <Grid item xs={12}>
           <ComparisonEntityContexts
             selectorA={selectorA}

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -17,7 +17,9 @@ import EntitySelector, {
 } from 'src/features/entity_selector/EntitySelector';
 import { UID_YT_NAMESPACE } from 'src/utils/constants';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
-import ComparisonEntityContexts from './ComparisonEntityContexts';
+import ComparisonEntityContexts, {
+  selectorHasContext,
+} from './ComparisonEntityContexts';
 import ComparisonHelper from './ComparisonHelper';
 
 export const UID_PARAMS: { vidA: string; vidB: string } = {
@@ -273,9 +275,15 @@ const Comparison = ({
       >
         <ComparisonHelper />
       </Grid>
-      <Grid item xs={12}>
-        <ComparisonEntityContexts selectorA={selectorA} selectorB={selectorB} />
-      </Grid>
+      {selectorHasContext(selectorA) ||
+        (selectorHasContext(selectorB) && (
+          <Grid item xs={12}>
+            <ComparisonEntityContexts
+              selectorA={selectorA}
+              selectorB={selectorB}
+            />
+          </Grid>
+        ))}
       <Grid
         item
         xs={12}

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -178,12 +178,13 @@ const Comparison = ({
       if (initialComparison) {
         const { entity_a, entity_b, criteria_scores, duration_ms } = c;
         if (partialUpdate === true) {
-          await UsersService.usersMeComparisonsPartialUpdate({
+          const resp = await UsersService.usersMeComparisonsPartialUpdate({
             pollName,
             uidA: entity_a.uid,
             uidB: entity_b.uid,
             requestBody: { criteria_scores, duration_ms },
           });
+          setInitialComparison(resp);
         } else {
           await UsersService.usersMeComparisonsUpdate({
             pollName,
@@ -312,6 +313,7 @@ const Comparison = ({
               uidA={uidA || ''}
               uidB={uidB || ''}
               onSubmit={onSubmitComparison}
+              initialComparison={initialComparison}
             />
           )
         ) : (

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -216,10 +216,8 @@ const Comparison = ({
     showSuccessAlert(t('comparison.successfullySubmitted'));
   };
 
-  const selectorHasContextA = selectorHasContext(selectorA);
-  const selectorHasContextB = selectorHasContext(selectorB);
-
-  const displayContexts = selectorHasContextA || selectorHasContextB;
+  const displayContexts =
+    selectorHasContext(selectorA) || selectorHasContext(selectorB);
 
   return (
     <Grid container maxWidth="880px" gap={1}>

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -216,6 +216,13 @@ const Comparison = ({
     showSuccessAlert(t('comparison.successfullySubmitted'));
   };
 
+  const selectorHasContextA = selectorHasContext(selectorA);
+  const selectorHasContextB = selectorHasContext(selectorB);
+
+  const displayContexts = () => {
+    return selectorHasContextA || selectorHasContextB;
+  };
+
   return (
     <Grid
       container
@@ -275,15 +282,14 @@ const Comparison = ({
       >
         <ComparisonHelper />
       </Grid>
-      {selectorHasContext(selectorA) ||
-        (selectorHasContext(selectorB) && (
-          <Grid item xs={12}>
-            <ComparisonEntityContexts
-              selectorA={selectorA}
-              selectorB={selectorB}
-            />
-          </Grid>
-        ))}
+      {displayContexts() && (
+        <Grid item xs={12}>
+          <ComparisonEntityContexts
+            selectorA={selectorA}
+            selectorB={selectorB}
+          />
+        </Grid>
+      )}
       <Grid
         item
         xs={12}

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -21,6 +21,7 @@ import ComparisonEntityContexts, {
   selectorHasContext,
 } from './ComparisonEntityContexts';
 import ComparisonHelper from './ComparisonHelper';
+import ComparisonCriteriaButtons from './ComparisonCriteriaButtons';
 
 export const UID_PARAMS: { vidA: string; vidB: string } = {
   vidA: 'uidA',
@@ -169,16 +170,28 @@ const Comparison = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentLang]);
 
-  const onSubmitComparison = async (c: ComparisonRequest) => {
+  const onSubmitComparison = async (
+    c: ComparisonRequest,
+    partialUpdate?: boolean
+  ) => {
     try {
       if (initialComparison) {
         const { entity_a, entity_b, criteria_scores, duration_ms } = c;
-        await UsersService.usersMeComparisonsUpdate({
-          pollName,
-          uidA: entity_a.uid,
-          uidB: entity_b.uid,
-          requestBody: { criteria_scores, duration_ms },
-        });
+        if (partialUpdate === true) {
+          await UsersService.usersMeComparisonsPartialUpdate({
+            pollName,
+            uidA: entity_a.uid,
+            uidB: entity_b.uid,
+            requestBody: { criteria_scores, duration_ms },
+          });
+        } else {
+          await UsersService.usersMeComparisonsUpdate({
+            pollName,
+            uidA: entity_a.uid,
+            uidB: entity_b.uid,
+            requestBody: { criteria_scores, duration_ms },
+          });
+        }
       } else {
         await UsersService.usersMeComparisonsCreate({
           pollName,
@@ -274,13 +287,15 @@ const Comparison = ({
           flexDirection: 'column',
           py: 3,
         }}
-        component={Card}
-        elevation={2}
+        // restore elevation for crit sliders
+        // component={Card}
+        // elevation={2}
       >
         {selectorA.rating && selectorB.rating ? (
           isLoading ? (
             <CircularProgress />
           ) : (
+            /*
             <ComparisonSliders
               submit={onSubmitComparison}
               initialComparison={initialComparison}
@@ -290,6 +305,13 @@ const Comparison = ({
                 selectorA.rating.individual_rating.is_public &&
                 selectorB.rating.individual_rating.is_public
               }
+            />
+            */
+            // XXX || '' should not be required
+            <ComparisonCriteriaButtons
+              uidA={uidA || ''}
+              uidB={uidB || ''}
+              onSubmit={onSubmitComparison}
             />
           )
         ) : (

--- a/frontend/src/features/comparisons/ComparisonCriteriaButtons.tsx
+++ b/frontend/src/features/comparisons/ComparisonCriteriaButtons.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import { useDrag } from '@use-gesture/react';
+import { Vector2 } from '@use-gesture/core/types';
+
+import { Box, Slide } from '@mui/material';
+
+import ComparisonCriterionButtons from 'src/features/comparisons/ComparisonCriterionButtons';
+import { useCurrentPoll } from 'src/hooks';
+import { ComparisonRequest } from 'src/services/openapi';
+
+const SWIPE_TIMEOUT = 225;
+const SWIPE_VELOCITY: number | Vector2 = [0.35, 0.35];
+
+interface ComparisonCriteriaButtonsProps {
+  uidA: string;
+  uidB: string;
+  onSubmit: (c: ComparisonRequest, partialUpdate?: boolean) => Promise<void>;
+}
+
+const ComparisonCriteriaButtons = ({
+  uidA,
+  uidB,
+  onSubmit,
+}: ComparisonCriteriaButtonsProps) => {
+  const { criterias, name: pollName } = useCurrentPoll();
+
+  const [slideIn, setSlideIn] = useState(true);
+  const [slideDirection, setSlideDirection] = useState<'up' | 'down'>('down');
+  const [currentCrit, setCurrentCrit] = useState(0);
+
+  const criterion = criterias[currentCrit];
+
+  const slide = () => {
+    if (slideIn === false) {
+      return;
+    }
+    setSlideIn(false);
+  };
+
+  const onSlideEntered = () => {
+    setSlideDirection('down');
+  };
+
+  const onSlideExited = () => {
+    setSlideDirection('up');
+
+    if (currentCrit + 1 < criterias.length) {
+      setCurrentCrit(currentCrit + 1);
+    } else {
+      setCurrentCrit(0);
+    }
+
+    setSlideIn(true);
+  };
+
+  const bindDrag = useDrag(
+    ({ swipe, type }) => {
+      if (slideIn === false) {
+        return;
+      }
+
+      if (type === 'pointerup' || type === 'touchend') {
+        if (swipe[1] < 0) {
+          slide();
+        }
+      }
+    },
+    { swipe: { velocity: SWIPE_VELOCITY } }
+  );
+
+  const onClick = async (criterion: string, score: number) => {
+    const comparisonRequest = {
+      pollName: pollName,
+      entity_a: { uid: uidA },
+      entity_b: { uid: uidB },
+      criteria_scores: [
+        {
+          criteria: criterion,
+          score: score,
+        },
+      ],
+    };
+
+    try {
+      await onSubmit(comparisonRequest, true);
+      slide();
+    } catch {
+      // XXX handle error
+    }
+  };
+
+  return (
+    <Box width="100%" {...bindDrag()} sx={{ touchAction: 'pan-x' }}>
+      <Slide
+        in={slideIn}
+        appear={false}
+        direction={slideDirection}
+        onEntered={onSlideEntered}
+        onExited={onSlideExited}
+        timeout={SWIPE_TIMEOUT}
+      >
+        <ComparisonCriterionButtons
+          critName={criterion.name}
+          critLabel={criterion.label}
+          onClick={onClick}
+        />
+      </Slide>
+    </Box>
+  );
+};
+
+export default ComparisonCriteriaButtons;

--- a/frontend/src/features/comparisons/ComparisonCriteriaButtons.tsx
+++ b/frontend/src/features/comparisons/ComparisonCriteriaButtons.tsx
@@ -14,12 +14,14 @@ const SWIPE_VELOCITY: number | Vector2 = [0.35, 0.35];
 interface ComparisonCriteriaButtonsProps {
   uidA: string;
   uidB: string;
+  initialComparison: ComparisonRequest | null;
   onSubmit: (c: ComparisonRequest, partialUpdate?: boolean) => Promise<void>;
 }
 
 const ComparisonCriteriaButtons = ({
   uidA,
   uidB,
+  initialComparison,
   onSubmit,
 }: ComparisonCriteriaButtonsProps) => {
   const { criterias, name: pollName } = useCurrentPoll();
@@ -29,6 +31,10 @@ const ComparisonCriteriaButtons = ({
   const [currentCrit, setCurrentCrit] = useState(0);
 
   const criterion = criterias[currentCrit];
+
+  const criterionScore = initialComparison?.criteria_scores.find(
+    (crit) => crit.criteria === criterion.name
+  );
 
   const slide = () => {
     if (slideIn === false) {
@@ -102,6 +108,7 @@ const ComparisonCriteriaButtons = ({
         <ComparisonCriterionButtons
           critName={criterion.name}
           critLabel={criterion.label}
+          givenScore={criterionScore?.score}
           onClick={onClick}
         />
       </Slide>

--- a/frontend/src/features/comparisons/ComparisonCriterionButtons.tsx
+++ b/frontend/src/features/comparisons/ComparisonCriterionButtons.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { Box, IconButton, Paper, Typography } from '@mui/material';
+import { Add, Balance } from '@mui/icons-material';
+
+import { CriteriaIcon } from 'src/components';
+import { CriteriaLabel } from './CriteriaSlider';
+
+interface CriterionComparisonButtonsProps {
+  critName: string;
+  critLabel: string;
+  onClick: (criteron: string, score: number) => Promise<void>;
+}
+
+const ComparisonCriterionButtons = React.forwardRef(function (
+  { critName, critLabel, onClick }: CriterionComparisonButtonsProps,
+  ref
+) {
+  return (
+    <Box ref={ref}>
+      <Paper sx={{ py: 2 }}>
+        <Box display="flex" justifyContent="center" mb={1}>
+          <CriteriaIcon criteriaName={critName} sx={{ mr: 1 }} />
+          <Typography fontSize={{ xs: '90%', sm: '100%' }}>
+            <CriteriaLabel criteria={critName} criteriaLabel={critLabel} />
+          </Typography>
+        </Box>
+        <Box display="flex" justifyContent="space-between" width="100%">
+          <IconButton
+            color="secondary"
+            aria-label="todo"
+            onClick={() => onClick(critName, -2)}
+          >
+            <Add />
+            <Add />
+          </IconButton>
+          <IconButton
+            color="secondary"
+            aria-label="todo"
+            onClick={() => onClick(critName, -1)}
+          >
+            <Add />
+          </IconButton>
+          <IconButton
+            color="secondary"
+            aria-label="todo"
+            onClick={() => onClick(critName, 0)}
+          >
+            <Balance />
+          </IconButton>
+          <IconButton
+            color="secondary"
+            aria-label="todo"
+            onClick={() => onClick(critName, 1)}
+          >
+            <Add />
+          </IconButton>
+          <IconButton
+            color="secondary"
+            aria-label="todo"
+            onClick={() => onClick(critName, 2)}
+          >
+            <Add />
+            <Add />
+          </IconButton>
+        </Box>
+      </Paper>
+    </Box>
+  );
+});
+
+ComparisonCriterionButtons.displayName = 'CriterionComparisonButtons';
+
+export default ComparisonCriterionButtons;

--- a/frontend/src/features/comparisons/ComparisonCriterionButtons.tsx
+++ b/frontend/src/features/comparisons/ComparisonCriterionButtons.tsx
@@ -1,24 +1,97 @@
 import React from 'react';
 
-import { Box, IconButton, Paper, Typography } from '@mui/material';
+import { Box, IconButton, Paper, Typography, useTheme } from '@mui/material';
 import { Add, Balance } from '@mui/icons-material';
 
 import { CriteriaIcon } from 'src/components';
 import { CriteriaLabel } from './CriteriaSlider';
 
-interface CriterionComparisonButtonsProps {
+interface ScoreButtonProps {
+  children: React.ReactNode;
   critName: string;
-  critLabel: string;
+  score: number;
+  selected: boolean;
   onClick: (criteron: string, score: number) => Promise<void>;
 }
 
+interface ComparisonCriterionButtonsProps {
+  critName: string;
+  critLabel: string;
+  givenScore?: number;
+  onClick: (criteron: string, score: number) => Promise<void>;
+}
+
+const ScoreButton = ({
+  children,
+  critName,
+  score,
+  selected,
+  onClick,
+}: ScoreButtonProps) => {
+  const theme = useTheme();
+
+  return (
+    <IconButton
+      color="secondary"
+      aria-label="todo"
+      onClick={() => onClick(critName, score)}
+      sx={{
+        borderRadius: '4px',
+        backgroundColor: selected ? theme.palette.secondary.main : undefined,
+        color: selected ? 'white' : undefined,
+        '&:hover': {
+          color: 'white',
+          backgroundColor: selected
+            ? theme.palette.secondary.dark
+            : theme.palette.secondary.main,
+        },
+      }}
+    >
+      {children}
+    </IconButton>
+  );
+};
+
 const ComparisonCriterionButtons = React.forwardRef(function (
-  { critName, critLabel, onClick }: CriterionComparisonButtonsProps,
+  { critName, critLabel, givenScore, onClick }: ComparisonCriterionButtonsProps,
   ref
 ) {
+  const scoreButtons = [
+    {
+      score: -2,
+      icons: (
+        <>
+          <Add />
+          <Add />
+        </>
+      ),
+    },
+    {
+      score: -1,
+      icons: <Add />,
+    },
+    {
+      score: 0,
+      icons: <Balance />,
+    },
+    {
+      score: 1,
+      icons: <Add />,
+    },
+    {
+      score: 2,
+      icons: (
+        <>
+          <Add />
+          <Add />
+        </>
+      ),
+    },
+  ];
+
   return (
     <Box ref={ref}>
-      <Paper sx={{ py: 2 }}>
+      <Paper sx={{ p: 2 }}>
         <Box display="flex" justifyContent="center" mb={1}>
           <CriteriaIcon criteriaName={critName} sx={{ mr: 1 }} />
           <Typography fontSize={{ xs: '90%', sm: '100%' }}>
@@ -26,43 +99,17 @@ const ComparisonCriterionButtons = React.forwardRef(function (
           </Typography>
         </Box>
         <Box display="flex" justifyContent="space-between" width="100%">
-          <IconButton
-            color="secondary"
-            aria-label="todo"
-            onClick={() => onClick(critName, -2)}
-          >
-            <Add />
-            <Add />
-          </IconButton>
-          <IconButton
-            color="secondary"
-            aria-label="todo"
-            onClick={() => onClick(critName, -1)}
-          >
-            <Add />
-          </IconButton>
-          <IconButton
-            color="secondary"
-            aria-label="todo"
-            onClick={() => onClick(critName, 0)}
-          >
-            <Balance />
-          </IconButton>
-          <IconButton
-            color="secondary"
-            aria-label="todo"
-            onClick={() => onClick(critName, 1)}
-          >
-            <Add />
-          </IconButton>
-          <IconButton
-            color="secondary"
-            aria-label="todo"
-            onClick={() => onClick(critName, 2)}
-          >
-            <Add />
-            <Add />
-          </IconButton>
+          {scoreButtons.map((btn, idx) => (
+            <ScoreButton
+              key={`criterion_button_${idx}`}
+              critName={critName}
+              score={btn.score}
+              selected={btn.score === givenScore}
+              onClick={onClick}
+            >
+              {btn.icons}
+            </ScoreButton>
+          ))}
         </Box>
       </Paper>
     </Box>

--- a/frontend/src/features/comparisons/ComparisonCriterionButtons.tsx
+++ b/frontend/src/features/comparisons/ComparisonCriterionButtons.tsx
@@ -8,22 +8,20 @@ import { CriteriaLabel } from './CriteriaSlider';
 
 interface ScoreButtonProps {
   children: React.ReactNode;
-  critName: string;
   score: number;
   selected: boolean;
-  onClick: (criteron: string, score: number) => Promise<void>;
+  onClick: (score: number) => Promise<void>;
 }
 
 interface ComparisonCriterionButtonsProps {
   critName: string;
   critLabel: string;
   givenScore?: number;
-  onClick: (criteron: string, score: number) => Promise<void>;
+  onClick: (score: number) => Promise<void>;
 }
 
 const ScoreButton = ({
   children,
-  critName,
   score,
   selected,
   onClick,
@@ -34,7 +32,7 @@ const ScoreButton = ({
     <IconButton
       color="secondary"
       aria-label="todo"
-      onClick={() => onClick(critName, score)}
+      onClick={() => onClick(score)}
       sx={{
         borderRadius: '4px',
         backgroundColor: selected ? theme.palette.secondary.main : undefined,
@@ -102,7 +100,6 @@ const ComparisonCriterionButtons = React.forwardRef(function (
           {scoreButtons.map((btn, idx) => (
             <ScoreButton
               key={`criterion_button_${idx}`}
-              critName={critName}
               score={btn.score}
               selected={btn.score === givenScore}
               onClick={onClick}

--- a/frontend/src/features/comparisons/ComparisonEntityContexts.tsx
+++ b/frontend/src/features/comparisons/ComparisonEntityContexts.tsx
@@ -13,6 +13,14 @@ interface EntityContextBoxProps {
   selectorB: SelectorValue;
 }
 
+export const selectorHasContext = (selector: SelectorValue) => {
+  return (
+    selector.uid &&
+    selector.rating &&
+    selector.rating.entity_contexts.length > 0
+  );
+};
+
 const ComparisonEntityContextsItem = ({
   selector,
   altAssociationDisclaimer,
@@ -22,15 +30,17 @@ const ComparisonEntityContextsItem = ({
 }) => {
   return (
     <>
-      {selector.rating && selector.uid && selector.rating.entity_contexts && (
-        <EntityContextBox
-          uid={selector.uid}
-          contexts={selector.rating.entity_contexts}
-          entityName={selector.rating?.entity?.metadata?.name}
-          altAssociationDisclaimer={altAssociationDisclaimer}
-          collapsible={true}
-        />
-      )}
+      {selector.uid &&
+        selector.rating &&
+        selector.rating.entity_contexts.length > 0 && (
+          <EntityContextBox
+            uid={selector.uid}
+            contexts={selector.rating.entity_contexts}
+            entityName={selector.rating?.entity?.metadata?.name}
+            altAssociationDisclaimer={altAssociationDisclaimer}
+            collapsible={true}
+          />
+        )}
     </>
   );
 };
@@ -45,6 +55,13 @@ const ComparisonEntityContexts = ({
   const { name: pollName } = useCurrentPoll();
 
   const entityName = getEntityName(t, pollName);
+
+  const selectorHasContextA = selectorHasContext(selectorA);
+  const selectorHasContextB = selectorHasContext(selectorB);
+
+  if (!selectorHasContextA && !selectorHasContextB) {
+    return <></>;
+  }
 
   return (
     <Grid
@@ -64,38 +81,42 @@ const ComparisonEntityContexts = ({
         </Grid>
       ) : (
         <>
-          <Grid item xs={12} sm={12} md={6}>
-            <ComparisonEntityContextsItem
-              selector={selectorA}
-              altAssociationDisclaimer={
-                <strong>
-                  <Trans
-                    t={t}
-                    i18nKey="entityContext.entityAtheAssociationWouldLikeToGiveYouContext"
-                  >
-                    <span className="primary">{{ entityName }} A</span> - The
-                    Tournesol association would like to give you some context.
-                  </Trans>
-                </strong>
-              }
-            />
-          </Grid>
-          <Grid item xs={12} sm={12} md={6}>
-            <ComparisonEntityContextsItem
-              selector={selectorB}
-              altAssociationDisclaimer={
-                <strong>
-                  <Trans
-                    t={t}
-                    i18nKey="entityContext.entityBtheAssociationWouldLikeToGiveYouContext"
-                  >
-                    <span className="primary">{{ entityName }} B</span> - The
-                    Tournesol association would like to give you some context.
-                  </Trans>
-                </strong>
-              }
-            />
-          </Grid>
+          {selectorHasContextA && (
+            <Grid item xs={12} sm={12} md={6}>
+              <ComparisonEntityContextsItem
+                selector={selectorA}
+                altAssociationDisclaimer={
+                  <strong>
+                    <Trans
+                      t={t}
+                      i18nKey="entityContext.entityAtheAssociationWouldLikeToGiveYouContext"
+                    >
+                      <span className="primary">{{ entityName }} A</span> - The
+                      Tournesol association would like to give you some context.
+                    </Trans>
+                  </strong>
+                }
+              />
+            </Grid>
+          )}
+          {selectorHasContextB && (
+            <Grid item xs={12} sm={12} md={6}>
+              <ComparisonEntityContextsItem
+                selector={selectorB}
+                altAssociationDisclaimer={
+                  <strong>
+                    <Trans
+                      t={t}
+                      i18nKey="entityContext.entityBtheAssociationWouldLikeToGiveYouContext"
+                    >
+                      <span className="primary">{{ entityName }} B</span> - The
+                      Tournesol association would like to give you some context.
+                    </Trans>
+                  </strong>
+                }
+              />
+            </Grid>
+          )}
         </>
       )}
     </Grid>

--- a/frontend/src/features/comparisons/ComparisonEntityContexts.tsx
+++ b/frontend/src/features/comparisons/ComparisonEntityContexts.tsx
@@ -81,42 +81,38 @@ const ComparisonEntityContexts = ({
         </Grid>
       ) : (
         <>
-          {selectorHasContextA && (
-            <Grid item xs={12} sm={12} md={6}>
-              <ComparisonEntityContextsItem
-                selector={selectorA}
-                altAssociationDisclaimer={
-                  <strong>
-                    <Trans
-                      t={t}
-                      i18nKey="entityContext.entityAtheAssociationWouldLikeToGiveYouContext"
-                    >
-                      <span className="primary">{{ entityName }} A</span> - The
-                      Tournesol association would like to give you some context.
-                    </Trans>
-                  </strong>
-                }
-              />
-            </Grid>
-          )}
-          {selectorHasContextB && (
-            <Grid item xs={12} sm={12} md={6}>
-              <ComparisonEntityContextsItem
-                selector={selectorB}
-                altAssociationDisclaimer={
-                  <strong>
-                    <Trans
-                      t={t}
-                      i18nKey="entityContext.entityBtheAssociationWouldLikeToGiveYouContext"
-                    >
-                      <span className="primary">{{ entityName }} B</span> - The
-                      Tournesol association would like to give you some context.
-                    </Trans>
-                  </strong>
-                }
-              />
-            </Grid>
-          )}
+          <Grid item xs={12} sm={12} md={6}>
+            <ComparisonEntityContextsItem
+              selector={selectorA}
+              altAssociationDisclaimer={
+                <strong>
+                  <Trans
+                    t={t}
+                    i18nKey="entityContext.entityAtheAssociationWouldLikeToGiveYouContext"
+                  >
+                    <span className="primary">{{ entityName }} A</span> - The
+                    Tournesol association would like to give you some context.
+                  </Trans>
+                </strong>
+              }
+            />
+          </Grid>
+          <Grid item xs={12} sm={12} md={6}>
+            <ComparisonEntityContextsItem
+              selector={selectorB}
+              altAssociationDisclaimer={
+                <strong>
+                  <Trans
+                    t={t}
+                    i18nKey="entityContext.entityBtheAssociationWouldLikeToGiveYouContext"
+                  >
+                    <span className="primary">{{ entityName }} B</span> - The
+                    Tournesol association would like to give you some context.
+                  </Trans>
+                </strong>
+              }
+            />
+          </Grid>
         </>
       )}
     </Grid>

--- a/frontend/src/features/comparisons/ComparisonEntityContexts.tsx
+++ b/frontend/src/features/comparisons/ComparisonEntityContexts.tsx
@@ -56,10 +56,7 @@ const ComparisonEntityContexts = ({
 
   const entityName = getEntityName(t, pollName);
 
-  const selectorHasContextA = selectorHasContext(selectorA);
-  const selectorHasContextB = selectorHasContext(selectorB);
-
-  if (!selectorHasContextA && !selectorHasContextB) {
+  if (!selectorHasContext(selectorA) && !selectorHasContext(selectorB)) {
     return <></>;
   }
 

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Tooltip, Button, useMediaQuery, IconButton } from '@mui/material';
-import { Autorenew } from '@mui/icons-material';
+import { Autorenew, SwipeUp } from '@mui/icons-material';
 
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import { theme } from 'src/theme';
@@ -13,7 +13,7 @@ interface Props {
   currentUid: string | null;
   otherUid: string | null;
   onResponse: (newUid: string | null) => void;
-  onClick: () => void;
+  onClick: () => Promise<void>;
   disabled?: boolean;
   autoFill?: boolean;
   variant?: 'compact' | 'full';
@@ -43,7 +43,7 @@ const AutoEntityButton = ({
 
   const askNewVideo = useCallback(
     async ({ fromAutoFill = false } = {}) => {
-      onClick();
+      await onClick();
 
       const newUid: string | null = await getUidForComparison(
         currentUid || '',
@@ -104,7 +104,7 @@ const AutoEntityButton = ({
           sx={{ fontSize: { xs: '0.7rem', sm: '0.8rem' } }}
           data-testid={`auto-entity-button-${variant}`}
         >
-          <Autorenew />
+          <SwipeUp />
         </IconButton>
       ) : (
         <Tooltip

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -16,6 +16,7 @@ interface Props {
   disabled?: boolean;
   autoFill?: boolean;
   variant?: 'compact' | 'full';
+  htmlId?: string;
 }
 
 const AutoEntityButton = ({
@@ -26,6 +27,7 @@ const AutoEntityButton = ({
   disabled = false,
   autoFill = false,
   variant = 'compact',
+  htmlId,
 }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
@@ -93,6 +95,7 @@ const AutoEntityButton = ({
           component to properly listen to fired events. */}
       <span>
         <Button
+          id={htmlId}
           fullWidth={variant === 'full' ? true : false}
           disabled={disabled}
           color="secondary"

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -190,7 +190,7 @@ const EntitySelectorInnerAuth = ({
 
     setTimeout(() => {
       setSlideDirection('down');
-    }, ENTITY_CARD_SWIPE_TIMEOUT + 1);
+    }, ENTITY_CARD_SWIPE_TIMEOUT + 8);
   }, [onChange, options?.comparisonsCanBePublic, pollName, uid]);
 
   /**

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useDrag } from '@use-gesture/react';
 
 import { useTheme } from '@mui/material/styles';
-import { Box, Grid, Slide, Typography } from '@mui/material';
+import { Box, Grid, Slide, Typography, useMediaQuery } from '@mui/material';
 
 import { useCurrentPoll, useEntityAvailable, useLoginState } from 'src/hooks';
 import { ENTITY_AVAILABILITY } from 'src/hooks/useEntityAvailable';
@@ -42,6 +42,12 @@ export interface SelectorValue {
 
 const isUidValid = (uid: string | null) =>
   uid === null ? false : uid.match(/\w+:.+/);
+
+const wait = (milliseconds: number) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+};
 
 const EntitySelector = ({
   alignment = 'left',
@@ -117,6 +123,8 @@ const EntitySelectorInnerAuth = ({
   const theme = useTheme();
   const { t } = useTranslation();
   const { name: pollName, options } = useCurrentPoll();
+
+  const smallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   const { uid, rating, ratingIsExpired } = value;
 
@@ -269,7 +277,7 @@ const EntitySelectorInnerAuth = ({
         }
       }
     },
-    { swipe: { velocity: [0.4, 0.4] } }
+    { swipe: { velocity: [0.35, 0.35] } }
   );
 
   return (
@@ -295,6 +303,7 @@ const EntitySelectorInnerAuth = ({
             spacing={1}
             display={uid ? 'flex' : 'none'}
             direction={alignment === 'left' ? 'row' : 'row-reverse'}
+            justifyContent={smallScreen ? 'space-around' : 'flex-start'}
           >
             <Grid item>
               <EntitySelectButton
@@ -309,9 +318,12 @@ const EntitySelectorInnerAuth = ({
                 disabled={loading}
                 currentUid={uid}
                 otherUid={otherUid}
-                onClick={() => {
+                onClick={async () => {
                   setLoading(true);
+                  setSlideIn(false);
+                  await wait(ENTITY_CARD_SWIPE_TIMEOUT + 1);
                   setInputValue('');
+                  setSlideDirection('up');
                 }}
                 onResponse={(uid) => {
                   uid ? onChange({ uid, rating: null }) : setLoading(false);
@@ -412,7 +424,7 @@ const EntitySelectorInnerAuth = ({
                       disabled={loading}
                       currentUid={uid}
                       otherUid={otherUid}
-                      onClick={() => {
+                      onClick={async () => {
                         setLoading(true);
                         setInputValue('');
                       }}

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -251,27 +251,30 @@ const EntitySelectorInnerAuth = ({
     [onChange]
   );
 
-  const bindDrag = useDrag(({ swipe, type }) => {
-    if (variant === 'noControl' || slideIn === false) {
-      return;
-    }
+  const bindDrag = useDrag(
+    ({ swipe, type }) => {
+      if (variant === 'noControl' || slideIn === false) {
+        return;
+      }
 
-    if (type === 'pointerup' || type === 'touchend') {
-      if (swipe[1] < 0) {
-        const autoButton = document.getElementById(
-          `auto-suggestion-${alignment}`
-        ) as HTMLElement;
+      if (type === 'pointerup' || type === 'touchend') {
+        if (swipe[1] < 0) {
+          const autoButton = document.getElementById(
+            `auto-suggestion-${alignment}`
+          ) as HTMLElement;
 
-        if (autoButton) {
-          setSlideIn(false);
-          setTimeout(() => {
-            setSlideDirection('up');
-            autoButton.click();
-          }, ENTITY_CARD_SWIPE_TIMEOUT + 1);
+          if (autoButton) {
+            setSlideIn(false);
+            setTimeout(() => {
+              setSlideDirection('up');
+              autoButton.click();
+            }, ENTITY_CARD_SWIPE_TIMEOUT + 1);
+          }
         }
       }
-    }
-  });
+    },
+    { swipe: { velocity: [0.4, 0.4] } }
+  );
 
   return (
     <>

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -239,18 +239,16 @@ const EntitySelectorInnerAuth = ({
     [onChange]
   );
 
-  const bindDrag = useDrag((state) => {
-    if (state.type === 'pointerup' || state.type === 'touchend') {
-      const swipe = state.swipe;
+  const bindDrag = useDrag(({ swipe, type }) => {
+    if (type === 'pointerup' || type === 'touchend') {
       if (swipe[1] < 0) {
-        // XXX:
-        //   - trigger the refresh of the correct entity selector
-        //   - use a more React strategy
-        (
-          document.querySelectorAll(
-            'button[data-testid="auto-entity-button-compact"]'
-          )[0] as HTMLElement
-        ).click();
+        const autoButton = document.getElementById(
+          `auto-suggestion-${alignment}`
+        ) as HTMLElement;
+
+        if (autoButton) {
+          autoButton.click();
+        }
       }
     }
   });
@@ -288,6 +286,7 @@ const EntitySelectorInnerAuth = ({
             </Grid>
             <Grid item>
               <AutoEntityButton
+                htmlId={`auto-suggestion-${alignment}`}
                 disabled={loading}
                 currentUid={uid}
                 otherUid={otherUid}

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -239,27 +239,19 @@ const EntitySelectorInnerAuth = ({
     [onChange]
   );
 
-  const bind = useDrag((state) => {
+  const bindDrag = useDrag((state) => {
     if (state.type === 'pointerup' || state.type === 'touchend') {
       const swipe = state.swipe;
       if (swipe[1] < 0) {
+        // XXX:
+        //   - trigger the refresh of the correct entity selector
+        //   - use a more React strategy
         (
           document.querySelectorAll(
             'button[data-testid="auto-entity-button-compact"]'
           )[0] as HTMLElement
         ).click();
       }
-
-      //const movement = state.movement;
-      /*
-      if (movement[1] < 0) {
-        (
-          document.querySelectorAll(
-            'button[data-testid="auto-entity-button-compact"]'
-          )[0] as HTMLElement
-        ).click();
-      }
-      */
     }
   });
 
@@ -320,7 +312,7 @@ const EntitySelectorInnerAuth = ({
           </Typography>
         </Box>
       )}
-      <Box {...bind()} sx={{ touchAction: 'none' }}>
+      <Box {...bindDrag()} sx={{ touchAction: 'pan-x' }}>
         {rating ? (
           <EntityCard
             compact

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDrag } from '@use-gesture/react';
 
 import { useTheme } from '@mui/material/styles';
 import { Box, Grid, Typography } from '@mui/material';
@@ -238,6 +239,18 @@ const EntitySelectorInnerAuth = ({
     [onChange]
   );
 
+  const bind = useDrag((state) => {
+    if (state.type === 'pointerup' || state.type === 'touchend') {
+      if (state.swipe[1] > 0) {
+        (
+          document.querySelectorAll(
+            'button[data-testid="auto-entity-button-compact"]'
+          )[0] as HTMLElement
+        ).click();
+      }
+    }
+  });
+
   return (
     <>
       {showEntityInput && (
@@ -295,7 +308,7 @@ const EntitySelectorInnerAuth = ({
           </Typography>
         </Box>
       )}
-      <>
+      <Box {...bind()}>
         {rating ? (
           <EntityCard
             compact
@@ -389,7 +402,7 @@ const EntitySelectorInnerAuth = ({
             </Grid>
           </>
         )}
-      </>
+      </Box>
     </>
   );
 };

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -123,15 +123,12 @@ const EntitySelectorInnerAuth = ({
   const theme = useTheme();
   const { t } = useTranslation();
   const { name: pollName, options } = useCurrentPoll();
-
   const smallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   const { uid, rating, ratingIsExpired } = value;
 
   const [slideIn, setSlideIn] = useState(true);
-  const [slideDirection, setSlideDirection] = useState<
-    'left' | 'right' | 'up' | 'down'
-  >('down');
+  const [slideDirection, setSlideDirection] = useState<'up' | 'down'>('down');
 
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -352,6 +352,7 @@ const EntitySelectorInnerAuth = ({
         onEntered={onSlideEntered}
         onExited={onSlideExited}
         timeout={ENTITY_CARD_SWIPE_TIMEOUT}
+        appear={variant === 'noControl' ? false : true}
       >
         {/* position: relative is required to correctly display the entity unavailable box */}
         <Box {...bindDrag()} sx={{ touchAction: 'pan-x' }} position="relative">

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -272,6 +272,29 @@ const EntitySelectorInnerAuth = ({
     { swipe: { velocity: [0.35, 0.35] } }
   );
 
+  const onSlideEntered = () => {
+    setSlideDirection('down');
+  };
+
+  const onSlideExited = () => {
+    setSlideDirection('up');
+
+    if (!loading) {
+      const autoButton = document.getElementById(
+        `auto-suggestion-${alignment}`
+      ) as HTMLElement;
+
+      if (autoButton) {
+        autoButton.click();
+      } else {
+        setSlideIn(true);
+        console.warn(
+          "Can't suggest new entity: Auto button not found in the DOM."
+        );
+      }
+    }
+  };
+
   return (
     <>
       {showEntityInput && (
@@ -312,9 +335,9 @@ const EntitySelectorInnerAuth = ({
                 otherUid={otherUid}
                 onClick={async () => {
                   setLoading(true);
+                  setInputValue('');
                   setSlideIn(false);
                   await wait(ENTITY_CARD_SWIPE_TIMEOUT + 8);
-                  setInputValue('');
                 }}
                 onResponse={(uid) => {
                   uid ? onChange({ uid, rating: null }) : setLoading(false);
@@ -326,26 +349,12 @@ const EntitySelectorInnerAuth = ({
         </Box>
       )}
       <Slide
+        mountOnEnter
         in={slideIn}
         direction={slideDirection}
-        mountOnEnter
+        onEntered={onSlideEntered}
+        onExited={onSlideExited}
         timeout={ENTITY_CARD_SWIPE_TIMEOUT}
-        onEntered={() => {
-          setSlideDirection('down');
-        }}
-        onExited={() => {
-          const autoButton = document.getElementById(
-            `auto-suggestion-${alignment}`
-          ) as HTMLElement;
-
-          setSlideDirection('up');
-
-          if (autoButton) {
-            autoButton.click();
-          } else {
-            setSlideIn(true);
-          }
-        }}
       >
         <Box {...bindDrag()} sx={{ touchAction: 'pan-x' }}>
           {rating ? (

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -241,7 +241,9 @@ const EntitySelectorInnerAuth = ({
 
   const bind = useDrag((state) => {
     if (state.type === 'pointerup' || state.type === 'touchend') {
-      if (state.swipe[1] > 0) {
+      const movement = state.movement;
+
+      if (movement[1] < 0) {
         (
           document.querySelectorAll(
             'button[data-testid="auto-entity-button-compact"]'
@@ -308,7 +310,7 @@ const EntitySelectorInnerAuth = ({
           </Typography>
         </Box>
       )}
-      <Box {...bind()}>
+      <Box {...bind()} sx={{ touchAction: 'none' }}>
         {rating ? (
           <EntityCard
             compact

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -356,7 +356,8 @@ const EntitySelectorInnerAuth = ({
         onExited={onSlideExited}
         timeout={ENTITY_CARD_SWIPE_TIMEOUT}
       >
-        <Box {...bindDrag()} sx={{ touchAction: 'pan-x' }}>
+        {/* position: relative is required to correctly display the entity unavailable box */}
+        <Box {...bindDrag()} sx={{ touchAction: 'pan-x' }} position="relative">
           {rating ? (
             <EntityCard
               compact

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -23,7 +23,7 @@ import EntitySelectButton from './EntitySelectButton';
 import { extractVideoId } from 'src/utils/video';
 import { entityCardMainSx } from 'src/components/entity/style';
 
-const ENTITY_CARD_SWIPE_TIMEOUT = 160;
+const ENTITY_CARD_SWIPE_TIMEOUT = 180;
 
 interface Props {
   alignment?: 'left' | 'right';
@@ -187,10 +187,6 @@ const EntitySelectorInnerAuth = ({
     }
     setLoading(false);
     setSlideIn(true);
-
-    setTimeout(() => {
-      setSlideDirection('down');
-    }, ENTITY_CARD_SWIPE_TIMEOUT + 8);
   }, [onChange, options?.comparisonsCanBePublic, pollName, uid]);
 
   /**
@@ -269,10 +265,6 @@ const EntitySelectorInnerAuth = ({
 
           if (autoButton) {
             setSlideIn(false);
-            setTimeout(() => {
-              setSlideDirection('up');
-              autoButton.click();
-            }, ENTITY_CARD_SWIPE_TIMEOUT + 8);
           }
         }
       }
@@ -323,7 +315,6 @@ const EntitySelectorInnerAuth = ({
                   setSlideIn(false);
                   await wait(ENTITY_CARD_SWIPE_TIMEOUT + 8);
                   setInputValue('');
-                  setSlideDirection('up');
                 }}
                 onResponse={(uid) => {
                   uid ? onChange({ uid, rating: null }) : setLoading(false);
@@ -339,6 +330,22 @@ const EntitySelectorInnerAuth = ({
         direction={slideDirection}
         mountOnEnter
         timeout={ENTITY_CARD_SWIPE_TIMEOUT}
+        onEntered={() => {
+          setSlideDirection('down');
+        }}
+        onExited={() => {
+          const autoButton = document.getElementById(
+            `auto-suggestion-${alignment}`
+          ) as HTMLElement;
+
+          setSlideDirection('up');
+
+          if (autoButton) {
+            autoButton.click();
+          } else {
+            setSlideIn(true);
+          }
+        }}
       >
         <Box {...bindDrag()} sx={{ touchAction: 'pan-x' }}>
           {rating ? (

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -23,6 +23,8 @@ import EntitySelectButton from './EntitySelectButton';
 import { extractVideoId } from 'src/utils/video';
 import { entityCardMainSx } from 'src/components/entity/style';
 
+const ENTITY_CARD_SWIPE_TIMEOUT = 160;
+
 interface Props {
   title: string;
   alignment?: 'left' | 'right';
@@ -123,6 +125,9 @@ const EntitySelectorInnerAuth = ({
   const { uid, rating, ratingIsExpired } = value;
 
   const [slideIn, setSlideIn] = useState(true);
+  const [slideDirection, setSlideDirection] = useState<
+    'left' | 'right' | 'up' | 'down'
+  >('down');
 
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);
@@ -178,6 +183,10 @@ const EntitySelectorInnerAuth = ({
     }
     setLoading(false);
     setSlideIn(true);
+
+    setTimeout(() => {
+      setSlideDirection('down');
+    }, ENTITY_CARD_SWIPE_TIMEOUT + 1);
   }, [onChange, options?.comparisonsCanBePublic, pollName, uid]);
 
   /**
@@ -256,8 +265,9 @@ const EntitySelectorInnerAuth = ({
         if (autoButton) {
           setSlideIn(false);
           setTimeout(() => {
+            setSlideDirection('up');
             autoButton.click();
-          }, 160);
+          }, ENTITY_CARD_SWIPE_TIMEOUT + 1);
         }
       }
     }
@@ -321,7 +331,12 @@ const EntitySelectorInnerAuth = ({
           </Typography>
         </Box>
       )}
-      <Slide in={slideIn} direction="down" mountOnEnter timeout={160}>
+      <Slide
+        in={slideIn}
+        direction={slideDirection}
+        mountOnEnter
+        timeout={ENTITY_CARD_SWIPE_TIMEOUT}
+      >
         <Box {...bindDrag()} sx={{ touchAction: 'pan-x' }}>
           {rating ? (
             <EntityCard

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -272,7 +272,7 @@ const EntitySelectorInnerAuth = ({
             setTimeout(() => {
               setSlideDirection('up');
               autoButton.click();
-            }, ENTITY_CARD_SWIPE_TIMEOUT + 1);
+            }, ENTITY_CARD_SWIPE_TIMEOUT + 8);
           }
         }
       }
@@ -321,7 +321,7 @@ const EntitySelectorInnerAuth = ({
                 onClick={async () => {
                   setLoading(true);
                   setSlideIn(false);
-                  await wait(ENTITY_CARD_SWIPE_TIMEOUT + 1);
+                  await wait(ENTITY_CARD_SWIPE_TIMEOUT + 8);
                   setInputValue('');
                   setSlideDirection('up');
                 }}

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDrag } from '@use-gesture/react';
+import { Vector2 } from '@use-gesture/core/types';
 
 import { useTheme } from '@mui/material/styles';
 import { Box, Grid, Slide, Typography, useMediaQuery } from '@mui/material';
@@ -24,6 +25,8 @@ import { extractVideoId } from 'src/utils/video';
 import { entityCardMainSx } from 'src/components/entity/style';
 
 const ENTITY_CARD_SWIPE_TIMEOUT = 180;
+// The minimum velocity per axis in pixels / ms.
+const ENTITY_CARD_SWIPE_VELOCITY: number | Vector2 = [0.35, 0.35];
 
 interface Props {
   alignment?: 'left' | 'right';
@@ -266,7 +269,7 @@ const EntitySelectorInnerAuth = ({
         }
       }
     },
-    { swipe: { velocity: [0.35, 0.35] } }
+    { swipe: { velocity: ENTITY_CARD_SWIPE_VELOCITY } }
   );
 
   const onSlideEntered = () => {

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -177,6 +177,7 @@ const EntitySelectorInnerAuth = ({
       }
     }
     setLoading(false);
+    setSlideIn(true);
   }, [onChange, options?.comparisonsCanBePublic, pollName, uid]);
 
   /**
@@ -242,6 +243,10 @@ const EntitySelectorInnerAuth = ({
   );
 
   const bindDrag = useDrag(({ swipe, type }) => {
+    if (variant === 'noControl' || slideIn === false) {
+      return;
+    }
+
     if (type === 'pointerup' || type === 'touchend') {
       if (swipe[1] < 0) {
         const autoButton = document.getElementById(
@@ -252,10 +257,6 @@ const EntitySelectorInnerAuth = ({
           setSlideIn(false);
           setTimeout(() => {
             autoButton.click();
-
-            setTimeout(() => {
-              setSlideIn(true);
-            }, 200);
           }, 160);
         }
       }

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useDrag } from '@use-gesture/react';
 
 import { useTheme } from '@mui/material/styles';
-import { Box, Grid, Typography } from '@mui/material';
+import { Box, Grid, Slide, Typography } from '@mui/material';
 
 import { useCurrentPoll, useEntityAvailable, useLoginState } from 'src/hooks';
 import { ENTITY_AVAILABILITY } from 'src/hooks/useEntityAvailable';
@@ -121,6 +121,8 @@ const EntitySelectorInnerAuth = ({
   const { name: pollName, options } = useCurrentPoll();
 
   const { uid, rating, ratingIsExpired } = value;
+
+  const [slideIn, setSlideIn] = useState(true);
 
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);
@@ -247,7 +249,14 @@ const EntitySelectorInnerAuth = ({
         ) as HTMLElement;
 
         if (autoButton) {
-          autoButton.click();
+          setSlideIn(false);
+          setTimeout(() => {
+            autoButton.click();
+
+            setTimeout(() => {
+              setSlideIn(true);
+            }, 200);
+          }, 160);
         }
       }
     }
@@ -311,101 +320,105 @@ const EntitySelectorInnerAuth = ({
           </Typography>
         </Box>
       )}
-      <Box {...bindDrag()} sx={{ touchAction: 'pan-x' }}>
-        {rating ? (
-          <EntityCard
-            compact
-            result={rating}
-            showRatingControl={showRatingControl}
-            onRatingChange={handleRatingUpdate}
-          ></EntityCard>
-        ) : (
-          <>
-            {(loading ||
-              !showEntityInput ||
-              entityAvailability === ENTITY_AVAILABILITY.UNAVAILABLE) && (
-              <EmptyEntityCard compact loading={loading} />
-            )}
-            {!loading &&
-              entityAvailability === ENTITY_AVAILABILITY.UNAVAILABLE && (
-                <Box
-                  display="flex"
-                  justifyContent="center"
-                  alignItems="center"
-                  position="absolute"
-                  top="0"
-                  color="white"
-                  bgcolor="rgba(0,0,0,.6)"
-                  width="100%"
-                  sx={{
-                    aspectRatio: '16/9',
-                    [theme.breakpoints.down('sm')]: {
-                      fontSize: '0.8rem',
-                    },
-                  }}
-                >
-                  <Typography textAlign="center" fontSize="inherit">
-                    {pollName === YOUTUBE_POLL_NAME
-                      ? t('entitySelector.youtubeVideoUnavailable')
-                      : t('entityCard.thisElementIsNotAvailable')}
-                  </Typography>
-                </Box>
+      <Slide in={slideIn} direction="down" mountOnEnter timeout={160}>
+        <Box {...bindDrag()} sx={{ touchAction: 'pan-x' }}>
+          {rating ? (
+            <EntityCard
+              compact
+              result={rating}
+              showRatingControl={showRatingControl}
+              onRatingChange={handleRatingUpdate}
+            ></EntityCard>
+          ) : (
+            <>
+              {(loading ||
+                !showEntityInput ||
+                entityAvailability === ENTITY_AVAILABILITY.UNAVAILABLE) && (
+                <EmptyEntityCard compact loading={loading} />
               )}
-            <Grid
-              container
-              sx={{
-                ...entityCardMainSx,
-                display:
-                  uid ||
-                  loading ||
-                  !showEntityInput ||
-                  entityAvailability === ENTITY_AVAILABILITY.UNAVAILABLE
-                    ? 'none'
-                    : 'flex',
-              }}
-            >
+              {!loading &&
+                entityAvailability === ENTITY_AVAILABILITY.UNAVAILABLE && (
+                  <Box
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                    position="absolute"
+                    top="0"
+                    color="white"
+                    bgcolor="rgba(0,0,0,.6)"
+                    width="100%"
+                    sx={{
+                      aspectRatio: '16/9',
+                      [theme.breakpoints.down('sm')]: {
+                        fontSize: '0.8rem',
+                      },
+                    }}
+                  >
+                    <Typography textAlign="center" fontSize="inherit">
+                      {pollName === YOUTUBE_POLL_NAME
+                        ? t('entitySelector.youtubeVideoUnavailable')
+                        : t('entityCard.thisElementIsNotAvailable')}
+                    </Typography>
+                  </Box>
+                )}
               <Grid
                 container
-                item
-                xs={12}
                 sx={{
-                  aspectRatio: '16 / 9',
-                  backgroundColor: '#fafafa',
+                  ...entityCardMainSx,
+                  display:
+                    uid ||
+                    loading ||
+                    !showEntityInput ||
+                    entityAvailability === ENTITY_AVAILABILITY.UNAVAILABLE
+                      ? 'none'
+                      : 'flex',
                 }}
-                spacing={1}
-                alignItems="center"
-                justifyContent="space-around"
-                wrap="wrap"
               >
-                <Grid container item xs={12} sm={5} justifyContent="center">
-                  <EntitySelectButton
-                    value={inputValue || uid || ''}
-                    onChange={handleChange}
-                    otherUid={otherUid}
-                    variant="full"
-                  />
-                </Grid>
-                <Grid container item xs={12} sm={5} justifyContent="center">
-                  <AutoEntityButton
-                    disabled={loading}
-                    currentUid={uid}
-                    otherUid={otherUid}
-                    onClick={() => {
-                      setLoading(true);
-                      setInputValue('');
-                    }}
-                    onResponse={(uid) =>
-                      uid ? onChange({ uid, rating: null }) : setLoading(false)
-                    }
-                    autoFill={false}
-                    variant="full"
-                  />
+                <Grid
+                  container
+                  item
+                  xs={12}
+                  sx={{
+                    aspectRatio: '16 / 9',
+                    backgroundColor: '#fafafa',
+                  }}
+                  spacing={1}
+                  alignItems="center"
+                  justifyContent="space-around"
+                  wrap="wrap"
+                >
+                  <Grid container item xs={12} sm={5} justifyContent="center">
+                    <EntitySelectButton
+                      value={inputValue || uid || ''}
+                      onChange={handleChange}
+                      otherUid={otherUid}
+                      variant="full"
+                    />
+                  </Grid>
+                  <Grid container item xs={12} sm={5} justifyContent="center">
+                    <AutoEntityButton
+                      disabled={loading}
+                      currentUid={uid}
+                      otherUid={otherUid}
+                      onClick={() => {
+                        setLoading(true);
+                        setInputValue('');
+                      }}
+                      onResponse={(uid) =>
+                        uid
+                          ? onChange({ uid, rating: null })
+                          : setLoading(false)
+                      }
+                      autoFill={false}
+                      variant="full"
+                    />
+                  </Grid>
                 </Grid>
               </Grid>
-            </Grid>
-          </>
-        )}
-      </Box>
+            </>
+          )}
+        </Box>
+      </Slide>
     </>
   );
 };

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -241,8 +241,17 @@ const EntitySelectorInnerAuth = ({
 
   const bind = useDrag((state) => {
     if (state.type === 'pointerup' || state.type === 'touchend') {
-      const movement = state.movement;
+      const swipe = state.swipe;
+      if (swipe[1] < 0) {
+        (
+          document.querySelectorAll(
+            'button[data-testid="auto-entity-button-compact"]'
+          )[0] as HTMLElement
+        ).click();
+      }
 
+      //const movement = state.movement;
+      /*
       if (movement[1] < 0) {
         (
           document.querySelectorAll(
@@ -250,6 +259,7 @@ const EntitySelectorInnerAuth = ({
           )[0] as HTMLElement
         ).click();
       }
+      */
     }
   });
 

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -392,11 +392,6 @@ const EntitySelectorInnerAuth = ({
                       ? 'none'
                       : 'flex',
                 }}
-                height="100%"
-                spacing={1}
-                alignItems="center"
-                justifyContent="space-around"
-                wrap="wrap"
               >
                 <Grid
                   container

--- a/frontend/src/features/goals/CollectiveGoalWeeklyProgress.tsx
+++ b/frontend/src/features/goals/CollectiveGoalWeeklyProgress.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { Box, LinearProgress, Typography } from '@mui/material';
+import { Box, LinearProgress, Typography, useMediaQuery } from '@mui/material';
 
 import { getPollStats } from 'src/features/statistics/stats';
 import { useCurrentPoll, useStats } from 'src/hooks';
+import { theme } from 'src/theme';
 
 import {
   WEEKLY_COMPARISON_GOAL,
@@ -14,6 +15,7 @@ import {
 const CollectiveGoalWeeklyProgress = () => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
+  const smallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   const stats = useStats({ poll: pollName });
   const pollStats = getPollStats(stats, pollName);
@@ -31,7 +33,7 @@ const CollectiveGoalWeeklyProgress = () => {
       flexDirection="column"
       alignItems="center"
       gap={1}
-      mb={4}
+      mb={smallScreen ? 2 : 4}
     >
       <Typography variant="h5" textAlign="center">
         <Trans

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,7 @@
+body {
+  overscroll-behavior-y: contain;
+}
+
 html, body, #root {
   margin: 0;
   width: 100%;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1351,6 +1351,18 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
+"@use-gesture/core@10.3.0":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.3.0.tgz#9afd3777a45b2a08990a5dcfcf8d9ddd55b00db9"
+  integrity sha512-rh+6MND31zfHcy9VU3dOZCqGY511lvGcfyJenN4cWZe0u1BH6brBpBddLVXhF2r4BMqWbvxfsbL7D287thJU2A==
+
+"@use-gesture/react@^10.3.0":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@use-gesture/react/-/react-10.3.0.tgz#180534c821fd635c2853cbcfa813f92c94f27e3f"
+  integrity sha512-3zc+Ve99z4usVP6l9knYVbVnZgfqhKah7sIG+PS2w+vpig2v2OLct05vs+ZXMzwxdNCMka8B+8WlOo0z6Pn6DA==
+  dependencies:
+    "@use-gesture/core" "10.3.0"
+
 "@vitejs/plugin-react@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.2.0.tgz#d71352b1a443c09c7aae8f278dd071ab3d9d8490"


### PR DESCRIPTION
**related to** #1940

---


### Description

{describe your PR here}

**to-do**

*back end - route*
- [ ] add the endpoint `PATCH /users/me/comparisons/{poll}/{uid_a}/{uid_b}`
- [ ] add tests for the new endpoint
- [ ] add API documentation

*back end - serializer*
- [ ] ensure comparisons cannot be created without the main criterion (as before)
  - a test should already exists 
- [ ] ensure comparisons can be patched without sending the main criterion in the request body 
  - [ ] add the related tests
- [ ] remove WIP comments 

*back end - model*
- [ ] add a new integer field to save the score amplitude in `ComparisonCriteriaScore`

*front end - comparison - features*
- [ ] on mobile, replace the sliders by buttons
- [ ] add the possibility to clear the score of an already submitted optional criterion
- [ ] add the possibility to view all criteria at once

*front end - comparison - ui*

- [ ] make it clear that the buttons are buttons
- [x] make them "selected" when a criterion has been given a score
- [ ] disable them during API requests
- [x] add the possibility to swipe up and down
- [ ] add hints about swipe up and down
- [ ] prevent skipping the main criterion of the poll

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines