### PR TITLE
[front] fix: forward ref and props on link components to be compatible with MUI Tooltip

### DIFF
--- a/frontend/src/components/Links.tsx
+++ b/frontend/src/components/Links.tsx
@@ -33,14 +33,13 @@ interface InternalLinkProps {
  *   - a media is playing on the page, and we don't want to interrupt it
  *   - etc.
  */
-export const ExternalLink = ({
-  children,
-  href,
-  target,
-  sx,
-}: ExternalLinkProps) => {
+export const ExternalLink = React.forwardRef<
+  HTMLAnchorElement,
+  ExternalLinkProps
+>(function ExternalLink({ children, href, target, sx, ...other }, ref) {
   return (
     <Link
+      ref={ref}
       href={href}
       target={target}
       rel="noreferrer"
@@ -49,25 +48,34 @@ export const ExternalLink = ({
         textDecoration: 'revert',
         ...sx,
       }}
+      {...other} // MUI Tooltip requires to forward both ref and props
     >
       {children}
     </Link>
   );
-};
+});
 
-export const InternalLink = ({
-  children,
-  to,
-  target,
-  id,
-  ariaLabel,
-  color = 'secondary',
-  underline = 'hover',
-  sx,
-}: InternalLinkProps) => {
+export const InternalLink = React.forwardRef<
+  HTMLAnchorElement,
+  InternalLinkProps
+>(function InternalLink(
+  {
+    children,
+    to,
+    target,
+    id,
+    ariaLabel,
+    color = 'secondary',
+    underline = 'hover',
+    sx,
+    ...other
+  },
+  ref
+) {
   return (
     <Link
       component={RouterLink}
+      ref={ref}
       to={to}
       target={target}
       id={id}
@@ -77,8 +85,9 @@ export const InternalLink = ({
       sx={{
         ...sx,
       }}
+      {...other} // MUI Tooltip requires to forward both ref and props
     >
       {children}
     </Link>
   );
-};
+});


### PR DESCRIPTION
### Description

In video cards, the tooltip on the channel name was broken after introducing `<InternalLink>` custom component.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
