### PR TITLE
[front] feat: replace message with loader when a video is being loaded during swipe

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -80,7 +80,6 @@
   },
   "comparison": {
     "successfullySubmitted": "The comparison has been successfully submitted.",
-    "pleaseSelectTwoItems": "Please select 2 items to compare them.",
     "itemsAreSimilar": "These two items are very similar, it is probably not useful to compare them.",
     "removeOptionalCriterias": "Remove optional criteria",
     "addOptionalCriterias": "Add optional criteria",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -84,7 +84,6 @@
   },
   "comparison": {
     "successfullySubmitted": "Comparaison bien enregistrée.",
-    "pleaseSelectTwoItems": "Sélectionnez 2 éléments pour les comparer.",
     "itemsAreSimilar": "Ces deux éléments sont très similaires, ce n'est probablement pas une bonne idée de les comparer.",
     "removeOptionalCriterias": "Supprimer les critères optionnels",
     "addOptionalCriterias": "Ajouter les critères optionnels",

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -3,7 +3,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Location } from 'history';
 
-import { CircularProgress, Grid, Typography, Card } from '@mui/material';
+import { CircularProgress, Grid, Card } from '@mui/material';
 
 import { useNotifications } from 'src/hooks';
 import {
@@ -273,13 +273,14 @@ const Comparison = ({
           alignItems: 'center',
           flexDirection: 'column',
           py: 3,
+          '&:empty': { display: 'none' },
         }}
         component={Card}
         elevation={2}
       >
         {selectorA.rating && selectorB.rating ? (
           isLoading ? (
-            <CircularProgress />
+            <CircularProgress color="secondary" />
           ) : (
             <ComparisonSliders
               submit={onSubmitComparison}
@@ -292,9 +293,10 @@ const Comparison = ({
               }
             />
           )
-        ) : (
-          <Typography>{t('comparison.pleaseSelectTwoItems')}</Typography>
-        )}
+        ) : selectorA.uid && selectorB.uid ? (
+          // Entities are selected but ratings are not loaded yet
+          <CircularProgress color="secondary" />
+        ) : null}
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
### Description
The message "Please select 2 items" is redundant with the buttons "select video". Instead a circular loader is displayed if the rating is not ready yet.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
