### PR TITLE
[front] fix: remove loading wrapper on tutorial

### DIFF
--- a/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
+++ b/frontend/src/features/comparisonSeries/ComparisonSeries.tsx
@@ -12,7 +12,6 @@ import {
 } from '@mui/material';
 
 import DialogBox from 'src/components/DialogBox';
-import LoaderWrapper from 'src/components/LoaderWrapper';
 import Comparison, { UID_PARAMS } from 'src/features/comparisons/Comparison';
 import { useLoginState } from 'src/hooks';
 import { alreadyComparedWith, selectRandomEntity } from 'src/utils/entity';
@@ -317,7 +316,7 @@ const ComparisonSeries = ({
 
   const currentDialog = dialogs?.[step];
   return (
-    <LoaderWrapper isLoading={initializing.current}>
+    <>
       {/*
         Do not display the dialog box while the alternatives array
         is being built, to avoid a blink effect.
@@ -363,7 +362,7 @@ const ComparisonSeries = ({
       {!initializing.current && (
         <Comparison afterSubmitCallback={afterSubmitCallback} />
       )}
-    </LoaderWrapper>
+    </>
   );
 };
 


### PR DESCRIPTION
Can be merged after https://github.com/tournesol-app/tournesol/pull/1930

### Description

The container created by the loading wrapper could cause vdeo cards to be resized during swipes.

The loader is not useful anymore as the entity selector can handle the absence of a video by themselves.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
