### PR TITLE
[front] feat: make `UidHistory` able to append entries to both ends

### DIFF
--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -159,7 +159,7 @@ const Comparison = ({
       if (uidA) {
         selectorAHistory.appendRight(pollName, uidA);
       } else if (autoFillSelectorA) {
-        autoUidA = await nextSuggestion(pollName, [uidA, uidB], 'A');
+        autoUidA = await nextSuggestion(pollName, [uidA, uidB], 'selectorA');
       }
 
       if (uidB) {
@@ -168,7 +168,7 @@ const Comparison = ({
         autoUidB = await nextSuggestion(
           pollName,
           [autoUidA || uidA, uidB],
-          'B'
+          'selectorB'
         );
       }
 
@@ -293,7 +293,7 @@ const Comparison = ({
           value={selectorA}
           onChange={onChangeA}
           otherUid={uidB}
-          historyId="A"
+          historyId="selectorA"
         />
       </Grid>
       <Grid item xs display="flex" flexDirection="column" alignSelf="stretch">
@@ -302,7 +302,7 @@ const Comparison = ({
           value={selectorB}
           onChange={onChangeB}
           otherUid={uidA}
-          historyId="B"
+          historyId="selectorB"
         />
       </Grid>
       <Grid

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -148,13 +148,13 @@ const Comparison = ({
       let autoUidB = null;
 
       if (uidA) {
-        selectorAHistory.push(pollName, uidA);
+        selectorAHistory.appendRight(pollName, uidA);
       } else if (autoFillSelectorA) {
         autoUidA = await nextSuggestion(pollName, [uidA, uidB], 'A');
       }
 
       if (uidB) {
-        selectorBHistory.push(pollName, uidB);
+        selectorBHistory.appendRight(pollName, uidB);
       } else if (autoFillSelectorB) {
         autoUidB = await nextSuggestion(
           pollName,

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -147,6 +147,15 @@ const Comparison = ({
       let autoUidA = null;
       let autoUidB = null;
 
+      // At this moment, the entities still present in selectorAHistory and
+      // selectorBHistory come from a previous comparison session. During this
+      // last session they may have been compared enough times to not be
+      // considered as suggestion by the API anymore. To avoid suggesting
+      // entities that don't match the suggestion strategies used by the API,
+      // we clear the history of all selectors.
+      selectorAHistory.clear();
+      selectorBHistory.clear();
+
       if (uidA) {
         selectorAHistory.appendRight(pollName, uidA);
       } else if (autoFillSelectorA) {

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -14,6 +14,7 @@ import { Search } from '@mui/icons-material';
 
 import { useTranslation } from 'react-i18next';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
+import { HistoryId, useSuggestions } from 'src/hooks/useSuggestions';
 import {
   PRESIDENTIELLE_2022_POLL_NAME,
   YOUTUBE_POLL_NAME,
@@ -37,6 +38,10 @@ interface Props {
   otherUid: string | null;
   variant?: 'compact' | 'full';
   disabled?: boolean;
+  // When provided with historyInsertion, the selected UID will be added to
+  // the specified history.
+  historyId?: HistoryId;
+  historyInsertion?: 'left' | 'right';
 }
 
 const VideoInput = ({
@@ -45,9 +50,12 @@ const VideoInput = ({
   otherUid,
   variant = 'compact',
   disabled = false,
+  historyId,
+  historyInsertion,
 }: Props) => {
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
+  const { insertInHistory } = useSuggestions();
 
   const selectorAnchor = useRef<HTMLDivElement>(null);
   const [suggestionsOpen, setSuggestionsOpen] = useState(false);
@@ -65,6 +73,10 @@ const VideoInput = ({
   const handleOptionClick = (uid: string) => {
     onChange(uid);
     setSuggestionsOpen(false);
+
+    if (historyId && historyInsertion) {
+      insertInHistory(pollName, historyId, historyInsertion, uid);
+    }
   };
 
   const toggleSuggestions = () => {

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -278,7 +278,11 @@ const EntitySelectorInnerAuth = ({
 
   const onSlideExited = async () => {
     if (slideDirection === 'up') {
-      const newUid = previousSuggestion(pollName, historyId);
+      const newUid = await previousSuggestion(
+        pollName,
+        [uid, otherUid],
+        historyId
+      );
 
       if (newUid) {
         setSlideDirection('down');

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -132,6 +132,7 @@ const EntitySelectorInnerAuth = ({
 
   const [slideIn, setSlideIn] = useState(true);
   const [slideDirection, setSlideDirection] = useState<'up' | 'down'>('down');
+  const [lastSlide, setLastSlide] = useState<'up' | 'down'>('up');
 
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);
@@ -308,6 +309,7 @@ const EntitySelectorInnerAuth = ({
       return;
     }
 
+    setLastSlide('up');
     setSlideDirection('down');
     setLoading(true);
     setInputValue('');
@@ -319,6 +321,7 @@ const EntitySelectorInnerAuth = ({
       return;
     }
 
+    setLastSlide('down');
     setSlideDirection('up');
     setLoading(true);
     setInputValue('');
@@ -355,6 +358,8 @@ const EntitySelectorInnerAuth = ({
                 value={inputValue || uid || ''}
                 onChange={handleChange}
                 otherUid={otherUid}
+                historyId={historyId}
+                historyInsertion={lastSlide === 'up' ? 'right' : 'left'}
               />
             </Grid>
             <Grid item>

--- a/frontend/src/features/suggestions/uidHistory.spec.ts
+++ b/frontend/src/features/suggestions/uidHistory.spec.ts
@@ -6,155 +6,227 @@ describe('class: UidHistory', () => {
 
   it('constructor', () => {
     const history = new UidHistory();
-    expect(history.isHistoryEmpty(pollA)).toEqual(true);
-    expect(history.isHistoryEmpty(pollB)).toEqual(true);
-    expect(history.previous(pollA)).toBeNull();
-    expect(history.previous(pollB)).toBeNull();
-    expect(history.next(pollA)).toBeNull();
-    expect(history.next(pollB)).toBeNull();
-    expect(history.hasNext(pollA)).toEqual(false);
-    expect(history.hasNext(pollB)).toEqual(false);
+    expect(history.isEmpty(pollA)).toEqual(true);
+    expect(history.isEmpty(pollB)).toEqual(true);
+    expect(history.moveLeft(pollA)).toBeNull();
+    expect(history.moveLeft(pollB)).toBeNull();
+    expect(history.moveRight(pollA)).toBeNull();
+    expect(history.moveRight(pollB)).toBeNull();
+    expect(history.hasNextLeft(pollA)).toEqual(false);
+    expect(history.hasNextLeft(pollB)).toEqual(false);
+    expect(history.hasNextRight(pollA)).toEqual(false);
+    expect(history.hasNextRight(pollB)).toEqual(false);
   });
 
-  it('method: isHistoryEmpty - is poll specific', () => {
+  it('method: isEmpty - is poll specific', () => {
     const history = new UidHistory();
-    history.push(pollA, 'uid1');
+    history.appendRight(pollA, 'uid1');
 
-    expect(history.isHistoryEmpty(pollA)).toEqual(false);
-    expect(history.isHistoryEmpty(pollB)).toEqual(true);
+    expect(history.isEmpty(pollA)).toEqual(false);
+    expect(history.isEmpty(pollB)).toEqual(true);
   });
 
-  it('method: push - is poll specific', () => {
+  it('method: appendLeft - is poll specific', () => {
     const history = new UidHistory();
-    ['uid1', 'uid2'].forEach((uid) => history.push(pollA, uid));
-    ['uidA', 'uidB'].forEach((uid) => history.push(pollB, uid));
+    ['uid1', 'uid2'].forEach((uid) => history.appendLeft(pollA, uid));
+    ['uidA', 'uidB'].forEach((uid) => history.appendLeft(pollB, uid));
 
-    expect(history.previous(pollA)).toEqual('uid1');
-    expect(history.previous(pollB)).toEqual('uidA');
+    expect(history.moveRight(pollA)).toEqual('uid1');
+    expect(history.moveRight(pollB)).toEqual('uidA');
   });
 
-  it('method: push - reset the history cursor', () => {
+  it('method: appendLeft - reset the history cursor', () => {
     const history = new UidHistory();
 
-    history.push(pollA, 'uid1');
-    expect(history.previous(pollA)).toBeNull();
+    history.appendLeft(pollA, 'uid1');
+    expect(history.moveRight(pollA)).toBeNull();
 
-    history.push(pollA, 'uid2');
-    expect(history.previous(pollA)).toEqual('uid1');
+    history.appendLeft(pollA, 'uid2');
+    expect(history.moveRight(pollA)).toEqual('uid1');
 
-    history.push(pollA, 'uid3');
-    history.push(pollA, 'uid4');
-    expect(history.previous(pollA)).toEqual('uid3');
+    history.appendLeft(pollA, 'uid3');
+    history.appendLeft(pollA, 'uid4');
+    expect(history.moveRight(pollA)).toEqual('uid3');
 
-    history.previous(pollA);
-    history.previous(pollA);
-    history.push(pollA, 'uid5');
-    expect(history.previous(pollA)).toEqual('uid4');
+    history.moveRight(pollA);
+    history.moveRight(pollA);
+    history.appendLeft(pollA, 'uid5');
+    expect(history.moveRight(pollA)).toEqual('uid4');
   });
 
-  it('method: previous - is poll specific', () => {
+  it('method: appendRight - is poll specific', () => {
     const history = new UidHistory();
-    ['uid1', 'uid2', 'uid3', 'uid4'].forEach((uid) => history.push(pollA, uid));
-    ['uidA', 'uidB', 'uidC', 'uidD'].forEach((uid) => history.push(pollB, uid));
+    ['uid1', 'uid2'].forEach((uid) => history.appendRight(pollA, uid));
+    ['uidA', 'uidB'].forEach((uid) => history.appendRight(pollB, uid));
 
-    expect(history.previous(pollA)).toEqual('uid3');
-    expect(history.previous(pollA)).toEqual('uid2');
-    expect(history.previous(pollA)).toEqual('uid1');
-    expect(history.previous(pollA)).toBeNull();
-
-    expect(history.previous(pollB)).toEqual('uidC');
-    expect(history.previous(pollB)).toEqual('uidB');
-    expect(history.previous(pollB)).toEqual('uidA');
-    expect(history.previous(pollB)).toBeNull();
+    expect(history.moveLeft(pollA)).toEqual('uid1');
+    expect(history.moveLeft(pollB)).toEqual('uidA');
   });
 
-  it('method: next - is poll specific', () => {
+  it('method: appendRight - reset the history cursor', () => {
     const history = new UidHistory();
-    ['uid1', 'uid2', 'uid3', 'uid4'].forEach((uid) => history.push(pollA, uid));
-    ['uidA', 'uidB', 'uidC', 'uidD'].forEach((uid) => history.push(pollB, uid));
 
-    expect(history.next(pollA)).toBeNull();
-    expect(history.next(pollB)).toBeNull();
+    history.appendRight(pollA, 'uid1');
+    expect(history.moveLeft(pollA)).toBeNull();
 
-    history.previous(pollA);
-    expect(history.next(pollA)).toEqual('uid4');
+    history.appendRight(pollA, 'uid2');
+    expect(history.moveLeft(pollA)).toEqual('uid1');
 
-    history.previous(pollA);
-    history.previous(pollA);
-    expect(history.next(pollA)).toEqual('uid3');
-    expect(history.next(pollA)).toEqual('uid4');
-    expect(history.next(pollA)).toBeNull();
+    history.appendRight(pollA, 'uid3');
+    history.appendRight(pollA, 'uid4');
+    expect(history.moveLeft(pollA)).toEqual('uid3');
+
+    history.moveLeft(pollA);
+    history.moveLeft(pollA);
+    history.appendRight(pollA, 'uid5');
+    expect(history.moveLeft(pollA)).toEqual('uid4');
+  });
+
+  it('method: moveLeft - is poll specific', () => {
+    const history = new UidHistory();
+    ['uid1', 'uid2', 'uid3', 'uid4'].forEach((uid) =>
+      history.appendRight(pollA, uid)
+    );
+    ['uidA', 'uidB', 'uidC', 'uidD'].forEach((uid) =>
+      history.appendRight(pollB, uid)
+    );
+
+    expect(history.moveLeft(pollA)).toEqual('uid3');
+    expect(history.moveLeft(pollA)).toEqual('uid2');
+    expect(history.moveLeft(pollA)).toEqual('uid1');
+    expect(history.moveLeft(pollA)).toBeNull();
+
+    expect(history.moveLeft(pollB)).toEqual('uidC');
+    expect(history.moveLeft(pollB)).toEqual('uidB');
+    expect(history.moveLeft(pollB)).toEqual('uidA');
+    expect(history.moveLeft(pollB)).toBeNull();
+  });
+
+  it('method: moveRight - is poll specific', () => {
+    const history = new UidHistory();
+    ['uid1', 'uid2', 'uid3', 'uid4'].forEach((uid) =>
+      history.appendRight(pollA, uid)
+    );
+    ['uidA', 'uidB', 'uidC', 'uidD'].forEach((uid) =>
+      history.appendRight(pollB, uid)
+    );
+
+    expect(history.moveRight(pollA)).toBeNull();
+    expect(history.moveRight(pollB)).toBeNull();
+
+    history.moveLeft(pollA);
+    expect(history.moveRight(pollA)).toEqual('uid4');
+
+    history.moveLeft(pollA);
+    history.moveLeft(pollA);
+    expect(history.moveRight(pollA)).toEqual('uid3');
+    expect(history.moveRight(pollA)).toEqual('uid4');
+    expect(history.moveRight(pollA)).toBeNull();
 
     for (let i = 0; i < 10; i++) {
-      history.previous(pollA);
+      history.moveLeft(pollA);
     }
-    expect(history.next(pollA)).toEqual('uid2');
+    expect(history.moveRight(pollA)).toEqual('uid2');
 
-    history.previous(pollB);
-    expect(history.next(pollB)).toEqual('uidD');
-    expect(history.next(pollB)).toBeNull();
+    history.moveLeft(pollB);
+    expect(history.moveRight(pollB)).toEqual('uidD');
+    expect(history.moveRight(pollB)).toBeNull();
   });
 
-  it('method: hasNext - is poll specific', () => {
+  it('method: hasNextLeft - is poll specific', () => {
     const history = new UidHistory();
-    ['uid1', 'uid2', 'uid3', 'uid4'].forEach((uid) => history.push(pollA, uid));
-    ['uidA', 'uidB', 'uidC', 'uidD'].forEach((uid) => history.push(pollB, uid));
+    ['uid1', 'uid2', 'uid3', 'uid4'].forEach((uid) =>
+      history.appendLeft(pollA, uid)
+    );
+    ['uidA', 'uidB', 'uidC', 'uidD'].forEach((uid) =>
+      history.appendLeft(pollB, uid)
+    );
 
-    expect(history.hasNext(pollA)).toEqual(false);
-    expect(history.hasNext(pollB)).toEqual(false);
+    expect(history.hasNextLeft(pollA)).toEqual(false);
+    expect(history.hasNextLeft(pollB)).toEqual(false);
 
-    history.previous(pollA);
-    expect(history.hasNext(pollA)).toEqual(true);
-    expect(history.next(pollA)).toEqual('uid4');
-    expect(history.hasNext(pollA)).toEqual(false);
+    history.moveRight(pollA);
+    expect(history.hasNextLeft(pollA)).toEqual(true);
+    expect(history.moveLeft(pollA)).toEqual('uid4');
+    expect(history.hasNextLeft(pollA)).toEqual(false);
 
     for (let i = 0; i < 10; i++) {
-      history.previous(pollA);
+      history.moveRight(pollA);
     }
-    expect(history.hasNext(pollA)).toEqual(true);
-    expect(history.next(pollA)).toEqual('uid2');
-    expect(history.hasNext(pollA)).toEqual(true);
+    expect(history.hasNextLeft(pollA)).toEqual(true);
+    expect(history.moveLeft(pollA)).toEqual('uid2');
+    expect(history.hasNextLeft(pollA)).toEqual(true);
 
-    history.previous(pollB);
-    expect(history.hasNext(pollB)).toEqual(true);
-    expect(history.next(pollB)).toEqual('uidD');
-    expect(history.hasNext(pollB)).toEqual(false);
+    history.moveRight(pollB);
+    expect(history.hasNextLeft(pollB)).toEqual(true);
+    expect(history.moveLeft(pollB)).toEqual('uidD');
+    expect(history.hasNextLeft(pollB)).toEqual(false);
+  });
+
+  it('method: hasNextRight - is poll specific', () => {
+    const history = new UidHistory();
+    ['uid1', 'uid2', 'uid3', 'uid4'].forEach((uid) =>
+      history.appendRight(pollA, uid)
+    );
+    ['uidA', 'uidB', 'uidC', 'uidD'].forEach((uid) =>
+      history.appendRight(pollB, uid)
+    );
+
+    expect(history.hasNextRight(pollA)).toEqual(false);
+    expect(history.hasNextRight(pollB)).toEqual(false);
+
+    history.moveLeft(pollA);
+    expect(history.hasNextRight(pollA)).toEqual(true);
+    expect(history.moveRight(pollA)).toEqual('uid4');
+    expect(history.hasNextRight(pollA)).toEqual(false);
+
+    for (let i = 0; i < 10; i++) {
+      history.moveLeft(pollA);
+    }
+    expect(history.hasNextRight(pollA)).toEqual(true);
+    expect(history.moveRight(pollA)).toEqual('uid2');
+    expect(history.hasNextRight(pollA)).toEqual(true);
+
+    history.moveLeft(pollB);
+    expect(history.hasNextRight(pollB)).toEqual(true);
+    expect(history.moveRight(pollB)).toEqual('uidD');
+    expect(history.hasNextRight(pollB)).toEqual(false);
   });
 
   it('method: clear - clears everything', () => {
     const history = new UidHistory();
     const pollC = 'foobar';
 
-    ['uid1', 'uid2', 'uid3'].forEach((uid) => history.push(pollA, uid));
-    ['uidA', 'uidB', 'uidC'].forEach((uid) => history.push(pollB, uid));
-    ['uidX', 'uidY', 'uidZ'].forEach((uid) => history.push(pollC, uid));
+    ['uid1', 'uid2', 'uid3'].forEach((uid) => history.appendRight(pollA, uid));
+    ['uidA', 'uidB', 'uidC'].forEach((uid) => history.appendRight(pollB, uid));
+    ['uidX', 'uidY', 'uidZ'].forEach((uid) => history.appendRight(pollC, uid));
 
     // Move at the beginning of the history A.
-    history.previous(pollA);
-    history.previous(pollA);
+    history.moveLeft(pollA);
+    history.moveLeft(pollA);
     // Move in the middle of the history B.
-    history.previous(pollB);
+    history.moveLeft(pollB);
 
-    expect(history.isHistoryEmpty(pollA)).toEqual(false);
-    expect(history.isHistoryEmpty(pollB)).toEqual(false);
-    expect(history.isHistoryEmpty(pollC)).toEqual(false);
+    expect(history.isEmpty(pollA)).toEqual(false);
+    expect(history.isEmpty(pollB)).toEqual(false);
+    expect(history.isEmpty(pollC)).toEqual(false);
 
     history.clear();
 
-    expect(history.isHistoryEmpty(pollA)).toEqual(true);
-    expect(history.isHistoryEmpty(pollB)).toEqual(true);
-    expect(history.isHistoryEmpty(pollC)).toEqual(true);
+    expect(history.isEmpty(pollA)).toEqual(true);
+    expect(history.isEmpty(pollB)).toEqual(true);
+    expect(history.isEmpty(pollC)).toEqual(true);
 
-    expect(history.previous(pollA)).toBeNull();
-    expect(history.previous(pollB)).toBeNull();
-    expect(history.previous(pollC)).toBeNull();
+    expect(history.moveLeft(pollA)).toBeNull();
+    expect(history.moveLeft(pollB)).toBeNull();
+    expect(history.moveLeft(pollC)).toBeNull();
 
-    expect(history.next(pollA)).toBeNull();
-    expect(history.next(pollB)).toBeNull();
-    expect(history.next(pollC)).toBeNull();
+    expect(history.moveRight(pollA)).toBeNull();
+    expect(history.moveRight(pollB)).toBeNull();
+    expect(history.moveRight(pollC)).toBeNull();
 
-    expect(history.hasNext(pollA)).toEqual(false);
-    expect(history.hasNext(pollB)).toEqual(false);
-    expect(history.hasNext(pollC)).toEqual(false);
+    expect(history.hasNextRight(pollA)).toEqual(false);
+    expect(history.hasNextRight(pollB)).toEqual(false);
+    expect(history.hasNextRight(pollC)).toEqual(false);
   });
 });

--- a/frontend/src/features/suggestions/uidHistory.ts
+++ b/frontend/src/features/suggestions/uidHistory.ts
@@ -1,5 +1,5 @@
 /**
- * A generic history of UIDs, supporting appends from both sides and multiple
+ * A generic history of UIDs, supporting appends to both ends and multiple
  * polls.
  *
  * A history can be used, for instance, to keep track of all UIDs that have

--- a/frontend/src/features/suggestions/uidHistory.ts
+++ b/frontend/src/features/suggestions/uidHistory.ts
@@ -1,5 +1,6 @@
 /**
- * A generic history of UIDs, supporting multiple polls
+ * A generic history of UIDs, supporting appends from both sides and multiple
+ * polls.
  *
  * A history can be used, for instance, to keep track of all UIDs that have
  * been displayed by an entity selector.
@@ -24,7 +25,7 @@ export class UidHistory {
     return true;
   }
 
-  isHistoryEmpty(poll: string) {
+  isEmpty(poll: string) {
     if (this.#history[poll] == undefined || this.#history[poll].length === 0) {
       return true;
     }
@@ -32,7 +33,16 @@ export class UidHistory {
     return false;
   }
 
-  push(poll: string, uid: string) {
+  appendLeft(poll: string, uid: string) {
+    if (this.#history[poll] == undefined) {
+      this.#history[poll] = [];
+    }
+
+    this.#history[poll].unshift(uid);
+    this.#cursor[poll] = 0;
+  }
+
+  appendRight(poll: string, uid: string) {
     if (this.#history[poll] == undefined) {
       this.#history[poll] = [];
     }
@@ -41,8 +51,8 @@ export class UidHistory {
     this.#cursor[poll] = this.#history[poll].length - 1;
   }
 
-  previous(poll: string): string | null {
-    if (this.isHistoryEmpty(poll)) {
+  moveLeft(poll: string): string | null {
+    if (this.isEmpty(poll)) {
       return null;
     }
 
@@ -50,7 +60,6 @@ export class UidHistory {
       this.#cursor[poll] = this.#history[poll].length;
     }
 
-    // End of the history. We could also restart at length - 1 instead.
     if (this.#cursor[poll] <= 0) {
       return null;
     }
@@ -59,8 +68,8 @@ export class UidHistory {
     return this.#history[poll].at(this.#cursor[poll]) ?? null;
   }
 
-  next(poll: string): string | null {
-    if (this.isHistoryEmpty(poll)) {
+  moveRight(poll: string): string | null {
+    if (this.isEmpty(poll)) {
       return null;
     }
 
@@ -76,8 +85,8 @@ export class UidHistory {
     return this.#history[poll].at(this.#cursor[poll]) ?? null;
   }
 
-  hasNext(poll: string): boolean {
-    if (this.isHistoryEmpty(poll)) {
+  hasNextLeft(poll: string): boolean {
+    if (this.isEmpty(poll)) {
       return false;
     }
 
@@ -85,7 +94,19 @@ export class UidHistory {
       this.#cursor[poll] = this.#history[poll].length - 1;
     }
 
-    return this.#history[poll].at(this.#cursor[poll] + 1) !== undefined;
+    return this.#history[poll][this.#cursor[poll] - 1] !== undefined;
+  }
+
+  hasNextRight(poll: string): boolean {
+    if (this.isEmpty(poll)) {
+      return false;
+    }
+
+    if (!this.isCursorInitialized(poll)) {
+      this.#cursor[poll] = this.#history[poll].length - 1;
+    }
+
+    return this.#history[poll][this.#cursor[poll] + 1] !== undefined;
   }
 
   clear() {

--- a/frontend/src/features/suggestions/uidHistory.ts
+++ b/frontend/src/features/suggestions/uidHistory.ts
@@ -33,6 +33,22 @@ export class UidHistory {
     return false;
   }
 
+  insert(poll: string, position: 'left' | 'right', uid: string) {
+    if (this.#history[poll] == undefined) {
+      this.#history[poll] = [];
+    }
+
+    if (this.#history[poll][this.#cursor[poll]] === uid) {
+      return;
+    }
+
+    if (position === 'right') {
+      this.#cursor[poll] += 1;
+    }
+
+    this.#history[poll].splice(this.#cursor[poll], 0, uid);
+  }
+
   appendLeft(poll: string, uid: string) {
     if (this.#history[poll] == undefined) {
       this.#history[poll] = [];

--- a/frontend/src/hooks/useSuggestions.ts
+++ b/frontend/src/hooks/useSuggestions.ts
@@ -50,14 +50,14 @@ export const useSuggestions = () => {
     ) => {
       const history = historyId === 'A' ? historyA : historyB;
 
-      if (history.hasNext(pollName)) {
-        return history.next(pollName);
+      if (history.hasNextRight(pollName)) {
+        return history.moveRight(pollName);
       }
 
       const suggestion = await randomUidFromSuggestions(pollName, exclude);
 
       if (suggestion) {
-        history.push(pollName, suggestion);
+        history.appendRight(pollName, suggestion);
       }
 
       return suggestion;
@@ -66,12 +66,30 @@ export const useSuggestions = () => {
   );
 
   /**
-   * Return the UID preceding the current point in the history.
+   * Return a new UID to compare from the suggestion pool.
+   *
+   * If the history has been browsed forwards, return the previous entry in the
+   * history instead.
    */
   const previousSuggestion = useCallback(
-    (pollName: string, historyId: HistoryId) => {
+    async (
+      pollName: string,
+      exclude: Array<string | null>,
+      historyId: HistoryId
+    ) => {
       const history = historyId === 'A' ? historyA : historyB;
-      return history.previous(pollName);
+
+      if (history.hasNextLeft(pollName)) {
+        return history.moveLeft(pollName);
+      }
+
+      const suggestion = await randomUidFromSuggestions(pollName, exclude);
+
+      if (suggestion) {
+        history.appendLeft(pollName, suggestion);
+      }
+
+      return suggestion;
     },
     []
   );

--- a/frontend/src/hooks/useSuggestions.ts
+++ b/frontend/src/hooks/useSuggestions.ts
@@ -33,9 +33,25 @@ export async function randomUidFromSuggestions(
   return autoSuggestionPool.random(poll, excluded);
 }
 
-export type HistoryId = 'A' | 'B';
+export type HistoryId = 'selectorA' | 'selectorB';
 
 export const useSuggestions = () => {
+  /**
+   * Insert an UID to the right or the left of the current history position.
+   */
+  const insertInHistory = useCallback(
+    (
+      pollName: string,
+      historyId: HistoryId,
+      position: 'left' | 'right',
+      uid: string
+    ) => {
+      const history = historyId === 'selectorA' ? historyA : historyB;
+      history.insert(pollName, position, uid);
+    },
+    []
+  );
+
   /**
    * Return a new UID to compare from the suggestion pool.
    *
@@ -48,7 +64,7 @@ export const useSuggestions = () => {
       exclude: Array<string | null>,
       historyId: HistoryId
     ) => {
-      const history = historyId === 'A' ? historyA : historyB;
+      const history = historyId === 'selectorA' ? historyA : historyB;
 
       if (history.hasNextRight(pollName)) {
         return history.moveRight(pollName);
@@ -77,7 +93,7 @@ export const useSuggestions = () => {
       exclude: Array<string | null>,
       historyId: HistoryId
     ) => {
-      const history = historyId === 'A' ? historyA : historyB;
+      const history = historyId === 'selectorA' ? historyA : historyB;
 
       if (history.hasNextLeft(pollName)) {
         return history.moveLeft(pollName);
@@ -95,6 +111,7 @@ export const useSuggestions = () => {
   );
 
   return {
+    insertInHistory,
     nextSuggestion,
     previousSuggestion,
   };

--- a/frontend/src/pages/home/videos/sections/HomeComparison.tsx
+++ b/frontend/src/pages/home/videos/sections/HomeComparison.tsx
@@ -140,7 +140,7 @@ const HomeComparison = () => {
           value={selectorA}
           onChange={setSelectorA}
           otherUid={uidB}
-          historyId="A"
+          historyId="selectorA"
         />
       </Grid>
       <Grid item xs display="flex" flexDirection="column" alignSelf="stretch">
@@ -149,7 +149,7 @@ const HomeComparison = () => {
           value={selectorB}
           onChange={setSelectorB}
           otherUid={uidA}
-          historyId="B"
+          historyId="selectorA"
         />
       </Grid>
       <Grid item xs={12} mt={1} component={Card} elevation={2}>


### PR DESCRIPTION
**related issues** #1931 

**target PR** #1954 

---

### Description

The entity selectors now suggest new UIDS after a swipe up and after a swipe down.

Before only a swipe up could suggest new entities to compare, making the swipe down only useful to go back in the suggestion history, but useless once the beginning of the history was reached. Now the history is able to append new entries to its "head" and to its "tail", making the navigation more comfortable and never blocking.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass



[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
