### PR TITLE
[back] feat: add vouchers.csv in public dataset

### DIFF
--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -4,6 +4,7 @@ The public dataset library.
 This module contains functions to retrieve data from the database and
 shortcuts to write these data in file-like objects.
 """
+
 import csv
 import json
 from datetime import datetime
@@ -15,6 +16,7 @@ from django.utils import timezone
 
 from ml.mehestan.run import MehestanParameters
 from tournesol.entities.base import UID_DELIMITER
+from vouch.models import Voucher
 from vouch.trust_algo import SINK_VOUCH, TRUSTED_EMAIL_PRETRUST, VOUCH_DECAY
 
 # The standard decimal precision of floating point numbers appearing in the
@@ -237,7 +239,7 @@ def get_collective_criteria_scores_data(poll_name: str) -> QuerySet:
     )
 
 
-def write_metadata_file(write_target, data_until: Optional[datetime] = None) -> None:
+def write_metadata_file(write_target, data_until: datetime) -> None:
     """
     Write the metadata as JSON in `write_target`, an
     object supporting the Python file API.
@@ -385,3 +387,21 @@ def write_collective_criteria_scores_file(poll_name: str, write_target) -> None:
     writer = csv.DictWriter(write_target, fieldnames=fieldnames)
     writer.writeheader()
     writer.writerows(rows)
+
+
+def write_vouchers_file(write_target):
+    fieldnames = [
+        "by_username",
+        "to_username",
+        "value",
+    ]
+    writer = csv.DictWriter(write_target, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(
+        {
+            "by_username": voucher.by.username,
+            "to_username": voucher.to.username,
+            "value": voucher.value,
+        }
+        for voucher in Voucher.objects.filter(is_public=True).select_related("by", "to")
+    )

--- a/backend/tournesol/lib/public_dataset.py
+++ b/backend/tournesol/lib/public_dataset.py
@@ -403,5 +403,7 @@ def write_vouchers_file(write_target):
             "to_username": voucher.to.username,
             "value": voucher.value,
         }
-        for voucher in Voucher.objects.filter(is_public=True).select_related("by", "to")
+        for voucher in Voucher.objects.filter(is_public=True)
+        .select_related("by", "to")
+        .order_by("by__username", "to__username")
     )

--- a/backend/tournesol/management/commands/create_dataset.py
+++ b/backend/tournesol/management/commands/create_dataset.py
@@ -1,13 +1,15 @@
 """
 Create and save a public dataset archive on the disk.
 """
+
+import codecs
 import zipfile
-from io import StringIO
 from os.path import getctime
 from pathlib import Path
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import connection, transaction
 from django.utils import timezone
 
 from core.utils.time import time_ago
@@ -17,6 +19,7 @@ from tournesol.lib.public_dataset import (
     write_individual_criteria_scores_file,
     write_metadata_file,
     write_users_file,
+    write_vouchers_file,
 )
 from tournesol.models.poll import Poll
 
@@ -67,54 +70,14 @@ class Command(BaseCommand):
             settings.APP_TOURNESOL["DATASETS_BUILD_DIR"]
         )
         datasets_build_dir.mkdir(parents=True, exist_ok=True)
-
-        # Only the default poll is exported for the moment.
-        poll_name = Poll.default_poll().name
-
+        dataset_base_name = settings.APP_TOURNESOL["DATASET_BASE_NAME"]
         archive_abs_path = datasets_build_dir.joinpath(dataset_base_name).with_suffix(".zip")
 
-        readme_path = Path("tournesol/resources/export_readme.txt")
-        license_path = Path("tournesol/resources/export_odc_by_1.0_public_text.txt")
-
-        first_day_of_week = time_ago(days=timezone.now().weekday()).date()
-
-        # BUILDING phase
-        with zipfile.ZipFile(archive_abs_path, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
-            with open(readme_path, "r", encoding="utf-8") as readme:
-                zip_file.writestr("README.txt", readme.read())
-
-            with open(license_path, "r", encoding="utf-8") as license_:
-                zip_file.writestr("LICENSE.txt", license_.read())
-
-            with StringIO() as output:
-                self.stdout.write("building tournesol metadata...")
-                write_metadata_file(output, data_until=first_day_of_week)
-                zip_file.writestr("metadata.json", output.getvalue())
-                self.stdout.write("- metadata.json written.")
-
-            with StringIO() as output:
-                self.stdout.write("retrieving users' data...")
-                write_users_file(poll_name, output)
-                zip_file.writestr("users.csv", output.getvalue())
-                self.stdout.write("- users.csv written.")
-
-            with StringIO() as output:
-                self.stdout.write("retrieving comparisons' data...")
-                write_comparisons_file(poll_name, output, until_=first_day_of_week)
-                zip_file.writestr("comparisons.csv", output.getvalue())
-                self.stdout.write("- comparisons.csv written.")
-
-            with StringIO() as output:
-                self.stdout.write("retrieving individual criteria scores' data...")
-                write_individual_criteria_scores_file(poll_name, output)
-                zip_file.writestr("individual_criteria_scores.csv", output.getvalue())
-                self.stdout.write("- individual_criteria_scores.csv written.")
-
-            with StringIO() as output:
-                self.stdout.write("retrieving collective criteria scores' data...")
-                write_collective_criteria_scores_file(poll_name, output)
-                zip_file.writestr("collective_criteria_scores.csv", output.getvalue())
-                self.stdout.write("- collective_criteria_scores.csv written.")
+        # TODO: write to temporary file?
+        with transaction.atomic():
+            cursor = connection.cursor()
+            cursor.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+            self.write_archive(archive_abs_path)
 
         self.stdout.write(self.style.SUCCESS(f"archive created at {archive_abs_path}"))
 
@@ -125,9 +88,67 @@ class Command(BaseCommand):
             all_datasets = list(datasets_build_dir.glob(f"{dataset_base_name}*"))
             all_datasets.sort(key=getctime, reverse=True)
 
-            for old_dataset in all_datasets[options["keep_only"]:]:
+            for old_dataset in all_datasets[options["keep_only"] :]:
                 old_dataset.unlink()
                 self.stdout.write(f"deleted old {old_dataset}")
 
         self.stdout.write(self.style.SUCCESS("success"))
         self.stdout.write("end")
+
+    def write_archive(self, archive_abs_path: Path):
+        # Only the default poll is exported for the moment.
+        poll_name = Poll.default_poll().name
+
+        readme_path = Path("tournesol/resources/export_readme.txt")
+        license_path = Path("tournesol/resources/export_odc_by_1.0_public_text.txt")
+
+        first_day_of_week = time_ago(days=timezone.now().weekday()).replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+
+        # BUILDING phase
+        with zipfile.ZipFile(archive_abs_path, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+            with open(readme_path, "r", encoding="utf-8") as readme:
+                zip_file.writestr("README.txt", readme.read())
+
+            with open(license_path, "r", encoding="utf-8") as license_file:
+                zip_file.writestr("LICENSE.txt", license_file.read())
+
+            with zip_file.open("metadata.json", "w") as output:
+                text_output = codecs.getwriter("utf8")(output)
+                self.stdout.write("building tournesol metadata...")
+                write_metadata_file(text_output, data_until=first_day_of_week)
+            self.stdout.write("- metadata.json written.")
+
+            with zip_file.open("users.csv", "w") as output:
+                text_output = codecs.getwriter("utf8")(output)
+                self.stdout.write("retrieving users' data...")
+                write_users_file(poll_name, text_output)
+            self.stdout.write("- users.csv written.")
+
+            with zip_file.open("comparisons.csv", "w") as output:
+                text_output = codecs.getwriter("utf8")(output)
+                self.stdout.write("retrieving comparisons' data...")
+                write_comparisons_file(poll_name, text_output, until_=first_day_of_week)
+            self.stdout.write("- comparisons.csv written.")
+
+            with zip_file.open("individual_criteria_scores.csv", "w") as output:
+                text_output = codecs.getwriter("utf8")(output)
+                self.stdout.write("retrieving individual criteria scores' data...")
+                write_individual_criteria_scores_file(poll_name, text_output)
+            self.stdout.write("- individual_criteria_scores.csv written.")
+
+            with zip_file.open("collective_criteria_scores.csv", "w") as output:
+                text_output = codecs.getwriter("utf8")(output)
+                self.stdout.write("retrieving collective criteria scores' data...")
+                write_collective_criteria_scores_file(poll_name, text_output)
+            self.stdout.write("- collective_criteria_scores.csv written.")
+
+            with zip_file.open("vouchers.csv", "w") as output:
+                text_output = codecs.getwriter("utf8")(output)
+                self.stdout.write("retrieving vouchers data...")
+                write_vouchers_file(text_output)
+            self.stdout.write("- vouchers.csv written")

--- a/backend/tournesol/management/commands/load_public_dataset.py
+++ b/backend/tournesol/management/commands/load_public_dataset.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict
 
 import pandas as pd
 from django.conf import settings
@@ -44,7 +43,7 @@ class Command(BaseCommand):
             user.save()
         return user
 
-    def create_videos(self, video_ids: pd.Series) -> Dict[int, Entity]:
+    def create_videos(self, video_ids: pd.Series) -> dict[int, Entity]:
         videos = {}
         for (entity_id, video_id) in video_ids.items():
             videos[entity_id] = Entity.create_from_video_id(video_id, fetch_metadata=False)

--- a/backend/tournesol/management/commands/load_public_dataset.py
+++ b/backend/tournesol/management/commands/load_public_dataset.py
@@ -1,5 +1,6 @@
-import concurrent
+import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
+from typing import Dict
 
 import pandas as pd
 from django.conf import settings
@@ -43,7 +44,7 @@ class Command(BaseCommand):
             user.save()
         return user
 
-    def create_videos(self, video_ids: pd.Series):
+    def create_videos(self, video_ids: pd.Series) -> Dict[int, Entity]:
         videos = {}
         for (entity_id, video_id) in video_ids.items():
             videos[entity_id] = Entity.create_from_video_id(video_id, fetch_metadata=False)
@@ -114,8 +115,8 @@ class Command(BaseCommand):
                 nb_comparisons += 1
             print(f"Created {nb_comparisons} comparisons")
 
-            for entity in Entity.objects.iterator():
-                entity.update_entity_poll_rating(poll=poll)
+            for video in videos.values():
+                video.update_entity_poll_rating(poll=poll)
 
             self.create_test_user()
             ContributorRating.objects.update(is_public=True)

--- a/backend/tournesol/resources/export_readme.txt
+++ b/backend/tournesol/resources/export_readme.txt
@@ -192,7 +192,9 @@ List of columns:
 vouchers.csv
 ------------
 
-This file contains all vouchers shared between users to obtain a higher trust score.
+This file contains all vouchers shared between users to obtain a higher trust
+score. The graph is oriented: the sender gives a voucher in order to propagate
+some trust to the receiver.
 
 List of columns:
 

--- a/backend/tournesol/resources/export_readme.txt
+++ b/backend/tournesol/resources/export_readme.txt
@@ -188,3 +188,22 @@ List of columns:
   uncertainty on the score value. For more detail, check out the algorithms
   implementation or the paper which describe them
   https://arxiv.org/abs/2211.01179
+
+vouchers.csv
+------------
+
+This file contains all vouchers shared between users to obtain a higher trust score.
+
+List of columns:
+
+- by_username:
+
+  The name of the user who gave the voucher
+
+- to_username:
+
+  The name of the user who received the voucher
+
+- value:
+
+  For the time being, the value of a voucher is always 1.

--- a/backend/tournesol/tests/management/test_create_dataset.py
+++ b/backend/tournesol/tests/management/test_create_dataset.py
@@ -7,15 +7,19 @@ from time import sleep
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import TransactionTestCase, override_settings
+
+from tournesol.models import Poll
 
 
 @override_settings(
     MEDIA_ROOT=gettempdir(),
     APP_TOURNESOL=ChainMap({"DATASETS_BUILD_DIR": "ts_api_test_datasets"}, settings.APP_TOURNESOL),
 )
-class CreateDatasetTestCase(TestCase):
+class CreateDatasetTestCase(TransactionTestCase):
     def setUp(self):
+        # Create poll if it does not exist
+        self.poll = Poll.default_poll()
         self.dataset_base_name = settings.APP_TOURNESOL["DATASET_BASE_NAME"]
 
     def tearDown(self):

--- a/backend/tournesol/tests/test_exports.py
+++ b/backend/tournesol/tests/test_exports.py
@@ -256,6 +256,7 @@ class ExportTest(TransactionTestCase):
                 "comparisons.csv",
                 "individual_criteria_scores.csv",
                 "collective_criteria_scores.csv",
+                "vouchers.csv",
             ]
             filenames = [filepath.rsplit("/", 1)[-1] for filepath in zip_file.namelist()]
             self.assertEqual(filenames, expected_filenames)

--- a/backend/tournesol/tests/test_exports.py
+++ b/backend/tournesol/tests/test_exports.py
@@ -14,7 +14,7 @@ import requests
 from django.conf import settings
 from django.core.cache import cache
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import TransactionTestCase, override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
 from solidago.pipeline.inputs import TournesolInputFromPublicDataset
@@ -41,7 +41,7 @@ from tournesol.tests.utils.mock_now import MockNow
         {"DATASETS_BUILD_DIR": "ts_api_test_datasets"}, settings.APP_TOURNESOL
     ),
 )
-class ExportTest(TestCase):
+class ExportTest(TransactionTestCase):
     @MockNow.Context()
     def setUp(self) -> None:
         self.poll_videos = Poll.default_poll()

--- a/solidago/src/solidago/pipeline/inputs.py
+++ b/solidago/src/solidago/pipeline/inputs.py
@@ -86,6 +86,8 @@ class TournesolInputFromPublicDataset(TournesolInput):
                 # such as "NA" are converted to float NaN.
                 self.users = pd.read_csv(users_file, keep_default_na=False)
                 self.users.index.name = "user_id"
+                # Fill trust_score on newly created users for which it was not computed yet
+                self.users.trust_score = pd.to_numeric(self.users.trust_score).fillna(0.0)
 
             username_to_user_id = pd.Series(
                 data=self.users.index, index=self.users["public_username"]


### PR DESCRIPTION
### Description

As discussed in #1879, the vouchers are already described as public information, so it makes sense to include them in the public dataset.

A few other improvements in this PR:
* files are written to the zip file on the fly, without loading the content in memory
* an isolated session is created in the database with the isolation level `repeatable read`, to make sure the public dataset is internally consistent, even if updates happen during its creation.


### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
