### PR TITLE
[solidago] optim: avoid creating Series on every iteration in `AffineOvertrust`

### DIFF
--- a/solidago/src/solidago/__version__.py
+++ b/solidago/src/solidago/__version__.py
@@ -1,4 +1,4 @@
 # Changing the version will automatically publish a new version on PyPI.
 # (see /.github/workflows/solidago-publish.yml)
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
### Description

The most expensive operation in `AffineOvertrust` is `min_voting_right()`, which computes the minimal voting right to apply in order to reach the overtrust threshold.

The existing implementation was creating a new `pandas.Series` to compute the overtrust on each iteration. Using numpy arrays only is more efficient.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
