### PR TITLE
[front] feat: always exclude compared videos when loading recommendations feed (PWA)

### DIFF
--- a/frontend/src/pages/feed/FeedCollectiveRecommendations.tsx
+++ b/frontend/src/pages/feed/FeedCollectiveRecommendations.tsx
@@ -13,10 +13,11 @@ const FeedCollectiveRecommendations = () => {
   const searchParams = getDefaultRecommendationsSearchParams(
     pollName,
     options,
-    userSettings
+    userSettings,
+    { forceExcludeCompared: true }
   );
 
-  return <Redirect to={`/recommendations${searchParams.toString()}`} />;
+  return <Redirect to={`/recommendations${searchParams}`} />;
 };
 
 export default FeedCollectiveRecommendations;

--- a/frontend/src/utils/userSettings.ts
+++ b/frontend/src/utils/userSettings.ts
@@ -35,15 +35,17 @@ export const buildVideosDefaultRecoSearchParams = (
   searchParams: URLSearchParams,
   userSettings: VideosPollUserSettings | undefined
 ) => {
-  const advancedFilters: string[] = [];
+  const advancedFilters = new Set(
+    searchParams.get('advanced')?.split(',') ?? []
+  );
   if (userSettings?.recommendations__default_unsafe) {
-    advancedFilters.push('unsafe');
+    advancedFilters.add('unsafe');
   }
   if (userSettings?.recommendations__default_exclude_compared_entities) {
-    advancedFilters.push('exclude_compared');
+    advancedFilters.add('exclude_compared');
   }
-  if (advancedFilters.length > 0) {
-    searchParams.set('advanced', advancedFilters.join(','));
+  if (advancedFilters.size > 0) {
+    searchParams.set('advanced', [...advancedFilters].join(','));
   }
 
   if (userSettings?.recommendations__default_date != undefined) {
@@ -66,11 +68,15 @@ export const buildVideosDefaultRecoSearchParams = (
 export const getDefaultRecommendationsSearchParams = (
   pollName: string,
   pollOptions: SelectablePoll | undefined,
-  userSettings: TournesolUserSettings
+  userSettings: TournesolUserSettings,
+  { forceExcludeCompared = false }: { forceExcludeCompared?: boolean } = {}
 ) => {
   const searchParams = new URLSearchParams(
     pollOptions?.defaultRecoSearchParams
   );
+  if (forceExcludeCompared) {
+    searchParams.set('advanced', 'exclude_compared');
+  }
 
   const userPollSettings = userSettings?.[pollName as PollUserSettingsKeys];
 

--- a/tests/cypress/e2e/frontend/feedRecommendationsPage.cy.ts
+++ b/tests/cypress/e2e/frontend/feedRecommendationsPage.cy.ts
@@ -30,7 +30,9 @@ describe('Feed - collective recommendations', () => {
       cy.visit('/feed/recommendations');
       cy.location('pathname').should('equal', '/recommendations');
       cy.location('search')
-        .should('contain', '?date=Today&advanced=unsafe%2Cexclude_compared&language=en');
+        .should('contain', 'date=Today')
+        .should('contain', 'advanced=exclude_compared%2Cunsafe')
+        .should('contain', 'language=en');
     });
   });
 });

--- a/tests/cypress/e2e/frontend/feedRecommendationsPage.cy.ts
+++ b/tests/cypress/e2e/frontend/feedRecommendationsPage.cy.ts
@@ -14,7 +14,7 @@ describe('Feed - collective recommendations', () => {
     it('anonymous users are redirected with default filters', () => {
       cy.visit('/feed/recommendations');
       cy.location('pathname').should('equal', '/recommendations');
-      cy.location('search').should('contain', '?date=Month');
+      cy.location('search').should('contain', '?date=Month&advanced=exclude_compared');
     });
 
     it('authenticated users are redirected with their preferences', () => {


### PR DESCRIPTION
### Description

Following #1920, this PR suggests to exclude already compared videos when loading the initial recommendations page from the PWA. Regular users should be able to find new content at a glance. This would also encourage users to compare videos they have already watched, to make them disappear from the feed.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
