### PR TITLE
[back] feat: /tocompare/ API uses the user's preferred languages

### DIFF
--- a/backend/core/models/user.py
+++ b/backend/core/models/user.py
@@ -153,6 +153,12 @@ class User(AbstractUser):
         domain = f"@{domain_part}".lower()
         EmailDomain.objects.get_or_create(domain=domain)
 
+    def get_recommendations_default_langs(self, poll: str):
+        try:
+            return self.settings[poll].get("recommendations__default_languages")
+        except KeyError:
+            return None
+
     def clean(self):
         value = self.email
 

--- a/backend/tournesol/lib/suggestions/strategies/base.py
+++ b/backend/tournesol/lib/suggestions/strategies/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from core.models import User
 from tournesol.models import Poll
@@ -12,9 +13,10 @@ class ContributionSuggestionStrategy(ABC):
     make, etc.
     """
 
-    def __init__(self, poll: Poll, user: User):
+    def __init__(self, poll: Poll, user: User, languages: Optional[list[str]] = None):
         self.poll = poll
         self.user = user
+        self.languages = languages
 
     @abstractmethod
     def get_results(self):

--- a/backend/tournesol/lib/suggestions/strategies/tocompare/classic.py
+++ b/backend/tournesol/lib/suggestions/strategies/tocompare/classic.py
@@ -128,6 +128,9 @@ class ClassicEntitySuggestionStrategy(ContributionSuggestionStrategy):
             ).isoformat(),
         }
 
+        if self.languages:
+            entity_filters["metadata__language"] = self.languages
+
         recommendations = self._get_recommendations(entity_filters, exclude_ids)
         already_compared = self._get_compared_sufficiently(entity_filters)
         results = [reco for reco in recommendations if reco not in already_compared]
@@ -148,6 +151,9 @@ class ClassicEntitySuggestionStrategy(ContributionSuggestionStrategy):
                 days=self.recent_recommendations_days
             ).isoformat(),
         }
+
+        if self.languages:
+            entity_filters["metadata__language"] = self.languages
 
         recommendations = self._get_recommendations(entity_filters, exclude_ids)[
             : self.top_recommendations_limit

--- a/backend/tournesol/lib/suggestions/strategies/tocompare/classic.py
+++ b/backend/tournesol/lib/suggestions/strategies/tocompare/classic.py
@@ -46,7 +46,6 @@ class ClassicEntitySuggestionStrategy(ContributionSuggestionStrategy):
         provided filters.
         """
         poll = self.poll
-
         return (
             Entity.objects.filter_safe_for_poll(poll)
             .filter(**entity_filters)
@@ -129,7 +128,7 @@ class ClassicEntitySuggestionStrategy(ContributionSuggestionStrategy):
         }
 
         if self.languages:
-            entity_filters["metadata__language"] = self.languages
+            entity_filters["metadata__language__in"] = self.languages
 
         recommendations = self._get_recommendations(entity_filters, exclude_ids)
         already_compared = self._get_compared_sufficiently(entity_filters)
@@ -153,7 +152,7 @@ class ClassicEntitySuggestionStrategy(ContributionSuggestionStrategy):
         }
 
         if self.languages:
-            entity_filters["metadata__language"] = self.languages
+            entity_filters["metadata__language__in"] = self.languages
 
         recommendations = self._get_recommendations(entity_filters, exclude_ids)[
             : self.top_recommendations_limit

--- a/backend/tournesol/tests/lib/suggestions/test_tocompare_classic.py
+++ b/backend/tournesol/tests/lib/suggestions/test_tocompare_classic.py
@@ -76,12 +76,25 @@ class ClassicEntitySuggestionStrategyTestCase(TestCase):
         self.videos_new_it = VideoFactory.create_batch(
             10, metadata__language="it", metadata__publication_date=today.isoformat()
         )
-        self.videos_new = self.videos_new_es + self.videos_new_fr + self.videos_new_it
 
-        self.videos_past = VideoFactory.create_batch(
-            20, metadata__publication_date=(today - timedelta(days=60)).isoformat()
+        self.videos_past_es = VideoFactory.create_batch(
+            5,
+            metadata__language="es",
+            metadata__publication_date=(today - timedelta(days=60)).isoformat(),
+        )
+        self.videos_past_fr = VideoFactory.create_batch(
+            5,
+            metadata__language="fr",
+            metadata__publication_date=(today - timedelta(days=60)).isoformat(),
+        )
+        self.videos_past_it = VideoFactory.create_batch(
+            10,
+            metadata__language="it",
+            metadata__publication_date=(today - timedelta(days=60)).isoformat(),
         )
 
+        self.videos_new = self.videos_new_es + self.videos_new_fr + self.videos_new_it
+        self.videos_past = self.videos_past_es + self.videos_past_fr + self.videos_past_it
         self.videos = self.videos_new + self.videos_past
 
     def test_get_recommendations(self):
@@ -392,6 +405,47 @@ class ClassicEntitySuggestionStrategyTestCase(TestCase):
         results = self.strategy._ids_from_pool_reco_all_time(past_entities[:5])
         self.assertEqual(len(results), 5)
         self.assertTrue(set(results) == set(past_entities[5:]))
+
+    def test_ids_from_pool_reco_all_time_lang_filter(self):
+        # [WHEN] the strategy is initialized with one language
+        strategy = ClassicEntitySuggestionStrategy(self.poll1, self.user1, ["es"])
+        results = strategy._ids_from_pool_reco_all_time([])
+        self.assertEqual(len(results), 0)
+
+        entities_es = create_entity_poll_ratings(self.poll1, self.videos_past_es, True)
+        entities_fr = create_entity_poll_ratings(self.poll1, self.videos_past_fr, True)
+        entities_it = create_entity_poll_ratings(self.poll1, self.videos_past_it[:5], True)
+        create_entity_poll_ratings(self.poll1, self.videos_past_it[5:], False)
+        create_entity_poll_ratings(self.poll1, self.videos_new, True)
+
+        # [THEN] all recommended "past" entities matching this language should be returned.
+        results = strategy._ids_from_pool_reco_all_time([])
+        self.assertEqual(len(results), 5)
+        self.assertTrue(set(results) == set(entities_es))
+
+        # [WHEN] the strategy is initialized with several languages
+        strategy = ClassicEntitySuggestionStrategy(self.poll1, self.user1, ["it", "fr"])
+
+        # [THEN] all recommended "past" entities matching those languages should be returned.
+        results = strategy._ids_from_pool_reco_all_time([])
+        self.assertEqual(len(results), 10)
+        self.assertTrue(set(results) == set(entities_fr + entities_it))
+
+        # [WHEN] the strategy is initialized with no language
+        strategy = ClassicEntitySuggestionStrategy(self.poll1, self.user1, [])
+
+        # [THEN] all recommended "past" entities should be returned.
+        results = strategy._ids_from_pool_reco_all_time([])
+        self.assertEqual(len(results), 15)
+        self.assertTrue(set(results) == set(entities_es + entities_fr + entities_it))
+
+        # [WHEN] the strategy is initialized with no language
+        strategy = ClassicEntitySuggestionStrategy(self.poll1, self.user1, None)
+
+        # [THEN] all recommended "past" entities should be returned.
+        results = strategy._ids_from_pool_reco_all_time([])
+        self.assertEqual(len(results), 15)
+        self.assertTrue(set(results) == set(entities_es + entities_fr + entities_it))
 
     def test_consolidate_results(self):
         """

--- a/backend/tournesol/tests/lib/suggestions/test_tocompare_classic.py
+++ b/backend/tournesol/tests/lib/suggestions/test_tocompare_classic.py
@@ -67,9 +67,16 @@ class ClassicEntitySuggestionStrategyTestCase(TestCase):
 
         today = timezone.now().date()
 
-        self.videos_new = VideoFactory.create_batch(
-            20, metadata__publication_date=today.isoformat()
+        self.videos_new_es = VideoFactory.create_batch(
+            5, metadata__language="es", metadata__publication_date=today.isoformat()
         )
+        self.videos_new_fr = VideoFactory.create_batch(
+            5, metadata__language="fr", metadata__publication_date=today.isoformat()
+        )
+        self.videos_new_it = VideoFactory.create_batch(
+            10, metadata__language="it", metadata__publication_date=today.isoformat()
+        )
+        self.videos_new = self.videos_new_es + self.videos_new_fr + self.videos_new_it
 
         self.videos_past = VideoFactory.create_batch(
             20, metadata__publication_date=(today - timedelta(days=60)).isoformat()
@@ -319,6 +326,47 @@ class ClassicEntitySuggestionStrategyTestCase(TestCase):
         results = self.strategy._ids_from_pool_reco_last_month(recent_entities[:5])
         self.assertEqual(len(results), 5)
         self.assertTrue(set(results) == set(recent_entities[5:]))
+
+    def test_ids_from_pool_reco_last_month_lang_filter(self):
+        # [WHEN] the strategy is initialized with one language
+        strategy = ClassicEntitySuggestionStrategy(self.poll1, self.user1, ["es"])
+        results = strategy._ids_from_pool_reco_last_month([])
+        self.assertEqual(len(results), 0)
+
+        entities_es = create_entity_poll_ratings(self.poll1, self.videos_new_es, True)
+        entities_fr = create_entity_poll_ratings(self.poll1, self.videos_new_fr, True)
+        entities_it = create_entity_poll_ratings(self.poll1, self.videos_new_it[:5], True)
+        create_entity_poll_ratings(self.poll1, self.videos_new_it[5:], False)
+        create_entity_poll_ratings(self.poll1, self.videos_past, True)
+
+        # [THEN] all recommended "recent" entities matching this language should be returned.
+        results = strategy._ids_from_pool_reco_last_month([])
+        self.assertEqual(len(results), 5)
+        self.assertTrue(set(results) == set(entities_es))
+
+        # [WHEN] the strategy is initialized with several languages
+        strategy = ClassicEntitySuggestionStrategy(self.poll1, self.user1, ["it", "fr"])
+
+        # [THEN] all recommended "recent" entities matching those languages should be returned.
+        results = strategy._ids_from_pool_reco_last_month([])
+        self.assertEqual(len(results), 10)
+        self.assertTrue(set(results) == set(entities_fr + entities_it))
+
+        # [WHEN] the strategy is initialized with no language
+        strategy = ClassicEntitySuggestionStrategy(self.poll1, self.user1, [])
+
+        # [THEN] all recommended "recent" entities should be returned.
+        results = strategy._ids_from_pool_reco_last_month([])
+        self.assertEqual(len(results), 15)
+        self.assertTrue(set(results) == set(entities_es + entities_fr + entities_it))
+
+        # [WHEN] the strategy is initialized with no language
+        strategy = ClassicEntitySuggestionStrategy(self.poll1, self.user1, None)
+
+        # [THEN] all recommended "recent" entities should be returned.
+        results = strategy._ids_from_pool_reco_last_month([])
+        self.assertEqual(len(results), 15)
+        self.assertTrue(set(results) == set(entities_es + entities_fr + entities_it))
 
     def test_ids_from_pool_reco_all_time(self):
         """

--- a/backend/tournesol/tests/test_api_suggestions_tocompare.py
+++ b/backend/tournesol/tests/test_api_suggestions_tocompare.py
@@ -122,6 +122,7 @@ class SuggestionsToCompareTestCase(TestCase):
         today = timezone.now().date()
         recommendations_new = VideoFactory.create_batch(
             4,
+            metadata__language="en",
             metadata__publication_date=today.isoformat(),
             make_safe_for_poll=self.poll1,
         )
@@ -129,6 +130,7 @@ class SuggestionsToCompareTestCase(TestCase):
         long_time_ago = timezone.now() - timedelta(days=120)
         recommendations_past = VideoFactory.create_batch(
             4,
+            metadata__language="en",
             metadata__publication_date=long_time_ago.isoformat(),
             make_safe_for_poll=self.poll1
         )

--- a/backend/tournesol/tests/test_api_suggestions_tocompare.py
+++ b/backend/tournesol/tests/test_api_suggestions_tocompare.py
@@ -11,7 +11,6 @@ from core.tests.factories.user import UserFactory
 from tournesol.models import Poll, RateLater
 from tournesol.tests.factories.comparison import ComparisonFactory
 from tournesol.tests.factories.entity import VideoFactory
-from tournesol.tests.factories.entity_poll_rating import EntityPollRatingFactory
 from tournesol.tests.factories.poll import PollWithCriteriasFactory
 from tournesol.tests.factories.ratings import ContributorRatingCriteriaScoreFactory
 
@@ -132,7 +131,7 @@ class SuggestionsToCompareTestCase(TestCase):
             4,
             metadata__language="en",
             metadata__publication_date=long_time_ago.isoformat(),
-            make_safe_for_poll=self.poll1
+            make_safe_for_poll=self.poll1,
         )
 
         self.client.force_authenticate(self.user1)

--- a/backend/tournesol/tests/test_utils_http.py
+++ b/backend/tournesol/tests/test_utils_http.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+
+from tournesol.utils.http import langs_from_header_accept_language
+
+
+class HTTPUtilsTestCase(TestCase):
+    def test_langs_from_header_accept_language(self):
+        langs = langs_from_header_accept_language("")
+        self.assertEqual(langs, [])
+
+        langs = langs_from_header_accept_language("fr")
+        self.assertEqual(langs, ["fr"])
+
+        langs = langs_from_header_accept_language("da, en-gb;q=0.8, en;q=0.7")
+        self.assertEqual(langs, ["da", "en-gb", "en"])

--- a/backend/tournesol/utils/http.py
+++ b/backend/tournesol/utils/http.py
@@ -1,0 +1,11 @@
+from django.utils.translation.trans_real import parse_accept_lang_header
+
+
+def langs_from_header_accept_language(header: str) -> list[str]:
+    """
+    Return a list of language tags from a given Accept-Language HTTP
+    header.
+
+    See: https://www.rfc-editor.org/rfc/rfc9110#field.accept-language
+    """
+    return [lang[0] for lang in parse_accept_lang_header(header)]

--- a/backend/tournesol/views/suggestions/to_compare.py
+++ b/backend/tournesol/views/suggestions/to_compare.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import IsAuthenticated
 
 from tournesol.lib.suggestions.strategies import ClassicEntitySuggestionStrategy
 from tournesol.serializers.suggestion import EntityToCompare
+from tournesol.utils.http import langs_from_header_accept_language
 from tournesol.views import PollScopedViewMixin
 
 
@@ -46,22 +47,13 @@ class SuggestionsToCompare(PollScopedViewMixin, generics.ListAPIView):
     # from this list, use the fallback language.
     min_lang_set = ["en", "fr"]
 
-    def _langs_from_accept_language(self, header: str) -> list[str]:
-        """
-        Return a list of language tags from a given Accept-Language HTTP
-        header.
-
-        See https://www.rfc-editor.org/rfc/rfc9110#field.accept-language
-        """
-        return [lang.split(';')[0].strip() for lang in header.split(",")]
-
     def _get_user_preferred_langs(self, fallback: Optional[str] = None) -> list[str]:
         preferred_langs = self.request.user.get_recommendations_default_langs(
             self.poll_from_url.name
         )
 
         if preferred_langs is None:
-            langs = self._langs_from_accept_language(
+            langs = langs_from_header_accept_language(
                 self.request.headers.get("accept-language", "en")
             )
         else:


### PR DESCRIPTION
**related issues** #1834 

---

### Description

This PR makes the endpoint `/users/me/suggestions/{poll_name}/tocompare/` able to return recommended entities matching the logged user's preferred languages. This should close the milestone _Video selector redesign_.

The preferred languages are determined using the following procedure:
- check the user's settings for the poll
- if the setting hasn't been configured, check the HTTP header `Accept-Language`
- if the languages `en` or `fr` are not present in the preferred languages, add `en`

The fallback language `en` is explicitly hardcoded in the back end. This might not be satisfactory if we want to make the back end generic. This trick ensures new users without entities in their rate-later list will always be suggested entities by the Auto button, even if there is no recommendations matching their preferred languages.

See also the behaviour of the tutorial: https://github.com/tournesol-app/tournesol/blob/4f67252a9a702b0e376d961577ad439b81a3d69d/frontend/src/utils/polls/videos.tsx#L54

**to-do**

*model - User*

- [x] add a method `get_recommendations_default_langs` take a poll name as argument

*view - SuggestionsToCompare*

- [x] call `get_recommendations_default_langs`
- [x] refactor the fallback on lang `en`

*tests*

- [x] test the new language filter added to `ClassicEntitySuggestionStrategy`
- [x] update the API tests

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
