### PR TITLE
[front] fix: do not truncate individual scores and context chips

### DIFF
--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import CSS from 'csstype';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -38,7 +37,10 @@ import EntityCardTitle from './EntityCardTitle';
 import EntityCardScores from './EntityCardScores';
 import EntityContextChip from './EntityContextChip';
 import EntityImagery from './EntityImagery';
-import EntityMetadata, { VideoMetadata } from './EntityMetadata';
+import EntityMetadata, {
+  EntityMetadataVariant,
+  VideoMetadata,
+} from './EntityMetadata';
 import EntityIndividualScores from './EntityIndividualScores';
 import { entityCardMainSx } from './style';
 
@@ -247,13 +249,13 @@ export const RowEntityCard = ({
   withLink = false,
   individualScores,
   displayEntityContextChip = true,
-  flexWrapMetadata,
+  metadataVariant,
 }: {
   result: EntityResult;
   withLink?: boolean;
   individualScores?: ContributorCriteriaScore[];
   displayEntityContextChip?: boolean;
-  flexWrapMetadata?: CSS.Properties['flexWrap'];
+  metadataVariant?: EntityMetadataVariant;
 }) => {
   const entity = result.entity;
   return (
@@ -290,7 +292,7 @@ export const RowEntityCard = ({
             uploader={entity.metadata.uploader}
             publicationDate={entity.metadata.publication_date}
             withLinks={false}
-            flexWrap={flexWrapMetadata}
+            variant={metadataVariant}
           />
         )}
 

--- a/frontend/src/components/entity/EntityCard.tsx
+++ b/frontend/src/components/entity/EntityCard.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
+import CSS from 'csstype';
 import { useTranslation } from 'react-i18next';
+
 import {
   Box,
   Collapse,
@@ -245,11 +247,13 @@ export const RowEntityCard = ({
   withLink = false,
   individualScores,
   displayEntityContextChip = true,
+  flexWrapMetadata,
 }: {
   result: EntityResult;
   withLink?: boolean;
   individualScores?: ContributorCriteriaScore[];
   displayEntityContextChip?: boolean;
+  flexWrapMetadata?: CSS.Properties['flexWrap'];
 }) => {
   const entity = result.entity;
   return (
@@ -286,6 +290,7 @@ export const RowEntityCard = ({
             uploader={entity.metadata.uploader}
             publicationDate={entity.metadata.publication_date}
             withLinks={false}
+            flexWrap={flexWrapMetadata}
           />
         )}
 

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -58,7 +58,7 @@ export const VideoMetadata = ({
         alignContent: 'space-between',
         fontSize: '0.8rem',
         color: 'neutral.main',
-        columnGap: '10px',
+        columnGap: '12px',
       }}
     >
       {uploader && (

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -95,7 +95,9 @@ export const VideoMetadata = ({
         <Box component="span" flexShrink={flexShrink}>
           <Trans t={t} i18nKey="video.nbViews">
             {{
-              nbViews: views.toLocaleString(i18n.resolvedLanguage),
+              nbViews: Intl.NumberFormat(i18n.resolvedLanguage, {
+                notation: 'compact',
+              }).format(views),
             }}{' '}
             views
           </Trans>

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -28,14 +28,8 @@ export const VideoMetadata = ({
 }) => {
   const { t, i18n } = useTranslation();
 
-  let flexShrink = 1;
-  let flexWrap = 'wrap';
-
-  switch (variant) {
-    case 'uploaderOnly':
-      flexShrink = 0;
-      flexWrap = 'nowrap';
-  }
+  const flexWrap = variant === "wrap" ? "wrap" : "nowrap";
+  const flexShrink = variant === "wrap" ? 1 : 0;
 
   let displayedDate;
   // Instead of displaying the date in the same format for every user, we

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -7,7 +7,7 @@ import { InternalLink } from 'src/components';
 import { TypeEnum } from 'src/services/openapi';
 import { EntityObject } from 'src/utils/types';
 
-export type EntityMetadataVariant = 'singleLine' | 'wrap';
+export type EntityMetadataVariant = 'uploaderOnly' | 'wrap';
 
 const toPaddedString = (num: number): string => {
   return num.toString().padStart(2, '0');
@@ -32,7 +32,7 @@ export const VideoMetadata = ({
   let flexWrap = 'wrap';
 
   switch (variant) {
-    case 'singleLine':
+    case 'uploaderOnly':
       flexShrink = 0;
       flexWrap = 'nowrap';
   }
@@ -61,22 +61,6 @@ export const VideoMetadata = ({
         columnGap: '10px',
       }}
     >
-      {views && (
-        <Box component="span" flexShrink={flexShrink}>
-          <Trans t={t} i18nKey="video.nbViews">
-            {{
-              nbViews: views.toLocaleString(i18n.resolvedLanguage),
-            }}{' '}
-            views
-          </Trans>
-        </Box>
-      )}
-      {publicationDate && (
-        <Box component="span" flexShrink={flexShrink}>
-          {displayedDate}
-        </Box>
-      )}
-
       {uploader && (
         <Box component="span" flexShrink={flexShrink}>
           {withLinks ? (
@@ -100,6 +84,21 @@ export const VideoMetadata = ({
           ) : (
             uploader
           )}
+        </Box>
+      )}
+      {variant === 'wrap' && publicationDate && (
+        <Box component="span" flexShrink={flexShrink}>
+          {displayedDate}
+        </Box>
+      )}
+      {variant === 'wrap' && views && (
+        <Box component="span" flexShrink={flexShrink}>
+          <Trans t={t} i18nKey="video.nbViews">
+            {{
+              nbViews: views.toLocaleString(i18n.resolvedLanguage),
+            }}{' '}
+            views
+          </Trans>
         </Box>
       )}
     </Box>

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import CSS from 'csstype';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Box, Tooltip } from '@mui/material';
@@ -16,11 +17,13 @@ export const VideoMetadata = ({
   publicationDate,
   uploader,
   withLinks = true,
+  flexWrap = 'wrap',
 }: {
   views?: number | null;
   publicationDate?: string | null;
   uploader?: string | null;
   withLinks?: boolean;
+  flexWrap?: CSS.Properties['flexWrap'];
 }) => {
   const { t, i18n } = useTranslation();
 
@@ -41,15 +44,15 @@ export const VideoMetadata = ({
     <Box
       sx={{
         display: 'flex',
-        flexWrap: 'wrap',
+        flexWrap: flexWrap,
         alignContent: 'space-between',
         fontSize: '0.8rem',
         color: 'neutral.main',
-        columnGap: '12px',
+        columnGap: '10px',
       }}
     >
       {views && (
-        <Box component="span">
+        <Box component="span" flexShrink={0}>
           <Trans t={t} i18nKey="video.nbViews">
             {{
               nbViews: views.toLocaleString(i18n.resolvedLanguage),
@@ -58,41 +61,55 @@ export const VideoMetadata = ({
           </Trans>
         </Box>
       )}
-      {publicationDate && <Box component="span">{displayedDate}</Box>}
+      {publicationDate && (
+        <Box component="span" flexShrink={0}>
+          {displayedDate}
+        </Box>
+      )}
 
-      {uploader &&
-        (withLinks ? (
-          <Tooltip
-            title={`${t('video.seeRecommendedVideosSameUploader')}`}
-            placement="bottom"
-          >
-            <InternalLink
-              to={`/recommendations?language=&uploader=${encodeURIComponent(
-                uploader
-              )}`}
-              color="inherit"
-              underline="always"
-              sx={{
-                fontWeight: 600,
-              }}
+      {uploader && (
+        <Box component="span" flexShrink={0}>
+          {withLinks ? (
+            <Tooltip
+              title={`${t('video.seeRecommendedVideosSameUploader')}`}
+              placement="bottom"
             >
-              {uploader}
-            </InternalLink>
-          </Tooltip>
-        ) : (
-          uploader
-        ))}
+              <InternalLink
+                to={`/recommendations?language=&uploader=${encodeURIComponent(
+                  uploader
+                )}`}
+                color="inherit"
+                underline="always"
+                sx={{
+                  fontWeight: 600,
+                }}
+              >
+                {uploader}
+              </InternalLink>
+            </Tooltip>
+          ) : (
+            uploader
+          )}
+        </Box>
+      )}
     </Box>
   );
 };
 
-const EntityMetadata = ({ entity }: { entity: EntityObject }) => {
+const EntityMetadata = ({
+  entity,
+  flexWrap,
+}: {
+  entity: EntityObject;
+  flexWrap?: CSS.Properties['flexWrap'];
+}) => {
   if (entity.type === TypeEnum.VIDEO) {
     return (
       <VideoMetadata
         views={entity.metadata.views}
         publicationDate={entity.metadata.publication_date}
         uploader={entity.metadata.uploader}
+        flexWrap={flexWrap}
       />
     );
   }

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import CSS from 'csstype';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Box, Tooltip } from '@mui/material';
@@ -7,6 +6,8 @@ import { Box, Tooltip } from '@mui/material';
 import { InternalLink } from 'src/components';
 import { TypeEnum } from 'src/services/openapi';
 import { EntityObject } from 'src/utils/types';
+
+export type EntityMetadataVariant = 'singleLine' | 'wrap';
 
 const toPaddedString = (num: number): string => {
   return num.toString().padStart(2, '0');
@@ -17,15 +18,24 @@ export const VideoMetadata = ({
   publicationDate,
   uploader,
   withLinks = true,
-  flexWrap = 'wrap',
+  variant = 'wrap',
 }: {
   views?: number | null;
   publicationDate?: string | null;
   uploader?: string | null;
   withLinks?: boolean;
-  flexWrap?: CSS.Properties['flexWrap'];
+  variant?: EntityMetadataVariant;
 }) => {
   const { t, i18n } = useTranslation();
+
+  let flexShrink = 1;
+  let flexWrap = 'wrap';
+
+  switch (variant) {
+    case 'singleLine':
+      flexShrink = 0;
+      flexWrap = 'nowrap';
+  }
 
   let displayedDate;
   // Instead of displaying the date in the same format for every user, we
@@ -52,7 +62,7 @@ export const VideoMetadata = ({
       }}
     >
       {views && (
-        <Box component="span" flexShrink={0}>
+        <Box component="span" flexShrink={flexShrink}>
           <Trans t={t} i18nKey="video.nbViews">
             {{
               nbViews: views.toLocaleString(i18n.resolvedLanguage),
@@ -62,13 +72,13 @@ export const VideoMetadata = ({
         </Box>
       )}
       {publicationDate && (
-        <Box component="span" flexShrink={0}>
+        <Box component="span" flexShrink={flexShrink}>
           {displayedDate}
         </Box>
       )}
 
       {uploader && (
-        <Box component="span" flexShrink={0}>
+        <Box component="span" flexShrink={flexShrink}>
           {withLinks ? (
             <Tooltip
               title={`${t('video.seeRecommendedVideosSameUploader')}`}
@@ -98,10 +108,10 @@ export const VideoMetadata = ({
 
 const EntityMetadata = ({
   entity,
-  flexWrap,
+  variant = 'wrap',
 }: {
   entity: EntityObject;
-  flexWrap?: CSS.Properties['flexWrap'];
+  variant?: EntityMetadataVariant;
 }) => {
   if (entity.type === TypeEnum.VIDEO) {
     return (
@@ -109,7 +119,7 @@ const EntityMetadata = ({
         views={entity.metadata.views}
         publicationDate={entity.metadata.publication_date}
         uploader={entity.metadata.uploader}
-        flexWrap={flexWrap}
+        variant={variant}
       />
     );
   }

--- a/frontend/src/components/entity/EntityMetadata.tsx
+++ b/frontend/src/components/entity/EntityMetadata.tsx
@@ -28,8 +28,8 @@ export const VideoMetadata = ({
 }) => {
   const { t, i18n } = useTranslation();
 
-  const flexWrap = variant === "wrap" ? "wrap" : "nowrap";
-  const flexShrink = variant === "wrap" ? 1 : 0;
+  const flexWrap = variant === 'wrap' ? 'wrap' : 'nowrap';
+  const flexShrink = variant === 'wrap' ? 1 : 0;
 
   let displayedDate;
   // Instead of displaying the date in the same format for every user, we

--- a/frontend/src/features/entity_selector/EntitySearchInput.tsx
+++ b/frontend/src/features/entity_selector/EntitySearchInput.tsx
@@ -66,7 +66,11 @@ const EntitySearchResultsList = ({
                 key={res.entity.uid}
                 onClick={onSelect && (() => onSelect(res.entity.uid))}
               >
-                <RowEntityCard key={res.entity.uid} result={res} />
+                <RowEntityCard
+                  key={res.entity.uid}
+                  result={res}
+                  metadataVariant="singleLine"
+                />
               </li>
             ))}
           </ul>

--- a/frontend/src/features/entity_selector/EntitySearchInput.tsx
+++ b/frontend/src/features/entity_selector/EntitySearchInput.tsx
@@ -69,7 +69,7 @@ const EntitySearchResultsList = ({
                 <RowEntityCard
                   key={res.entity.uid}
                   result={res}
-                  metadataVariant="singleLine"
+                  metadataVariant="uploaderOnly"
                 />
               </li>
             ))}

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -240,6 +240,7 @@ const VideoInput = ({
                 elevation={10}
                 entitySearchInput={true}
                 displayDescription={comparisonsCount < 8}
+                metadataVariant="uploaderOnly"
               />
             </SelectorPopper>
           )}

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -289,6 +289,7 @@ const EntityTabsBox = ({
                 <RowEntityCard
                   result={res}
                   withLink={withLink}
+                  flexWrapMetadata="nowrap"
                   individualScores={
                     displayIndividualScores
                       ? getIndividualScores(res)

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -15,6 +15,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { EntityResult } from 'src/utils/types';
 import { ExternalLink } from 'src/components';
 import { RowEntityCard } from 'src/components/entity/EntityCard';
+import { EntityMetadataVariant } from 'src/components/entity/EntityMetadata';
 import LoaderWrapper from 'src/components/LoaderWrapper';
 import EntitySearchInput from './EntitySearchInput';
 import { getWebExtensionUrl } from 'src/utils/extension';
@@ -28,6 +29,7 @@ interface Props {
   withLink?: boolean;
   entitySearchInput?: boolean;
   displayDescription?: boolean;
+  metadataVariant?: EntityMetadataVariant;
 }
 
 export interface EntitiesTab {
@@ -106,6 +108,7 @@ const EntityTabsBox = ({
   withLink = false,
   entitySearchInput = false,
   displayDescription = true,
+  metadataVariant = 'wrap',
 }: Props) => {
   const { t } = useTranslation();
 
@@ -289,7 +292,7 @@ const EntityTabsBox = ({
                 <RowEntityCard
                   result={res}
                   withLink={withLink}
-                  metadataVariant="uploaderOnly"
+                  metadataVariant={metadataVariant}
                   individualScores={
                     displayIndividualScores
                       ? getIndividualScores(res)

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -289,7 +289,7 @@ const EntityTabsBox = ({
                 <RowEntityCard
                   result={res}
                   withLink={withLink}
-                  flexWrapMetadata="nowrap"
+                  metadataVariant="singleLine"
                   individualScores={
                     displayIndividualScores
                       ? getIndividualScores(res)

--- a/frontend/src/features/entity_selector/EntityTabsBox.tsx
+++ b/frontend/src/features/entity_selector/EntityTabsBox.tsx
@@ -289,7 +289,7 @@ const EntityTabsBox = ({
                 <RowEntityCard
                   result={res}
                   withLink={withLink}
-                  metadataVariant="singleLine"
+                  metadataVariant="uploaderOnly"
                   individualScores={
                     displayIndividualScores
                       ? getIndividualScores(res)

--- a/frontend/src/features/videos/VideoCard.spec.tsx
+++ b/frontend/src/features/videos/VideoCard.spec.tsx
@@ -54,7 +54,7 @@ describe('VideoCard content', () => {
       'Video title'
     );
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
-      '154,988 views'
+      '155K views'
     );
     expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
       '9 comparisons by 4 contributors'
@@ -106,7 +106,7 @@ describe('VideoCard content', () => {
       'Video title'
     );
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
-      '154,988 views'
+      '155K views'
     );
     expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
       '9 comparisons by 4 contributors'
@@ -207,7 +207,7 @@ describe('VideoCard content', () => {
       'Video title'
     );
     expect(screen.getByTestId('video-card-info')).toHaveTextContent(
-      '154,988 views'
+      '155K views'
     );
     expect(screen.getByTestId('video-card-ratings')).toHaveTextContent(
       '9 comparisons by 4 contributors'


### PR DESCRIPTION
**related issues** #1875

---

### Description

This PR refactors the display of entity metadata to fix some bugs and make them easier to read.

(a) The entity metadata can now be displayed on a single line. The raw entity cards displayed in the tabs of the entity selector use this configuration to fix the bug described in #1875.

(b) In addition to this, to avoid displaying a truncated uploader on small device, the metadata are now displayed in the following order on all devices: uploader, publication date, views (instead of  view, publication date, uploader).

(c) For more clarity, only the uploader is displayed by the component `<RawEntityCard>` on all devices. This affects only the tabs of the entity selector displayed in the comparison page (not the one displayed by the entity analysis page).

(e) Finally, like in the browser extension the number of views in all entity cards is formatted with `Intl.NumberFormat` to make it more compact.

The tabs of the entity selector on iPhone 12/13 mini

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/a8f3e7f6-52ab-4fb3-a294-30b0f712a223)

The metadata box displayed in the entity analysis page

![capture](https://github.com/tournesol-app/tournesol/assets/39056254/3c22dac0-ac5b-4e5b-9ec2-f8ab503d6dc3)

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
