### PR TITLE
[dataviz] perf: load reco with several HTTP requests

### DIFF
--- a/data-visualization/pages/02_Videos_and_channels.py
+++ b/data-visualization/pages/02_Videos_and_channels.py
@@ -3,13 +3,14 @@ import pandas as pd
 import plotly.graph_objects as go
 import seaborn as sns
 import streamlit as st
+
 from utils import (
     CRITERI_EXT,
     CRITERIA,
     MSG_NO_DATA,
     MSG_NOT_ENOUGH_DATA,
     TCOLOR,
-    api_get_tournesol_scores,
+    api_get_tournesol_df,
     thumbnail_url,
 )
 
@@ -47,7 +48,7 @@ def add_sidebar_select_channels():
     min_contributor = st.sidebar.number_input(
         "Minimum number of contributors to be included", value=3, min_value=1
     )
-    df = df[df["rating_n_contributors"] >= min_contributor]
+    df = df[df["n_contributors"] >= min_contributor]
 
     st.session_state.df_scores = df
     st.session_state.all_uploaders = all_uploaders
@@ -219,7 +220,7 @@ def add_expander_detailed_correlation():
 st.title("Videos and channels (computed scores)")
 
 # Load public dataset (the function is cached to not overload the API)
-st.session_state.df_scores = api_get_tournesol_scores()
+st.session_state.df_scores = api_get_tournesol_df()
 
 # Select uploaders
 add_sidebar_select_channels()

--- a/data-visualization/pages/02_Videos_and_channels.py
+++ b/data-visualization/pages/02_Videos_and_channels.py
@@ -219,7 +219,7 @@ def add_expander_detailed_correlation():
 
 st.title("Videos and channels (computed scores)")
 
-# Load public dataset (the function is cached to not overload the API)
+# Load the recommendations (the function is cached to not overload the API)
 st.session_state.df_scores = api_get_tournesol_df()
 
 # Select uploaders

--- a/data-visualization/requirements.txt
+++ b/data-visualization/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.30.0
+streamlit==1.35.0
 numpy==1.24.2
 pandas==1.5.3
 seaborn==0.11.1

--- a/data-visualization/utils.py
+++ b/data-visualization/utils.py
@@ -102,11 +102,9 @@ def api_get_tournesol_df():
     Return a DataFrame created from the Tournesol recommendations.
     """
     limit = 2000
-    offset = 0
 
-    response = get_tournesol_reco(limit, offset)
+    response = get_tournesol_reco(limit, 0)
     df = pd.DataFrame.from_dict(response["results"])
-    offset += limit
 
     reco_urls = [
         f"https://api.tournesol.app/polls/videos/recommendations/?limit={limit}&offset={offset}&unsafe=true"

--- a/data-visualization/utils.py
+++ b/data-visualization/utils.py
@@ -113,7 +113,7 @@ def api_get_tournesol_df():
         for offset in range(limit, 100_000, limit)
     ]
 
-    with ThreadPool(16) as pool:
+    with ThreadPool(10) as pool:
         for result in pool.map(get_url_json, reco_urls):
             if not result["results"]:
                 continue

--- a/data-visualization/utils.py
+++ b/data-visualization/utils.py
@@ -79,7 +79,7 @@ def get_criterion_score(row, name):
 
 def get_tournesol_reco(limit: int, offset: int):
     return requests.get(
-        f"https://api.tournesol.app/polls/videos/recommendations/?limit={limit}&offset={offset}"
+        f"https://api.tournesol.app/polls/videos/recommendations/?limit={limit}&offset={offset}&unsafe=true"
     ).json()
 
 
@@ -91,11 +91,12 @@ def get_collective_n_contributor(row):
     return row["collective_rating"]["n_contributors"]
 
 
+@st.cache_data
 def api_get_tournesol_df():
     """
     Return a DataFrame created from the Tournesol recommendations.
     """
-    limit = 200
+    limit = 2000
     offset = 0
 
     response = get_tournesol_reco(limit, offset)


### PR DESCRIPTION
**related issues** #1867

---

### Description

The page "Videos and channels" now retrieves the recommendations from the API `/polls/` instead of the legacy API `/video/`.

Instead of retrieving up to 99999 entities in one single HTTP request, the new method uses a thread pool and several requests to fetch batches of 2000 entities. The new method takes ~ 28 seconds vs ~ 50 seconds for the previous one.

We can tweak several parameters to adapt the server workload:
- lowering the query parameter **limit** will reduce the execution time per request but will increase the total number of requests (and vice versa) 
- lowering the number of **worker threads** will reduce the number of concurrent HTTP requests and increase the loading time of the Streamlit page 

Let me know if you think 2000 is too low or too high.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
