### PR TITLE
[front] style: make the Preferences page more user friendly

### DIFF
--- a/frontend/src/features/settings/preferences/GeneralUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/GeneralUserSettingsForm.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Alert, AlertTitle, Grid, Typography } from '@mui/material';
+import { Alert, AlertTitle, Grid } from '@mui/material';
 
 import { Notifications_langEnum } from 'src/services/openapi';
 
 import NotificationsEmailResearch from './fields/NotificationsEmailResearch';
 import NotificationsEmailNewFeatures from './fields/NotificationsEmailNewFeatures';
 import NotificationsLang from './fields/NotificationsLang';
+import SettingsHeading from './SettingsHeading';
 
 interface GeneralSettingsFormProps {
   notificationsLang: Notifications_langEnum;
@@ -35,9 +36,10 @@ const GeneralUserSettingsForm = ({
   return (
     <Grid container spacing={4} direction="column" alignItems="stretch">
       <Grid item>
-        <Typography id="notifications" variant="h5">
-          {t('generalUserSettingsForm.emailNotifications')}
-        </Typography>
+        <SettingsHeading
+          id="notifications"
+          text={t('generalUserSettingsForm.emailNotifications')}
+        />
       </Grid>
       <Grid item>
         <Alert severity="info">

--- a/frontend/src/features/settings/preferences/SettingsHeading.tsx
+++ b/frontend/src/features/settings/preferences/SettingsHeading.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { Typography } from '@mui/material';
+
+interface SettingsHeadingProps {
+  id: string;
+  text: string;
+}
+
+const SettingsHeading = ({ id, text }: SettingsHeadingProps) => {
+  return (
+    <Typography
+      id={id}
+      variant="h5"
+      sx={(theme) => ({
+        textDecorationLine: 'underline',
+        textDecorationColor: theme.palette.primary.main,
+        textDecorationThickness: '0.2em',
+        textDecorationSkipInk: 'none',
+        textUnderlineOffset: '0.1em',
+      })}
+    >
+      {text}
+    </Typography>
+  );
+};
+
+export default SettingsHeading;

--- a/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/VideosPollUserSettingsForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { Alert, Grid, Typography } from '@mui/material';
+import { Alert, Box, Grid } from '@mui/material';
 
 import {
   ApiError,
@@ -18,6 +18,7 @@ import RateLaterAutoRemoveField from './fields/RateLaterAutoRemove';
 import WeeklyCollectiveGoalDisplayField from './fields/WeeklyCollectiveGoalDisplay';
 import RecommendationsDefaultLanguage from './fields/RecommendationsDefaultLanguage';
 import RecommendationsDefaultDate from './fields/RecommendationsDefaultDate';
+import SettingsHeading from './SettingsHeading';
 
 interface VideosPollUserSettingsFormProps {
   extSearchRecommendation: boolean;
@@ -80,40 +81,48 @@ const VideosPollUserSettingsForm = ({
   const { t } = useTranslation();
 
   return (
-    <Grid container spacing={4} direction="column" alignItems="stretch">
-      <Grid item>
-        <Typography id="comparison_page" variant="h5">
-          {t('pollUserSettingsForm.comparisonPage')}
-        </Typography>
-      </Grid>
-      <Grid item>
-        <WeeklyCollectiveGoalDisplayField
-          value={compUiWeeklyColGoalDisplay}
-          onChange={setCompUiWeeklyColGoalDisplay}
-          pollName={pollName}
-        />
-      </Grid>
-      <Grid item container spacing={1} direction="column" alignItems="stretch">
+    <Box display="flex" flexDirection="column" rowGap={6}>
+      <Grid container spacing={4} direction="column" alignItems="stretch">
         <Grid item>
-          <BooleanField
-            scope={pollName}
-            name="comparison_ui__weekly_collective_goal_mobile"
-            label={t('pollUserSettingsForm.displayCollectiveGoalOnMobile')}
-            value={compUiWeeklyColGoalMobile}
-            onChange={setCompUiWeeklyColGoalMobile}
+          <SettingsHeading
+            id="comparison_page"
+            text={t('pollUserSettingsForm.comparisonPage')}
           />
         </Grid>
         <Grid item>
-          <BooleanField
-            scope={pollName}
-            name="comparison__auto_select_entities"
-            label={t('pollUserSettingsForm.letTournesolSuggestElements')}
-            value={compAutoSelectEntities}
-            onChange={setCompAutoSelectEntities}
+          <WeeklyCollectiveGoalDisplayField
+            value={compUiWeeklyColGoalDisplay}
+            onChange={setCompUiWeeklyColGoalDisplay}
+            pollName={pollName}
           />
         </Grid>
-      </Grid>
-      {/*
+        <Grid
+          item
+          container
+          spacing={1}
+          direction="column"
+          alignItems="stretch"
+        >
+          <Grid item>
+            <BooleanField
+              scope={pollName}
+              name="comparison_ui__weekly_collective_goal_mobile"
+              label={t('pollUserSettingsForm.displayCollectiveGoalOnMobile')}
+              value={compUiWeeklyColGoalMobile}
+              onChange={setCompUiWeeklyColGoalMobile}
+            />
+          </Grid>
+          <Grid item>
+            <BooleanField
+              scope={pollName}
+              name="comparison__auto_select_entities"
+              label={t('pollUserSettingsForm.letTournesolSuggestElements')}
+              value={compAutoSelectEntities}
+              onChange={setCompAutoSelectEntities}
+            />
+          </Grid>
+        </Grid>
+        {/*
           Ideally the following field could be displayed under the title
           Comparison, instead of Comparison (page). Updating the optinal
           criteria displayed by default will affect all comparison UIs and not
@@ -121,96 +130,115 @@ const VideosPollUserSettingsForm = ({
           to customize the comparisons (not the page), consider the creation of
           a section Comparison.
         */}
-      <Grid item>
-        <ComparisonOptionalCriteriaDisplayed
-          displayedCriteria={displayedCriteria}
-          onChange={setDisplayedCriteria}
-        />
-      </Grid>
-      <Grid item>
-        <Typography id="extension_youtube" variant="h5">
-          {t('pollUserSettingsForm.extensionYoutube')}
-        </Typography>
-      </Grid>
-      <Grid item>
-        <ExtSearchRecommendation
-          value={extSearchRecommendation}
-          onChange={setExtSearchRecommendation}
-          pollName={pollName}
-        />
-      </Grid>
-      <Grid item>
-        <Typography id="rate_later" variant="h5">
-          {t('pollUserSettingsForm.rateLater')}
-        </Typography>
-      </Grid>
-      <Grid item>
-        <RateLaterAutoRemoveField
-          apiErrors={apiErrors}
-          value={rateLaterAutoRemoval}
-          onChange={setRateLaterAutoRemoval}
-          pollName={pollName}
-        />
-      </Grid>
-      <Grid item>
-        <Typography id="recommendations" variant="h5">
-          {t('pollUserSettingsForm.recommendations')}
-        </Typography>
-      </Grid>
-      <Grid item>
-        <RecommendationsDefaultLanguage
-          value={recoDefaultLanguages}
-          onChange={setRecoDefaultLanguages}
-        />
-      </Grid>
-      <Grid item>
-        <Typography id="recommendations_page" variant="h5">
-          {t('pollUserSettingsForm.recommendationsPage')}
-        </Typography>
-      </Grid>
-      <Grid item>
-        <Alert severity="info">
-          <Trans
-            t={t}
-            i18nKey="pollUserSettingsForm.customizeYourDefaultSearchFilter"
-          >
-            Customize <strong>the default search filters</strong> according to
-            your own preferences. Those filters are applied{' '}
-            <strong>only</strong> when you access the recommendations from the{' '}
-            <strong>main menu</strong>.
-          </Trans>
-        </Alert>
-      </Grid>
-      <Grid item>
-        <RecommendationsDefaultDate
-          value={recoDefaultUploadDate}
-          onChange={setRecoDefaultUploadDate}
-          pollName={pollName}
-        />
-      </Grid>
-      <Grid item container spacing={1} direction="column" alignItems="stretch">
         <Grid item>
-          <BooleanField
-            scope={pollName}
-            name="recommendations__default_unsafe"
-            label={t('videosUserSettingsForm.recommendations.defaultUnsafe')}
-            value={recoDefaultUnsafe}
-            onChange={setRecoDefaultUnsafe}
-          />
-        </Grid>
-        <Grid item>
-          <BooleanField
-            scope={pollName}
-            name="recommendations__default_exclude_compared_entities"
-            label={t(
-              'videosUserSettingsForm.recommendations.defaultExcludeCompared'
-            )}
-            value={recoDefaultExcludeCompared}
-            onChange={setRecoDefaultExcludeCompared}
+          <ComparisonOptionalCriteriaDisplayed
+            displayedCriteria={displayedCriteria}
+            onChange={setDisplayedCriteria}
           />
         </Grid>
       </Grid>
-    </Grid>
+      <Grid container spacing={4} direction="column" alignItems="stretch">
+        <Grid item>
+          <SettingsHeading
+            id="extension_youtube"
+            text={t('pollUserSettingsForm.extensionYoutube')}
+          />
+        </Grid>
+        <Grid item>
+          <ExtSearchRecommendation
+            value={extSearchRecommendation}
+            onChange={setExtSearchRecommendation}
+            pollName={pollName}
+          />
+        </Grid>
+      </Grid>
+      <Grid container spacing={4} direction="column" alignItems="stretch">
+        <Grid item>
+          <SettingsHeading
+            id="rate_later"
+            text={t('pollUserSettingsForm.rateLater')}
+          />
+        </Grid>
+        <Grid item>
+          <RateLaterAutoRemoveField
+            apiErrors={apiErrors}
+            value={rateLaterAutoRemoval}
+            onChange={setRateLaterAutoRemoval}
+            pollName={pollName}
+          />
+        </Grid>
+      </Grid>
+      <Grid container spacing={4} direction="column" alignItems="stretch">
+        <Grid item>
+          <SettingsHeading
+            id="recommendations"
+            text={t('pollUserSettingsForm.recommendations')}
+          />
+        </Grid>
+        <Grid item>
+          <RecommendationsDefaultLanguage
+            value={recoDefaultLanguages}
+            onChange={setRecoDefaultLanguages}
+          />
+        </Grid>
+      </Grid>
+      <Grid container spacing={4} direction="column" alignItems="stretch">
+        <Grid item>
+          <SettingsHeading
+            id="recommendations_page"
+            text={t('pollUserSettingsForm.recommendationsPage')}
+          />
+        </Grid>
+        <Grid item>
+          <Alert severity="info">
+            <Trans
+              t={t}
+              i18nKey="pollUserSettingsForm.customizeYourDefaultSearchFilter"
+            >
+              Customize <strong>the default search filters</strong> according to
+              your own preferences. Those filters are applied{' '}
+              <strong>only</strong> when you access the recommendations from the{' '}
+              <strong>main menu</strong>.
+            </Trans>
+          </Alert>
+        </Grid>
+        <Grid item>
+          <RecommendationsDefaultDate
+            value={recoDefaultUploadDate}
+            onChange={setRecoDefaultUploadDate}
+            pollName={pollName}
+          />
+        </Grid>
+        <Grid
+          item
+          container
+          spacing={1}
+          direction="column"
+          alignItems="stretch"
+        >
+          <Grid item>
+            <BooleanField
+              scope={pollName}
+              name="recommendations__default_unsafe"
+              label={t('videosUserSettingsForm.recommendations.defaultUnsafe')}
+              value={recoDefaultUnsafe}
+              onChange={setRecoDefaultUnsafe}
+            />
+          </Grid>
+          <Grid item>
+            <BooleanField
+              scope={pollName}
+              name="recommendations__default_exclude_compared_entities"
+              label={t(
+                'videosUserSettingsForm.recommendations.defaultExcludeCompared'
+              )}
+              value={recoDefaultExcludeCompared}
+              onChange={setRecoDefaultExcludeCompared}
+            />
+          </Grid>
+        </Grid>
+      </Grid>
+    </Box>
   );
 };
 


### PR DESCRIPTION
### Description

The sub-sections of the Preferences page are now more distinct. More settings will be added by the future pages For you and Top videos. The new layout should make the settings configuration a bit more user friendly.

It's a first step, I'll probably update the page style after the new settings have been added. 

| before | after |
|---|---|
| ![screencapture-localhost-3000-settings-preferences-2024-06-13-11_13_09](https://github.com/tournesol-app/tournesol/assets/39056254/2d80ded1-c63a-4135-a928-572c600ae364) | ![screencapture-localhost-3000-settings-preferences-2024-06-13-11_12_37](https://github.com/tournesol-app/tournesol/assets/39056254/cbb8d003-0b0d-4247-a347-0b3b8b628702) |

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
