### PR TITLE
[ext] build separate packages for Firefox and Chrome (manifest v3)

### DIFF
--- a/.github/workflows/browser-extension-release.yml
+++ b/.github/workflows/browser-extension-release.yml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: 
-          fetch-depth: 0
-      - uses: actions/setup-node@v2
+          fetch-tags: true
+
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
 
@@ -40,7 +41,8 @@ jobs:
       - name: Build browser extension
         if: ${{ env.tag_exist == 0 }}
         run: |
-          ./build.sh
+          EXTENSION_BROWSER=firefox MANIFEST_VERSION=2 ./build.sh -o tournesol_extension_firefox.zip
+          EXTENSION_BROWSER=chrome MANIFEST_VERSION=3 ./build.sh -o tournesol_extension_chrome.zip
 
       - name: Error message
         if: failure()
@@ -51,11 +53,11 @@ jobs:
           More detail: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
           ${{ secrets.DISCORD_BROWSER_EXTENSION_WEBHOOK_URL }}
           
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ env.tag_exist == 0 }}
         with:
-          name: browser-extension-zipfile
-          path: browser-extension/tournesol_extension.zip
+          name: browser-extension-zipfiles
+          path: browser-extension/tournesol_extension*.zip
 
       - name: Send zip file on Discord
         if: ${{ env.tag_exist == 0 }}
@@ -64,5 +66,6 @@ jobs:
           -F 'payload_json={"username": "ExtensionBot",
           "content": "The browser extension version **${{ env.ext_version }}** has been built.\n
           More detail: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
-          -F "file1=@tournesol_extension.zip"
+          -F "files[0]=@tournesol_extension_firefox.zip"
+          -F "files[1]=@tournesol_extension_chrome.zip"
           ${{ secrets.DISCORD_BROWSER_EXTENSION_WEBHOOK_URL }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,18 +12,18 @@ jobs:
   e2e-browser-extension:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
 
       - name: Prepare extension
         working-directory: browser-extension
         run: |
-          node prepareExtension.js
+          EXTENSION_BROWSER=chrome MANIFEST_VERSION=3 yarn configure
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@v6
         with:
           working-directory: tests
           browser: chrome
@@ -40,18 +40,18 @@ jobs:
   e2e-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Start dev env
         run: ./dev-env/run-docker-compose.sh
         env:
           FRONTEND_START_SCRIPT: "start:e2e"
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@v6
         with:
           working-directory: tests
           browser: chrome

--- a/browser-extension/build.sh
+++ b/browser-extension/build.sh
@@ -8,20 +8,31 @@
 
 set -eu
 
+usage() { echo "Usage: $0 [-o tournesol_extension.zip]" 1>&2 ; }
+
 SCRIPT_PATH="$(realpath -e "$(dirname "$0")")"
 SOURCE_DIR='src'
-TARGET_BASENAME='tournesol_extension.zip'
+OUTPUT_FILE='tournesol_extension.zip'
 
+while getopts "ho:" opt; do
+    case $opt in
+        o ) OUTPUT_FILE=$OPTARG;;
+        h ) usage
+        exit 0;;
+        *) usage
+        exit 1;;
+    esac
+done
 
-pushd ${SCRIPT_PATH} > /dev/null
+pushd "${SCRIPT_PATH}" > /dev/null
 
 node prepareExtension.js
 
 # zip the sources
 pushd ${SOURCE_DIR} > /dev/null
-zip -r -FS ../${TARGET_BASENAME} *
+zip -r -FS ../"${OUTPUT_FILE}" ./*
 popd > /dev/null
 
 # zip the license
-zip ${TARGET_BASENAME} LICENSE
+zip "${OUTPUT_FILE}" LICENSE
 popd > /dev/null

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/prepareExtension.js
+++ b/browser-extension/prepareExtension.js
@@ -49,9 +49,11 @@ const permissions = [
   // with version > 3.5.2.
   // These permissions can be removed as soon as we are confident
   // the next release works as expected.
-  'webRequest',
-  'webRequestBlocking',
-  ...selectValue(manifestVersion, { 2: [], 3: ['scripting'] }),
+  ...selectValue(manifestVersion,
+    {
+      2: ['webRequest', 'webRequestBlocking'],
+      3: ['scripting']
+    }),
 ];
 
 const allPermissions = selectValue(manifestVersion, {

--- a/browser-extension/prepareExtension.js
+++ b/browser-extension/prepareExtension.js
@@ -49,11 +49,10 @@ const permissions = [
   // with version > 3.5.2.
   // These permissions can be removed as soon as we are confident
   // the next release works as expected.
-  ...selectValue(manifestVersion,
-    {
-      2: ['webRequest', 'webRequestBlocking'],
-      3: ['scripting']
-    }),
+  ...selectValue(manifestVersion, {
+    2: ['webRequest', 'webRequestBlocking'],
+    3: ['scripting'],
+  }),
 ];
 
 const allPermissions = selectValue(manifestVersion, {


### PR DESCRIPTION
### Description

Chrome is deprecating Manifest v2.
https://blog.chromium.org/2024/05/manifest-v2-phase-out-begins.html

2 distinct builds will be released:
 * a version with manifest v2 for Firefox (unchanged)
 * a version with manifest v3 for the Chrome Web Store

The GitHub workflows are updated to write both versions in the artifact, and upload them to Discord.
The e2e tests workflow is also updated to use the Manifest v3 when testing the extension in Chrome.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass



[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
