### PR TITLE
[ext] fix: release workflow could not check a release tag already exists

### DIFF
--- a/.github/workflows/browser-extension-release.yml
+++ b/.github/workflows/browser-extension-release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: 
-          fetch-tags: true
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -46,7 +46,7 @@ jobs:
 
       - name: Error message
         if: failure()
-        run: |
+        run: >
           curl
           -F 'payload_json={"username": "ExtensionBot",
           "content": "Problem with the build of browser extension version **${{ env.ext_version }}**.\n


### PR DESCRIPTION
### Description

* Following  #1982, the existing tags were not fetch by ` actions/checkout`. The options `fetch-tags: true` is misleading.   
(See https://github.com/actions/checkout/issues/1471)

* Fix a typo in the command used to send an alert to Discord when the build fails

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
