### PR TITLE
[infra] update alert rule about slow requests with pending period

### DIFF
--- a/infra/ansible/roles/grafana_alerting/templates/defaultEvaluationGroup.yaml.j2
+++ b/infra/ansible/roles/grafana_alerting/templates/defaultEvaluationGroup.yaml.j2
@@ -26,34 +26,6 @@ groups:
                 maxDataPoints: 43200
                 queryType: range
                 refId: A
-            - refId: C
-              relativeTimeRange:
-                from: 1200
-                to: 0
-              datasourceUid: __expr__
-              model:
-                conditions:
-                    - evaluator:
-                        params:
-                            - 0.5
-                        type: gt
-                      operator:
-                        type: and
-                      query:
-                        params:
-                            - C
-                      reducer:
-                        params: []
-                        type: last
-                      type: query
-                datasource:
-                    type: __expr__
-                    uid: __expr__
-                expression: B
-                intervalMs: 1000
-                maxDataPoints: 43200
-                refId: C
-                type: threshold
             - refId: B
               relativeTimeRange:
                 from: 1200
@@ -81,16 +53,43 @@ groups:
                 expression: A
                 intervalMs: 1000
                 maxDataPoints: 43200
-                reducer: mean
+                reducer: last
                 refId: B
                 settings:
-                    mode: dropNN
+                    mode: replaceNN
+                    replaceWithValue: 0
                 type: reduce
+            - refId: C
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 0.5
+                            - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params: []
+                      reducer:
+                        params: []
+                        type: avg
+                      type: query
+                datasource:
+                    name: Expression
+                    type: __expr__
+                    uid: __expr__
+                expression: B
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
           dashboardUid: {{grafana.dashboard_alerting_uid}}
           panelId: 7
           noDataState: OK
           execErrState: Error
-          for: 0s
+          for: 8m
           annotations:
             __dashboardUid__: {{grafana.dashboard_alerting_uid}}
             __panelId__: "7"

--- a/infra/ansible/roles/grafana_alerting/templates/defaultEvaluationGroup.yaml.j2
+++ b/infra/ansible/roles/grafana_alerting/templates/defaultEvaluationGroup.yaml.j2
@@ -89,7 +89,7 @@ groups:
           panelId: 7
           noDataState: OK
           execErrState: Error
-          for: 8m
+          for: 6m
           annotations:
             __dashboardUid__: {{grafana.dashboard_alerting_uid}}
             __panelId__: "7"


### PR DESCRIPTION
### Description

The metric defined to trigger the alert is unchanged: 95th percentile of request time, on a 2-minute window.
The difference is on the moment when the alert is triggered:

**Before**: as soon as the average of the metric is above 500ms in the last 20 minutes. (May be triggered immediately if a request is very slow and the traffic is low, especially on staging).

**After**: when the last measure is above 500ms for a pending period of 8 minutes. It should be less sensitive to traffic spike.


### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
