### PR TITLE
[back] fix: validate score and score_max in ComparisonCriteriaScore form

### DIFF
--- a/backend/tournesol/models/comparisons.py
+++ b/backend/tournesol/models/comparisons.py
@@ -38,13 +38,13 @@ class Comparison(models.Model):
         related_name="comparisons"
     )
     entity_1 = models.ForeignKey(
-        'Entity',
+        "Entity",
         on_delete=models.CASCADE,
         related_name="comparisons_entity_1",
         help_text="Left entity to compare",
     )
     entity_2 = models.ForeignKey(
-        'Entity',
+        "Entity",
         on_delete=models.CASCADE,
         related_name="comparisons_entity_2",
         help_text="Right entity to compare",
@@ -165,7 +165,7 @@ class ComparisonCriteriaScore(models.Model):
         try:
             self._validate_score_max()
         except (TypeError, ValueError) as err:
-            raise ValidationError({"score_max":  err.args[0]})
+            raise ValidationError({"score_max": err.args[0]}) from err
 
     def save(self, *args, **kwargs):
         self._validate_score_max()

--- a/backend/tournesol/tests/test_model_comparisoncriteriascore.py
+++ b/backend/tournesol/tests/test_model_comparisoncriteriascore.py
@@ -103,51 +103,51 @@ class ComparisonCriteriaScoreTestCase(TestCase):
         The method `clean` should call the method `_validate_score_max` and
         transform its exceptions into `ValidationError`.
         """
-        score_test = ComparisonCriteriaScore(
-            comparison=self.comparison,
-            criteria=self.poll.main_criteria,
-            score=11,
-            score_max=10,
-        )
-
-        score_test._validate_score_max = Mock()
-        score_test.clean()
-        score_test._validate_score_max.assert_called_once()
-
-        # The exceptions raised by _validate_score_max should be transformed
-        # into `ValidationError` by the method `clean`.
-        expected_exceptions = [TypeError("oops"), ValueError("oops")]
-        for exception in expected_exceptions:
-            score_test._validate_score_max = Mock(side_effect=exception)
-
-            with self.assertRaises(ValidationError):
-                score_test.clean()
-
-        # All other exceptions should not be transformed.
-        score_test._validate_score_max = Mock(side_effect=KeyError)
-        with self.assertRaises(KeyError):
-            score_test.clean()
-
-    def test_save_calls_validate_score_max(self):
-        """
-        The method `save` should call the method `_validate_score_max`.
-        """
-        score_test = ComparisonCriteriaScore(
+        score = ComparisonCriteriaScore(
             comparison=self.comparison,
             criteria=self.poll.main_criteria,
             score=10,
             score_max=10,
         )
 
-        score_test._validate_score_max = Mock()
-        score_test.save()
-        score_test._validate_score_max.assert_called_once()
+        score._validate_score_max = Mock()
+        score.clean()
+        score._validate_score_max.assert_called_once()
+
+        # The exceptions raised by _validate_score_max should be transformed
+        # into `ValidationError` by the method `clean`.
+        expected_exceptions = [TypeError("oops"), ValueError("oops")]
+        for exception in expected_exceptions:
+            score._validate_score_max = Mock(side_effect=exception)
+
+            with self.assertRaises(ValidationError):
+                score.clean()
+
+        # All other exceptions should not be transformed.
+        score._validate_score_max = Mock(side_effect=KeyError)
+        with self.assertRaises(KeyError):
+            score.clean()
+
+    def test_save_calls_validate_score_max(self):
+        """
+        The method `save` should call the method `_validate_score_max`.
+        """
+        score = ComparisonCriteriaScore(
+            comparison=self.comparison,
+            criteria=self.poll.main_criteria,
+            score=10,
+            score_max=10,
+        )
+
+        score._validate_score_max = Mock()
+        score.save()
+        score._validate_score_max.assert_called_once()
 
         # All exceptions raised by _validate_score_max should not be
         # transformed by `save`.
         expected_exceptions = [KeyError, TypeError, ValueError]
         for exception in expected_exceptions:
-            score_test._validate_score_max = Mock(side_effect=exception)
+            score._validate_score_max = Mock(side_effect=exception)
 
             with self.assertRaises(exception):
-                score_test.save()
+                score.save()

--- a/backend/tournesol/tests/test_model_comparisoncriteriascore.py
+++ b/backend/tournesol/tests/test_model_comparisoncriteriascore.py
@@ -43,8 +43,8 @@ class ComparisonCriteriaScoreTestCase(TestCase):
         score.score_max = 1
         score.clean_fields()
 
-    def test_save_validate_score(self):
-        score = ComparisonCriteriaScore(
+    def test_method_validate_score_max(self):
+        score_test = ComparisonCriteriaScore(
             comparison=self.comparison,
             criteria=self.poll.main_criteria,
             score=11,
@@ -53,27 +53,26 @@ class ComparisonCriteriaScoreTestCase(TestCase):
 
         # The score cannot be greater than score_max.
         with self.assertRaises(ValueError):
-            score.save()
+            score_test._validate_score_max()
 
-        score.score = -11
+        score_test.score = -11
         # The absolute value of the score cannot be greater than score_max.
         with self.assertRaises(ValueError):
-            score.save()
+            score_test._validate_score_max()
 
         # The score can be zero.
-        score.score = 0
-        score.save()
+        score_test.score = 0
+        score_test._validate_score_max()
 
         # The score can be equal to the score_max.
-        score.score = score.score_max
-        score.save()
+        score_test.score = score_test.score_max
+        score_test._validate_score_max()
 
         # The absolute value of the score can be lesser than score_max.
-        score.score = -1
-        score.save()
+        score_test.score = -1
+        score_test._validate_score_max()
 
-    def test_save_validate_score_max(self):
-        score = ComparisonCriteriaScore(
+        score_max_test = ComparisonCriteriaScore(
             comparison=self.comparison,
             criteria=self.poll.main_criteria,
             score=5,
@@ -82,17 +81,124 @@ class ComparisonCriteriaScoreTestCase(TestCase):
 
         # score_max cannot be None.
         with self.assertRaises(TypeError):
-            score.save()
+            score_max_test._validate_score_max()
 
-        score.score_max = 0
+        score_max_test.score_max = 0
         # score_max cannot be zero.
         with self.assertRaises(ValueError):
-            score.save()
+            score_max_test._validate_score_max()
 
-        score.score_max = -10
+        score_max_test.score_max = -10
         # score_max cannot be negative.
         with self.assertRaises(ValueError):
-            score.save()
+            score_max_test._validate_score_max()
 
-        score.score_max = 10
-        score.save()
+        score_max_test.score_max = 10
+        score_max_test._validate_score_max()
+
+    def test_method_clean_calls_validate_score_max(self):
+        score_test = ComparisonCriteriaScore(
+            comparison=self.comparison,
+            criteria=self.poll.main_criteria,
+            score=11,
+            score_max=10,
+        )
+
+        # The score cannot be greater than score_max.
+        with self.assertRaises(ValidationError):
+            score_test.clean()
+
+        score_test.score = -11
+        # The absolute value of the score cannot be greater than score_max.
+        with self.assertRaises(ValidationError):
+            score_test.clean()
+
+        # The score can be zero.
+        score_test.score = 0
+        score_test.clean()
+
+        # The score can be equal to the score_max.
+        score_test.score = score_test.score_max
+        score_test.clean()
+
+        # The absolute value of the score can be lesser than score_max.
+        score_test.score = -1
+        score_test.clean()
+
+        score_max_test = ComparisonCriteriaScore(
+            comparison=self.comparison,
+            criteria=self.poll.main_criteria,
+            score=5,
+            score_max=None,
+        )
+
+        # score_max cannot be None.
+        with self.assertRaises(ValidationError):
+            score_max_test.clean()
+
+        score_max_test.score_max = 0
+        # score_max cannot be zero.
+        with self.assertRaises(ValidationError):
+            score_max_test.clean()
+
+        score_max_test.score_max = -10
+        # score_max cannot be negative.
+        with self.assertRaises(ValidationError):
+            score_max_test.clean()
+
+        score_max_test.score_max = 10
+        score_max_test.clean()
+
+    def test_method_save_calls_validate_score_max(self):
+        score_test = ComparisonCriteriaScore(
+            comparison=self.comparison,
+            criteria=self.poll.main_criteria,
+            score=11,
+            score_max=10,
+        )
+
+        # The score cannot be greater than score_max.
+        with self.assertRaises(ValueError):
+            score_test.save()
+
+        score_test.score = -11
+        # The absolute value of the score cannot be greater than score_max.
+        with self.assertRaises(ValueError):
+            score_test.save()
+
+        # The score can be zero.
+        score_test.score = 0
+        score_test.save()
+
+        # The score can be equal to the score_max.
+        score_test.score = score_test.score_max
+        score_test.save()
+
+        # The absolute value of the score can be lesser than score_max.
+        score_test.score = -1
+        score_test.save()
+        score_test.delete()
+
+        score_max_test = ComparisonCriteriaScore(
+            comparison=self.comparison,
+            criteria=self.poll.main_criteria,
+            score=5,
+            score_max=None,
+        )
+
+        # score_max cannot be None.
+        with self.assertRaises(TypeError):
+            score_max_test.save()
+
+        score_max_test.score_max = 0
+        # score_max cannot be zero.
+        with self.assertRaises(ValueError):
+            score_max_test.save()
+
+        score_max_test.score_max = -10
+        # score_max cannot be negative.
+        with self.assertRaises(ValueError):
+            score_max_test.save()
+
+        score_max_test.score_max = 10
+        score_max_test.save()


### PR DESCRIPTION
### Description

The back end doesn't crash anymore when submitting/editing a `ComparisonCriteriaScore` from the admin interface, with a `score_max` less than `score`.

We should not use the admin interface to edit `ComparisonCriteriaScore` but it is useful for testing and debugging.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
