### PR TITLE
[ext] fix: translate the buttons rate now, rate later and watch

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -142,6 +142,10 @@
     "message": "Rate Later",
     "description": "Label of the button displayed on video pages."
   },
+  "rateLaterButtonSuccessLabel": {
+    "message": "Added!",
+    "description": "It replaces the Rate Later button label after a successful add."
+  },
   "watchOnTournesolButtonLabel": {
     "message": "Watch on Tournesol",
     "description": "Label of the button displayed on video pages."

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -133,5 +133,17 @@
   "closeIconAlt": {
     "message": "Close icon",
     "description": "Alt text of the close icon displayed when there's a banner"
+  },
+  "rateNowButtonLabel": {
+    "message": "Rate Now",
+    "description": "Label of the button displayed on video pages."
+  },
+  "rateLaterButtonLabel": {
+    "message": "Rate Later",
+    "description": "Label of the button displayed on video pages."
+  },
+  "watchOnTournesolButtonLabel": {
+    "message": "Watch on Tournesol",
+    "description": "Label of the button displayed on video pages."
   }
 }

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -131,5 +131,17 @@
   "closeIconAlt": {
     "message": "Icône de fermeture",
     "description": "Texte alternatif à l'icône de fermeture de la bannière"
+  },
+  "rateNowButtonLabel": {
+    "message": "Comparer",
+    "description": "Label du bouton affiché sur les pages de vidéo."
+  },
+  "rateLaterButtonLabel": {
+    "message": "Plus Tard",
+    "description": "Label du bouton affiché sur les pages de vidéo."
+  },
+  "watchOnTournesolButtonLabel": {
+    "message": "Regarder sur Tournesol",
+    "description": "Label du bouton affiché sur les pages de vidéo."
   }
 }

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -140,6 +140,10 @@
     "message": "Plus Tard",
     "description": "Label du bouton affiché sur les pages de vidéo."
   },
+  "rateLaterButtonSuccessLabel": {
+    "message": "Ajoutée !",
+    "description": "Ça remplace le texte du bouton Plus Tard après un ajout réussi."
+  },
   "watchOnTournesolButtonLabel": {
     "message": "Regarder sur Tournesol",
     "description": "Label du bouton affiché sur les pages de vidéo."

--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -164,7 +164,7 @@ function addVideoButtons() {
               },
               (data) => {
                 if (data.success) {
-                  setRateLaterButtonLabel('Added!');
+                  setRateLaterButtonLabel(chrome.i18n.getMessage('rateLaterButtonSuccessLabel'));
                   setRateLaterButtonIcon(
                     chrome.runtime.getURL('images/checkmark.svg')
                   );

--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -164,7 +164,9 @@ function addVideoButtons() {
               },
               (data) => {
                 if (data.success) {
-                  setRateLaterButtonLabel(chrome.i18n.getMessage('rateLaterButtonSuccessLabel'));
+                  setRateLaterButtonLabel(
+                    chrome.i18n.getMessage('rateLaterButtonSuccessLabel')
+                  );
                   setRateLaterButtonIcon(
                     chrome.runtime.getURL('images/checkmark.svg')
                   );

--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -118,7 +118,7 @@ function addVideoButtons() {
       if (items.access_token) {
         addVideoButton({
           id: 'tournseol-watch-button',
-          label: 'Watch on Tournesol',
+          label: chrome.i18n.getMessage('watchOnTournesolButtonLabel'),
           iconSrc: chrome.runtime.getURL('images/watch.svg'),
           onClick: () => {
             window.open(
@@ -131,7 +131,7 @@ function addVideoButtons() {
 
       addVideoButton({
         id: 'tournesol-rate-now-button',
-        label: 'Rate Now',
+        label: chrome.i18n.getMessage('rateNowButtonLabel'),
         iconSrc: chrome.runtime.getURL('images/compare.svg'),
         onClick: () => {
           chrome.runtime.sendMessage({
@@ -150,7 +150,7 @@ function addVideoButtons() {
         setIcon: setRateLaterButtonIcon,
       } = addVideoButton({
         id: 'tournesol-rate-later-button',
-        label: 'Rate Later',
+        label: chrome.i18n.getMessage('rateLaterButtonLabel'),
         iconSrc: chrome.runtime.getURL('images/add.svg'),
         iconClass: 'tournesol-rate-later',
         onClick: () => {


### PR DESCRIPTION
**related issues** #1917 

---

### Description

The buttons Rate Now, Rate Later and Watch on Tournesol displayed on the YT video pages are now translated in French (in addition to English). 

![capture](https://github.com/user-attachments/assets/2a4cc0d1-4e15-4849-bdc1-59be23f57d3e)

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
