### PR TITLE
[back] fix: API comparisons should return 400 instead of 500

### DIFF
--- a/backend/core/locale/fr/LC_MESSAGES/django.po
+++ b/backend/core/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-22 14:56+0000\n"
+"POT-Creation-Date: 2024-08-06 08:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,42 +18,42 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: backoffice/admin.py:70
+#: backoffice/admin.py:71
 msgid "Enable the selected banners."
 msgstr "Activer les bannières sélectionnées."
 
-#: backoffice/admin.py:74
+#: backoffice/admin.py:75
 msgid "Disable the selected banners."
 msgstr "Désactiver les bannières sélectionnées."
 
-#: backoffice/admin.py:80
+#: backoffice/admin.py:81
 msgid "has answer?"
 msgstr "a une réponse?"
 
-#: backoffice/admin.py:85
+#: backoffice/admin.py:86
 msgid "Yes"
 msgstr "Oui"
 
-#: backoffice/admin.py:86
+#: backoffice/admin.py:87
 msgid "No"
 msgstr "Non"
 
-#: backoffice/admin.py:131
+#: backoffice/admin.py:132
 msgid "Enable the selected entries."
 msgstr "Activer les entrées sélectionnées."
 
-#: backoffice/admin.py:137
+#: backoffice/admin.py:138
 #, python-format
 msgid "%d entry was successfully marked as enabled."
 msgid_plural "%d entries were successfully marked as enabled."
 msgstr[0] "%d entrée a été activée avec succès."
 msgstr[1] "%d entrées ont été activées avec succès."
 
-#: backoffice/admin.py:145
+#: backoffice/admin.py:146
 msgid "Disable the selected entries."
 msgstr "Désactiver les entrées sélectionnées."
 
-#: backoffice/admin.py:151
+#: backoffice/admin.py:152
 #, python-format
 msgid "%d entry was successfully marked as disabled."
 msgid_plural "%d entries were successfully marked as disabled."
@@ -107,7 +107,7 @@ msgstr ""
 "Un utilisateur avec un e-mail commençant par '%(email)s' existe déjà dans ce "
 "domaine."
 
-#: core/models/user.py:163 core/serializers/user.py:20
+#: core/models/user.py:169 core/serializers/user.py:20
 msgid "A user with this email address already exists."
 msgstr "Un utilisateur avec cet e-mail existe déjà."
 
@@ -120,24 +120,24 @@ msgstr "'%(name)s' est un nom d'utilisateur reservé"
 msgid "'@' is not allowed in username"
 msgstr "Un nom d'utilisateur ne peut pas contenir '@'"
 
-#: core/serializers/user_settings.py:55
+#: core/serializers/user_settings.py:56
 msgid "The main criterion cannot be in the list."
 msgstr "Le critère principal ne peut pas être présent."
 
-#: core/serializers/user_settings.py:58
+#: core/serializers/user_settings.py:59
 msgid "The list cannot contain duplicates."
 msgstr "La liste ne peut pas contenir des doublons."
 
-#: core/serializers/user_settings.py:63
+#: core/serializers/user_settings.py:64
 #, python-format
 msgid "Unknown criterion: %(criterion)s."
 msgstr "Critère inconnu: %(criterion)s."
 
-#: core/serializers/user_settings.py:70
+#: core/serializers/user_settings.py:71
 msgid "This parameter cannot be lower than 1."
 msgstr "Ce paramètre ne peut pas être inférieur à 1."
 
-#: core/serializers/user_settings.py:108
+#: core/serializers/user_settings.py:109
 #, python-format
 msgid "Unknown language code: %(lang)s."
 msgstr "Code de langue inconnu : %(lang)s."

--- a/backend/tournesol/locale/fr/LC_MESSAGES/django.po
+++ b/backend/tournesol/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-18 15:23+0000\n"
+"POT-Creation-Date: 2024-08-06 08:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,6 +34,23 @@ msgstr "Oui"
 #: tournesol/admin.py:378
 msgid "No"
 msgstr "Non"
+
+#: tournesol/models/comparisons.py:155
+msgid "The value of score_max cannot be None."
+msgstr "La valeur de score_max ne peut pas être None."
+
+#: tournesol/models/comparisons.py:158
+msgid "The value of score_max must be greater than or equal to 1."
+msgstr "La valeur de score_max doit être supérieure ou égale à 1."
+
+#: tournesol/models/comparisons.py:163
+#, python-format
+msgid ""
+"The absolute value of the score %(score)s given to the criterion "
+"%(criterion)s can't be greater than the value of score_max %(score_max)s."
+msgstr ""
+"La valeur absolue du score %(score)s donnée au critère "
+"%(criterion)s ne peut pas être supérieure à la valeur de score_max %(score_max)s."
 
 #: tournesol/serializers/rate_later.py:60
 msgid "The entity is already in the rate-later list of this poll."

--- a/backend/tournesol/models/comparisons.py
+++ b/backend/tournesol/models/comparisons.py
@@ -148,25 +148,26 @@ class ComparisonCriteriaScore(models.Model):
     def __str__(self):
         return f"{self.comparison}/{self.criteria}/{self.score}"
 
-    def _validate_score_max(self):
-        if self.score_max is None:
+    @staticmethod
+    def validate_score_max(score: float, score_max: int, criterion: str):
+        if score_max is None:
             raise TypeError("The value of score_max cannot be None.")
 
-        if self.score_max <= 0:
+        if score_max <= 0:
             raise ValueError("The value of score_max must be greater than or equal to 1.")
 
-        if abs(self.score) > self.score_max:
+        if abs(score) > score_max:
             raise ValueError(
-                f"The absolute value of the score {self.score} given to the criterion "
-                f"{self.criteria} can't be greater than the value of score_max {self.score_max}."
+                f"The absolute value of the score {score} given to the criterion "
+                f"{criterion} can't be greater than the value of score_max {score_max}."
             )
 
     def clean(self):
         try:
-            self._validate_score_max()
+            self.validate_score_max(self.score, self.score_max, self.criteria)
         except (TypeError, ValueError) as err:
             raise ValidationError({"score_max": err.args[0]}) from err
 
     def save(self, *args, **kwargs):
-        self._validate_score_max()
+        self.validate_score_max(self.score, self.score_max, self.criteria)
         return super().save(*args, **kwargs)

--- a/backend/tournesol/models/comparisons.py
+++ b/backend/tournesol/models/comparisons.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.db.models import F, ObjectDoesNotExist, Q
+from django.utils.translation import gettext_lazy as _
 
 from core.models import User
 
@@ -151,15 +152,18 @@ class ComparisonCriteriaScore(models.Model):
     @staticmethod
     def validate_score_max(score: float, score_max: int, criterion: str):
         if score_max is None:
-            raise TypeError("The value of score_max cannot be None.")
+            raise TypeError(_("The value of score_max cannot be None."))
 
         if score_max <= 0:
-            raise ValueError("The value of score_max must be greater than or equal to 1.")
+            raise ValueError(_("The value of score_max must be greater than or equal to 1."))
 
         if abs(score) > score_max:
             raise ValueError(
-                f"The absolute value of the score {score} given to the criterion "
-                f"{criterion} can't be greater than the value of score_max {score_max}."
+                _(
+                    "The absolute value of the score %(score)s given to the criterion "
+                    "%(criterion)s can't be greater than the value of score_max %(score_max)s."
+                )
+                % {"score": score, "criterion": criterion, "score_max": score_max}
             )
 
     def clean(self):

--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -21,16 +21,16 @@ class ComparisonCriteriaScoreSerializer(ModelSerializer):
             )
         return value
 
-    def validate(self, data):
+    def validate(self, attrs):
         try:
             ComparisonCriteriaScore.validate_score_max(
-                data["score"],
-                data["score_max"],
-                data["criteria"],
+                attrs["score"],
+                attrs["score_max"],
+                attrs["criteria"],
             )
         except (TypeError, ValueError) as err:
             raise ValidationError({"score_max": err.args[0]}) from err
-        return data
+        return attrs
 
 
 class ComparisonSerializerMixin:

--- a/backend/tournesol/serializers/comparison.py
+++ b/backend/tournesol/serializers/comparison.py
@@ -21,6 +21,17 @@ class ComparisonCriteriaScoreSerializer(ModelSerializer):
             )
         return value
 
+    def validate(self, data):
+        try:
+            ComparisonCriteriaScore.validate_score_max(
+                data["score"],
+                data["score_max"],
+                data["criteria"],
+            )
+        except (TypeError, ValueError) as err:
+            raise ValidationError({"score_max": err.args[0]}) from err
+        return data
+
 
 class ComparisonSerializerMixin:
     def format_entity_contexts(self, poll, contexts, metadata):

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -578,8 +578,8 @@ class ComparisonApiTestCase(TestCase):
 
     def test_authenticated_cant_create_invalid_score_max(self):
         """
-        An authenticated user can't create a comparison with a criterion
-        having a score > to score_max.
+        An authenticated user can't create a comparison with a criterion whose
+        score is higher than score_max.
         """
         initial_comparisons_nbr = Comparison.objects.all().count()
         data = deepcopy(self.non_existing_comparison)
@@ -1086,8 +1086,8 @@ class ComparisonApiTestCase(TestCase):
 
     def test_authenticated_cant_patch_invalid_score_max(self):
         """
-        An authenticated user can't patch the score of a criterion with value
-        superior to score_max.
+        An authenticated user can't patch the score of a criterion with a
+        value higher than score_max.
         """
         self.client.force_authenticate(user=self.user)
         self.comparisons[0].criteria_scores.all().delete()

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -576,6 +576,28 @@ class ComparisonApiTestCase(TestCase):
             initial_comparisons_nbr + 1,
         )
 
+    def test_authenticated_cant_create_invalid_score_max(self):
+        """
+        An authenticated user can't create a comparison with a criterion
+        having a score > to score_max.
+        """
+        initial_comparisons_nbr = Comparison.objects.all().count()
+        data = deepcopy(self.non_existing_comparison)
+        data["criteria_scores"][0]["score"] = 10
+        data["criteria_scores"][0]["score_max"] = 5
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            self.comparisons_base_url,
+            data,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            Comparison.objects.all().count(),
+            initial_comparisons_nbr,
+        )
+
     def test_anonymous_cant_list(self):
         """
         An anonymous user can't list its comparisons.
@@ -988,6 +1010,7 @@ class ComparisonApiTestCase(TestCase):
                     {
                         "criteria": optional,
                         "score": 4,
+                        "score_max": 8,
                     }
                 ]
             },
@@ -1060,6 +1083,41 @@ class ComparisonApiTestCase(TestCase):
                 {"criteria": "pedagogy", "score": 5.0, "score_max": 9, "weight": 1.0},
             ],
         )
+
+    def test_authenticated_cant_patch_invalid_score_max(self):
+        """
+        An authenticated user can't patch the score of a criterion with value
+        superior to score_max.
+        """
+        self.client.force_authenticate(user=self.user)
+        self.comparisons[0].criteria_scores.all().delete()
+
+        ComparisonCriteriaScore.objects.create(
+            comparison=self.comparisons[0],
+            criteria="largely_recommended",
+            score=8,
+            score_max=10,
+        )
+
+        response = self.client.patch(
+            "{}/{}/{}/".format(
+                self.comparisons_base_url,
+                self._uid_01,
+                self._uid_02,
+            ),
+            data={
+                "criteria_scores": [
+                    {
+                        "criteria": "largely_recommended",
+                        "score": 10,
+                        "score_max": 8,
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_anonymous_cant_delete(self):
         """

--- a/backend/tournesol/tests/test_model_comparisoncriteriascore.py
+++ b/backend/tournesol/tests/test_model_comparisoncriteriascore.py
@@ -55,24 +55,44 @@ class ComparisonCriteriaScoreTestCase(TestCase):
 
         # The score cannot be greater than score_max.
         with self.assertRaises(ValueError):
-            score_test._validate_score_max()
+            score_test.validate_score_max(
+                score=score_test.score,
+                score_max=score_test.score_max,
+                criterion=score_test.criteria,
+            )
 
         score_test.score = -11
         # The absolute value of the score cannot be greater than score_max.
         with self.assertRaises(ValueError):
-            score_test._validate_score_max()
+            score_test.validate_score_max(
+                score=score_test.score,
+                score_max=score_test.score_max,
+                criterion=score_test.criteria,
+            )
 
         # The score can be zero.
         score_test.score = 0
-        score_test._validate_score_max()
+        score_test.validate_score_max(
+            score=score_test.score,
+            score_max=score_test.score_max,
+            criterion=score_test.criteria,
+        )
 
         # The score can be equal to the score_max.
         score_test.score = score_test.score_max
-        score_test._validate_score_max()
+        score_test.validate_score_max(
+            score=score_test.score,
+            score_max=score_test.score_max,
+            criterion=score_test.criteria,
+        )
 
         # The absolute value of the score can be lesser than score_max.
         score_test.score = -1
-        score_test._validate_score_max()
+        score_test.validate_score_max(
+            score=score_test.score,
+            score_max=score_test.score_max,
+            criterion=score_test.criteria,
+        )
 
         score_max_test = ComparisonCriteriaScore(
             comparison=self.comparison,
@@ -83,24 +103,40 @@ class ComparisonCriteriaScoreTestCase(TestCase):
 
         # score_max cannot be None.
         with self.assertRaises(TypeError):
-            score_max_test._validate_score_max()
+            score_max_test.validate_score_max(
+                score=score_max_test.score,
+                score_max=score_max_test.score_max,
+                criterion=score_max_test.criteria,
+            )
 
         score_max_test.score_max = 0
         # score_max cannot be zero.
         with self.assertRaises(ValueError):
-            score_max_test._validate_score_max()
+            score_max_test.validate_score_max(
+                score=score_max_test.score,
+                score_max=score_max_test.score_max,
+                criterion=score_max_test.criteria,
+            )
 
         score_max_test.score_max = -10
         # score_max cannot be negative.
         with self.assertRaises(ValueError):
-            score_max_test._validate_score_max()
+            score_max_test.validate_score_max(
+                score=score_max_test.score,
+                score_max=score_max_test.score_max,
+                criterion=score_max_test.criteria,
+            )
 
         score_max_test.score_max = 10
-        score_max_test._validate_score_max()
+        score_max_test.validate_score_max(
+            score=score_max_test.score,
+            score_max=score_max_test.score_max,
+            criterion=score_max_test.criteria,
+        )
 
     def test_clean_calls_validate_score_max(self):
         """
-        The method `clean` should call the method `_validate_score_max` and
+        The method `clean` should call the method `validate_score_max` and
         transform its exceptions into `ValidationError`.
         """
         score = ComparisonCriteriaScore(
@@ -110,27 +146,27 @@ class ComparisonCriteriaScoreTestCase(TestCase):
             score_max=10,
         )
 
-        score._validate_score_max = Mock()
+        score.validate_score_max = Mock()
         score.clean()
-        score._validate_score_max.assert_called_once()
+        score.validate_score_max.assert_called_once()
 
-        # The exceptions raised by _validate_score_max should be transformed
+        # The exceptions raised by validate_score_max should be transformed
         # into `ValidationError` by the method `clean`.
         expected_exceptions = [TypeError("oops"), ValueError("oops")]
         for exception in expected_exceptions:
-            score._validate_score_max = Mock(side_effect=exception)
+            score.validate_score_max = Mock(side_effect=exception)
 
             with self.assertRaises(ValidationError):
                 score.clean()
 
         # All other exceptions should not be transformed.
-        score._validate_score_max = Mock(side_effect=KeyError)
+        score.validate_score_max = Mock(side_effect=KeyError)
         with self.assertRaises(KeyError):
             score.clean()
 
     def test_save_calls_validate_score_max(self):
         """
-        The method `save` should call the method `_validate_score_max`.
+        The method `save` should call the method `validate_score_max`.
         """
         score = ComparisonCriteriaScore(
             comparison=self.comparison,
@@ -139,15 +175,15 @@ class ComparisonCriteriaScoreTestCase(TestCase):
             score_max=10,
         )
 
-        score._validate_score_max = Mock()
+        score.validate_score_max = Mock()
         score.save()
-        score._validate_score_max.assert_called_once()
+        score.validate_score_max.assert_called_once()
 
-        # All exceptions raised by _validate_score_max should not be
+        # All exceptions raised by validate_score_max should not be
         # transformed by `save`.
         expected_exceptions = [KeyError, TypeError, ValueError]
         for exception in expected_exceptions:
-            score._validate_score_max = Mock(side_effect=exception)
+            score.validate_score_max = Mock(side_effect=exception)
 
             with self.assertRaises(exception):
                 score.save()


### PR DESCRIPTION
**related issues** #2001

---

### Description

Instead of returning a HTTP 500 error, the API now returns a proper HTTP 400 Bad Request when a user submits a comparison with an invalid `score_max`.

The comparison UI is able to display the error messages from the API, so I translated the messages to make them match the front end UI language. As long as the front end correctly sets the `score_max` of each criterion these messages shouldn't be displayed to the users.   

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
