### PR TITLE
[front] feat: normalize the size of Y axis of scores distribution

### DIFF
--- a/frontend/src/features/charts/CriteriaScoresDistribution.tsx
+++ b/frontend/src/features/charts/CriteriaScoresDistribution.tsx
@@ -45,9 +45,11 @@ const binLabel = (index: number, bins: number[], t: TFunction) => {
 const CriteriaScoresDistributionChart = ({
   criterion,
   criteriaDistributionScore,
+  yMax = 'dataMax',
 }: {
   criterion: string;
   criteriaDistributionScore: CriteriaDistributionScore;
+  yMax?: string | number;
 }) => {
   const { t } = useTranslation();
   const { bins, distribution } = criteriaDistributionScore;
@@ -115,6 +117,7 @@ const CriteriaScoresDistributionChart = ({
           }}
         />
         <YAxis
+          domain={[0, yMax]}
           label={{
             value: t('criteriaScoresDistribution.numberOfRatings'),
             angle: -90,
@@ -144,6 +147,7 @@ const CriteriaScoresDistribution = ({
   const { selectedCriterion, setSelectedCriterion } = useSelectedCriterion();
   const entity = reco.entity;
 
+  const [yAxisMax, setYAxisMax] = useState(0);
   const [criteriaScoresDistribution, setCriteriaScoresDistribution] = useState<
     CriteriaDistributionScore[]
   >([]);
@@ -171,6 +175,16 @@ const CriteriaScoresDistribution = ({
           uid: entity.uid,
         });
       setCriteriaScoresDistribution(result.criteria_scores_distributions);
+
+      let yMax = 0;
+      result.criteria_scores_distributions.forEach((criterion) => {
+        const distribMax = Math.max(...criterion.distribution);
+        if (distribMax > yMax) {
+          yMax = distribMax;
+        }
+      });
+
+      setYAxisMax(yMax);
     };
     getDistribution();
   }, [entity.uid, pollName]);
@@ -196,6 +210,7 @@ const CriteriaScoresDistribution = ({
           <CriteriaScoresDistributionChart
             criterion={selectedCriterion}
             criteriaDistributionScore={criteriaDistributionScore}
+            yMax={yAxisMax}
           />
         </Box>
       )}

--- a/frontend/src/features/charts/CriteriaScoresDistribution.tsx
+++ b/frontend/src/features/charts/CriteriaScoresDistribution.tsx
@@ -118,6 +118,10 @@ const CriteriaScoresDistributionChart = ({
         />
         <YAxis
           domain={[0, yMax]}
+          // Only display a tick for integer steps.
+          tickCount={
+            typeof yMax === 'number' && yMax <= 5 ? yMax + 1 : undefined
+          }
           label={{
             value: t('criteriaScoresDistribution.numberOfRatings'),
             angle: -90,


### PR DESCRIPTION
### Description

As suggested on Discord, the size of the y axis of the score distribution bar chart is now the same for each criterion of a given video. The size is equal to the highest number of ratings among all bins. 

### Preview

![screencapture-localhost-3000-entities-yt-WPPPFqsECz0-2024-08-06-15_04_31](https://github.com/user-attachments/assets/ce972abd-fe70-4e88-af40-72cf3537ddc2)

![screencapture-localhost-3000-entities-yt-WPPPFqsECz0-2024-08-06-15_04_55](https://github.com/user-attachments/assets/b9ff817e-d044-4cfe-9e1e-0c609eef2ef1)

![screencapture-localhost-3000-entities-yt-WPPPFqsECz0-2024-08-06-15_10_23](https://github.com/user-attachments/assets/826810f9-e0f8-4de9-ac54-c7a48013e843)

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
