### PR TITLE
[back] refactor: all responses of the vouchers API are now ordered

### DIFF
--- a/backend/vouch/tests/test_api_voucher.py
+++ b/backend/vouch/tests/test_api_voucher.py
@@ -227,6 +227,8 @@ class VoucherGivenListAPIViewTestCase(TestCase):
         results = response.data
         self.assertEqual(len(results), 2)
 
+        # Vouchers should be sorted in ascending order of the recipient's
+        # username.
         self.assertDictEqual(
             results[0],
             {
@@ -297,6 +299,8 @@ class VoucherReceivedListAPIViewTestCase(TestCase):
         results = response.data
         self.assertEqual(len(results), 2)
 
+        # Vouchers should be sorted in ascending order of the issuer's
+        # username.
         self.assertDictEqual(
             results[0],
             {

--- a/backend/vouch/views.py
+++ b/backend/vouch/views.py
@@ -44,7 +44,7 @@ class VoucherGivenListAPIView(generics.ListAPIView):
         return Voucher.objects.filter(
             by=self.request.user,
             to__is_active=True,
-        )
+        ).order_by('to__username')
 
 
 @extend_schema_view(


### PR DESCRIPTION
### Description

The API responses of the vouch API should now be deterministic, and the related tests should now fail anymore.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
