### PR TITLE
[infra] fix: close connection on https request without host

### DIFF
--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -1,6 +1,7 @@
 server {
     # if no Host match, close the connection to prevent host spoofing
     listen 80 default_server;
+    listen 443 ssl default_server;
     return 444;
 }
 

--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -1,7 +1,11 @@
 server {
     # if no Host match, close the connection to prevent host spoofing
     listen 80 default_server;
-    listen 443 ssl default_server;
+
+    # On port 443 it would be cleaner to use "ssl" with "ssl_reject_handshake on;"
+    # but that requires Nginx >= 1.19.4. Instead the default server use HTTP only.
+    listen 443 default_server;
+
     return 444;
 }
 

--- a/infra/ansible/roles/django/templates/tournesol.j2
+++ b/infra/ansible/roles/django/templates/tournesol.j2
@@ -2,9 +2,11 @@ server {
     # if no Host match, close the connection to prevent host spoofing
     listen 80 default_server;
 
-    # On port 443 it would be cleaner to use "ssl" with "ssl_reject_handshake on;"
-    # but that requires Nginx >= 1.19.4. Instead the default server use HTTP only.
-    listen 443 default_server;
+    # Nginx requires certificates to be defined here. It would be cleaner to
+    # use "ssl_reject_handshake on;" but that requires Nginx >= 1.19.4.
+    listen 443 ssl default_server;
+    ssl_certificate /etc/letsencrypt/live/{{domain_name}}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{domain_name}}/privkey.pem;
 
     return 444;
 }


### PR DESCRIPTION
### Description

Contrary to http, the default server for https was grafana, causing timeouts on some requests from bots.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
