### PR TITLE
[back] fix: read default log level from server settings if it's present

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -364,6 +364,11 @@ DISCORD_CHANNEL_WEBHOOKS = server_settings.get("DISCORD_CHANNEL_WEBHOOKS", {})
 
 TWITTERBOT_CREDENTIALS = server_settings.get("TWITTERBOT_CREDENTIALS", {})
 
+if "DJANGO_LOG_LEVEL" in os.environ:
+    DJANGO_LOG_LEVEL = os.environ["DJANGO_LOG_LEVEL"]
+else:
+    DJANGO_LOG_LEVEL = server_settings.get("DJANGO_LOG_LEVEL", "INFO")
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -374,7 +379,7 @@ LOGGING = {
     },
     "root": {
         "handlers": ["console"],
-        "level": os.environ.get("DJANGO_LOG_LEVEL", "DEBUG"),
+        "level": DJANGO_LOG_LEVEL,
     },
     "loggers": {
         "factory": {


### PR DESCRIPTION
### Description

The value `DJANGO_LOG_LEVEL` configured on the server was ignored.

After the change,  it's still possible to use the environment variable `DJANGO_LOG_LEVEL`  to override the settings if necessary. The default level is also modified from "DEBUG" to "INFO".

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
