### PR TITLE
[solidago] Keep get_collective_scores() specific to the public dataset, count comparisons lazily

### DIFF
--- a/solidago/tests/test_pipeline.py
+++ b/solidago/tests/test_pipeline.py
@@ -50,6 +50,7 @@ def test_tournesol_get_individual_scores():
     found = dataset.get_individual_scores(
         criteria="importance",
         user_id=user_id,
+        with_n_comparisons=True,
     )
     assert len(found) == 1123
     as_dict = found.to_dict(orient="records")[0]
@@ -60,7 +61,7 @@ def test_tournesol_get_individual_scores():
         'score': 82.81,
         'uncertainty': 24.37,
         'voting_right': 1.0,
-        'comparisons': 10,
+        'n_comparisons': 10,
     }
 
 
@@ -91,6 +92,6 @@ def test_tournesol_get_collective_scores():
         'criteria': 'importance',
         'score': 18.22,
         'uncertainty': 60.09,
-        'users': 3,
-        'comparisons': 12,
+        'n_users': 3,
+        'n_comparisons': 12,
     }


### PR DESCRIPTION
### Description

This PR relies on the work initiated by @NatNgs in #1994.

The implementation of `get_individual_scores()` is a prerequisite to initialize the scores (with their previous values) when running GBT in the Solidago pipeline.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
