### PR TITLE
[solidago] chore: plug individual scores initialization and more consistent naming

### DIFF
--- a/backend/ml/inputs.py
+++ b/backend/ml/inputs.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pandas as pd
 from django.db.models import Case, F, Q, QuerySet, When
 from django.db.models.expressions import RawSQL
-from solidago.pipeline import TournesolInput
+from solidago.pipeline import PipelineInput
 
 from core.models import User
 from tournesol.models import (
@@ -17,7 +17,7 @@ from tournesol.models import (
 from vouch.models import Voucher
 
 
-class MlInputFromDb(TournesolInput):
+class MlInputFromDb(PipelineInput):
     SCALING_CALIBRATION_MIN_ENTITIES_TO_COMPARE = 20
 
     def __init__(self, poll_name: str):

--- a/backend/ml/inputs.py
+++ b/backend/ml/inputs.py
@@ -168,7 +168,7 @@ class MlInputFromDb(TournesolInput):
         return pd.DataFrame(values)
 
     def get_individual_scores(
-        self, criteria: Optional[str] = None, user_id: Optional[int] = None
+        self, user_id: Optional[int] = None, criteria: Optional[str] = None,
     ) -> pd.DataFrame:
         scores_queryset = ContributorRatingCriteriaScore.objects.filter(
             contributor_rating__poll__name=self.poll_name,
@@ -182,14 +182,14 @@ class MlInputFromDb(TournesolInput):
         values = scores_queryset.values(
             "raw_score",
             "criteria",
-            entity=F("contributor_rating__entity_id"),
+            entity_id=F("contributor_rating__entity_id"),
             user_id=F("contributor_rating__user_id"),
         )
         if len(values) == 0:
-            return pd.DataFrame(columns=["user_id", "entity", "criteria", "raw_score"])
+            return pd.DataFrame(columns=["user_id", "entity_id", "criteria", "raw_score"])
 
         dtf = pd.DataFrame(values)
-        return dtf[["user_id", "entity", "criteria", "raw_score"]]
+        return dtf[["user_id", "entity_id", "criteria", "raw_score"]]
 
     def get_vouches(self):
         values = Voucher.objects.filter(

--- a/backend/ml/management/commands/ml_train.py
+++ b/backend/ml/management/commands/ml_train.py
@@ -1,5 +1,6 @@
 import os
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from functools import cache
 
 from django import db
 from django.conf import settings
@@ -18,6 +19,7 @@ from tournesol.models import EntityPollRating, Poll
 from tournesol.models.poll import ALGORITHM_MEHESTAN, DEFAULT_POLL_NAME
 
 
+@cache
 def get_solidago_pipeline(run_trust_propagation: bool = True):
     if run_trust_propagation:
         trust_algo = LipschiTrust()

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -4,7 +4,7 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_compl
 
 from django import db
 from django.conf import settings
-from solidago.pipeline import TournesolInput
+from solidago.pipeline import PipelineInput
 from solidago.pipeline.legacy2023.criterion_pipeline import run_pipeline_for_criterion
 from solidago.pipeline.legacy2023.individual_scores import get_individual_scores
 
@@ -45,7 +45,7 @@ def close_db_connection_callback():
 
 
 def run_mehestan(
-    ml_input: TournesolInput, poll: Poll, parameters: MehestanParameters, main_criterion_only=False
+    ml_input: PipelineInput, poll: Poll, parameters: MehestanParameters, main_criterion_only=False
 ):
     """
     This function use multiprocessing.

--- a/backend/ml/mehestan/run.py
+++ b/backend/ml/mehestan/run.py
@@ -21,15 +21,15 @@ logger = logging.getLogger(__name__)
 def update_user_scores(poll: Poll, user: User):
     params = MehestanParameters()
     ml_input = MlInputFromDb(poll_name=poll.name)
-    for criteria in poll.criterias_list:
-        output = TournesolPollOutput(poll_name=poll.name, criterion=criteria)
+    for criterion in poll.criterias_list:
+        output = TournesolPollOutput(poll_name=poll.name, criterion=criterion)
         scores = get_individual_scores(
             ml_input,
-            criteria,
+            criterion,
             parameters=params,
             single_user_id=user.pk,
         )
-        scores["criteria"] = criteria
+        scores["criterion"] = criterion
         scores.rename(
             columns={
                 "score": "raw_score",

--- a/backend/ml/outputs.py
+++ b/backend/ml/outputs.py
@@ -257,7 +257,7 @@ def apply_score_scalings(poll: Poll, contributor_scores: pd.DataFrame):
         contributor_scores: DataFrame with columns:
             user_id: int
             entity_id: int
-            criteria: str
+            criterion: str
             raw_score: float
             raw_uncertainty: float
 
@@ -270,9 +270,9 @@ def apply_score_scalings(poll: Poll, contributor_scores: pd.DataFrame):
         return contributor_scores
 
     ml_input = MlInputFromDb(poll_name=poll.name)
-    scalings = ml_input.get_user_scalings().set_index(["user_id", "criteria"])
+    scalings = ml_input.get_user_scalings().set_index(["user_id", "criterion"])
     contributor_scores = contributor_scores.join(
-        scalings, on=["user_id", "criteria"], how="left"
+        scalings, on=["user_id", "criterion"], how="left"
     )
     contributor_scores["scale"].fillna(1, inplace=True)
     contributor_scores["translation"].fillna(0, inplace=True)

--- a/backend/ml/outputs.py
+++ b/backend/ml/outputs.py
@@ -166,7 +166,7 @@ class TournesolPollOutput(PipelineOutput):
                         raw_uncertainty=row.raw_uncertainty,
                         voting_right=row.voting_right,
                     )
-                    for _, row in scores.iterrows()
+                    for row in scores.itertuples()
                 ),
                 batch_size=10000,
             )

--- a/backend/ml/outputs.py
+++ b/backend/ml/outputs.py
@@ -273,11 +273,14 @@ def apply_score_scalings(poll: Poll, contributor_scores: pd.DataFrame):
     scalings = ml_input.get_user_scalings().set_index(["user_id", "criterion"])
     contributor_scores = contributor_scores.join(
         scalings, on=["user_id", "criterion"], how="left"
+    ).fillna(
+        {
+            "scale": 1.0,
+            "translation": 0.0,
+            "scale_uncertainty": 0.0,
+            "translation_uncertatinty": 0.0,
+        }
     )
-    contributor_scores["scale"].fillna(1, inplace=True)
-    contributor_scores["translation"].fillna(0, inplace=True)
-    contributor_scores["scale_uncertainty"].fillna(0, inplace=True)
-    contributor_scores["translation_uncertainty"].fillna(0, inplace=True)
 
     # Apply individual scaling
     contributor_scores["uncertainty"] = (

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,14 +37,14 @@ PyYAML==6.0.1
 langdetect==1.0.9
 # Pandas is used extensively in the ML algorithms and for some data management
 # tasks such as building the public dataset
-pandas==2.1.2
+pandas==2.2.3
 # Numba provides just-in-time compilation to run optimized machine code
 # for performance-critical functions in Mehestan implementation.
-numba==0.58.1
+numba==0.60.0
 # Numpy is used extensively in the ML algorithms and in some other algorithms
 # such as computing comparison suggestions. See https://numpy.org/
 # Check the compatibility with Numba before upgrading.
-numpy==1.26.1
+numpy==1.26.4
 # Scipy is used in some ML algorithms
 scipy==1.11.3
 # API Youtube data

--- a/backend/tournesol/management/commands/load_public_dataset.py
+++ b/backend/tournesol/management/commands/load_public_dataset.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from solidago.pipeline.inputs import TournesolInputFromPublicDataset
+from solidago.pipeline.inputs import TournesolDataset
 
 from core.models import User
 from core.models.user import EmailDomain
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         parser.add_argument("--user-sampling", type=float, default=None)
         parser.add_argument("--dataset-url", type=str, default=PUBLIC_DATASET_URL)
 
-    def create_user(self, username: str, ml_input: TournesolInputFromPublicDataset):
+    def create_user(self, username: str, ml_input: TournesolDataset):
         user = ml_input.users.loc[ml_input.users.public_username == username].iloc[0]
         is_pretrusted = user.trust_score > 0.5
         email = f"{username}@trusted.example" if is_pretrusted else f"{username}@example.com"
@@ -66,7 +66,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        public_dataset = TournesolInputFromPublicDataset(options["dataset_url"])
+        public_dataset = TournesolDataset(options["dataset_url"])
         nb_comparisons = 0
 
         with transaction.atomic():

--- a/backend/tournesol/management/commands/load_public_dataset.py
+++ b/backend/tournesol/management/commands/load_public_dataset.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
                 for values in rows.itertuples(index=False):
                     ComparisonCriteriaScore.objects.create(
                         comparison=comparison,
-                        criteria=values.criteria,
+                        criteria=values.criterion,
                         score=values.score,
                         score_max=values.score_max,
                     )

--- a/backend/tournesol/tests/test_api_exports.py
+++ b/backend/tournesol/tests/test_api_exports.py
@@ -17,7 +17,7 @@ from django.core.management import call_command
 from django.test import TransactionTestCase, override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
-from solidago.pipeline.inputs import TournesolInputFromPublicDataset
+from solidago.pipeline.inputs import TournesolDataset
 
 from core.models import User
 from core.tests.factories.user import UserFactory
@@ -542,7 +542,7 @@ class ExportTest(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         zip_content = io.BytesIO(response.content)
 
-        ml_input = TournesolInputFromPublicDataset(zip_content)
+        ml_input = TournesolDataset(zip_content)
         comparisons_df = ml_input.get_comparisons()
         rating_properties = ml_input.ratings_properties
 

--- a/backend/tournesol/tests/test_api_exports.py
+++ b/backend/tournesol/tests/test_api_exports.py
@@ -549,7 +549,7 @@ class ExportTest(TransactionTestCase):
         self.assertEqual(len(comparisons_df), 1)
         self.assertEqual(
             list(comparisons_df.columns),
-            ["user_id", "entity_a", "entity_b", "criteria", "score", "score_max", "weight"],
+            ["user_id", "entity_a", "entity_b", "criterion", "score", "score_max", "weight"],
         )
 
         self.assertEqual(len(rating_properties), 2)

--- a/solidago/experiments/data_analysis.py
+++ b/solidago/experiments/data_analysis.py
@@ -1,10 +1,10 @@
-from solidago.pipeline.inputs import TournesolInputFromPublicDataset
+from solidago.pipeline.inputs import TournesolDataset
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import scipy
 
-data = TournesolInputFromPublicDataset.download()
+data = TournesolDataset.download()
 
 criteria = {
     "reliability": "Reliable and not misleading",

--- a/solidago/experiments/tournesol.py
+++ b/solidago/experiments/tournesol.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 
 from threading import Thread
 
-from solidago.pipeline.inputs import TournesolInputFromPublicDataset
+from solidago.pipeline.inputs import TournesolDataset
 
 from solidago.trust_propagation import LipschiTrust
 from solidago.voting_rights import AffineOvertrust
@@ -32,7 +32,7 @@ for module in info_loggers:
     info_logger.addHandler(ch)
 
 logger.info("Retrieve public dataset")
-inputs = TournesolInputFromPublicDataset.download()
+inputs = TournesolDataset.download()
 video_id_to_entity_id = { 
     video_id: entity_id 
     for entity_id, video_id in enumerate(inputs.entity_id_to_video_id)

--- a/solidago/pyproject.toml
+++ b/solidago/pyproject.toml
@@ -20,7 +20,7 @@ keywords = ["tournesol", "collaborative recommendations", "judgement aggregation
 dependencies = [
     "pandas>=1.5.3,<3.0",
     "numpy>=1.24.3,<1.27",
-    "numba==0.58.1",
+    "numba==0.60.0",
 ]
 dynamic = ["version"]
 

--- a/solidago/src/solidago/__version__.py
+++ b/solidago/src/solidago/__version__.py
@@ -1,4 +1,4 @@
 # Changing the version will automatically publish a new version on PyPI.
 # (see /.github/workflows/solidago-publish.yml)
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/solidago/src/solidago/pipeline/__init__.py
+++ b/solidago/src/solidago/pipeline/__init__.py
@@ -1,5 +1,5 @@
-from .inputs import TournesolInput
+from .inputs import PipelineInput
 from .outputs import PipelineOutput
 from .pipeline import DefaultPipeline, Pipeline
 
-__all__ = ["TournesolInput", "DefaultPipeline", "Pipeline", "PipelineOutput"]
+__all__ = ["PipelineInput", "DefaultPipeline", "Pipeline", "PipelineOutput"]

--- a/solidago/src/solidago/pipeline/inputs.py
+++ b/solidago/src/solidago/pipeline/inputs.py
@@ -30,7 +30,7 @@ class TournesolInput(ABC):
     @abstractmethod
     def get_comparisons(
         self,
-        criteria: Optional[str] = None,
+        criterion: Optional[str] = None,
         user_id: Optional[int] = None,
     ) -> pd.DataFrame:
         """Fetch data about comparisons submitted by users
@@ -40,7 +40,7 @@ class TournesolInput(ABC):
             * `user_id`: int
             * `entity_a`: int or str
             * `entity_b`: int or str
-            * `criteria`: str
+            * `criterion`: str
             * `score`: float
             * `score_max`: int
             * `weight`: float
@@ -66,7 +66,7 @@ class TournesolInput(ABC):
     def get_individual_scores(
         self,
         user_id: Optional[int] = None,
-        criteria: Optional[str] = None,
+        criterion: Optional[str] = None,
     ) -> pd.DataFrame:
         """Fetch data about previously computed individual scores
 
@@ -74,7 +74,7 @@ class TournesolInput(ABC):
         - DataFrame with columns
             * `user_id`: int
             * `entity_id`: int
-            * `criteria`: str
+            * `criterion`: str
             * `score`: float
             * `raw_score`: float (optional column)
         """
@@ -101,7 +101,7 @@ class TournesolInput(ABC):
         ratings_properties = self.ratings_properties
         users = self.get_users()
         vouches = self.get_vouches()
-        comparisons = self.get_comparisons(criteria=criterion)
+        comparisons = self.get_comparisons(criterion=criterion)
         entities_ids = set(comparisons["entity_a"].unique()) | set(
             comparisons["entity_b"].unique()
         )
@@ -124,7 +124,7 @@ class TournesolInput(ABC):
             )
         )
 
-        individual_scores = self.get_individual_scores(criteria=criterion)
+        individual_scores = self.get_individual_scores(criterion=criterion)
         if "raw_score" in individual_scores:
             init_user_models = {
                 user_id: DirectScoringModel(
@@ -145,21 +145,21 @@ class TournesolInput(ABC):
         }
 
     def get_comparisons_counts(
-        self, criteria: Optional[str] = None, user_id: Optional[int] = None
+        self, criterion: Optional[str] = None, user_id: Optional[int] = None
     ):
-        comparisons = self.get_comparisons(criteria=criteria, user_id=user_id)
+        comparisons = self.get_comparisons(criterion=criterion, user_id=user_id)
         return (
             pd.concat(
                 [
-                    comparisons[["user_id", "entity_a", "criteria"]].rename(
+                    comparisons[["user_id", "entity_a", "criterion"]].rename(
                         columns={"entity_a": "entity_id"}
                     ),
-                    comparisons[["user_id", "entity_b", "criteria"]].rename(
+                    comparisons[["user_id", "entity_b", "criterion"]].rename(
                         columns={"entity_b": "entity_id"}
                     ),
                 ]
             )
-            .groupby(["user_id", "entity_id", "criteria"])
+            .groupby(["user_id", "entity_id", "criterion"])
             .size()
             .reset_index(name="n_comparisons")
         )
@@ -181,15 +181,21 @@ class TournesolInputFromPublicDataset(TournesolInput):
                 # Fill trust_score on newly created users for which it was not computed yet
                 self.users.trust_score = pd.to_numeric(self.users.trust_score).fillna(0.0)
 
-            with (zipfile.Path(zip_file) / "collective_criteria_scores.csv").open(mode="rb") as collective_scores_file:
+            with (zipfile.Path(zip_file) / "collective_criteria_scores.csv").open(
+                mode="rb"
+            ) as collective_scores_file:
                 # keep_default_na=False is required otherwise some public usernames
                 # such as "NA" are converted to float NaN.
-                collective_scores = pd.read_csv(collective_scores_file, keep_default_na=False)
+                collective_scores = pd.read_csv(
+                    collective_scores_file, keep_default_na=False
+                ).rename(columns={"criteria": "criterion"})
 
             with (zipfile.Path(zip_file) / "comparisons.csv").open(mode="rb") as comparison_file:
                 # keep_default_na=False is required otherwise some public usernames
                 # such as "NA" are converted to float NaN.
-                comparisons = pd.read_csv(comparison_file, keep_default_na=False)
+                comparisons = pd.read_csv(comparison_file, keep_default_na=False).rename(
+                    columns={"criteria": "criterion"}
+                )
 
             with (zipfile.Path(zip_file) / "vouchers.csv").open(mode="rb") as vouchers_file:
                 # keep_default_na=False is required otherwise some public usernames
@@ -233,19 +239,23 @@ class TournesolInputFromPublicDataset(TournesolInput):
                 # such as "NA" are converted to float NaN.
                 individual_scores = pd.read_csv(individual_scores_file, keep_default_na=False)
                 # Convert usernames and video_id to user_id and entity_id
-                self.individual_scores = individual_scores.assign(
-                    entity_id=individual_scores["video"].map(self.video_id_to_entity_id),
-                    user_id=individual_scores["public_username"].map(self.username_to_user_id),
-                ).drop(columns=["public_username", "video"])
+                self.individual_scores = (
+                    individual_scores.assign(
+                        entity_id=individual_scores["video"].map(self.video_id_to_entity_id),
+                        user_id=individual_scores["public_username"].map(self.username_to_user_id),
+                    )
+                    .rename(columns={"criteria": "criterion"})
+                    .drop(columns=["public_username", "video"])
+                )
 
     @classmethod
     def download(cls) -> "TournesolInputFromPublicDataset":
         return cls(dataset_zip="https://api.tournesol.app/exports/all")
 
-    def get_comparisons(self, criteria=None, user_id=None) -> pd.DataFrame:
+    def get_comparisons(self, criterion=None, user_id=None) -> pd.DataFrame:
         dtf = self.comparisons.copy(deep=False)
-        if criteria is not None:
-            dtf = dtf[dtf.criteria == criteria]
+        if criterion is not None:
+            dtf = dtf[dtf.criterion == criterion]
         if user_id is not None:
             dtf = dtf[dtf.user_id == user_id]
         dtf["weight"] = 1
@@ -256,7 +266,7 @@ class TournesolInputFromPublicDataset(TournesolInput):
             "user_id",
             "entity_a",
             "entity_b",
-            "criteria",
+            "criterion",
             "score",
             "score_max",
             "weight"
@@ -284,30 +294,30 @@ class TournesolInputFromPublicDataset(TournesolInput):
     def get_individual_scores(
         self,
         user_id: Optional[int] = None,
-        criteria: Optional[str] = None,
+        criterion: Optional[str] = None,
         with_n_comparisons = False,
     ) -> pd.DataFrame:
         dtf = self.individual_scores
-        if criteria is not None:
-            dtf = dtf[dtf.criteria == criteria]
+        if criterion is not None:
+            dtf = dtf[dtf.criterion == criterion]
         if user_id is not None:
             dtf = dtf[dtf.user_id == user_id]
 
         dtf = dtf[[
             "user_id",
             "entity_id",
-            "criteria",
+            "criterion",
             "score",
             "uncertainty",
             "voting_right",
         ]]
 
         if with_n_comparisons:
-            comparison_counts = self.get_comparisons_counts(user_id=user_id, criteria=criteria)
+            comparison_counts = self.get_comparisons_counts(user_id=user_id, criterion=criterion)
             dtf = dtf.merge(
                 comparison_counts,
                 how="left",
-                on=["user_id", "entity_id", "criteria"]
+                on=["user_id", "entity_id", "criterion"]
             )
 
         return dtf
@@ -315,17 +325,17 @@ class TournesolInputFromPublicDataset(TournesolInput):
     def get_collective_scores(
         self,
         entity_id: Optional[str] = None,
-        criteria: Optional[str] = None,
+        criterion: Optional[str] = None,
     ) -> pd.DataFrame:
         dtf: pd.DataFrame = self.collective_scores
-        if criteria is not None:
-            dtf = dtf[dtf["criteria"] == criteria]
+        if criterion is not None:
+            dtf = dtf[dtf["criterion"] == criterion]
         if entity_id is not None:
             dtf = dtf[dtf["entity_id"] == entity_id]
 
         counts = (
-            self.get_comparisons_counts(criteria=criteria)
-            .groupby(["criteria", "entity_id"])
+            self.get_comparisons_counts(criterion=criterion)
+            .groupby(["criterion", "entity_id"])
             .agg(
                 n_comparisons=("n_comparisons", "sum"),
                 n_users=("user_id", "nunique"),
@@ -333,7 +343,7 @@ class TournesolInputFromPublicDataset(TournesolInput):
         )
 
         return (
-            dtf.join(counts, how="left", on=["criteria", "entity_id"])
+            dtf.join(counts, how="left", on=["criterion", "entity_id"])
             # Entities that have been compared privately only
             # will not appear in comparisons.csv. That's why we need
             # to fill for missing values here.

--- a/solidago/src/solidago/pipeline/inputs.py
+++ b/solidago/src/solidago/pipeline/inputs.py
@@ -11,7 +11,7 @@ from solidago.judgments import DataFrameJudgments
 from solidago.scoring_model import DirectScoringModel
 
 
-class TournesolInput(ABC):
+class PipelineInput(ABC):
     """
     An abstract base class for handling input data of Solidago pipeline.
 
@@ -76,7 +76,7 @@ class TournesolInput(ABC):
             * `entity_id`: int
             * `criterion`: str
             * `score`: float
-            * `raw_score`: float (optional column)
+            * `raw_score`: float (optional column, used to initialize preference learning)
         """
         raise NotImplementedError
 
@@ -165,7 +165,7 @@ class TournesolInput(ABC):
         )
 
 
-class TournesolInputFromPublicDataset(TournesolInput):
+class TournesolDataset(PipelineInput):
     def __init__(self, dataset_zip: Union[str, BinaryIO]):
         if isinstance(dataset_zip, str) and (
             dataset_zip.startswith("http://") or dataset_zip.startswith("https://")
@@ -249,7 +249,7 @@ class TournesolInputFromPublicDataset(TournesolInput):
                 )
 
     @classmethod
-    def download(cls) -> "TournesolInputFromPublicDataset":
+    def download(cls) -> "TournesolDataset":
         return cls(dataset_zip="https://api.tournesol.app/exports/all")
 
     def get_comparisons(self, criterion=None, user_id=None) -> pd.DataFrame:

--- a/solidago/src/solidago/pipeline/legacy2023/collaborative_scaling/scaling.py
+++ b/solidago/src/solidago/pipeline/legacy2023/collaborative_scaling/scaling.py
@@ -2,14 +2,14 @@ import logging
 
 import pandas as pd
 
-from solidago.pipeline import TournesolInput
+from solidago.pipeline import PipelineInput
 from solidago.primitives import qr_quantile, qr_standard_deviation
 from .scaling_step import compute_scaling
 
 
 def compute_individual_scalings(
     individual_scores: pd.DataFrame,
-    tournesol_input: TournesolInput,
+    tournesol_input: PipelineInput,
     W: float,
 ) -> pd.DataFrame:
     """
@@ -20,7 +20,7 @@ def compute_individual_scalings(
         * raw_score
         * raw_uncertainty
 
-    - tournesol_input: TournesolInput used to fetch user details (used in calibration step)
+    - tournesol_input: PipelineInput used to fetch user details (used in calibration step)
 
     Returns:
     - scalings: DataFrame with index `user_id` and columns:

--- a/solidago/src/solidago/pipeline/legacy2023/collaborative_scaling/scaling_step.py
+++ b/solidago/src/solidago/pipeline/legacy2023/collaborative_scaling/scaling_step.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 from numba import njit
 
-from solidago.pipeline import TournesolInput
+from solidago.pipeline import PipelineInput
 from solidago.primitives import (
     lipschitz_resilient_mean,
     qr_median,
@@ -32,7 +32,7 @@ def get_significantly_different_pairs_indices(scores, uncertainties):
 
 
 
-def get_user_scaling_weights(input: TournesolInput, W: float):
+def get_user_scaling_weights(input: PipelineInput, W: float):
     ratings_properties = input.ratings_properties[
         ["user_id", "trust_score", "is_scaling_calibration_user"]
     ].copy()
@@ -77,7 +77,7 @@ def get_significantly_different_pairs(scores: pd.DataFrame):
 
 def compute_scaling(
     df: pd.DataFrame,
-    tournesol_input: TournesolInput,
+    tournesol_input: PipelineInput,
     W: float,
     users_to_compute=None,
     reference_users=None,

--- a/solidago/src/solidago/pipeline/legacy2023/criterion_pipeline.py
+++ b/solidago/src/solidago/pipeline/legacy2023/criterion_pipeline.py
@@ -7,7 +7,7 @@ from .global_scores import (
     get_squash_function,
     ALL_SCORE_MODES,
 )
-from solidago.pipeline import TournesolInput, PipelineOutput
+from solidago.pipeline import PipelineInput, PipelineOutput
 from . import collaborative_scaling
 from .individual_scores import get_individual_scores
 from .parameters import PipelineParameters
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 def run_pipeline_for_criterion(
     criterion: str,
-    input: TournesolInput,
+    input: PipelineInput,
     parameters: PipelineParameters,
     output: PipelineOutput,
     done_callback: Optional[Callable] = None,

--- a/solidago/src/solidago/pipeline/legacy2023/individual_scores.py
+++ b/solidago/src/solidago/pipeline/legacy2023/individual_scores.py
@@ -2,12 +2,12 @@ from typing import Optional
 
 import pandas as pd
 
-from solidago.pipeline import TournesolInput
+from solidago.pipeline import PipelineInput
 from .parameters import PipelineParameters
 
 
 def get_individual_scores(
-    input: TournesolInput,
+    input: PipelineInput,
     criteria: str,
     parameters: PipelineParameters,
     single_user_id: Optional[int] = None,

--- a/solidago/src/solidago/pipeline/legacy2023/individual_scores.py
+++ b/solidago/src/solidago/pipeline/legacy2023/individual_scores.py
@@ -21,11 +21,13 @@ def get_individual_scores(
             f"Found {dict(score_max_series.value_counts())}"
         )
 
-    initial_contributor_scores = input.get_individual_scores(
+    individual_scores = input.get_individual_scores(
         criteria=criteria, user_id=single_user_id
     )
-    if initial_contributor_scores is not None:
-        initial_contributor_scores = initial_contributor_scores.groupby("user_id")
+    if individual_scores is not None and "raw_score" in individual_scores:
+        initial_contributor_scores = individual_scores.groupby("user_id")
+    else:
+        initial_contributor_scores = None
 
     individual_scores = []
     for user_id, user_comparisons in comparisons_df.groupby("user_id"):
@@ -35,7 +37,7 @@ def get_individual_scores(
             try:
                 contributor_score_df = initial_contributor_scores.get_group(user_id)
                 initial_entity_scores = pd.Series(
-                    data=contributor_score_df.raw_score, index=contributor_score_df.entity
+                    data=contributor_score_df.raw_score, index=contributor_score_df.entity_id
                 )
             except KeyError:
                 initial_entity_scores = None

--- a/solidago/src/solidago/pipeline/legacy2023/individual_scores.py
+++ b/solidago/src/solidago/pipeline/legacy2023/individual_scores.py
@@ -12,7 +12,7 @@ def get_individual_scores(
     parameters: PipelineParameters,
     single_user_id: Optional[int] = None,
 ) -> pd.DataFrame:
-    comparisons_df = input.get_comparisons(criteria=criteria, user_id=single_user_id)
+    comparisons_df = input.get_comparisons(criterion=criteria, user_id=single_user_id)
     # Legacy pipeline assumes all comparisons use the same 'score_max'
     score_max_series = comparisons_df.pop("score_max")
     if score_max_series.nunique() > 1:
@@ -21,9 +21,7 @@ def get_individual_scores(
             f"Found {dict(score_max_series.value_counts())}"
         )
 
-    individual_scores = input.get_individual_scores(
-        criteria=criteria, user_id=single_user_id
-    )
+    individual_scores = input.get_individual_scores(criterion=criteria, user_id=single_user_id)
     if individual_scores is not None and "raw_score" in individual_scores:
         initial_contributor_scores = individual_scores.groupby("user_id")
     else:

--- a/solidago/src/solidago/pipeline/pipeline.py
+++ b/solidago/src/solidago/pipeline/pipeline.py
@@ -16,7 +16,7 @@ from solidago.scaling import Scaling, ScalingCompose, Mehestan, QuantileZeroShif
 from solidago.aggregation import Aggregation, StandardizedQrMedian, StandardizedQrQuantile, Average, EntitywiseQrQuantile
 from solidago.post_process import PostProcess, Squash, NoPostProcess
 
-from solidago.pipeline.inputs import TournesolInput
+from solidago.pipeline.inputs import PipelineInput
 from solidago.pipeline.outputs import PipelineOutput
 
 logger = logging.getLogger(__name__)
@@ -122,14 +122,11 @@ class Pipeline:
 
     def run(
         self,
-        input: TournesolInput,
+        input: PipelineInput,
         criterion: str,
         output: Optional[PipelineOutput] = None
     ):
-        # TODO: criterion should be managed by TournesolInput
-
-        # TODO: read existing individual scores from input
-        # to pass `init_user_models`
+        # TODO: `criterion` should be managed by PipelineInput ?
         return self(
             **input.get_pipeline_kwargs(criterion),
             output=output,

--- a/solidago/src/solidago/preference_learning/generalized_bradley_terry.py
+++ b/solidago/src/solidago/preference_learning/generalized_bradley_terry.py
@@ -119,10 +119,10 @@ class GeneralizedBradleyTerry(ComparisonBasedPreferenceLearning):
 
         init_solution = np.zeros(len(entities))
         if initialization is not None:
-            for (entity_id, entity_coord) in entity_coordinates.items():
-                entity_init_values = initialization(entity_id)
-                if entity_init_values is not None:
-                    init_solution[entity_coord] = entity_init_values[0]
+            for (entity_id, model_values) in initialization.iter_entities():
+                entity_coord = entity_coordinates.get(entity_id)
+                if entity_coord is not None:
+                    init_solution[entity_coord] = model_values[0]
 
         updated_coordinates = list() if updated_entities is None else [
             entity_coordinates[entity] for entity in updated_entities

--- a/solidago/tests/test_pipeline.py
+++ b/solidago/tests/test_pipeline.py
@@ -1,7 +1,7 @@
 import pytest
 from importlib import import_module
 from solidago.pipeline import Pipeline
-from solidago.pipeline.inputs import TournesolInputFromPublicDataset
+from solidago.pipeline.inputs import TournesolDataset
 
 
 @pytest.mark.parametrize("test", range(5))
@@ -11,7 +11,7 @@ def test_pipeline_test_data(test):
 
 
 def test_tournesol_get_comparisons():
-    dataset = TournesolInputFromPublicDataset("tests/data/tiny_tournesol.zip")
+    dataset = TournesolDataset("tests/data/tiny_tournesol.zip")
 
     # Test no filter
     assert len(dataset.get_comparisons()) == 38387
@@ -32,7 +32,7 @@ def test_tournesol_get_comparisons():
 
 
 def test_tournesol_get_individual_scores():
-    dataset = TournesolInputFromPublicDataset("tests/data/tiny_tournesol.zip")
+    dataset = TournesolDataset("tests/data/tiny_tournesol.zip")
 
     # Test no filter
     assert len(dataset.get_individual_scores()) == 17319
@@ -66,7 +66,7 @@ def test_tournesol_get_individual_scores():
 
 
 def test_tournesol_get_collective_scores():
-    dataset = TournesolInputFromPublicDataset("tests/data/tiny_tournesol.zip")
+    dataset = TournesolDataset("tests/data/tiny_tournesol.zip")
 
     # Test no filter
     assert len(dataset.get_collective_scores()) == 12184

--- a/solidago/tests/test_pipeline.py
+++ b/solidago/tests/test_pipeline.py
@@ -18,7 +18,7 @@ def test_tournesol_get_comparisons():
 
     # Test single filter
     assert len(dataset.get_comparisons(
-            criteria="importance"
+            criterion="importance"
         )) == 17143
     assert len(dataset.get_comparisons(
             user_id=dataset.username_to_user_id["le_science4all"]
@@ -26,7 +26,7 @@ def test_tournesol_get_comparisons():
 
     # Test all filters
     assert len(dataset.get_comparisons(
-            criteria="largely_recommended",
+            criterion="largely_recommended",
             user_id=dataset.username_to_user_id["lpfaucon"]
         )) == 8471
 
@@ -39,7 +39,7 @@ def test_tournesol_get_individual_scores():
 
     # Test single filter
     assert len(dataset.get_individual_scores(
-            criteria="largely_recommended"
+            criterion="largely_recommended"
         )) == 9176
     assert len(dataset.get_individual_scores(
             user_id=dataset.username_to_user_id["aidjango"]
@@ -48,7 +48,7 @@ def test_tournesol_get_individual_scores():
     # Test all filters
     user_id = dataset.username_to_user_id["le_science4all"]
     found = dataset.get_individual_scores(
-        criteria="importance",
+        criterion="importance",
         user_id=user_id,
         with_n_comparisons=True,
     )
@@ -56,7 +56,7 @@ def test_tournesol_get_individual_scores():
     as_dict = found.to_dict(orient="records")[0]
     assert as_dict == {
         'user_id': user_id,
-        'criteria': 'importance',
+        'criterion': 'importance',
         'entity_id': dataset.video_id_to_entity_id["03dTJ4nXkXw"],
         'score': 82.81,
         'uncertainty': 24.37,
@@ -73,7 +73,7 @@ def test_tournesol_get_collective_scores():
 
     # Test single filter
     assert len(dataset.get_collective_scores(
-            criteria="largely_recommended"
+            criterion="largely_recommended"
         )) == 6227
     assert len(dataset.get_collective_scores(
             entity_id=dataset.video_id_to_entity_id["kX3JKg-H5qM"]
@@ -82,14 +82,14 @@ def test_tournesol_get_collective_scores():
     # Test all filters
     entity_id = dataset.video_id_to_entity_id["OlhC6n9Hhac"]
     found = dataset.get_collective_scores(
-        criteria="importance",
+        criterion="importance",
         entity_id=entity_id
     )
     assert len(found) == 1
     as_dict = found.to_dict(orient="records")[0]
     assert as_dict == {
         'entity_id': entity_id,
-        'criteria': 'importance',
+        'criterion': 'importance',
         'score': 18.22,
         'uncertainty': 60.09,
         'n_users': 3,

--- a/solidago/tests/test_privacy_settings.py
+++ b/solidago/tests/test_privacy_settings.py
@@ -1,4 +1,4 @@
-from solidago.pipeline.inputs import TournesolInputFromPublicDataset
+from solidago.pipeline.inputs import TournesolDataset
 from solidago.privacy_settings import PrivacySettings
 
 def test_privacy_io():
@@ -10,7 +10,7 @@ def test_privacy_io():
     assert privacy[0, 2] is None
 
 def test_tournesol_import():
-    inputs = TournesolInputFromPublicDataset("tests/data/tiny_tournesol.zip")
+    inputs = TournesolDataset("tests/data/tiny_tournesol.zip")
     privacy = inputs.get_pipeline_kwargs(criterion="largely_recommended")["privacy"]
     aidjango_id = inputs.users[inputs.users["public_username"] == "aidjango"].index[0]
     video_id_to_entity_id = {

--- a/solidago/tests/test_trust_propagation.py
+++ b/solidago/tests/test_trust_propagation.py
@@ -2,7 +2,7 @@ import pytest
 import importlib
 import pandas as pd
 
-from solidago.pipeline.inputs import TournesolInputFromPublicDataset
+from solidago.pipeline.inputs import TournesolDataset
 from solidago.trust_propagation.lipschitrust import LipschiTrust
 from solidago.trust_propagation.trust_all import TrustAll
 


### PR DESCRIPTION
### Description

* Use previously computed individual scores to initialize preference learning in Solidago pipeline
* Rename class `TournesolInput` into `PipelineInput` in solidago
* Rename class `TournesolInputFromPublicDataset` into `TournesolDataset`
* Rename arguments `criteria` into `criterion` for consistency
* Upgrade dependencies `pandas`, `numpy` (keeping <2.0 for now) and `numba`

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
