### PR TITLE
[front] ui: make 'next' buttons glow after has user has looped through all criteria

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -80,7 +80,7 @@
   },
   "comparison": {
     "newComparison": "New comparison",
-    "ok": "OK",
+    "saved": "Saved",
     "successfullySubmitted": "Comparison successfully submitted.",
     "removeOptionalCriterias": "Remove optional criteria",
     "addOptionalCriterias": "Add optional criteria",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -84,7 +84,7 @@
   },
   "comparison": {
     "newComparison": "Nouvelle comparaison",
-    "ok": "OK",
+    "saved": "Validé",
     "successfullySubmitted": "Comparaison bien enregistrée.",
     "removeOptionalCriterias": "Supprimer les critères optionnels",
     "addOptionalCriterias": "Ajouter les critères optionnels",

--- a/frontend/src/components/ContentHeader.tsx
+++ b/frontend/src/components/ContentHeader.tsx
@@ -19,7 +19,7 @@ const ContentHeader = ({
   chipLabel?: string;
 }) => {
   return (
-    <Box px={[2, 4]} py={2} color="text.secondary">
+    <Box px={[2, 4]} pt={2} color="text.secondary">
       <Grid container spacing={1} justifyContent="space-between">
         <Grid item>
           <Typography

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -40,6 +41,7 @@ import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import ComparisonEntityContexts from './ComparisonEntityContexts';
 import ComparisonHelper from './ComparisonHelper';
 import ComparisonInput from './ComparisonInput';
+import { ComparisonsContext } from 'src/pages/comparisons/Comparison';
 
 export const UID_PARAMS: { vidA: string; vidB: string } = {
   vidA: 'uidA',
@@ -120,6 +122,7 @@ const Comparison = ({
   const history = useHistory();
   const location = useLocation();
   const { showSuccessAlert, displayErrorsFrom } = useNotifications();
+  const { setHasLoopedThroughCriteria } = useContext(ComparisonsContext);
 
   const { name: pollName, options } = useCurrentPoll();
   const mainCriterion = options?.mainCriterionName;
@@ -180,8 +183,10 @@ const Comparison = ({
       } else if (vidKey === 'vidB') {
         setSelectorB(newValue);
       }
+
+      setHasLoopedThroughCriteria?.(false);
     },
-    [history]
+    [history, setHasLoopedThroughCriteria]
   );
 
   const onChangeA = useMemo(() => onChange('vidA'), [onChange]);

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -359,7 +359,7 @@ const Comparison = ({
     }
 
     if (smallScreen) {
-      showSuccessAlert(t('comparison.ok'), 1200);
+      showSuccessAlert(t('comparison.saved'), 1200);
     } else {
       showSuccessAlert(t('comparison.successfullySubmitted'));
     }

--- a/frontend/src/features/comparisons/ComparisonInput.tsx
+++ b/frontend/src/features/comparisons/ComparisonInput.tsx
@@ -15,6 +15,7 @@ import { ComparisonRequest } from 'src/services/openapi';
 import ComparisonSliders from 'src/features/comparisons/ComparisonSliders';
 import { TutorialContext } from 'src/features/comparisonSeries/TutorialContext';
 import { getCriterionScoreMax } from 'src/utils/criteria';
+import { ComparisonsContext } from 'src/pages/comparisons/Comparison';
 
 import CriteriaButtons from './inputs/CriteriaButtons';
 import { BUTTON_SCORE_MAX } from './inputs/CriterionButtons';
@@ -73,7 +74,8 @@ const ComparisonInput = ({
   isComparisonPublic,
 }: ComparisonInputProps) => {
   const { t } = useTranslation();
-  const { options } = useCurrentPoll();
+  const { options, criterias } = useCurrentPoll();
+  const comparisonsContext = useContext(ComparisonsContext);
   const pointerFine = useMediaQuery('(pointer:fine)', { noSsr: true });
 
   // Position of the displayed criterion in the list of criteria.
@@ -90,6 +92,11 @@ const ComparisonInput = ({
 
   const changePosition = (newPos: number) => {
     setPosition(newPos);
+    if (position === criterias.length - 1 && newPos === 0) {
+      comparisonsContext.setHasLoopedThroughCriteria?.(true);
+    } else {
+      comparisonsContext.setHasLoopedThroughCriteria?.(false);
+    }
   };
 
   return (

--- a/frontend/src/features/comparisons/inputs/CriteriaButtons.tsx
+++ b/frontend/src/features/comparisons/inputs/CriteriaButtons.tsx
@@ -239,7 +239,13 @@ const CriteriaButtons = ({
             cancelling each other transition. */}
         <div>
           <Fade in={slideIn} appear={true} timeout={SWIPE_TIMEOUT}>
-            <Box {...bindDrag()} sx={{ touchAction: 'none' }}>
+            <Box
+              {...bindDrag()}
+              sx={{
+                touchAction: 'none',
+                pointerEvents: disableScoreButtons ? 'none' : undefined,
+              }}
+            >
               <CriterionButtons
                 critName={criterion.name}
                 critLabel={criterion.label}

--- a/frontend/src/features/entity_selector/AutoEntityButton.tsx
+++ b/frontend/src/features/entity_selector/AutoEntityButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Tooltip, Button, useMediaQuery } from '@mui/material';
@@ -7,6 +7,7 @@ import { Autorenew, SwipeUp } from '@mui/icons-material';
 import { useCurrentPoll } from 'src/hooks/useCurrentPoll';
 import { theme } from 'src/theme';
 import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import { ComparisonsContext } from 'src/pages/comparisons/Comparison';
 
 interface Props {
   onClick: () => Promise<void>;
@@ -26,6 +27,7 @@ const AutoEntityButton = ({
   const { t } = useTranslation();
   const { name: pollName } = useCurrentPoll();
   const smallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const context = useContext(ComparisonsContext);
 
   if (pollName !== YOUTUBE_POLL_NAME) {
     return null;
@@ -35,6 +37,7 @@ const AutoEntityButton = ({
     <>
       {smallScreen && variant === 'compact' ? (
         <Button
+          className={context.hasLoopedThroughCriteria ? 'glowing' : undefined}
           disabled={disabled}
           color="secondary"
           size="small"

--- a/frontend/src/features/entity_selector/EntitySelectButton.tsx
+++ b/frontend/src/features/entity_selector/EntitySelectButton.tsx
@@ -26,7 +26,7 @@ import { getAllCandidates } from 'src/utils/polls/presidentielle2022';
 import SelectorListBox, { EntitiesTab } from './EntityTabsBox';
 import SelectorPopper from './SelectorPopper';
 import { useLoginState, usePreferredLanguages } from 'src/hooks';
-import { ComparisonsCountContext } from 'src/pages/comparisons/Comparison';
+import { ComparisonsContext } from 'src/pages/comparisons/Comparison';
 import { EntityObject } from 'src/utils/types';
 
 // in milliseconds
@@ -62,7 +62,7 @@ const VideoInput = ({
     { noSsr: true }
   );
 
-  const comparisonsCount = useContext(ComparisonsCountContext).comparisonsCount;
+  const comparisonsCount = useContext(ComparisonsContext).comparisonsCount;
 
   const preferredLanguages = usePreferredLanguages({ pollName });
 

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState } from 'react';
+import React, { useEffect, useCallback, useState, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDrag } from '@use-gesture/react';
 import { Vector2 } from '@use-gesture/core/types';
@@ -31,6 +31,7 @@ import EntitySelectButton from './EntitySelectButton';
 import EntitySelectorControls from './EntitySelectorControls';
 import { extractVideoId } from 'src/utils/video';
 import { entityCardMainSx } from 'src/components/entity/style';
+import { ComparisonsContext } from 'src/pages/comparisons/Comparison';
 
 const ENTITY_CARD_SWIPE_TIMEOUT = 180;
 // The minimum velocity per axis in pixels / ms.
@@ -147,10 +148,10 @@ const EntitySelectorInnerAuth = ({
 
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState(value.uid);
-
   const { availability: entityAvailability } = useEntityAvailable(
     value.uid ?? ''
   );
+  const { setHasLoopedThroughCriteria } = useContext(ComparisonsContext);
 
   let showEntityInput = true;
   let showRatingControl = true;
@@ -326,6 +327,7 @@ const EntitySelectorInnerAuth = ({
     setLoading(true);
     setInputValue('');
     setSlideIn(false);
+    setHasLoopedThroughCriteria?.(false);
   };
 
   const slideDown = () => {
@@ -337,6 +339,7 @@ const EntitySelectorInnerAuth = ({
     setLoading(true);
     setInputValue('');
     setSlideIn(false);
+    setHasLoopedThroughCriteria?.(false);
   };
 
   return (

--- a/frontend/src/features/entity_selector/EntitySelector.tsx
+++ b/frontend/src/features/entity_selector/EntitySelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState, useContext } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDrag } from '@use-gesture/react';
 import { Vector2 } from '@use-gesture/core/types';
@@ -31,7 +31,6 @@ import EntitySelectButton from './EntitySelectButton';
 import EntitySelectorControls from './EntitySelectorControls';
 import { extractVideoId } from 'src/utils/video';
 import { entityCardMainSx } from 'src/components/entity/style';
-import { ComparisonsContext } from 'src/pages/comparisons/Comparison';
 
 const ENTITY_CARD_SWIPE_TIMEOUT = 180;
 // The minimum velocity per axis in pixels / ms.
@@ -151,7 +150,6 @@ const EntitySelectorInnerAuth = ({
   const { availability: entityAvailability } = useEntityAvailable(
     value.uid ?? ''
   );
-  const { setHasLoopedThroughCriteria } = useContext(ComparisonsContext);
 
   let showEntityInput = true;
   let showRatingControl = true;
@@ -327,7 +325,6 @@ const EntitySelectorInnerAuth = ({
     setLoading(true);
     setInputValue('');
     setSlideIn(false);
-    setHasLoopedThroughCriteria?.(false);
   };
 
   const slideDown = () => {
@@ -339,7 +336,6 @@ const EntitySelectorInnerAuth = ({
     setLoading(true);
     setInputValue('');
     setSlideIn(false);
-    setHasLoopedThroughCriteria?.(false);
   };
 
   return (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -73,3 +73,20 @@ html.embedded .SnackbarContainer-root.belowTopBar {
 }
 
 /* -- end: third-party packages customization -- */
+
+
+/* Custom animation to draw attention on buttons */
+.glowing {
+  animation: glow 1.5s infinite alternate
+}
+
+@keyframes glow {
+  0%,
+  40% {
+    box-shadow: 0 0 6px -6px currentColor;
+  }
+
+  100% {
+    box-shadow: 0 0 6px 3px currentColor;
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,22 @@ code {
   width: 100%;
 }
 
+/* Custom animation to draw attention on buttons */
+.glowing {
+  animation: glow 1.4s infinite alternate
+}
+
+@keyframes glow {
+  0%,
+  40% {
+    box-shadow: 0 0 6px -6px currentColor;
+  }
+
+  100% {
+    box-shadow: 0 0 6px 3px currentColor;
+  }
+}
+
 /* -- start: third-party packages customization -- */
 
 /* pkg: notistack */
@@ -73,20 +89,3 @@ html.embedded .SnackbarContainer-root.belowTopBar {
 }
 
 /* -- end: third-party packages customization -- */
-
-
-/* Custom animation to draw attention on buttons */
-.glowing {
-  animation: glow 1.5s infinite alternate
-}
-
-@keyframes glow {
-  0%,
-  40% {
-    box-shadow: 0 0 6px -6px currentColor;
-  }
-
-  100% {
-    box-shadow: 0 0 6px 3px currentColor;
-  }
-}

--- a/frontend/src/pages/comparisons/Comparison.tsx
+++ b/frontend/src/pages/comparisons/Comparison.tsx
@@ -62,11 +62,15 @@ const displayWeeklyCollectiveGoal = (
   return false;
 };
 
-interface ComparisonsCountContextValue {
+interface ComparisonsContextValue {
   comparisonsCount: number;
+  hasLoopedThroughCriteria?: boolean;
+  setHasLoopedThroughCriteria?: (value: boolean) => void;
 }
-export const ComparisonsCountContext =
-  React.createContext<ComparisonsCountContextValue>({ comparisonsCount: 0 });
+
+export const ComparisonsContext = React.createContext<ComparisonsContextValue>({
+  comparisonsCount: 0,
+});
 
 /**
  * Display the standard comparison UI or the poll tutorial.
@@ -92,8 +96,10 @@ const ComparisonPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [comparisonsCount, setComparisonsCount] = useState(0);
   const [userComparisons, setUserComparisons] = useState<string[]>();
-
   const [userComparisonsRetrieved, setUserComparisonsRetrieved] =
+    useState(false);
+
+  const [hasLoopedThroughCriteria, setHasLoopedThroughCriteria] =
     useState(false);
 
   useEffect(() => {
@@ -224,14 +230,18 @@ const ComparisonPage = () => {
                   weeklyCollectiveGoalMobile,
                   smallScreen
                 ) && <CollectiveGoalWeeklyProgress />}
-                <ComparisonsCountContext.Provider
-                  value={{ comparisonsCount: comparisonsCount }}
+                <ComparisonsContext.Provider
+                  value={{
+                    comparisonsCount,
+                    hasLoopedThroughCriteria,
+                    setHasLoopedThroughCriteria,
+                  }}
                 >
                   <Comparison
                     autoFillSelectorA={autoSelectEntities}
                     autoFillSelectorB={autoSelectEntities}
                   />
-                </ComparisonsCountContext.Provider>
+                </ComparisonsContext.Provider>
               </>
             ))}
         </Box>


### PR DESCRIPTION
Based on #1968 

### Description

After going from the last criterion back to the first on, draw attention on the "next" buttons to go to next comparison.



https://github.com/user-attachments/assets/b649604c-14e5-4e87-bfe5-8c0d97884522




### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
