### PR TITLE
[front] fix: in the comp. ui the glow effect is now triggered properly

### DIFF
--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -178,15 +178,22 @@ const Comparison = ({
         searchParams.delete(LEGACY_PARAMS[vidKey]);
         history.replace({ search: searchParams.toString() });
       }
+
       if (vidKey === 'vidA') {
         setSelectorA(newValue);
+
+        if (newValue.uid !== selectorA.uid) {
+          setHasLoopedThroughCriteria?.(false);
+        }
       } else if (vidKey === 'vidB') {
         setSelectorB(newValue);
-      }
 
-      setHasLoopedThroughCriteria?.(false);
+        if (newValue.uid !== selectorB.uid) {
+          setHasLoopedThroughCriteria?.(false);
+        }
+      }
     },
-    [history, setHasLoopedThroughCriteria]
+    [history, selectorA.uid, selectorB.uid, setHasLoopedThroughCriteria]
   );
 
   const onChangeA = useMemo(() => onChange('vidA'), [onChange]);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,7 +37,7 @@ code {
 
 /* Custom animation to draw attention on buttons */
 .glowing {
-  animation: glow 1.4s infinite alternate
+  animation: glow 1.4s infinite alternate;
 }
 
 @keyframes glow {


### PR DESCRIPTION
### Description

The `onChange` callback was stopping the glow effect for each submitted criterion. Now the effect is stopped only when one of the two UIDs changes. 

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
