### PR TITLE
[back] feat: display the score max in ComparisonCriteriaScore admin

### DIFF
--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -290,10 +290,29 @@ class ComparisonAdmin(admin.ModelAdmin):
         return obj.poll.name
 
 
+class ScoreMaxListFilter(admin.SimpleListFilter):
+    title = _("score max")
+    parameter_name = "score_max"
+    relevant_score_max = (2, 10)
+
+    def lookups(self, request, model_admin):
+        return [(score_max, score_max) for score_max in self.relevant_score_max]
+
+    def queryset(self, request, queryset):
+        try:
+            if int(self.value()) in self.relevant_score_max:
+                return queryset.filter(
+                    score_max=int(self.value()),
+                )
+        except ValueError:
+            pass
+        return queryset
+
+
 @admin.register(ComparisonCriteriaScore)
 class ComparisonCriteriaScoreAdmin(admin.ModelAdmin):
-    list_filter = ("comparison__poll__name",)
-    list_display = ("id", "comparison", "criteria", "score")
+    list_filter = ("comparison__poll__name", ScoreMaxListFilter)
+    list_display = ("id", "comparison", "criteria", "score_max", "score")
     readonly_fields = ("comparison",)
     search_fields = (
         "criteria",

--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -264,6 +264,7 @@ class ComparisonAdmin(admin.ModelAdmin):
         "entity_1",
         "entity_2",
         "poll",
+        "user",
     )
     raw_id_fields = (
         "user",

--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -314,11 +314,10 @@ class ScoreMaxListFilter(admin.SimpleListFilter):
 
 @admin.register(ComparisonCriteriaScore)
 class ComparisonCriteriaScoreAdmin(admin.ModelAdmin):
-    list_filter = ("comparison__poll__name", ScoreMaxListFilter)
+    list_filter = ("comparison__poll__name", ScoreMaxListFilter, "criteria")
     list_display = ("id", "comparison", "criteria", "score_max", "score")
     readonly_fields = ("comparison",)
     search_fields = (
-        "criteria",
         "comparison__entity_1__uid",
         "comparison__entity_2__uid",
     )

--- a/backend/tournesol/admin.py
+++ b/backend/tournesol/admin.py
@@ -299,6 +299,9 @@ class ScoreMaxListFilter(admin.SimpleListFilter):
         return [(score_max, score_max) for score_max in self.relevant_score_max]
 
     def queryset(self, request, queryset):
+        if self.value() is None:
+            return queryset
+
         try:
             if int(self.value()) in self.relevant_score_max:
                 return queryset.filter(

--- a/backend/tournesol/locale/fr/LC_MESSAGES/django.po
+++ b/backend/tournesol/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-06 08:43+0000\n"
+"POT-Creation-Date: 2024-11-14 15:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,15 +23,19 @@ msgstr ""
 msgid "Successfully refreshed the metadata of %(count)s entities."
 msgstr "Les métadonnées de %(count)s entités ont été mises à jour."
 
-#: tournesol/admin.py:372
+#: tournesol/admin.py:294
+msgid "score max"
+msgstr "score max"
+
+#: tournesol/admin.py:391
 msgid "has text?"
 msgstr "contient du texte?"
 
-#: tournesol/admin.py:377
+#: tournesol/admin.py:396
 msgid "Yes"
 msgstr "Oui"
 
-#: tournesol/admin.py:378
+#: tournesol/admin.py:397
 msgid "No"
 msgstr "Non"
 
@@ -49,8 +53,8 @@ msgid ""
 "The absolute value of the score %(score)s given to the criterion "
 "%(criterion)s can't be greater than the value of score_max %(score_max)s."
 msgstr ""
-"La valeur absolue du score %(score)s donnée au critère "
-"%(criterion)s ne peut pas être supérieure à la valeur de score_max %(score_max)s."
+"La valeur absolue du score %(score)s donnée au critère %(criterion)s ne peut "
+"pas être supérieure à la valeur de score_max %(score_max)s."
 
 #: tournesol/serializers/rate_later.py:60
 msgid "The entity is already in the rate-later list of this poll."

--- a/backend/tournesol/locale/fr/LC_MESSAGES/django.po
+++ b/backend/tournesol/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-14 15:02+0000\n"
+"POT-Creation-Date: 2024-11-14 15:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,15 +27,15 @@ msgstr "Les métadonnées de %(count)s entités ont été mises à jour."
 msgid "score max"
 msgstr "score max"
 
-#: tournesol/admin.py:391
+#: tournesol/admin.py:393
 msgid "has text?"
 msgstr "contient du texte?"
 
-#: tournesol/admin.py:396
+#: tournesol/admin.py:398
 msgid "Yes"
 msgstr "Oui"
 
-#: tournesol/admin.py:397
+#: tournesol/admin.py:399
 msgid "No"
 msgstr "Non"
 


### PR DESCRIPTION
### Description

This PR adds the possibility to filter the `ComparisonCriteriaScore` by `score_max` and `criteria` in the admin interface.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
