### PR TITLE
[front] style: set a fixed height to criteria icons in CriteriaButtonsScoreReview.tsx

### DIFF
--- a/frontend/src/features/comparisons/inputs/CriteriaButtonsScoreReview.tsx
+++ b/frontend/src/features/comparisons/inputs/CriteriaButtonsScoreReview.tsx
@@ -47,7 +47,7 @@ const CriteriaButtonsScoreReview = ({
           alignItems="center"
           rowGap={1}
         >
-          <Box px={1} color="grey.500" sx={{ height: '1.8rem' }}>
+          <Box px={1} color="grey.500" height="1.8rem">
             {scoreBtn.icons}
           </Box>
 
@@ -57,7 +57,7 @@ const CriteriaButtonsScoreReview = ({
 
             return (
               <Zoom in={true} key={crit.criteria}>
-                <Box>
+                <Box display="flex" alignItems="center" height="1.4rem">
                   <CriteriaIcon criteriaName={crit.criteria} />
                 </Box>
               </Zoom>

--- a/frontend/src/features/comparisons/inputs/CriteriaButtonsScoreReview.tsx
+++ b/frontend/src/features/comparisons/inputs/CriteriaButtonsScoreReview.tsx
@@ -47,7 +47,7 @@ const CriteriaButtonsScoreReview = ({
           alignItems="center"
           rowGap={1}
         >
-          <Box px={1} color="grey.500">
+          <Box px={1} color="grey.500" sx={{ height: '1.8rem' }}>
             {scoreBtn.icons}
           </Box>
 


### PR DESCRIPTION
### Description

This PR defines a common height for all displayed criteria icons in the component `<CriteriaButtonsScoreReview>`. The icons should stay aligned regardless of the browser font size.

The height of the criteria icons has been set to match the size of the biggest icon: important & actionable. 

| before | after |
|---|---|
| ![capture0](https://github.com/user-attachments/assets/be2fe49d-b61b-4c62-a4fc-b5d757ea65ec) | ![capture](https://github.com/user-attachments/assets/8a7d1ccf-2c3c-4fb9-8b34-4882098a55dc) |

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
