### PR TITLE
Solidago: Fixed toy.json which had deprecated arguments

### DIFF
--- a/solidago/experiments/toy.json
+++ b/solidago/experiments/toy.json
@@ -28,8 +28,7 @@
         }], 
         "engagement_model": ["SimpleEngagementModel", {
             "p_per_criterion": {"0": 1.0}, 
-            "p_private": 0.2,
-            "entity_bias_noise": 1.0
+            "p_private": 0.2
         }], 
         "comparison_model": ["KnaryGBT", {
             "n_options": 21, 
@@ -50,7 +49,6 @@
         }], 
         "preference_learning": ["UniformGBT", {
             "prior_std_dev": 7, 
-            "comparison_max": 10, 
             "convergence_error": 1e-05, 
             "cumulant_generating_function_error": 1e-05
         }], 


### PR DESCRIPTION
### Description

This is a minor fix. The toy json that facilitates experimentations and tests had deprecated arguments, which raised errors when loading it.

### Checklist

- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
