### PR TITLE
Inverted steps 2 and 3 of the Solidago pipeline

### DIFF
--- a/solidago/src/solidago/pipeline/pipeline.py
+++ b/solidago/src/solidago/pipeline/pipeline.py
@@ -10,8 +10,8 @@ from solidago import PrivacySettings, Judgments
 from solidago.scoring_model import ScoringModel, ScaledScoringModel
 
 from solidago.trust_propagation import TrustPropagation, TrustAll, LipschiTrust, NoTrustPropagation
-from solidago.voting_rights import VotingRights, VotingRightsAssignment, AffineOvertrust, IsTrust
 from solidago.preference_learning import PreferenceLearning, UniformGBT
+from solidago.voting_rights import VotingRights, VotingRightsAssignment, AffineOvertrust, IsTrust
 from solidago.scaling import Scaling, ScalingCompose, Mehestan, QuantileZeroShift, Standardize, NoScaling
 from solidago.aggregation import Aggregation, StandardizedQrMedian, StandardizedQrQuantile, Average, EntitywiseQrQuantile
 from solidago.post_process import PostProcess, Squash, NoPostProcess
@@ -33,15 +33,15 @@ class DefaultPipeline:
         sink_vouch=5.0,
         error=1e-8
     )
-    voting_rights: VotingRightsAssignment = AffineOvertrust(
-        privacy_penalty=0.5, 
-        min_overtrust=2.0,
-        overtrust_ratio=0.1,
-    )
     preference_learning: PreferenceLearning = UniformGBT(
         prior_std_dev=7,
         convergence_error=1e-5,
         cumulant_generating_function_error=1e-5,
+    )
+    voting_rights: VotingRightsAssignment = AffineOvertrust(
+        privacy_penalty=0.5, 
+        min_overtrust=2.0,
+        overtrust_ratio=0.1,
     )
     scaling: Scaling = ScalingCompose(
         Mehestan(
@@ -77,8 +77,8 @@ class Pipeline:
     def __init__(
         self,
         trust_propagation: TrustPropagation = DefaultPipeline.trust_propagation,
-        voting_rights: VotingRightsAssignment = DefaultPipeline.voting_rights,
         preference_learning: PreferenceLearning = DefaultPipeline.preference_learning,
+        voting_rights: VotingRightsAssignment = DefaultPipeline.voting_rights,
         scaling: Scaling = DefaultPipeline.scaling,
         aggregation: Aggregation = DefaultPipeline.aggregation,
         post_process: PostProcess = DefaultPipeline.post_process,
@@ -102,8 +102,8 @@ class Pipeline:
             and make it readily usable for applications.
         """
         self.trust_propagation = trust_propagation
-        self.voting_rights = voting_rights
         self.preference_learning = preference_learning
+        self.voting_rights = voting_rights
         self.scaling = scaling
         self.aggregation = aggregation
         self.post_process = post_process
@@ -113,8 +113,8 @@ class Pipeline:
     def from_json(cls, json) -> "Pipeline":
         return Pipeline(
             trust_propagation=trust_propagation_from_json(json["trust_propagation"]),
-            voting_rights=voting_rights_from_json(json["voting_rights"]),
             preference_learning=preference_learning_from_json(json["preference_learning"]),
+            voting_rights=voting_rights_from_json(json["voting_rights"]),
             scaling=scaling_from_json(json["scaling"]),
             aggregation=aggregation_from_json(json["aggregation"]),
             post_process=post_process_from_json(json["post_process"]),
@@ -185,20 +185,20 @@ class Pipeline:
         logger.info(f"Pipeline 1. Terminated in {np.round(start_step2 - start_step1, 2)} seconds")
         if output is not None:
             output.save_trust_scores(trusts=users)
+        
+        logger.info(f"Pipeline 2. Learning preferences with {str(self.preference_learning)}")
+        user_models = self.preference_learning(judgments, users, entities, init_user_models)
+        start_step3 = timeit.default_timer()
+        logger.info(f"Pipeline 2. Terminated in {np.round(start_step3 - start_step2, 2)} seconds")
+        raw_scorings = user_models
             
-        logger.info(f"Pipeline 2. Computing voting rights with {str(self.voting_rights)}")
+        logger.info(f"Pipeline 3. Computing voting rights with {str(self.voting_rights)}")
         # WARNING: `privacy` may contain (user, entity) even if user has expressed no judgement
         # about the entity. These users should not be given a voting right on the entity.
         # For now, irrelevant privacy values are excluded in `input.get_pipeline_kwargs()`
-        voting_rights, entities = self.voting_rights(users, entities, vouches, privacy)
-        start_step3 = timeit.default_timer()
-        logger.info(f"Pipeline 2. Terminated in {np.round(start_step3 - start_step2, 2)} seconds")
-        
-        logger.info(f"Pipeline 3. Learning preferences with {str(self.preference_learning)}")
-        user_models = self.preference_learning(judgments, users, entities, init_user_models)
+        voting_rights, entities = self.voting_rights(users, entities, vouches, privacy, user_models)
         start_step4 = timeit.default_timer()
-        logger.info(f"Pipeline 3. Terminated in {int(start_step4 - start_step3)} seconds")
-        raw_scorings = user_models
+        logger.info(f"Pipeline 3. Terminated in {np.round(start_step4 - start_step3, 2)} seconds")
         
         logger.info(f"Pipeline 4. Collaborative scaling with {str(self.scaling)}")
         user_models = self.scaling(user_models, users, entities, voting_rights, privacy)

--- a/solidago/src/solidago/voting_rights/affine_overtrust.py
+++ b/solidago/src/solidago/voting_rights/affine_overtrust.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 import pandas as pd
 
@@ -30,6 +32,7 @@ class AffineOvertrust(VotingRightsAssignment):
         entities: pd.DataFrame,
         vouches: pd.DataFrame,
         privacy: PrivacySettings,
+        user_models: Optional[dict[int, "ScoringModel"]]=None
     ) -> tuple[VotingRights, pd.DataFrame]:
         """Compute voting rights
 
@@ -40,11 +43,11 @@ class AffineOvertrust(VotingRightsAssignment):
             * trust_score (float)
         entities: DataFrame with columns
             * entity_id (int, index)
-        vouches: DataFrame
-            This is not used by VotingRightsWithLimitedOvertrust
+        vouches: not used
         privacy: PrivacySettings
             privacy[user, entity] is the privacy setting of user for entity
             May be True, False or None
+        user_models: not used
 
         Returns
         -------

--- a/solidago/src/solidago/voting_rights/base.py
+++ b/solidago/src/solidago/voting_rights/base.py
@@ -15,6 +15,7 @@ class VotingRightsAssignment(ABC):
         entities: pd.DataFrame,
         vouches: pd.DataFrame,
         privacy: PrivacySettings,
+        user_models: dict[int, "ScoringModel"]
     ) -> tuple[VotingRights, pd.DataFrame]:
         """ Compute voting rights
         
@@ -31,6 +32,8 @@ class VotingRightsAssignment(ABC):
             * vouch (float)
         privacy: PrivacySettings
             privacy[user, entity] in { True, False, None }
+        user_models: dict[int, ScoringModel]
+            user_models[user_id] is the user's scoring model
         
         Returns
         -------

--- a/solidago/src/solidago/voting_rights/is_trust.py
+++ b/solidago/src/solidago/voting_rights/is_trust.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pandas as pd
 import numpy as np
 
@@ -14,7 +16,8 @@ class IsTrust(VotingRightsAssignment):
         users: pd.DataFrame,
         entities: pd.DataFrame,
         vouches: pd.DataFrame,
-        privacy: pd.DataFrame
+        privacy: "PrivacySettings",
+        user_models: Optional[dict[int, "ScoringModel"]]=None
     ) -> tuple[VotingRights, pd.DataFrame]:
         """ Compute voting rights
         
@@ -25,12 +28,10 @@ class IsTrust(VotingRightsAssignment):
             * trust_score (float)
         entities: DataFrame with columns
             * entity_id (int, index)
-        vouches: DataFrame with columns
-            * voucher (int)
-            * vouchee (int)
-            * vouch (float)
+        vouches: Not used
         privacy: PrivacySettings
             privacy[user, entity] in { True, False, None }
+        user_models: Not used
         
         Returns
         -------


### PR DESCRIPTION
A step towards Liquid Democracy #2042

---

### Description

Steps 2 (voting rights assignment) and 3 (individual preference learning) of Solidago were so far independent, and thus commutative.
Here, we invert them (thereby not affecting correctness), and we add the possibility of voting rights assignment to depend on learned individual preferences.
This is important as a user may typically want to delegate their voting rights on an entity, if the uncertainty on their score for this entity is too large.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
