### PR TITLE
[front] feat: make the PWA store ready

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -36,7 +36,6 @@
   "scope": "/",
   "start_url": "/pwa/start?utm_source=pwa",
   "display": "standalone",
-  "display_override": ["minimal-ui"],
   "orientation": "any",
   "theme_color": "#ffc800",
   "background_color": "#a09b87",
@@ -79,5 +78,6 @@
       "form_factor": "narrow",
       "label": "Tournesol comparison page on Mobile"
     }
-  ]
+  ],
+  "prefer_related_applications": false
 }

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -43,6 +43,7 @@
   "launch_handler": {
     "client_mode": ["focus-existing", "auto"]
   },
+  "handle_links": "preferred",
   "share_target": {
     "action": "/shared-content",
     "method": "GET",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -21,7 +21,8 @@
     {
       "src": "/icons/favicon-512x512.png",
       "type": "image/png",
-      "sizes": "512x512"
+      "sizes": "512x512",
+      "purpose": "any"
     },
     {
       "src": "/icons/maskable-icon-512x512.png",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -36,6 +36,7 @@
   "scope": "/",
   "start_url": "/pwa/start?utm_source=pwa",
   "display": "standalone",
+  "display_override": ["minimal-ui"],
   "orientation": "any",
   "theme_color": "#ffc800",
   "background_color": "#a09b87",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -45,7 +45,7 @@
   },
   "handle_links": "preferred",
   "share_target": {
-    "action": "/shared-content",
+    "action": "https://tournesol.app/shared-content",
     "method": "GET",
     "params": {
       "title": "title",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -36,8 +36,12 @@
   "scope": "/",
   "start_url": "/pwa/start?utm_source=pwa",
   "display": "standalone",
+  "orientation": "any",
   "theme_color": "#ffc800",
   "background_color": "#a09b87",
+  "launch_handler": {
+    "client_mode": ["focus-existing", "auto"]
+  },
   "share_target": {
     "action": "/shared-content",
     "method": "GET",
@@ -74,9 +78,5 @@
       "form_factor": "narrow",
       "label": "Tournesol comparison page on Mobile"
     }
-  ],
-  "launch_handler": {
-    "client_mode": ["focus-existing", "auto"]
-  },
-  "orientation": "any"
+  ]
 }

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -41,7 +41,7 @@
   "theme_color": "#ffc800",
   "background_color": "#a09b87",
   "launch_handler": {
-    "client_mode": ["focus-existing", "auto"]
+    "client_mode": ["auto"]
   },
   "handle_links": "preferred",
   "share_target": {

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -73,5 +73,8 @@
       "form_factor": "narrow",
       "label": "Tournesol comparison page on Mobile"
     }
-  ]
+  ],
+  "launch_handler": {
+    "client_mode": ["focus-existing", "auto"]
+  }
 }

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -76,5 +76,6 @@
   ],
   "launch_handler": {
     "client_mode": ["focus-existing", "auto"]
-  }
+  },
+  "orientation": "any"
 }

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -36,6 +36,7 @@
   "scope": "/",
   "start_url": "/pwa/start?utm_source=pwa",
   "display": "standalone",
+  "display_override": ["window-controls-overlay"],
   "orientation": "any",
   "theme_color": "#ffc800",
   "background_color": "#a09b87",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -37,7 +37,7 @@
   "start_url": "/pwa/start?utm_source=pwa",
   "display": "standalone",
   "display_override": ["window-controls-overlay"],
-  "orientation": "any",
+  "orientation": "natural",
   "theme_color": "#ffc800",
   "background_color": "#a09b87",
   "launch_handler": {

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -2,7 +2,7 @@
   "short_name": "Tournesol",
   "name": "Tournesol",
   "description": "Compare online content and contribute to the development of responsible content recommendations.",
-  "categories": ["education"],
+  "categories": ["video_players", "entertainment", "research", "democracy", "crowdsourcing"],
   "icons": [
     {
       "src": "/icons/favicon.ico",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -2,6 +2,7 @@
   "short_name": "Tournesol",
   "name": "Tournesol",
   "description": "Compare online content and contribute to the development of responsible content recommendations.",
+  "categories": ["education"],
   "icons": [
     {
       "src": "/icons/favicon.ico",


### PR DESCRIPTION
**related to** #1892

---

### Description

This PR updates the `manifest.json` of the front end to make the PWA ready for Android stores.

Visit https://www.pwabuilder.com/reportcard?site=https://staging.tournesol.app to see the current state of the `manifest.json` of the staging server. 

#### Details

`categories`

I'm not sure which categories best fit the Tournesol platform. I chose the standard `education`, but on the Google Play Store, this category contains apps to learn mathematics, new languages, how to play music, etc.

I think we could use less common tags, like `['videos', 'science', 'democracy']`.

Here is a standard list of categories maintained by the W3C: https://github.com/w3c/manifest/wiki/Categories

Examples for the Play Store:
https://support.google.com/googleplay/android-developer/answer/9859673?hl=en#zippy=%2Capps 

`orientation`

The value `natural` makes the app use the most natural orientation of the device, which will be `portrait-primary` for mobile phone and probably `landscape-primary` for tablets. `natural` prevents the app to be rotated. I tried to use `any`, to make the app able to rotate, it works, but on Android it works even when the rotation setting is off... 

#### Questions

`lang`

It's an optional attribute that may help the app to be discovered. Unfortunately it accepts a single language, so I didn't set it.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
