### PR TITLE
[infra] chore: automatically configure assetlinks.json

### DIFF
--- a/frontend/public/.well-known/assetlinks.tournesol.app.json
+++ b/frontend/public/.well-known/assetlinks.tournesol.app.json
@@ -1,0 +1,8 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+  "namespace": "android_app",
+  "package_name": "app.tournesol.twa",
+    "sha256_cert_fingerprints": ["27:C5:B9:36:69:2E:5A:46:96:50:4A:3F:BB:65:A1:44:BE:46:6D:CC:93:0E:BE:18:70:EF:80:2D:DC:87:BC:8E"]
+  }
+}]

--- a/infra/ansible/roles/frontend/handlers/main.yml
+++ b/infra/ansible/roles/frontend/handlers/main.yml
@@ -22,6 +22,8 @@
   stat:
     path: "/home/react/tournesol-frontend/public/.well-known/assetlinks.{{ domain_name }}.json"
   register: assetlinks_file
+  become: yes
+  become_user: react
 
 - name: Copy assetlinks.json
   file:

--- a/infra/ansible/roles/frontend/handlers/main.yml
+++ b/infra/ansible/roles/frontend/handlers/main.yml
@@ -18,6 +18,19 @@
   become: yes
   become_user: react
 
+- name: Check assetlinks.json
+  stat:
+    path: "/home/react/tournesol-frontend/public/.well-known/assetlinks.{{ domain_name }}.json"
+  register: assetlinks_file
+
+- name: Copy assetlinks.json
+  file:
+    src: "/home/react/tournesol-frontend/public/.well-known/assetlinks.{{ domain_name }}.json"
+    dest: /home/react/tournesol-frontend/public/.well-known/assetlinks.json
+  when: assetlinks_file.stat.exists
+  become: yes
+  become_user: react
+
 - name: Yarn build
   shell:
     cmd: . ~/.nvm/nvm.sh && NVM_DIR=/home/react/.nvm nvm use lts/{{npm_lts_version}} && yarn build

--- a/infra/ansible/roles/frontend/handlers/main.yml
+++ b/infra/ansible/roles/frontend/handlers/main.yml
@@ -27,6 +27,7 @@
   file:
     src: "/home/react/tournesol-frontend/public/.well-known/assetlinks.{{ domain_name }}.json"
     dest: /home/react/tournesol-frontend/public/.well-known/assetlinks.json
+    state: hard
   when: assetlinks_file.stat.exists
   become: yes
   become_user: react

--- a/infra/ansible/roles/frontend/tasks/main.yml
+++ b/infra/ansible/roles/frontend/tasks/main.yml
@@ -45,6 +45,8 @@
   notify:
     - Install Node
     - Yarn install
+    - Check assetlinks.json
+    - Copy assetlinks.json
     - Yarn build
     - Copy frontend files
     - Create Frontend OAuth application in Django database
@@ -83,6 +85,8 @@
   become_user: react
   notify:
     - Yarn install
+    - Check assetlinks.json
+    - Copy assetlinks.json
     - Yarn build
     - Generate Client from OpenAPI Specification
     - Copy frontend files
@@ -96,6 +100,8 @@
     group: react
   notify:
     - Yarn install
+    - Check assetlinks.json
+    - Copy assetlinks.json
     - Yarn build
     - Generate Client from OpenAPI Specification
     - Copy frontend files


### PR DESCRIPTION
### Description

The file `assetlinks.json` is generated by PWABuilder and allows to link our Android app to our website. It has been manually deployed in production recently, and this PR makes Ansible responsible of its future deployments.

I plan to create an app for our staging environment, and add the required file `assetlinks.staging.tournesol.app.json` in a following pull request.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
