### PR TITLE
[front] chore: set the iarc_rating_id in manifest.json

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -3,6 +3,7 @@
   "name": "Tournesol",
   "description": "Compare online content and contribute to the development of responsible content recommendations.",
   "categories": ["video_players", "entertainment", "research", "democracy", "crowdsourcing"],
+  "iarc_rating_id": "5510f1c2-d410-4ef1-9033-56b6459d50e1",
   "icons": [
     {
       "src": "/icons/favicon.ico",


### PR DESCRIPTION
### Description

We just received our id from the International Age Rating Coalition.

> The International Age Rating Coalition (IARC) is a revolutionary effort administered by the world's leading content rating authorities that globally unifies and streamlines the age classification process for digitally delivered games and apps, ensuring the consistent accessibility of established, trusted rating systems by today's digital consumers.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
