### PR TITLE
[back] chore: adjust min reliability score for videos posted by bots

### DIFF
--- a/backend/twitterbot/settings.py
+++ b/backend/twitterbot/settings.py
@@ -1,7 +1,7 @@
 # Quality criteria
 MIN_NB_CONTRIBUTORS = 5
 MIN_NB_RATINGS = 15
-MIN_RELIABILITY_SCORE = 25
+MIN_RELIABILITY_SCORE = 20
 MIN_TOURNESOL_SCORE = 25
 
 # Date range for videos to be considered


### PR DESCRIPTION
### Description

The latest changes in solidago make it harder for videos to reach score 25, especially on criteria that are evaluated less often by contributors and score uncertainties are high.

As discussed, let's relax the constraint to make more videos available for the bots.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
