### PR TITLE
[ext] feat: display a feedback to the user when the end of history is reached

### DIFF
--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -166,15 +166,15 @@
     "description": "When the import is complete, it replaces the title of the import status box."
   },
   "rateLaterHistoryStatusBoxMessage": {
-    "message": "Press Stop when the visible videos count doesn't increase anymore or when you think enough videos have been imported.",
+    "message": "Press Stop when the import is complete or when you think enough videos have been imported.",
     "description": "Instructions displayed on the rate later history import status box."
   },
   "rateLaterHistoryVideoCount": {
-    "message": "Videos visible in history:",
+    "message": "Videos visible in your YouTube history:",
     "description": "Label showing the count of videos found in the YouTube history during import."
   },
   "rateLaterHistoryAddedCount": {
-    "message": "Videos added to rate later:",
+    "message": "Videos added to your Tournesol rate-later list:",
     "description": "Label showing the count of videos successfully added to the rate later list."
   },
   "rateLaterHistoryFailureCount": {

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -161,6 +161,10 @@
     "message": "Videos are being imported, please wait.",
     "description": "Title of the the rate later history import status box."
   },
+  "rateLaterHistoryStatusBoxTitleFinish": {
+    "message": "✅️ Import complete!",
+    "description": "When the import is complete, it replaces the title of the import status box."
+  },
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Press Stop when the visible videos count doesn't increase anymore or when you think enough videos have been imported.",
     "description": "Instructions displayed on the rate later history import status box."

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -164,15 +164,15 @@
     "description": "Remplace le titre de l'écran d'import lorsque celui-ci est terminé."
   },
   "rateLaterHistoryStatusBoxMessage": {
-    "message": "Appuyez sur Stop quand le nombre de vidéos visibles n'augmente plus ou que vous pensez que suffisamment de vidéos ont été importées.",
+    "message": "Appuyez sur Stop quand l'import est terminé ou que vous pensez que suffisamment de vidéos ont été importées.",
     "description": "Instructions affichées sur l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."
   },
   "rateLaterHistoryVideoCount": {
-    "message": "Vidéos visibles dans l'historique :",
+    "message": "Vidéos visibles dans votre historique YouTube :",
     "description": "Étiquette indiquant le nombre de vidéos trouvées dans l'historique YouTube pendant l'import."
   },
   "rateLaterHistoryAddedCount": {
-    "message": "Vidéos importées dans les vidéos à comparer :",
+    "message": "Vidéos importées dans votre liste à comparer de Tournesol :",
     "description": "Étiquette indiquant le nombre de vidéos ajoutées avec succès à la liste des vidéos à comparer plus tard."
   },
   "rateLaterHistoryFailureCount": {

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -159,6 +159,10 @@
     "message": "Les vidéos sont en train d'être importées, veuillez patienter.",
     "description": "Titre de l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."
   },
+  "rateLaterHistoryStatusBoxTitleFinish": {
+    "message": "✅️ L'import est terminé !",
+    "description": "Remplace le titre de l'écran d'import lorsque celui-ci est terminé."
+  },
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Appuyez sur Stop quand le nombre de vidéos visibles n'augmente plus ou que vous pensez que suffisamment de vidéos ont été importées.",
     "description": "Instructions affichées sur l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."


### PR DESCRIPTION
target PR #2059

---

### Description

Display a visual feedback to the users when the import is complete.  

![capture](https://github.com/user-attachments/assets/b0e49354-7386-4a5c-b095-5a40faf47212)

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
