### PR TITLE
[back][ext] feat: add rate limit to the bulk create route of the rate-later API

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -313,6 +313,7 @@ REST_FRAMEWORK = {
         "api_video_post": "50/min",
         "api_users_me_export": "10/min",
         "api_export_comparisons": "10/min",
+        "api_rate_later_bulk_create": "20/day",
         # global throttle on account registrations and password reset
         "email": server_settings.get("THROTTLE_EMAIL_GLOBAL", "15/min"),
     },

--- a/backend/tournesol/views/rate_later.py
+++ b/backend/tournesol/views/rate_later.py
@@ -82,6 +82,7 @@ class RateLaterBulkCreate(RateLaterQuerysetMixin, generics.CreateAPIView):
     """
 
     permission_classes = [IsAuthenticated]
+    throttle_scope = "api_rate_later_bulk_create"
     serializer_class = RateLaterSerializer
 
     def get_serializer(self, *args, **kwargs):

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -173,6 +173,14 @@
     "message": "Videos added to rate later:",
     "description": "Label showing the count of videos successfully added to the rate later list."
   },
+  "rateLaterHistoryAddedNewCount": {
+    "message": "new videos:",
+    "description": "Label showing the number of successfully imported videos that were NOT already in the rate later list before the import."
+  },
+  "rateLaterHistoryAddedExistingCount": {
+    "message": "already in your list:",
+    "description": "Label showing the number of successfully imported videos that were already in the rate later list before the import."
+  },
   "rateLaterHistoryFailureCount": {
     "message": "Failures:",
     "description": "Label showing the count of videos that failed to be added to the rate later list."

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -162,12 +162,16 @@
     "description": "Title of the the rate later history import status box."
   },
   "rateLaterHistoryStatusBoxRateLimited": {
-    "message": "The limit of videos imported in your Rate-Later list has been reached for now.",
+    "message": "You have imported the maximum number of videos allowed today.",
     "description": "Title of the the rate later history import status box after rate limit has been reached."
   },
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Press Stop when the visible videos count doesn't increase anymore or when you think enough videos have been imported.",
     "description": "Instructions displayed on the rate later history import status box."
+  },
+  "rateLaterHistoryStatusBoxMessageRateLimited": {
+    "message": "You'll be able to start a new import in 24 hours, after having watched new videos.",
+    "description": "Instructions displayed on the rate later history import status box after rate limist has been reached."
   },
   "rateLaterHistoryVideoCount": {
     "message": "Videos visible in history:",
@@ -188,6 +192,10 @@
   "rateLaterHistoryFailureCount": {
     "message": "Failures:",
     "description": "Label showing the count of videos that failed to be added to the rate later list."
+  },
+  "rateLaterHistoryCloseButtonLabel": {
+    "message": "Close",
+    "description": "Label of the button to close the import status box, when the import is over."
   },
   "rateLaterHistoryStopButtonLabel": {
     "message": "Stop",

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -161,6 +161,10 @@
     "message": "Videos are being imported, please wait.",
     "description": "Title of the the rate later history import status box."
   },
+  "rateLaterHistoryStatusBoxRateLimited": {
+    "message": "The limit of videos imported in your Rate-Later list has been reached for now.",
+    "description": "Title of the the rate later history import status box after rate limit has been reached."
+  },
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Press Stop when the visible videos count doesn't increase anymore or when you think enough videos have been imported.",
     "description": "Instructions displayed on the rate later history import status box."

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -160,12 +160,16 @@
     "description": "Titre de l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."
   },
   "rateLaterHistoryStatusBoxRateLimited": {
-    "message": "Vous avez atteint le nombre maximal de vidéos importées pour le moment.",
+    "message": "Vous avez importé le nombre maximal de vidéos autorisé aujourd'hui.",
     "description": "Titre de l'écran d'import de l'historique YouTube lorsque la limite quotidienne est atteinte."
   },
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Appuyez sur Stop quand le nombre de vidéos visibles n'augmente plus ou que vous pensez que suffisamment de vidéos ont été importées.",
     "description": "Instructions affichées sur l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."
+  },
+  "rateLaterHistoryStatusBoxMessageRateLimited": {
+    "message": "Vous pourrez relancer un import dans 24 heures, après avoir vu de nouvelles vidéos.",
+    "description": "Instructions affichées sur l'écran d'import de l'historique YouTube, lorsque la limite quotidienne est atteinte."
   },
   "rateLaterHistoryVideoCount": {
     "message": "Vidéos visibles dans l'historique :",
@@ -186,6 +190,10 @@
   "rateLaterHistoryFailureCount": {
     "message": "Échecs :",
     "description": "Étiquette indiquant le nombre de vidéos qui n'ont pas pu être ajoutées à la liste."
+  },
+  "rateLaterHistoryCloseButtonLabel": {
+    "message": "Fermer",
+    "description": "Texte du bouton permettant de fermer l'écran d'import, lorsque celui-ci est terminé."
   },
   "rateLaterHistoryStopButtonLabel": {
     "message": "Stop",

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -159,6 +159,10 @@
     "message": "Les vidéos sont en train d'être importées, veuillez patienter.",
     "description": "Titre de l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."
   },
+  "rateLaterHistoryStatusBoxRateLimited": {
+    "message": "Vous avez atteint le nombre maximal de vidéos importées pour le moment.",
+    "description": "Titre de l'écran d'import de l'historique YouTube lorsque la limite quotidienne est atteinte."
+  },
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Appuyez sur Stop quand le nombre de vidéos visibles n'augmente plus ou que vous pensez que suffisamment de vidéos ont été importées.",
     "description": "Instructions affichées sur l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -169,7 +169,15 @@
   },
   "rateLaterHistoryAddedCount": {
     "message": "Vidéos importées dans les vidéos à comparer :",
-    "description": "Étiquette indiquant le nombre de vidéos ajoutées avec succès à la liste des vidéos à comparer plus tard."
+    "description": "Étiquette indiquant le nombre total de vidéos envoyées avec succès à la liste des vidéos à comparer plus tard."
+  },
+  "rateLaterHistoryAddedNewCount": {
+    "message": "nouvelles vidéos :",
+    "description": "Étiquette indiquant le nombre de vidéos envoyées avec succès qui n'étaient PAS déjà présentes dans la liste à comparer plus tard avant l'import."
+  },
+  "rateLaterHistoryAddedExistingCount": {
+    "message": "déjà présentes dans votre liste :",
+    "description": "Étiquette indiquant le nombre de vidéos envoyées avec succès qui étaient déjà présentes dans la liste à comparer plus tard avant l'import."
   },
   "rateLaterHistoryFailureCount": {
     "message": "Échecs :",

--- a/browser-extension/src/rateLaterHistory.css
+++ b/browser-extension/src/rateLaterHistory.css
@@ -71,8 +71,24 @@ body.tournesol-capturing-history ytd-thumbnail {
   gap: 8px;
 }
 
+#tournesol-rate-later-history-status-box ul {
+  list-style-position: inside;
+}
+
+#tournesol-rate-later-history-status-box ul li:not(:first-child) {
+  margin-top: 4px;
+}
+
+#tournesol-rate-later-history-status-box .counter-section {
+  margin-top: 8px;
+}
+
 #tournesol-rate-later-history-status-box .count {
   font-weight: bold;
+}
+
+#tournesol-rate-later-history-status-box #when-to-stop {
+  margin-top: 16px;
 }
 
 #tournesol-rate-later-history-stop-button {

--- a/browser-extension/src/rateLaterHistory.js
+++ b/browser-extension/src/rateLaterHistory.js
@@ -44,6 +44,12 @@ const addOverlay = () => {
     title.textContent = chrome.i18n.getMessage(
       'rateLaterHistoryStatusBoxRateLimited'
     );
+    message.textContent = chrome.i18n.getMessage(
+      'rateLaterHistoryStatusBoxMessageRateLimited'
+    );
+    stopButton.textContent = chrome.i18n.getMessage(
+      'rateLaterHistoryCloseButtonLabel'
+    );
   };
 
   const addCounter = ({ label, initialValue = 0 }) => {
@@ -208,7 +214,7 @@ const addVideoIdsToRateLater = async (videoIds) => {
     } catch (e) {
       console.error(e);
       chunk.forEach((videoId) => failedSet.add(videoId));
-      if (e?.cause?.status === 429) {
+      if (e?.message === 'http429') {
         tooManyRequests = true;
         break;
       }
@@ -259,12 +265,13 @@ const startHistoryCapture = async () =>
       displaySentVideoCount,
       displayNewVideosCount,
       displayFailedVideoCount,
+      showTooManyRequests,
       stopButton,
     } = addOverlay();
 
     let timeout;
 
-    const abortCapture = ({ close = false }) => {
+    const abortCapture = ({ close = false } = {}) => {
       abort = true;
       if (timeout) clearTimeout(timeout);
       if (close) {
@@ -304,6 +311,7 @@ const startHistoryCapture = async () =>
 
         if (tooManyRequests) {
           abortCapture();
+          showTooManyRequests();
           return;
         }
       }

--- a/browser-extension/src/rateLaterHistory.js
+++ b/browser-extension/src/rateLaterHistory.js
@@ -106,7 +106,10 @@ const addOverlay = () => {
   });
 
   const { displayCounts: displayNewVideosCount } = addCounterList({
-    labels: ["nouvelle vidéos", "déjà dans votre liste"], // todo: translate
+    labels: [
+      chrome.i18n.getMessage('rateLaterHistoryAddedNewCount'),
+      chrome.i18n.getMessage('rateLaterHistoryAddedExistingCount')
+    ],
   });
 
   const { displayCount: displayFailedVideoCount } = addCounter({

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -98,9 +98,11 @@ export const addRateLaterBulk = async (videoIds) => {
     }
   );
   if (!ratingStatusReponse?.ok) {
-    throw new Error('addRateLaterBulk request failed', {
-      cause: ratingStatusReponse,
-    });
+    if (ratingStatusReponse?.status === 429) {
+      throw new Error('http429');
+    } else {
+      throw new Error('addRateLaterBulk request failed');
+    }
   }
 
   return await ratingStatusReponse.json();

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -97,8 +97,11 @@ export const addRateLaterBulk = async (videoIds) => {
       data: videoIds.map((videoId) => ({ entity: { uid: 'yt:' + videoId } })),
     }
   );
-  if (!ratingStatusReponse?.ok)
-    throw new Error('addRateLaterBulk request failed');
+  if (!ratingStatusReponse?.ok) {
+    throw new Error('addRateLaterBulk request failed', {
+      cause: ratingStatusReponse,
+    });
+  }
 
   return await ratingStatusReponse.json();
 };


### PR DESCRIPTION
**target PR**: #2059

---

### Description

- limit the call to the rate-later bulk create API to 20 requests/day
- handle the HTTP 429 status in the extension
- display the number of new videos imported and the number of skipped videos

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
