### PR TITLE
[ext] feat: keep imported videos in cache to not import them again

### DIFF
--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -166,16 +166,12 @@
     "description": "First paragraph of the alert message, displayed when the daily import limit is reached."
   },
   "rateLaterHistoryStatusBox429AlertP2" : {
-    "message": "You have imported the maximum number of videos allowed today.",
+    "message": "You have imported the maximum number of videos allowed today. You can start a new import in 24 hours.",
     "description": "Second paragraph of the alert message, displayed when the daily import limit is reached."
   },
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Press Stop when the visible videos count doesn't increase anymore or when you think enough videos have been imported.",
     "description": "Instructions displayed on the rate later history import status box."
-  },
-  "rateLaterHistoryStatusBoxMessageRateLimited": {
-    "message": "You'll be able to start a new import in 24 hours, after having watched new videos.",
-    "description": "Instructions displayed on the rate later history import status box after rate limist has been reached."
   },
   "rateLaterHistoryVideoCount": {
     "message": "Videos visible in history:",

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -177,21 +177,21 @@
     "message": "Videos visible in history:",
     "description": "Label showing the count of videos found in the YouTube history during import."
   },
-  "rateLaterHistoryAddedCount": {
-    "message": "Videos added to rate later:",
-    "description": "Label showing the count of videos successfully added to the rate later list."
+  "rateLaterHistoryProcessedCount": {
+    "message": "Videos processed during the import:",
+    "description": "Label showing the count of videos processed by the import."
   },
-  "rateLaterHistoryAddedNewCount": {
-    "message": "new videos:",
-    "description": "Label showing the number of successfully imported videos that were NOT already in the rate later list before the import."
+  "rateLaterHistorySentCount": {
+    "message": "imported videos:",
+    "description": "Label showing the number of sent videos successfully imported in the rate later list (including those already present)."
   },
-  "rateLaterHistoryAddedExistingCount": {
-    "message": "already in your list:",
-    "description": "Label showing the number of successfully imported videos that were already in the rate later list before the import."
+  "rateLaterHistorySkippedCount": {
+    "message": "skipped videos (previously imported):",
+    "description": "Label showing the number of videos that have NOT been sent to the Tournesol server, because they were present in the cache of previously imported videos."
   },
   "rateLaterHistoryFailureCount": {
-    "message": "Failures:",
-    "description": "Label showing the count of videos that failed to be added to the rate later list."
+    "message": "failures:",
+    "description": "Label showing the count of sent videos that failed to be added to the rate later list, because of a server error."
   },
   "rateLaterHistoryCloseButtonLabel": {
     "message": "Close",

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -158,7 +158,7 @@
     "description": "Label of the button displayed on the YouTube history page to import the history into your 'rate later' list."
   },
   "rateLaterHistoryStatusBoxTitle": {
-    "message": "Videos are being imported, please wait.",
+    "message": "Import of the YouTube history",
     "description": "Title of the the rate later history import status box."
   },
   "rateLaterHistoryStatusBox429AlertP1" : {

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -161,9 +161,13 @@
     "message": "Videos are being imported, please wait.",
     "description": "Title of the the rate later history import status box."
   },
-  "rateLaterHistoryStatusBoxRateLimited": {
+  "rateLaterHistoryStatusBox429AlertP1" : {
+    "message": "The import is complete.",
+    "description": "First paragraph of the alert message, displayed when the daily import limit is reached."
+  },
+  "rateLaterHistoryStatusBox429AlertP2" : {
     "message": "You have imported the maximum number of videos allowed today.",
-    "description": "Title of the the rate later history import status box after rate limit has been reached."
+    "description": "Second paragraph of the alert message, displayed when the daily import limit is reached."
   },
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Press Stop when the visible videos count doesn't increase anymore or when you think enough videos have been imported.",

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -159,10 +159,6 @@
     "message": "Import de l'historique YouTube",
     "description": "Titre de l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."
   },
-  "rateLaterHistoryStatusBoxRateLimited": {
-    "message": "Vous avez importé le nombre maximal de vidéos autorisé aujourd'hui.",
-    "description": "Titre de l'écran d'import de l'historique YouTube lorsque la limite quotidienne est atteinte."
-  },
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Appuyez sur Stop quand le nombre de vidéos visibles n'augmente plus ou que vous pensez que suffisamment de vidéos ont été importées.",
     "description": "Instructions affichées sur l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."
@@ -172,12 +168,8 @@
     "description": "Premier paragraphe du message d'alerte, lorsque la limite d'import quotidienne est atteinte."
   },
   "rateLaterHistoryStatusBox429AlertP2" : {
-    "message": "Vous avez importé le nombre maximal de vidéos autorisé aujourd'hui.",
+    "message": "Vous avez importé le nombre maximal de vidéos autorisé aujourd'hui. Vous pourrez lancer un nouvel import dans 24h.",
     "description": "Deuxième paragraphe du message d'alerte, lorsque la limite d'import quotidienne est atteinte."
-  },
-  "rateLaterHistoryStatusBoxMessageRateLimited": {
-    "message": "Vous pourrez relancer un import dans 24 heures, après avoir vu de nouvelles vidéos.",
-    "description": "Instructions affichées sur l'écran d'import de l'historique YouTube, lorsque la limite quotidienne est atteinte."
   },
   "rateLaterHistoryVideoCount": {
     "message": "Vidéos visibles dans l'historique :",

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -175,21 +175,21 @@
     "message": "Vidéos visibles dans l'historique :",
     "description": "Étiquette indiquant le nombre de vidéos trouvées dans l'historique YouTube pendant l'import."
   },
-  "rateLaterHistoryAddedCount": {
-    "message": "Vidéos importées dans les vidéos à comparer :",
-    "description": "Étiquette indiquant le nombre total de vidéos envoyées avec succès à la liste des vidéos à comparer plus tard."
+  "rateLaterHistoryProcessedCount": {
+    "message": "Vidéos traitées par le processus d'import :",
+    "description": "Étiquette indiquant le nombre total de vidéos traitées par le processus d'import."
   },
-  "rateLaterHistoryAddedNewCount": {
-    "message": "nouvelles vidéos :",
-    "description": "Étiquette indiquant le nombre de vidéos envoyées avec succès qui n'étaient PAS déjà présentes dans la liste à comparer plus tard avant l'import."
+  "rateLaterHistorySentCount": {
+    "message": "vidéos importées :",
+    "description": "Étiquette indiquant le nombre de vidéos envoyées qui ont été ajoutées avec succès dans la liste à comparer plus tard (inclus les vidéos déjà présentes)."
   },
-  "rateLaterHistoryAddedExistingCount": {
-    "message": "déjà présentes dans votre liste :",
-    "description": "Étiquette indiquant le nombre de vidéos envoyées avec succès qui étaient déjà présentes dans la liste à comparer plus tard avant l'import."
+  "rateLaterHistorySkippedCount": {
+    "message": "vidéos évitées (importées précédemment) :",
+    "description": "Étiquette indiquant le nombre de vidéos non envoyées au serveur Tournesol, car déjà présentes dans le cache de vidéos précédement envoyées."
   },
   "rateLaterHistoryFailureCount": {
-    "message": "Échecs :",
-    "description": "Étiquette indiquant le nombre de vidéos qui n'ont pas pu être ajoutées à la liste."
+    "message": "échecs :",
+    "description": "Étiquette indiquant le nombre de vidéos envoyées qui n'ont pas pu être ajoutées à la liste à comparer plus tard, à cause d'une erreur du serveur."
   },
   "rateLaterHistoryCloseButtonLabel": {
     "message": "Fermer",

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -156,7 +156,7 @@
     "description": "Label du  bouton affiché sur l'historique YouTube pour l'importer dans les vidéos à comparer plus tard."
   },
   "rateLaterHistoryStatusBoxTitle": {
-    "message": "Les vidéos sont en train d'être importées, veuillez patienter.",
+    "message": "Import de l'historique YouTube",
     "description": "Titre de l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."
   },
   "rateLaterHistoryStatusBoxRateLimited": {
@@ -166,6 +166,14 @@
   "rateLaterHistoryStatusBoxMessage": {
     "message": "Appuyez sur Stop quand le nombre de vidéos visibles n'augmente plus ou que vous pensez que suffisamment de vidéos ont été importées.",
     "description": "Instructions affichées sur l'écran d'import de l'historique YouTube vers la liste des vidéos à comparer plus tard."
+  },
+  "rateLaterHistoryStatusBox429AlertP1" : {
+    "message": "L'import est terminée.",
+    "description": "Premier paragraphe du message d'alerte, lorsque la limite d'import quotidienne est atteinte."
+  },
+  "rateLaterHistoryStatusBox429AlertP2" : {
+    "message": "Vous avez importé le nombre maximal de vidéos autorisé aujourd'hui.",
+    "description": "Deuxième paragraphe du message d'alerte, lorsque la limite d'import quotidienne est atteinte."
   },
   "rateLaterHistoryStatusBoxMessageRateLimited": {
     "message": "Vous pourrez relancer un import dans 24 heures, après avoir vu de nouvelles vidéos.",

--- a/browser-extension/src/rateLaterHistory.css
+++ b/browser-extension/src/rateLaterHistory.css
@@ -76,7 +76,7 @@ body.tournesol-capturing-history ytd-thumbnail {
 }
 
 #tournesol-rate-later-history-status-box ul li:not(:first-child) {
-  margin-top: 4px;
+  margin-top: 6px;
 }
 
 #tournesol-rate-later-history-status-box .counter-section {

--- a/browser-extension/src/rateLaterHistory.css
+++ b/browser-extension/src/rateLaterHistory.css
@@ -122,9 +122,7 @@ body.tournesol-capturing-history ytd-thumbnail {
 }
 
 .lds-dual-ring {
-  margin: auto;
-  margin-top: 16px;
-  margin-bottom: 16px;
+  margin: 16px auto;
 }
 
 .lds-dual-ring,

--- a/browser-extension/src/rateLaterHistory.css
+++ b/browser-extension/src/rateLaterHistory.css
@@ -158,3 +158,6 @@ body.tournesol-capturing-history ytd-thumbnail {
   display: none;
 }
 
+.visibility-hidden {
+  visibility: hidden;
+}

--- a/browser-extension/src/rateLaterHistory.css
+++ b/browser-extension/src/rateLaterHistory.css
@@ -71,6 +71,31 @@ body.tournesol-capturing-history ytd-thumbnail {
   gap: 8px;
 }
 
+#tournesol-rate-later-history-status-box h3 {
+  margin-bottom: 8px;
+  text-decoration-line: underline;
+  text-decoration-color: rgb(255, 211, 51);
+  text-decoration-thickness: 0.4em;
+  text-decoration-skip-ink: none;
+  text-underline-offset: 0.2em;
+}
+
+#tournesol-rate-later-history-status-box .alert-box {
+  padding: 16px;
+  border-radius: 4px;
+
+  font-weight: 400;
+  line-height: 1.43;
+  letter-spacing: 0.02em;
+
+  color: rgb(30, 70, 32);
+  background-color: rgb(237, 247, 237);
+}
+
+#tournesol-rate-later-history-status-box .alert-box p:not(:first-child){
+  margin-top: 8px;
+}
+
 #tournesol-rate-later-history-status-box ul {
   list-style-position: inside;
 }
@@ -98,6 +123,8 @@ body.tournesol-capturing-history ytd-thumbnail {
 
 .lds-dual-ring {
   margin: auto;
+  margin-top: 16px;
+  margin-bottom: 16px;
 }
 
 .lds-dual-ring,
@@ -128,3 +155,8 @@ body.tournesol-capturing-history ytd-thumbnail {
     transform: rotate(360deg);
   }
 }
+
+.display-none {
+  display: none;
+}
+

--- a/browser-extension/src/rateLaterHistory.js
+++ b/browser-extension/src/rateLaterHistory.js
@@ -217,9 +217,6 @@ const saveImportedToLocalStorage = async (importedVideosSet) => {
     videosStr = videosStr.substring(1);
   }
 
-  console.log('found ', historyInStorage);
-  console.log('new ', videosStr);
-
   await chrome.storage.local.set({
     youtubeHistoryImported: historyInStorage
       ? historyInStorage + videosStr
@@ -346,7 +343,7 @@ const startHistoryCapture = async () =>
       try {
         newVideosToSend = await skipPreviouslyImported(videosToSend);
       } catch (error) {
-        console.log(error);
+        console.error(error);
         newVideosToSend = videosToSend;
       }
 

--- a/browser-extension/src/rateLaterHistory.js
+++ b/browser-extension/src/rateLaterHistory.js
@@ -57,10 +57,8 @@ const addOverlay = () => {
     loader.classList.add('display-none');
     loader.classList.remove('lds-dual-ring');
     alertBox.classList.remove('display-none');
+    message.classList.add('visibility-hidden');
 
-    message.textContent = chrome.i18n.getMessage(
-      'rateLaterHistoryStatusBoxMessageRateLimited'
-    );
     stopButton.textContent = chrome.i18n.getMessage(
       'rateLaterHistoryCloseButtonLabel'
     );

--- a/browser-extension/src/rateLaterHistory.js
+++ b/browser-extension/src/rateLaterHistory.js
@@ -35,15 +35,29 @@ const addOverlay = () => {
   title.textContent = chrome.i18n.getMessage('rateLaterHistoryStatusBoxTitle');
   statusBox.append(title);
 
+  const alertBox = document.createElement('div');
+  alertBox.classList.add('alert-box', 'display-none');
+  const alertBoxText1 = document.createElement('p');
+  alertBoxText1.textContent = chrome.i18n.getMessage(
+    'rateLaterHistoryStatusBox429AlertP1'
+  );
+  const alertBoxText2 = document.createElement('p');
+  alertBoxText2.textContent = chrome.i18n.getMessage(
+    'rateLaterHistoryStatusBox429AlertP2'
+  );
+  alertBox.append(alertBoxText1);
+  alertBox.append(alertBoxText2);
+  statusBox.append(alertBox);
+
   const loader = document.createElement('div');
   loader.classList.add('lds-dual-ring');
   statusBox.append(loader);
 
   const showTooManyRequests = () => {
+    loader.classList.add('display-none');
     loader.classList.remove('lds-dual-ring');
-    title.textContent = chrome.i18n.getMessage(
-      'rateLaterHistoryStatusBoxRateLimited'
-    );
+    alertBox.classList.remove('display-none');
+
     message.textContent = chrome.i18n.getMessage(
       'rateLaterHistoryStatusBoxMessageRateLimited'
     );


### PR DESCRIPTION
### Description

The history imports made by the browser extension now remembers the YouTube id of imported videos. This allows the users to import new batch of their history daily, without wasting their limited Tournesol API requests by trying to import already imported videos.

To simplify the UI, and to hide the implementation details, the users will see a single number of successfully imported videos, named `imported videos:`. This number was previously split in two distinct labels `new videos` and `already in your list`. A value of 10 means 10 videos from the history are now in your rate later list (some were already present, some are new, but in the end all videos are in the rate-later list).

### Preview

During the import 👇️

![cap0](https://github.com/user-attachments/assets/5e8007cd-0cc6-496a-a41c-77a3f7446c27)

When the Tournesol API returns a HTTP 429 response 👇️

![capture](https://github.com/user-attachments/assets/8ab3b5b0-13e2-4450-b67b-6de94c996e37)


#### Questions

Do we want to allow the users to clear their import cache, to allow them to import a second time their history? 

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
