### PR TITLE
[front] feat: add an private personal stats page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -346,7 +346,8 @@
   "joinUsButton": "Join us",
   "personalMenu": {
     "yourRecommendations": "My recommendations",
-    "vouching": "Vouch for other users"
+    "vouching": "Vouch for other users",
+    "myActivityStats": "My stats"
   },
   "logoutButton": "Logout",
   "pwaBanner": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -353,7 +353,8 @@
   "joinUsButton": "S'inscrire",
   "personalMenu": {
     "yourRecommendations": "Mes recommandations",
-    "vouching": "Me porter garant"
+    "vouching": "Me porter garant",
+    "myActivityStats": "Mes statistiques"
   },
   "logoutButton": "Se déconnecter",
   "pwaBanner": {

--- a/frontend/src/app/PollRoutes.tsx
+++ b/frontend/src/app/PollRoutes.tsx
@@ -13,6 +13,7 @@ import CriteriaPage from 'src/pages/criteria/CriteriaPage';
 import FeedbackPage from 'src/pages/personal/feedback/FeedbackPage';
 import EntityAnalysisPage from 'src/pages/entities/EntityAnalysisPage';
 import HomePage from 'src/pages/home/Home';
+import PersonalStatsPage from 'src/pages/me/stats/PersonalStatsPage';
 import ProofByKeywordPage from 'src/pages/me/proof/ProofByKeywordPage';
 import RecommendationPage from 'src/pages/recommendations/RecommendationPage';
 import VideoRatingsPage from 'src/pages/videos/VideoRatings';
@@ -142,6 +143,12 @@ const PollRoutes = ({ pollName }: Props) => {
       id: RouteID.MyProofByKeyword,
       url: 'me/proof/:keyword',
       page: ProofByKeywordPage,
+      type: PrivateRoute,
+    },
+    {
+      id: RouteID.MyStats,
+      url: 'me/stats',
+      page: PersonalStatsPage,
       type: PrivateRoute,
     },
     {

--- a/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
+++ b/frontend/src/features/frame/components/topbar/PersonalMenu.tsx
@@ -10,7 +10,12 @@ import {
   MenuList,
   MenuItem,
 } from '@mui/material';
-import { Logout, VideoLibrary, HowToReg } from '@mui/icons-material';
+import {
+  HowToReg,
+  Logout,
+  QueryStats,
+  VideoLibrary,
+} from '@mui/icons-material';
 import { TournesolMenuItemType, settingsMenu } from 'src/utils/menus';
 import { useCurrentPoll, useLoginState } from 'src/hooks';
 
@@ -72,6 +77,17 @@ const PersonalMenu = ({
             <HowToReg fontSize="small" />
           </ListItemIcon>
           <ListItemText>{t('personalMenu.vouching')}</ListItemText>
+        </MenuItem>
+        <MenuItem
+          key="my-activity-stats"
+          component={RouterLink}
+          to="/me/stats"
+          onClick={onItemClick}
+        >
+          <ListItemIcon>
+            <QueryStats fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>{t('personalMenu.myActivityStats')}</ListItemText>
         </MenuItem>
         <Divider key="my-things-divider" />
         {/* -- settings section -- */}

--- a/frontend/src/pages/me/stats/PersonalStatsPage.tsx
+++ b/frontend/src/pages/me/stats/PersonalStatsPage.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { Box } from '@mui/material';
+
+import { ContentBox, ContentHeader } from 'src/components';
+
+const ProofByKeywordPage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ContentHeader title="Mes statistiques" />
+      <ContentBox maxWidth="xl">
+        <Box></Box>
+      </ContentBox>
+    </>
+  );
+};
+
+export default ProofByKeywordPage;

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -69,6 +69,7 @@ export enum RouteID {
   MyRateLaterList = 'myRateLaterList',
   MyFeedback = 'myFeedback',
   MyProofByKeyword = 'myProofByKeyword',
+  MyStats = 'myStats',
 }
 
 export type OrderedDialogs = {


### PR DESCRIPTION
### Description

This PR adds a private personal stats page, that display the logged user activity on the platform.

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
