### PR TITLE
[ext] More flexible layout for recos

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -248,11 +248,8 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
 .video_card {
   position: relative;
 
-  width: calc(
-    100% / min(4, var(--ytd-rich-grid-items-per-row))
-    - var(--ytd-rich-grid-item-margin)
-    - 0.01px
-  );
+  --ytd-rich-item-row-usable-width: calc(100% - var(--ytd-rich-grid-gutter-margin)*2);
+  width: calc(var(--ytd-rich-item-row-usable-width)/var(--ytd-rich-grid-items-per-row) - var(--ytd-rich-grid-item-margin) - .01px);
 }
 
 .video_thumb {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -179,14 +179,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       const extraNbr = request.additionalVideosNumber;
 
       const recentToLoadRow1 = Math.round(nbrPerRow * RECENT_VIDEOS_RATIO);
-      const oldToLoadRow1 = Math.round(nbrPerRow * (1 - RECENT_VIDEOS_RATIO));
+      const oldToLoadRow1 = nbrPerRow - recentToLoadRow1;
 
       const recentToLoadExtra = Math.round(
         extraNbr * RECENT_VIDEOS_EXTRA_RATIO
       );
-      const oldToLoadExtra = Math.round(
-        extraNbr * (1 - RECENT_VIDEOS_EXTRA_RATIO)
-      );
+      const oldToLoadExtra = extraNbr - recentToLoadExtra;
 
       const process = async () => {
         const threeWeeksAgo = getDateThreeWeeksAgo();

--- a/browser-extension/src/displayHomeRecommendations.js
+++ b/browser-extension/src/displayHomeRecommendations.js
@@ -30,7 +30,19 @@ const getHomeRecommendationsLayout = () =>
     const startTime = new Date();
     const maximumSecondsWaitingForThumbnails = 5;
     const millisecondsBetweenRetries = 300;
-    const defaultLayout = { videosPerRow: 4, rowsWhenExpanded: 3 };
+    const defaultLayout = {
+      videosPerRow: 4,
+      rowsWhenCollapsed: 1,
+      rowsWhenExpanded: 3,
+    };
+    const layoutByYoutubeVideosPerRow = {
+      1: { rowsWhenCollapsed: 2, rowsWhenExpanded: 12 },
+      2: { rowsWhenCollapsed: 2, rowsWhenExpanded: 6 },
+      3: { rowsWhenCollapsed: 1, rowsWhenExpanded: 4 },
+      4: { rowsWhenCollapsed: 1, rowsWhenExpanded: 3 },
+      5: { rowsWhenCollapsed: 1, rowsWhenExpanded: 2 },
+      6: { rowsWhenCollapsed: 1, rowsWhenExpanded: 2 },
+    };
 
     const getLayout = () => {
       const elapsedSeconds = (new Date() - startTime) / 1000;
@@ -46,9 +58,15 @@ const getHomeRecommendationsLayout = () =>
         return;
       }
 
+      const layout = layoutByYoutubeVideosPerRow[youtubeVideosPerRow];
+      if (layout === undefined) {
+        resolve(defaultLayout);
+        return;
+      }
+
       const videosPerRow = youtubeVideosPerRow;
-      const rowsWhenExpanded = 3;
-      resolve({ videosPerRow, rowsWhenExpanded });
+      const { rowsWhenCollapsed, rowsWhenExpanded } = layout;
+      resolve({ videosPerRow, rowsWhenCollapsed, rowsWhenExpanded });
     };
 
     getLayout();
@@ -72,11 +90,12 @@ const getHomeRecommendationsLayout = () =>
 
     const banner = await fetchBanner();
 
-    const { videosPerRow, rowsWhenExpanded } =
+    const { videosPerRow, rowsWhenCollapsed, rowsWhenExpanded } =
       await getHomeRecommendationsLayout();
 
     const options = new TournesolRecommendationsOptions({
       videosPerRow,
+      rowsWhenCollapsed,
       rowsWhenExpanded,
       banner,
       parentComponentQuery: '#primary > ytd-rich-grid-renderer',

--- a/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
+++ b/browser-extension/src/models/tournesolRecommendations/TournesolRecommendations.js
@@ -13,6 +13,7 @@ export class TournesolRecommendations {
     this.tournesolContainer = new TournesolContainer(this, options.banner);
 
     this.videosPerRow = options.videosPerRow;
+    this.rowsWhenCollapsed = options.rowsWhenCollapsed;
     this.rowsWhenExpanded = options.rowsWhenExpanded;
     this.parentComponentQuery = options.parentComponentQuery;
     this.displayCriteria = options.displayCriteria;
@@ -113,8 +114,9 @@ export class TournesolRecommendations {
   }) {
     this.areRecommendationsLoading = false;
     this.areRecommendationsLoaded = true;
-    this.videos = videosResponse.slice(0, this.videosPerRow);
-    this.additionalVideos = videosResponse.slice(this.videosPerRow);
+    const videoCountWhenCollapsed = this.videosPerRow * this.rowsWhenCollapsed;
+    this.videos = videosResponse.slice(0, videoCountWhenCollapsed);
+    this.additionalVideos = videosResponse.slice(videoCountWhenCollapsed);
     this.recommandationsLanguages = languagesString;
 
     if (this.isPageLoaded) {
@@ -130,8 +132,9 @@ export class TournesolRecommendations {
     chrome.runtime.sendMessage(
       {
         message: 'getTournesolRecommendations',
-        videosNumber: this.videosPerRow,
-        additionalVideosNumber: this.videosPerRow * (this.rowsWhenExpanded - 1),
+        videosNumber: this.videosPerRow * this.rowsWhenCollapsed,
+        additionalVideosNumber:
+          this.videosPerRow * (this.rowsWhenExpanded - this.rowsWhenCollapsed),
         queryParamBundle: this.varyQueryParamBundle(),
       },
       this.handleResponse

--- a/browser-extension/src/models/tournesolRecommendations/TournesolRecommendationsOptions.js
+++ b/browser-extension/src/models/tournesolRecommendations/TournesolRecommendationsOptions.js
@@ -1,12 +1,14 @@
 export class TournesolRecommendationsOptions {
   constructor({
     videosPerRow,
+    rowsWhenCollapsed,
     rowsWhenExpanded,
     banner,
     parentComponentQuery,
     displayCriteria,
   }) {
     this.videosPerRow = videosPerRow;
+    this.rowsWhenCollapsed = rowsWhenCollapsed;
     this.rowsWhenExpanded = rowsWhenExpanded;
     this.banner = banner;
     this.parentComponentQuery = parentComponentQuery;


### PR DESCRIPTION
**related issues** #1791

---

### Description

The extension now adjusts the number of items per row and the number of rows based on the number of YouTube videos per row.

It doesn't adjust again if the window is resized because that would require a much bigger change to the extension (mainly rewriting [the code that loads the recommendations](https://github.com/tournesol-app/tournesol/blob/dc7e8d019d825469b6656b0e8c7f044668e2a14f/browser-extension/src/background.js#L169-L257) and moving it into the content script). Doing these big changes would be beneficial, so maybe we should do it, but I figured I would rather make a simpler version first. We could update the recommendations when we detect a window resize, but with the current code that would replace the recommendations with new ones, and we probably don't want that.

One difference with the table in the issue is when YouTube videos per row is > 6. In that case the extension use the default layout. I think YouTube cannot actually display more than 6 videos per row anyway.

If no YouTube video is found within 5 seconds, it uses the default layout.

YouTube reduces the thumbnail size on large screens, so I had to update Tournesol thumbnail size (in 719ff6e1ddf1b83dcaef92f42f49d18d98b2d6a7).

If there's not enough recent videos (happened to me in dev) then the number of videos returned by the background script is sometimes wrong. I did not try to fix that.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
