### PR TITLE
[ext] fix: support URLs for shorts when interacting with video URLs

### DIFF
--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -141,6 +141,22 @@
     "message": "Close icon",
     "description": "Alt text of the close icon displayed when there's a banner"
   },
+  "alertNotYoutubeVideo": {
+    "message": "This is not a YouTube video.",
+    "description": "Alert shown when trying to use on a non-YouTube video link/page"
+  },
+  "alertVideoAdded": {
+    "message": "Video added!",
+    "description": "Alert message indicating a video was added successfully"
+  },
+  "alertAlreadyAdded": {
+    "message": "Video already added.",
+    "description": "Alert message indicating a video was already added"
+  },
+  "alertFailed": {
+    "message": "Failed.",
+    "description": "Alert message indicating an action failed"
+  },
   "rateNowButtonLabel": {
     "message": "Rate Now",
     "description": "Label of the button displayed on video pages."

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -17,6 +17,10 @@
   "menuRateLaterHistory": {
     "message": "Import YouTube watch history"
   },
+  "contextMenuRateLater": {
+    "message": "Rate later on Tournesol",
+    "description": "Label of the rate-later menu item (after right-click on a link)."
+  },
   "recommendedByTournesol": {
     "message": "Recommended by Tournesol",
     "description": "Title of the main Tournesol container."

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -139,6 +139,22 @@
     "message": "Icône de fermeture",
     "description": "Texte alternatif à l'icône de fermeture de la bannière"
   },
+  "alertNotYoutubeVideo": {
+    "message": "Ceci n'est pas une vidéo YouTube.",
+    "description": "Alerte affichée lorsqu'on tente d'utiliser un lien/une page qui n'est pas une vidéo YouTube"
+  },
+  "alertVideoAdded": {
+    "message": "Vidéo ajoutée !",
+    "description": "Message d'alerte indiquant qu'une vidéo a été ajoutée avec succès"
+  },
+  "alertAlreadyAdded": {
+    "message": "Vidéo déjà ajoutée.",
+    "description": "Message d'alerte indiquant qu'une vidéo a déjà été ajoutée"
+  },
+  "alertFailed": {
+    "message": "Échec.",
+    "description": "Message d'alerte indiquant qu'une action a échoué"
+  },
   "rateNowButtonLabel": {
     "message": "Comparer",
     "description": "Label du bouton affiché sur les pages de vidéo."

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -17,6 +17,10 @@
   "menuRateLaterHistory": {
     "message": "Importer l'historique YouTube"
   },
+  "contextMenuRateLater": {
+    "message": "Comparer plus tard sur Tournesol",
+    "description": "Label du menu permettant d'ajouter une vidéo à sa liste à Comparer plus tard (lors d'un clic droit sur un lien)."
+  },
   "recommendedByTournesol": {
     "message": "Recommandées par Tournesol",
     "description": "Titre du conteneur principal affichant les recommandations."

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -3,6 +3,7 @@ import {
   addRateLaterBulk,
   alertOnCurrentTab,
   alertUseOnLinkToYoutube,
+  extractVideoId,
   fetchTournesolApi,
   getAccessToken,
   getRandomSubarray,
@@ -27,13 +28,18 @@ const createContextMenu = function createContextMenu() {
   chrome.contextMenus.removeAll(function () {
     chrome.contextMenus.create({
       id: 'tournesol_add_rate_later',
-      title: 'Rate later on Tournesol',
+      title: chrome.i18n.getMessage("contextMenuRateLater"),
       contexts: ['link'],
+      targetUrlPatterns: [
+        "*://*.youtube.com/*",
+        "*://*.youtu.be/*",
+        "*://tournesol.app/*",
+      ]
     });
   });
 
   chrome.contextMenus.onClicked.addListener(function (e, tab) {
-    var videoId = new URL(e.linkUrl).searchParams.get('v');
+    const videoId = extractVideoId(e.linkUrl)
     if (!videoId) {
       alertUseOnLinkToYoutube(tab);
     } else {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -28,18 +28,18 @@ const createContextMenu = function createContextMenu() {
   chrome.contextMenus.removeAll(function () {
     chrome.contextMenus.create({
       id: 'tournesol_add_rate_later',
-      title: chrome.i18n.getMessage("contextMenuRateLater"),
+      title: chrome.i18n.getMessage('contextMenuRateLater'),
       contexts: ['link'],
       targetUrlPatterns: [
-        "*://*.youtube.com/*",
-        "*://*.youtu.be/*",
-        "*://tournesol.app/*",
-      ]
+        '*://*.youtube.com/*',
+        '*://*.youtu.be/*',
+        '*://tournesol.app/*',
+      ],
     });
   });
 
   chrome.contextMenus.onClicked.addListener(function (e, tab) {
-    const videoId = extractVideoId(e.linkUrl)
+    const videoId = extractVideoId(e.linkUrl);
     if (!videoId) {
       alertUseOnLinkToYoutube(tab);
     } else {

--- a/browser-extension/src/browserAction/menu.js
+++ b/browser-extension/src/browserAction/menu.js
@@ -81,7 +81,10 @@ function addToRateLaterAction(event) {
     },
     () => {
       button.disabled = true;
-      button.setAttribute('data-error', 'Not a YouTube video page.');
+      button.setAttribute(
+        'data-error',
+        chrome.i18n.getMessage('alertNotYoutubeVideo')
+      );
     }
   );
 }
@@ -99,7 +102,10 @@ function openAnalysisPageAction(event) {
     },
     () => {
       button.disabled = true;
-      button.setAttribute('data-error', 'Not a YouTube video page.');
+      button.setAttribute(
+        'data-error',
+        chrome.i18n.getMessage('alertNotYoutubeVideo')
+      );
     }
   );
 }

--- a/browser-extension/src/browserAction/menu.js
+++ b/browser-extension/src/browserAction/menu.js
@@ -1,4 +1,4 @@
-import { addRateLater } from '../utils.js';
+import { addRateLater, extractVideoId } from '../utils.js';
 import { frontendUrl } from '../config.js';
 
 const i18n = chrome.i18n;
@@ -7,7 +7,7 @@ function get_current_tab_video_id() {
   function get_tab_video_id(tabs) {
     for (let tab of tabs) {
       // only one tab is returned
-      var video_id = new URL(tab.url).searchParams.get('v');
+      const video_id = extractVideoId(tab.url);
       if (video_id == null || video_id === '') {
         return Promise.reject(new Error('not a video id'));
       }

--- a/browser-extension/src/rateLaterHistory.js
+++ b/browser-extension/src/rateLaterHistory.js
@@ -280,8 +280,7 @@ const forEachVisibleVideoId = (callback) => {
   previews.forEach((preview) => {
     const title = preview.querySelector('#video-title');
     const href = title.getAttribute('href');
-    const params = new URLSearchParams(href.replace(/.*\?/, ''));
-    const videoId = params.get('v');
+    const videoId = new URL(href).searchParams.get('v');
     if (videoId) callback(videoId);
   });
 };

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -284,3 +284,23 @@ export const getSingleSetting = async (
 
   return settings.body?.[scope]?.[name] ?? default_;
 };
+
+export function extractVideoId(url) {
+  const protocol = /(?:https?:\/\/)?/;
+  const subdomain = /(?:www\.|m\.)?/;
+  const youtubeWatchUrl = /(?:youtube\.com\/(?:watch\?v=|live\/|v\/|shorts\/))/;
+  const youtubeShortUrl = /(?:youtu\.be\/)/;
+  const tournesolEntityUrl = /(?:[.\w]+\/entities\/)/;
+
+  const videoId = /([A-Za-z0-9-_]{11})/;
+  const videoIdOrUid = new RegExp(`(?:yt:)?${videoId.source}`);
+
+  const matchUrl = url.match(
+    new RegExp(
+      `^${protocol.source}${subdomain.source}` +
+        `(?:${youtubeWatchUrl.source}|${youtubeShortUrl.source}|${tournesolEntityUrl.source})?` +
+        `${videoIdOrUid.source}`
+    )
+  );
+  return matchUrl ? matchUrl[1] : null;
+}

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -33,7 +33,7 @@ export const alertOnCurrentTab = async (msg, tab) => {
 };
 
 export const alertUseOnLinkToYoutube = (tab) => {
-  alertOnCurrentTab('This must be used on a link to a youtube video', tab);
+  alertOnCurrentTab(chrome.i18n.getMessage('alertNotYoutubeVideo'), tab);
 };
 
 export const fetchTournesolApi = async (path, options = {}) => {
@@ -74,18 +74,18 @@ export const addRateLater = async (video_id) => {
   if (ratingStatusReponse && ratingStatusReponse.ok) {
     return {
       success: true,
-      message: 'Done!',
+      message: chrome.i18n.getMessage('alertVideoAdded'),
     };
   }
   if (ratingStatusReponse && ratingStatusReponse.status === 409) {
     return {
       success: true,
-      message: 'Already added.',
+      message: chrome.i18n.getMessage('alertAlreadyAdded'),
     };
   }
   return {
     success: false,
-    message: 'Failed.',
+    message: chrome.i18n.getMessage('alertFailed'),
   };
 };
 
@@ -298,7 +298,7 @@ export function extractVideoId(url) {
   const matchUrl = url.match(
     new RegExp(
       `^${protocol.source}${subdomain.source}` +
-        `(?:${youtubeWatchUrl.source}|${youtubeShortUrl.source}|${tournesolEntityUrl.source})?` +
+        `(?:${youtubeWatchUrl.source}|${youtubeShortUrl.source}|${tournesolEntityUrl.source})` +
         `${videoIdOrUid.source}`
     )
   );


### PR DESCRIPTION
### Description

Following #2071, a similar issue exists in the browser extension. 
The implementation of `extractVideoId()` is derived from the frontend.

This PR also add translations for errors and messages related to these actions.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass



[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
