### PR TITLE
[ext] fix: remove unnecessary delay to render recommendations when YouTube history is disabled

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/displayHomeRecommendations.js
+++ b/browser-extension/src/displayHomeRecommendations.js
@@ -1,13 +1,20 @@
 const getYoutubeVideosPerRow = () => {
-  const youtubeThumbnail = document.querySelector(
+  let youtubeThumbnailReference = document.querySelector(
     '#primary #contents > ytd-rich-item-renderer.ytd-rich-grid-renderer'
   );
-  if (!youtubeThumbnail) {
-    return undefined;
+  if (!youtubeThumbnailReference) {
+    // When Youtube personal history is disabled, no thumbnail will be visible
+    // on the homepage. Let's use the "nudge" banner as the reference instead.
+    youtubeThumbnailReference = document.querySelector(
+      'ytd-feed-nudge-renderer'
+    );
+    if (!youtubeThumbnailReference) {
+      return undefined;
+    }
   }
 
   const itemsPerRowCssValue = window
-    .getComputedStyle(youtubeThumbnail)
+    .getComputedStyle(youtubeThumbnailReference)
     .getPropertyValue('--ytd-rich-grid-items-per-row');
   if (!itemsPerRowCssValue) {
     return undefined;


### PR DESCRIPTION
### Description

A small fix, following #2073 .

cc @sigmike @GresilleSiffle 

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
