### PR TITLE
[front] chore: upgrade notistack to v3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "i18next-http-backend": "^2.1.1",
     "linkify-string": "^4.1",
     "linkifyjs": "^4.1",
-    "notistack": "^2.0.3",
+    "notistack": "^3.0.2",
     "plausible-tracker": "^0.3.8",
     "precompress": "7.0.1",
     "react": "^17.0.2",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -69,6 +69,10 @@ html.embedded .notistack-SnackbarContainer.belowTopBar {
   .notistack-SnackbarContainer.belowTopBar {
     width: auto;
   }
+
+  .notistack-SnackbarContainer.belowTopBar .notistack-Snackbar {
+    min-width: unset;
+  }
 }
 
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -54,19 +54,19 @@ code {
 /* -- start: third-party packages customization -- */
 
 /* pkg: notistack */
-.SnackbarContainer-root.belowTopBar {
+.notistack-SnackbarContainer.belowTopBar {
   /* Display alerts below the top bar, to avoid hiding buttons. This value
      should be greater or equal to the top bar height. */
   top: 62px;
 }
-html.embedded .SnackbarContainer-root.belowTopBar {
+html.embedded .notistack-SnackbarContainer.belowTopBar {
   /* When the site is embedded in the browser extension iframe, we move the
      snackbar into the empty page title bar in order to avoid shadowing any
      page content. */
   top: 4px;
 }
 @media (max-width: 600px) {
-  .SnackbarContainer-root.belowTopBar {
+  .notistack-SnackbarContainer.belowTopBar {
     width: auto;
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3079,6 +3079,11 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.0.33:
+  version "2.1.16"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.16.tgz#7d548eb9b83ff0988d102be71f271ca8f9c82a95"
+  integrity sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==
+
 gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
@@ -4085,13 +4090,13 @@ normalize-path@3.0.0, normalize-path@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-notistack@^2.0.3:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/notistack/-/notistack-2.0.8.tgz#78cdf34c64e311bf1d1d71c2123396bcdea5e95b"
-  integrity sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==
+notistack@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-3.0.2.tgz#009799c3fccddeffac58565ba1657d27616dfabd"
+  integrity sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==
   dependencies:
     clsx "^1.1.0"
-    hoist-non-react-statics "^3.3.0"
+    goober "^2.0.33"
 
 now-and-later@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Description

This branch upgrade the front end package `notistack` to v3, as required by the recent upgrade of Material UI to version 6.

This is still warning when running `yarn install`

> warning "notistack > goober@2.1.16" has unmet peer dependency "csstype@^3.0.10".

It seems to be a problem known since 2023:
- https://github.com/iamhosseindhv/notistack/issues/561
- https://github.com/iamhosseindhv/notistack/pull/562

Nevertheless the package `csstype` is required by other packages, and correctly installed.   

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
