### PR TITLE
chore: Upgrade Node.js from v18 to v22

### DIFF
--- a/.github/workflows/browser-extension-ci.yml
+++ b/.github/workflows/browser-extension-ci.yml
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '22'
       - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/.github/workflows/browser-extension-release.yml
+++ b/.github/workflows/browser-extension-release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Check extension version in the manifest
         run: |      

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Prepare extension
         working-directory: browser-extension
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - uses: cypress-io/github-action@v6
         with:
@@ -61,7 +61,7 @@ jobs:
       - name: Print dev-env logs
         if: failure()
         working-directory: ./dev-env
-        run: docker-compose logs -t --tail=300
+        run: docker compose logs -t --tail=300
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '22'
       - run: yarn install --frozen-lockfile
       - run: ./scripts/generate-services-from-openapi.sh
       - run: yarn test

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.3"
-   
 services:
   db:
     container_name: tournesol-dev-db
@@ -48,7 +46,7 @@ services:
         condition: service_healthy
 
   front:
-    image: node:18.20-bullseye-slim
+    image: node:22-bullseye-slim
     container_name: tournesol-dev-front
     working_dir: /frontend
     entrypoint: bash -c

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,7 +13,7 @@ This setup assumes that an API server is already configured.
 URLs and credentials can be configured in [.env.development](./.env.development).
 
 Requirements:
- * Node.js 18
+ * Node.js 22
  * yarn
 
 Setup:

--- a/frontend/i18next-parser.config.js
+++ b/frontend/i18next-parser.config.js
@@ -1,4 +1,4 @@
-import packageJson from "./package.json" assert { type: 'json' };
+import packageJson from "./package.json" with { type: 'json' };
 
 const SUPPORTED_LANGUAGES = packageJson.config.supported_languages;
 

--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -33,7 +33,7 @@ all:
             datasource_prometheus_uid: tRVp1rVIk
 
           nvm_version: "v0.38.0"
-          npm_lts_version: "hydrogen"  # codename for Node.js 18 (LTS)
+          npm_lts_version: "jod"  # codename for Node.js 22 (LTS)
           frontend_scheme: http
           frontend_csp_connect_src: https://noembed.com
           frontend_csp_frame_ancestors: "https://www.youtube.com moz-extension: chrome-extension:"
@@ -100,7 +100,7 @@ all:
             datasource_prometheus_uid: tRVp1rVIk
 
           nvm_version: "v0.38.0"
-          npm_lts_version: "hydrogen"  # codename for Node.js 18 (LTS)
+          npm_lts_version: "jod"  # codename for Node.js 22 (LTS)
           frontend_scheme: https
           frontend_csp_connect_src: https://noembed.com
           frontend_csp_frame_ancestors: "https://www.youtube.com moz-extension: chrome-extension:"
@@ -178,7 +178,7 @@ all:
             datasource_prometheus_uid: EjLpRC4Sk
 
           nvm_version: "v0.38.0"
-          npm_lts_version: "hydrogen"  # codename for Node.js 18 (LTS)
+          npm_lts_version: "jod"  # codename for Node.js 22 (LTS)
           frontend_scheme: https
           frontend_csp_connect_src: https://noembed.com
           frontend_csp_frame_ancestors: "https://www.youtube.com moz-extension: chrome-extension:"

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ An end-to-end tests suite, based on [Cypress](https://www.cypress.io/), for the 
 ## Requirements
 
 * A local instance of Tournesol, as provided by [dev-env](../dev-env/README.md), initialized with the default database only.
-* Node.js 18
+* Node.js 22
 
 ### Install the dependencies
 


### PR DESCRIPTION
### Description

Node.js 18 reached end-of-life on 2025-04-30. It's time to migrate to the most recent LTS.
See https://github.com/nodejs/release?tab=readme-ov-file#release-schedule

No significant change to report.
No compatibility issue detected in dependencies, except a small syntax change in "frontend/i18next-parser.config.js".

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
