### PR TITLE
[solidago] resolve logger warnings

### DIFF
--- a/solidago/experiments/synthetic.py
+++ b/solidago/experiments/synthetic.py
@@ -176,10 +176,10 @@ def run_from_hyperparameters_file(filename):
 
 
 if len(sys.argv) == 1:
-    logger.warn("Please specify the hyperparameters of the pipeline experiments in a json file.")
-    logger.warn("The file must specify n_users, n_entities, n_seeds, x_parameter, x_values,")
-    logger.warn("z_parameter, z_values. See `experiments/hyperparameters.json` for an example.")
-    logger.warn("You may then add the filename of the json hyperparameters file.")
+    logger.warning("Please specify the hyperparameters of the pipeline experiments in a json file.")
+    logger.warning("The file must specify n_users, n_entities, n_seeds, x_parameter, x_values,")
+    logger.warning("z_parameter, z_values. See `experiments/hyperparameters.json` for an example.")
+    logger.warning("You may then add the filename of the json hyperparameters file.")
 
 elif sys.argv[1] == "plot":
     from plot import plot_file


### PR DESCRIPTION
### Description

This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```


### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
