### PR TITLE
[front] chore: prepare upgrade of react-router-dom

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Switch, Redirect, useLocation } from 'react-router-dom';
+import { Switch, Redirect, useLocation, Route } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { i18n as i18nInterface } from 'i18next';
 
@@ -17,6 +17,7 @@ import Frame from './features/frame/Frame';
 import { StatsLazyProvider } from './features/statistics/StatsContext';
 import PublicRoute from './features/login/PublicRoute';
 import PrivateRoute from './features/login/PrivateRoute';
+import PublicRouteWrapper from './features/login/PublicRouteWrapper';
 
 import ActionsPage from './pages/actions/ActionsPage';
 import ForgotPassword from './pages/login/ForgotPassword';
@@ -87,44 +88,88 @@ function App() {
         <ScrollToTop />
         <Frame>
           <Switch>
-            <PublicRoute path="/actions">
-              <ActionsPage />
-            </PublicRoute>
-            <PublicRoute path="/action">
-              {/*
-                https://tournesol.app/action is the URL mentionned
-                in "La Dictature des Algorithmes" (page 318)
-              */}
-              <Redirect to="/actions" />
-            </PublicRoute>
-            <PublicRoute path="/faq">
-              <FAQ />
-            </PublicRoute>
-            <PublicRoute path="/events">
-              <AllEvents />
-            </PublicRoute>
-            <PublicRoute path="/live">
-              <TournesolLivePage />
-            </PublicRoute>
-            <PublicRoute path="/talks">
-              <TournesolTalksPage />
-            </PublicRoute>
+            <Route
+              path="/actions"
+              render={() => (
+                <PublicRouteWrapper>
+                  <ActionsPage />
+                </PublicRouteWrapper>
+              )}
+            />
+            <Route path="/action" render={() => <Redirect to="/actions" />} />
+            <Route
+              path="/faq"
+              render={() => (
+                <PublicRouteWrapper>
+                  <FAQ />
+                </PublicRouteWrapper>
+              )}
+            />
+            <Route
+              path="/events"
+              render={() => (
+                <PublicRouteWrapper>
+                  <AllEvents />
+                </PublicRouteWrapper>
+              )}
+            />
+            <Route
+              path="/live"
+              render={() => (
+                <PublicRouteWrapper>
+                  <TournesolLivePage />
+                </PublicRouteWrapper>
+              )}
+            />
+            <Route
+              path="/talks"
+              render={() => (
+                <PublicRouteWrapper>
+                  <TournesolTalksPage />
+                </PublicRouteWrapper>
+              )}
+            />
             {/* About routes */}
-            <PublicRoute path="/about/terms-of-service">
-              <TermsOfService />
-            </PublicRoute>
-            <PublicRoute path="/about/privacy_policy">
-              <PrivacyPolicy />
-            </PublicRoute>
-            <PublicRoute path="/about/trusted_domains">
-              <TrustedDomains />
-            </PublicRoute>
-            <PublicRoute path="/about/donate">
-              <DonatePage />
-            </PublicRoute>
-            <PublicRoute path="/about">
-              <About />
-            </PublicRoute>
+            <Route
+              path="/about/terms-of-service"
+              render={() => (
+                <PublicRouteWrapper>
+                  <TermsOfService />
+                </PublicRouteWrapper>
+              )}
+            />
+            <Route
+              path="/about/privacy_policy"
+              render={() => (
+                <PublicRouteWrapper>
+                  <PrivacyPolicy />
+                </PublicRouteWrapper>
+              )}
+            />
+            <Route
+              path="/about/trusted_domains"
+              render={() => (
+                <PublicRouteWrapper>
+                  <TrustedDomains />
+                </PublicRouteWrapper>
+              )}
+            />
+            <Route
+              path="/about/donate"
+              render={() => (
+                <PublicRouteWrapper>
+                  <DonatePage />
+                </PublicRouteWrapper>
+              )}
+            />
+            <Route
+              path="/about"
+              render={() => (
+                <PublicRouteWrapper>
+                  <About />
+                </PublicRouteWrapper>
+              )}
+            />
             {/* LEGAGY route used for retro-compatibility */}
             <PublicRoute path="/video/:video_id">
               <VideoAnalysisPage />

--- a/frontend/src/features/login/PublicRouteWrapper.tsx
+++ b/frontend/src/features/login/PublicRouteWrapper.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+
+import { useAppSelector, useAppDispatch } from 'src/app/hooks';
+import { selectLogin, getTokenFromRefreshAsync } from './loginSlice';
+import { isLoggedIn } from './loginUtils';
+import { LoginState } from './LoginState.model';
+
+const PublicRouteWrapper = ({ children }: { children: React.ReactNode }) => {
+  const login: LoginState = useAppSelector(selectLogin);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const should_refresh =
+      !isLoggedIn(login) ||
+      !login.access_token_expiration_date ||
+      // the token should be refreshed if it expires in less than 10 minutes
+      new Date(login.access_token_expiration_date) <
+        new Date(new Date().getTime() + 600000);
+
+    if (login.status !== 'loading' && login.refresh_token && should_refresh) {
+      console.log('token invalid but refresh token present, trying to refresh');
+      dispatch(getTokenFromRefreshAsync(login.refresh_token));
+    }
+  }, [login, dispatch]);
+
+  return <>{children}</>;
+};
+
+export default PublicRouteWrapper;


### PR DESCRIPTION
### Description

The upgrade of React from version 17 to 18 also requires upgrading several dependencies. I'm starting with `react-router-dom`. I'm not sure the our current version of `react-router-dom` is incompatible with React 18, but its version looks old enough to upgrade it.

This branch is a refactor to prepare the upgrade of `react-router-dom` from v5 to v6. If later we upgrade React to 18, we will be able to also upgrade `react-router-dom` to version 7.


### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
