### PR TITLE
 [back] fix: handle missing duration in YouTube metadata, add more logs 

### DIFF
--- a/backend/tournesol/tests/test_api_video.py
+++ b/backend/tournesol/tests/test_api_video.py
@@ -206,10 +206,10 @@ class VideoApi(TestCase):
         self.assertEqual(video.metadata["duration"], 1263)
 
     @patch("tournesol.utils.api_youtube.get_youtube_video_details")
-    def test_authenticated_can_create_with_yt_no_statistics(self, mock_youtube):
+    def test_authenticated_can_create_with_yt_fields_missing(self, mock_youtube):
         """
         An authenticated user can add a new video, even if the YouTube API
-        does not return its statistics.
+        does not return its statistics or its duration.
         """
         mock_youtube.return_value = {
             "items": [
@@ -219,7 +219,6 @@ class VideoApi(TestCase):
                         "contentRating": {},
                         "definition": "hd",
                         "dimension": "2d",
-                        "duration": "PT21M3S",
                         "licensedContent": True,
                         "projection": "rectangular",
                     },
@@ -265,6 +264,7 @@ class VideoApi(TestCase):
         video = Entity.get_from_video_id(video_id=new_video_id)
         self.assertEqual(response.json()["name"], "Entity title")
         self.assertEqual(video.metadata["views"], None)
+        self.assertEqual(video.metadata["duration"], None)
 
     @patch("tournesol.utils.api_youtube.get_youtube_video_details")
     def test_authenticated_cant_create_with_yt_no_result(self, mock_youtube):

--- a/backend/tournesol/utils/api_youtube.py
+++ b/backend/tournesol/utils/api_youtube.py
@@ -83,7 +83,7 @@ def get_video_metadata(video_id, compute_language=True):
         logger.warning("Video duration not found in metadata: %s", yt_info)
         duration = None
     else:
-        duration = parse_duration(yt_info["contentDetails"]["duration"])
+        duration = parse_duration(raw_duration)
 
     return {
         "source": "youtube",

--- a/backend/tournesol/utils/api_youtube.py
+++ b/backend/tournesol/utils/api_youtube.py
@@ -71,7 +71,6 @@ def get_video_metadata(video_id, compute_language=True):
     # we could truncate description to spare some space
     description = str(yt_info["snippet"]["description"])
     uploader = yt_info["snippet"]["channelTitle"]
-    channel_id = yt_info["snippet"]["channelId"]
     if compute_language:
         language = compute_video_language(uploader, title, description)
     else:
@@ -86,7 +85,6 @@ def get_video_metadata(video_id, compute_language=True):
     else:
         duration = parse_duration(yt_info["contentDetails"]["duration"])
 
-    is_unlisted = yt_info["status"].get("privacyStatus") == "unlisted"
     return {
         "source": "youtube",
         "name": title,
@@ -94,9 +92,9 @@ def get_video_metadata(video_id, compute_language=True):
         "publication_date": published_date,
         "views": nb_views,
         "uploader": uploader,
-        "channel_id": channel_id,
+        "channel_id": yt_info["snippet"]["channelId"],
         "language": language,
         "tags": tags,
         "duration": int(duration.total_seconds()) if duration else None,
-        "is_unlisted": is_unlisted,
+        "is_unlisted": yt_info["status"].get("privacyStatus") == "unlisted",
     }


### PR DESCRIPTION
### Description

Server errors occurred recently when a video has no "duration" field in the YouTube response.

This PR handles this case, and add more logs about requests to YouTube API.

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
