### PR TITLE
[infra] fix frontend handlers being run unnecessarily during deploy

### DIFF
--- a/infra/ansible/roles/frontend/handlers/main.yml
+++ b/infra/ansible/roles/frontend/handlers/main.yml
@@ -18,26 +18,26 @@
   become: yes
   become_user: react
 
+- name: Yarn build
+  shell:
+    cmd: . ~/.nvm/nvm.sh && NVM_DIR=/home/react/.nvm nvm use lts/{{npm_lts_version}} && yarn build
+    chdir: /home/react/tournesol-frontend
+  become: yes
+  become_user: react
+
 - name: Check assetlinks.json
   stat:
-    path: "/home/react/tournesol-frontend/public/.well-known/assetlinks.{{ domain_name }}.json"
+    path: "/home/react/tournesol-frontend/build/.well-known/assetlinks.{{ domain_name }}.json"
   register: assetlinks_file
   become: yes
   become_user: react
 
 - name: Copy assetlinks.json
   file:
-    src: "/home/react/tournesol-frontend/public/.well-known/assetlinks.{{ domain_name }}.json"
-    dest: /home/react/tournesol-frontend/public/.well-known/assetlinks.json
+    src: "/home/react/tournesol-frontend/build/.well-known/assetlinks.{{ domain_name }}.json"
+    dest: /home/react/tournesol-frontend/build/.well-known/assetlinks.json
     state: hard
   when: assetlinks_file.stat.exists
-  become: yes
-  become_user: react
-
-- name: Yarn build
-  shell:
-    cmd: . ~/.nvm/nvm.sh && NVM_DIR=/home/react/.nvm nvm use lts/{{npm_lts_version}} && yarn build
-    chdir: /home/react/tournesol-frontend
   become: yes
   become_user: react
 


### PR DESCRIPTION
### Description

Adding an extra file in `/home/react/tournesol-frontend/public/` causes the next ansible run to detect changes and to all frontend handlers unnecessarily. This is especially confusing as this extra file typically exists on production only, and shows a different deployment result and notifications between staging and prod.

This PR suggests to create the extra file in "/home/react/tournesol-frontend/build" directly, as this folder is already ignored by the task "Copy React application repository".

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
