### PR TITLE
dev-env: update db content and add option `--videos-limit` to init devenv with a subset of videos

### DIFF
--- a/backend/tournesol/management/commands/load_public_dataset.py
+++ b/backend/tournesol/management/commands/load_public_dataset.py
@@ -24,9 +24,10 @@ class Command(BaseCommand):
     help = "Generate a new database for dev purposes, derived from the public dataset"
 
     def add_arguments(self, parser):
-        parser.add_argument("--user-sampling", type=float, default=None)
-        parser.add_argument("--videos-limit", type=int, default=None)
         parser.add_argument("--dataset-url", type=str, default=PUBLIC_DATASET_URL)
+        samping_group = parser.add_mutually_exclusive_group()
+        samping_group.add_argument("--user-sampling", type=float, default=None)
+        samping_group.add_argument("--videos-limit", type=int, default=None)
 
     def create_user(self, username: str, ml_input: TournesolDataset):
         user = ml_input.users.loc[ml_input.users.public_username == username].iloc[0]

--- a/backend/tournesol/management/commands/load_public_dataset.py
+++ b/backend/tournesol/management/commands/load_public_dataset.py
@@ -1,6 +1,4 @@
 import concurrent.futures
-import itertools
-import random
 from concurrent.futures import ThreadPoolExecutor
 
 import pandas as pd
@@ -70,16 +68,27 @@ class Command(BaseCommand):
 
     @staticmethod
     def apply_videos_limit(limit: int, comparisons: pd.DataFrame):
-        counts_a = comparisons.drop_duplicates(subset=["entity_a", "public_username"], keep="first", inplace=False).entity_a.value_counts().rename("count_a")
-        counts_b = comparisons.drop_duplicates(subset=["entity_b", "public_username"], keep="first", inplace=False).entity_b.value_counts().rename("count_b")
+        counts_a = (
+            comparisons.drop_duplicates(
+                subset=["entity_a", "public_username"], keep="first", inplace=False
+            )
+            .entity_a.value_counts()
+            .rename("count_a")
+        )
+        counts_b = (
+            comparisons.drop_duplicates(
+                subset=["entity_b", "public_username"], keep="first", inplace=False
+            )
+            .entity_b.value_counts()
+            .rename("count_b")
+        )
         counts_combined = pd.concat([counts_a, counts_b], axis=1).fillna(0)
         counts_combined["total_count"] = counts_combined.count_a + counts_combined.count_b
         videos_to_keep = set(
             counts_combined.sort_values(by="total_count", ascending=False).index[:limit]
         )
         comparisons = comparisons[
-            comparisons.entity_a.isin(videos_to_keep) & 
-            comparisons.entity_b.isin(videos_to_keep)
+            comparisons.entity_a.isin(videos_to_keep) & comparisons.entity_b.isin(videos_to_keep)
         ]
         usernames_to_keep = comparisons.public_username.unique()
         print(

--- a/backend/tournesol/management/commands/load_public_dataset.py
+++ b/backend/tournesol/management/commands/load_public_dataset.py
@@ -25,9 +25,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--dataset-url", type=str, default=PUBLIC_DATASET_URL)
-        samping_group = parser.add_mutually_exclusive_group()
-        samping_group.add_argument("--user-sampling", type=float, default=None)
-        samping_group.add_argument("--videos-limit", type=int, default=None)
+        sampling_group = parser.add_mutually_exclusive_group()
+        sampling_group.add_argument("--user-sampling", type=float, default=None)
+        sampling_group.add_argument("--videos-limit", type=int, default=None)
 
     def create_user(self, username: str, ml_input: TournesolDataset):
         user = ml_input.users.loc[ml_input.users.public_username == username].iloc[0]

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: tournesol-dev-db
-    image: ${DB_IMAGE:-ghcr.io/tournesol-app/postgres-dev-env:2025-07-10}
+    image: ${DB_IMAGE:-ghcr.io/tournesol-app/postgres-dev-env:2025-07-12}
     user: ${DB_UID}:${DB_GID}
     volumes:
       - ./db-data:/var/lib/postgresql/data

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: tournesol-dev-db
-    image: ${DB_IMAGE:-ghcr.io/tournesol-app/postgres-dev-env:2023-10-27}
+    image: ${DB_IMAGE:-ghcr.io/tournesol-app/postgres-dev-env:2025-07-10}
     user: ${DB_UID}:${DB_GID}
     volumes:
       - ./db-data:/var/lib/postgresql/data

--- a/dev-env/dump-db.sh
+++ b/dev-env/dump-db.sh
@@ -10,7 +10,13 @@ set -x
 DUMP_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 DUMP_FILE="./db/dump_$DUMP_DATE.sql.gz"
 
-docker exec tournesol-dev-db bash -c "pg_dump -U tournesol -d tournesol --exclude-table-data 'django_admin_log' --exclude-table-data 'django_session' --exclude-table-data 'oauth2*' | gzip > /tmp/dump.sql.gz"
+docker exec tournesol-dev-db bash -c "
+    pg_dump -U tournesol -d tournesol \
+    --exclude-table-data 'default_cache_table' \
+    --exclude-table-data 'django_admin_log' \
+    --exclude-table-data 'django_session' \
+    --exclude-table-data 'oauth2*' \
+    | gzip > /tmp/dump.sql.gz"
 
 docker cp tournesol-dev-db:/tmp/dump.sql.gz "$DUMP_FILE"
 

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -154,7 +154,7 @@ Commands:
   WARNING: if a Youtube API key has been configured, a large amount of queries
   to the API may be required to fetch metadata about all videos.
     ./run-docker-compose.sh download
-    ./run-docker-compose.sh download --videos-limit 10000
+    ./run-docker-compose.sh download --videos-limit 8000
 
   restart
   Restart all dev_env services using the existing database and containers.

--- a/dev-env/run-docker-compose.sh
+++ b/dev-env/run-docker-compose.sh
@@ -154,7 +154,7 @@ Commands:
   WARNING: if a Youtube API key has been configured, a large amount of queries
   to the API may be required to fetch metadata about all videos.
     ./run-docker-compose.sh download
-    ./run-docker-compose.sh download --user-sampling 0.1
+    ./run-docker-compose.sh download --videos-limit 10000
 
   restart
   Restart all dev_env services using the existing database and containers.

--- a/tests/cypress/e2e/frontend/comparisonPage.cy.ts
+++ b/tests/cypress/e2e/frontend/comparisonPage.cy.ts
@@ -195,8 +195,8 @@ describe('Comparison page', () => {
         pasteInVideoInput('aaaabbbbccccdddd');
         cy.contains('0 results for "aaaabbbbccccdddd"');
 
-        pasteInVideoInput('charrue');
-        cy.contains('1 result for "charrue"');
+        pasteInVideoInput('charrue moloch');
+        cy.contains('1 result for "charrue moloch"');
 
         cy.get('button[aria-label="Close search"]').click()
         cy.contains('charrue', {matchCase: false})
@@ -214,11 +214,11 @@ describe('Comparison page', () => {
 
         cy.get("[data-testid=entity-select-button-compact]").first().click();
 
-        pasteInVideoInput('charrue');
-        cy.contains('1 result for "charrue"');
+        pasteInVideoInput('charrue moloch');
+        cy.contains('1 result for "charrue moloch"');
         cy.contains('De la charrue', {matchCase: false}).click();
 
-        cy.contains('1 result for "charrue"')
+        cy.contains('1 result for "charrue moloch"')
           .should('not.exist');
         cy.get('button[aria-label="Close search"]')
           .should('not.exist');

--- a/tests/cypress/e2e/frontend/feedTopItemsPage.cy.ts
+++ b/tests/cypress/e2e/frontend/feedTopItemsPage.cy.ts
@@ -92,7 +92,6 @@ describe('Page - Top items', () => {
           cy.get('input[type=checkbox][name="Year"]').should('be.checked');
           cy.get('input[type=checkbox][name=Month]').should('not.be.checked');
           cy.location('search').should('contain', 'date=Year');
-          cy.contains('No item matches your search filters.', {matchCase: false}).should('be.visible');
         });
 
         it('shows no videos for 1 day ago', () => {

--- a/tests/cypress/e2e/frontend/myRatedVideosPage.cy.ts
+++ b/tests/cypress/e2e/frontend/myRatedVideosPage.cy.ts
@@ -127,7 +127,7 @@ describe('My rated elements page', () => {
           expect(loc.search).to.eq('?orderBy=-n_comparisons')
         });
 
-        cy.contains('29 comparisons by you').should('be.visible');
+        cy.contains(/2\d comparisons by you/).should('be.visible');
       });
 
       it('the ratings can be order by video specific metadata fields', () => {

--- a/tests/cypress/e2e/frontend/recommendationsPage.cy.ts
+++ b/tests/cypress/e2e/frontend/recommendationsPage.cy.ts
@@ -69,7 +69,6 @@ describe('Recommendations page', () => {
           cy.contains('A month ago', {matchCase: false}).click();
           cy.get('input[type=checkbox][name=Month]').should('be.checked');
           cy.get('input[type=checkbox][name=""]').should('not.be.checked');
-          cy.contains('No item matches your search filters.', {matchCase: false}).should('be.visible');
         });
 
         it('allows to filter: a year ago', () => {

--- a/tests/cypress/e2e/frontend/resetPassword.cy.ts
+++ b/tests/cypress/e2e/frontend/resetPassword.cy.ts
@@ -1,9 +1,9 @@
 describe('Password reset', () => {
   beforeEach(() => {
-    cy.recreateUser("username-pwreset", "test@example.com", "forgottenPassword");
+    cy.recreateUser("username-pwreset", "test-pwreset@example.test", "forgottenPassword");
   });
 
-  ["username-pwreset", "test@example.com"].forEach(login => {
+  ["username-pwreset", "test-pwreset@example.test"].forEach(login => {
     it(`can reset password for ${login}`, () => {
       cy.visit('/login');
       cy.contains('Forgot').click();

--- a/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
+++ b/tests/cypress/e2e/frontend/settingsPreferencesPage.cy.ts
@@ -245,10 +245,18 @@ describe('Settings - preferences page', () => {
           cy.contains('A day ago').click();
           cy.contains('Update preferences').click();
 
+          cy.intercept('http://localhost:8000/users/me/settings/')
+            .as('settingsRetrievedFromAPI');
+
           cy.visit('/feed/foryou');
+          cy.wait('@settingsRetrievedFromAPI')
+            .its('response.body')
+            .should(settings => {
+              expect(settings["videos"]["feed_foryou__date"]).equals("TODAY")
+            });
           cy.contains(
             "There doesn't seem to be anything to display at the moment.",
-            {matchCase: false}
+            { matchCase: false }
           ).should('be.visible');
         });
 
@@ -260,11 +268,15 @@ describe('Settings - preferences page', () => {
           cy.contains('A week ago').click();
           cy.contains('Update preferences').click();
 
+          cy.intercept('http://localhost:8000/users/me/settings/')
+            .as('settingsRetrievedFromAPI');
+
           cy.visit('/feed/foryou');
-          cy.contains(
-            "There doesn't seem to be anything to display at the moment.",
-            {matchCase: false}
-          ).should('be.visible');
+          cy.wait('@settingsRetrievedFromAPI')
+            .its('response.body')
+            .should(settings => {
+              expect(settings["videos"]["feed_foryou__date"]).equals("WEEK")
+            });
         });
 
         it('handles the value A month ago', () => {
@@ -275,12 +287,6 @@ describe('Settings - preferences page', () => {
           cy.get(
             '[data-testid=videos_feed_foryou__date]'
           ).should('have.value', 'MONTH');
-
-          cy.visit('/feed/foryou');
-          cy.contains(
-            "There doesn't seem to be anything to display at the moment.",
-            {matchCase: false}
-          ).should('be.visible');
         });
 
         it('handles the value A year ago', () => {
@@ -291,11 +297,15 @@ describe('Settings - preferences page', () => {
           cy.contains('A year ago').click();
           cy.contains('Update preferences').click();
 
+          cy.intercept('http://localhost:8000/users/me/settings/')
+            .as('settingsRetrievedFromAPI');
+
           cy.visit('/feed/foryou');
-          cy.contains(
-            "There doesn't seem to be anything to display at the moment.",
-            {matchCase: false}
-          ).should('not.exist');
+          cy.wait('@settingsRetrievedFromAPI')
+            .its('response.body')
+            .should(settings => {
+              expect(settings["videos"]["feed_foryou__date"]).equals("YEAR")
+            });
         });
 
         it('handles the value All time', () => {
@@ -309,7 +319,7 @@ describe('Settings - preferences page', () => {
           cy.visit('/feed/foryou');
           cy.contains(
             "There doesn't seem to be anything to display at the moment.",
-            {matchCase: false}
+            { matchCase: false }
           ).should('not.exist');
         });
       });
@@ -333,7 +343,7 @@ describe('Settings - preferences page', () => {
 
           cy.contains(
             "The score of this video is below the recommendability threshold defined by Tournesol.",
-            {matchCase: false}
+            { matchCase: false }
           ).should('not.exist');
         });
 
@@ -353,7 +363,7 @@ describe('Settings - preferences page', () => {
 
           cy.contains(
             "The score of this video is below the recommendability threshold defined by Tournesol.",
-            {matchCase: false}
+            { matchCase: false }
           ).should('be.visible');
         });
       });
@@ -405,7 +415,7 @@ describe('Settings - preferences page', () => {
                 .should('eq', videoTitle);
             });
 
-            cy.deleteUser('test_exclude_false');
+          cy.deleteUser('test_exclude_false');
         });
 
         it('handles the value true (exclude)', () => {
@@ -453,7 +463,7 @@ describe('Settings - preferences page', () => {
                 .first()
                 .invoke('attr', 'title')
                 .should('not.eq', videoTitle);
-          });
+            });
 
           cy.deleteUser('test_exclude_true');
         });


### PR DESCRIPTION
### Description

With `./run-docker-compose.sh download --videos-limit 10000` a subset of users will be selected until the limit is reached, to stay below the default quota of YouTube API keys (10000 video metadata requests per day).

A new database image `ghcr.io/tournesol-app/postgres-dev-env:2025-07-10` has been created with this option and is uploaded to the docker registry to be used by default by the dev-env.

@lfaucon There is one caveat with this approach: the numbers of selected users is relatively low (~400 with the current public dataset). The 5 `SEED_USERS` bring more than 8000 videos already.
As a consequence, the most recent videos are compared by a small number of videos and there is no video in the last month reaching the recommendability threshold.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
