### PR TITLE
[ext] feat: add videos stats on YouTube watch page

### DIFF
--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -222,7 +222,7 @@
     "description": "Label of the button to stop the YouTube history import process."
   },
   "videoNotRatedMessage": {
-    "message": "This video hasn't been rated on Tournesol yet. Be the first to compare it!",
+    "message": "This video is not rated on Tournesol yet. Be the first to compare it!",
     "description": "Message shown when a video has no ratings on Tournesol."
   }
 }

--- a/browser-extension/src/_locales/en/messages.json
+++ b/browser-extension/src/_locales/en/messages.json
@@ -220,5 +220,9 @@
   "rateLaterHistoryStopButtonLabel": {
     "message": "Stop",
     "description": "Label of the button to stop the YouTube history import process."
+  },
+  "videoNotRatedMessage": {
+    "message": "This video hasn't been rated on Tournesol yet. Be the first to compare it!",
+    "description": "Message shown when a video has no ratings on Tournesol."
   }
 }

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -218,5 +218,9 @@
   "rateLaterHistoryStopButtonLabel": {
     "message": "Stop",
     "description": "Texte du bouton permettant d'arrêter le processus d'import de l'historique YouTube."
+  },
+  "videoNotRatedMessage": {
+    "message": "Cette vidéo n'a pas encore été notée sur Tournesol. Soyez le premier à la comparer !",
+    "description": "Message affiché lorsqu'une vidéo n'a pas encore de note sur Tournesol."
   }
 }

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -220,7 +220,7 @@
     "description": "Texte du bouton permettant d'arrêter le processus d'import de l'historique YouTube."
   },
   "videoNotRatedMessage": {
-    "message": "Cette vidéo n'a pas encore été notée sur Tournesol. Soyez la première personne à la comparer !",
+    "message": "Cette vidéo n'est pas encore notée sur Tournesol. Soyez la première personne à la comparer !",
     "description": "Message affiché lorsqu'une vidéo n'a pas encore de note sur Tournesol."
   }
 }

--- a/browser-extension/src/_locales/fr/messages.json
+++ b/browser-extension/src/_locales/fr/messages.json
@@ -220,7 +220,7 @@
     "description": "Texte du bouton permettant d'arrêter le processus d'import de l'historique YouTube."
   },
   "videoNotRatedMessage": {
-    "message": "Cette vidéo n'a pas encore été notée sur Tournesol. Soyez le premier à la comparer !",
+    "message": "Cette vidéo n'a pas encore été notée sur Tournesol. Soyez la première personne à la comparer !",
     "description": "Message affiché lorsqu'une vidéo n'a pas encore de note sur Tournesol."
   }
 }

--- a/browser-extension/src/addVideoButtons.css
+++ b/browser-extension/src/addVideoButtons.css
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: row;
   gap: 8px;
+  margin-left: auto;
 }
 
 button.tournesol-video-button {

--- a/browser-extension/src/addVideoButtons.css
+++ b/browser-extension/src/addVideoButtons.css
@@ -2,10 +2,17 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
   gap: 8px;
 
   margin-top: 12px;
+}
+
+.ts-video-actions-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
 }
 
 button.tournesol-video-button {

--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -39,11 +39,16 @@ const createVideoActionsRow = () => {
   const videoActions = document.createElement('div');
   videoActions.id = TS_ACTIONS_ROW_ID;
 
+  // Create a container for the buttons
+  const buttonsGroup = document.createElement('div');
+  buttonsGroup.className = 'ts-video-actions-buttons';
+  videoActions.appendChild(buttonsGroup);
+
   const beforeRef = document.getElementById(TS_ACTIONS_ROW_BEFORE_REF);
   const parent = document.getElementById(beforeRef.parentElement.id);
 
   parent.insertBefore(videoActions, beforeRef);
-  return videoActions;
+  return { videoActions, buttonsGroup };
 };
 
 function createVideoActionsRowParent() {
@@ -74,7 +79,13 @@ function addVideoButtons() {
     }
 
     window.clearInterval(timer);
-    const videoActions = createVideoActionsRow();
+    const { videoActions, buttonsGroup } = createVideoActionsRow();
+
+    // Move statistics info to the left of the container if it exists
+    const statsInfo = document.getElementById('tournesol-statistics-info');
+    if (statsInfo) {
+      videoActions.insertBefore(statsInfo, videoActions.firstChild);
+    }
 
     const addVideoButton = ({ id, label, iconSrc, iconClass, onClick }) => {
       // Create Button
@@ -103,7 +114,8 @@ function addVideoButtons() {
       };
 
       button.onclick = onClick;
-      videoActions.appendChild(button);
+      // Instead of appending to videoActions, append to buttonsGroup
+      buttonsGroup.appendChild(button);
 
       return { button, setLabel, setIcon };
     };

--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -9,19 +9,8 @@ import { frontendUrl } from './config.js';
 const TS_ACTIONS_ROW_ID = 'ts-video-actions-row';
 const TS_ACTIONS_ROW_BEFORE_REF = 'bottom-row';
 
-/**
- * Youtube doesnt completely load a video page, so content script doesn't
- * launch correctly without these events.
- *
- * This part is called on connection for the first time on youtube.com/*
- */
+// Refresh buttons at the end of YT page transition
 document.addEventListener('yt-navigate-finish', addVideoButtons);
-
-if (document.body) {
-  addVideoButtons();
-} else {
-  document.addEventListener('DOMContentLoaded', addVideoButtons);
-}
 
 /**
  * The Tournesol video actions row contains the video actions related to the

--- a/browser-extension/src/addVideoButtons.js
+++ b/browser-extension/src/addVideoButtons.js
@@ -68,10 +68,10 @@ function addVideoButtons() {
     }
 
     window.clearInterval(timer);
+    const statsInfo = document.getElementById('tournesol-statistics-info');
     const { videoActions, buttonsGroup } = createVideoActionsRow();
 
     // Move statistics info to the left of the container if it exists
-    const statsInfo = document.getElementById('tournesol-statistics-info');
     if (statsInfo) {
       videoActions.insertBefore(statsInfo, videoActions.firstChild);
     }

--- a/browser-extension/src/addVideoStatistics.css
+++ b/browser-extension/src/addVideoStatistics.css
@@ -17,8 +17,6 @@
   align-items: center;
   margin-right: 8px;
   font-size: 28px;
-  font-weight: bold;
-  color: #ffc800;
 }
 
 .tournesol-statistics-icon {

--- a/browser-extension/src/addVideoStatistics.css
+++ b/browser-extension/src/addVideoStatistics.css
@@ -1,13 +1,56 @@
-button#tournesol-details-button {
-  background: transparent;
-  border: none;
-  border-radius: 2px;
-  cursor: pointer;
+.tournesol-statistics-info {
+  display: flex;
+  align-items: center;
+  margin-left: 16px;
   font-family: 'Roboto', 'Noto', sans-serif;
-  color: #f3bd00;
-  margin-left: 8px;
-  display: inline-block;
-  vertical-align: middle;
-  text-transform: uppercase;
+  font-size: 18px;
+  color: #ffc800;
   font-weight: 500;
+  background: transparent;
+  border-radius: 18px;
+  padding: 0 8px;
+  white-space: nowrap;
+}
+
+.tournesol-statistics-score {
+  display: flex;
+  align-items: center;
+  margin-right: 8px;
+  font-size: 28px;
+  font-weight: bold;
+  color: #ffc800;
+}
+
+.tournesol-statistics-icon {
+  width: 28px;
+  height: 28px;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+.tournesol-statistics-comparisons,
+.tournesol-statistics-contributors {
+  margin-right: 8px;
+  font-size: 18px;
+  color: #ffc800;
+  font-weight: 500;
+}
+
+@media (max-width: 990px) {
+  .tournesol-statistics-info {
+    margin-left: 6px;
+    font-size: 16px;
+  }
+  .tournesol-statistics-score,
+  .tournesol-statistics-comparisons,
+  .tournesol-statistics-contributors {
+    margin-right: 6px;
+    font-size: 16px;
+    font-weight: 500;
+  }
+  .tournesol-statistics-icon {
+    width: 20px;
+    height: 20px;
+    margin-right: 6px;
+  }
 }

--- a/browser-extension/src/addVideoStatistics.css
+++ b/browser-extension/src/addVideoStatistics.css
@@ -29,9 +29,6 @@
 .tournesol-statistics-comparisons,
 .tournesol-statistics-contributors {
   margin-right: 8px;
-  font-size: 18px;
-  color: #ffc800;
-  font-weight: 500;
 }
 
 @media (max-width: 990px) {

--- a/browser-extension/src/addVideoStatistics.css
+++ b/browser-extension/src/addVideoStatistics.css
@@ -1,15 +1,14 @@
 .tournesol-statistics-info {
   display: flex;
   align-items: center;
-  margin-left: 16px;
   font-family: 'Roboto', 'Noto', sans-serif;
-  font-size: 18px;
-  color: #ffc800;
-  font-weight: 500;
-  background: transparent;
-  border-radius: 18px;
+  font-size: 16px;
   padding: 0 8px;
   white-space: nowrap;
+  border-radius: 12px;
+  background-color: #f3bd0020;
+  color: var(--yt-spec-text-primary);
+  min-height: 36px;
 }
 
 .tournesol-statistics-score {
@@ -30,6 +29,9 @@
 .tournesol-statistics-contributors {
   margin-right: 8px;
 }
+.unsafe{
+  filter: grayscale(100%);
+}
 
 @media (max-width: 990px) {
   .tournesol-statistics-info {
@@ -40,8 +42,6 @@
   .tournesol-statistics-comparisons,
   .tournesol-statistics-contributors {
     margin-right: 6px;
-    font-size: 16px;
-    font-weight: 500;
   }
   .tournesol-statistics-icon {
     width: 20px;

--- a/browser-extension/src/addVideoStatistics.css
+++ b/browser-extension/src/addVideoStatistics.css
@@ -32,20 +32,3 @@
 .unsafe{
   filter: grayscale(100%);
 }
-
-@media (max-width: 990px) {
-  .tournesol-statistics-info {
-    margin-left: 6px;
-    font-size: 16px;
-  }
-  .tournesol-statistics-score,
-  .tournesol-statistics-comparisons,
-  .tournesol-statistics-contributors {
-    margin-right: 6px;
-  }
-  .tournesol-statistics-icon {
-    width: 20px;
-    height: 20px;
-    margin-right: 6px;
-  }
-}

--- a/browser-extension/src/addVideoStatistics.css
+++ b/browser-extension/src/addVideoStatistics.css
@@ -4,17 +4,19 @@
   font-family: 'Roboto', 'Noto', sans-serif;
   font-size: 16px;
   padding: 0 8px;
-  white-space: nowrap;
   border-radius: 12px;
   background-color: #f3bd0020;
-  color: var(--yt-spec-text-primary);
+  color: var(--yt-spec-text-secondary);
   min-height: 36px;
+}
+
+.tournesol-statistics-info span {
+  color: var(--yt-spec-text-primary);
 }
 
 .tournesol-statistics-score {
   display: flex;
   align-items: center;
-  margin-right: 8px;
   font-size: 28px;
 }
 

--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -96,14 +96,14 @@ function addVideoStatistics() {
         comparisonsSpan.className = 'tournesol-statistics-comparisons';
         comparisonsSpan.textContent = chrome.i18n.getMessage(
           'comparisonsBy',
-          details.n_contributors
+          details.n_comparisons
         );
 
         const contributorsSpan = document.createElement('span');
         contributorsSpan.className = 'tournesol-statistics-contributors';
         contributorsSpan.textContent = chrome.i18n.getMessage(
           'comparisonsContributors',
-          details.n_comparisons
+          details.n_contributors
         );
 
         infoElem.appendChild(sunflowerImg);

--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -39,35 +39,30 @@ function addVideoStatistics() {
     const actionsRow = document.getElementById(TS_ACTIONS_ROW_ID);
     if (!actionsRow) return;
 
+    const existingInfo = document.getElementById('tournesol-statistics-info');
+    if (existingInfo) {
+      existingInfo.remove();
+    }
+
     if (videoStatsResponse == null) {
       return;
     }
 
     window.clearInterval(timer);
 
-    if (document.getElementById('tournesol-statistics-info')) {
-      return;
-    }
-
     const infoElem = document.createElement('span');
     infoElem.setAttribute('id', 'tournesol-statistics-info');
     infoElem.className = 'tournesol-statistics-info';
 
-    if (
-      videoStatsResponse &&
-      videoStatsResponse.body
-    ) {
+    if (videoStatsResponse && videoStatsResponse.body) {
       const details = videoStatsResponse.body.collective_rating;
       if (details?.tournesol_score == null) {
-        infoElem.textContent = chrome.i18n.getMessage(
-          'videoNotRatedMessage'
-        );
+        infoElem.textContent = chrome.i18n.getMessage('videoNotRatedMessage');
       } else {
         // Show sunflower icon, score, comparisons, contributors
         const tournesolScore = document.createElement('span');
         tournesolScore.className = 'tournesol-statistics-score';
-        tournesolScore.textContent =
-          details.tournesol_score.toFixed(0);
+        tournesolScore.textContent = details.tournesol_score.toFixed(0);
 
         const dotSpan = document.createElement('span');
         dotSpan.classList.add('dot');
@@ -83,16 +78,15 @@ function addVideoStatistics() {
         }
         const comparisonsSpan = document.createElement('span');
         comparisonsSpan.className = 'tournesol-statistics-comparisons';
-        comparisonsSpan.textContent = chrome.i18n.getMessage(
-          'comparisonsBy',
-          details.n_comparisons
-        );
+        comparisonsSpan.textContent = chrome.i18n.getMessage('comparisonsBy', [
+          details.n_comparisons,
+        ]);
 
         const contributorsSpan = document.createElement('span');
         contributorsSpan.className = 'tournesol-statistics-contributors';
         contributorsSpan.textContent = chrome.i18n.getMessage(
           'comparisonsContributors',
-          details.n_contributors
+          [details.n_contributors]
         );
 
         infoElem.appendChild(sunflowerImg);

--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -50,15 +50,15 @@ function addVideoStatistics() {
     const actionsRow = document.getElementById(TS_ACTIONS_ROW_ID);
     if (!actionsRow) return;
 
-    if (document.getElementById('tournesol-statistics-info')) {
-      window.clearInterval(timer);
+    if (videoStatsResponse == null) {
       return;
     }
 
     window.clearInterval(timer);
-    
-    const prev = document.getElementById('tournesol-statistics-info');
-    if (prev) prev.remove();
+
+    if (document.getElementById('tournesol-statistics-info')) {
+      return;
+    }
 
     const infoElem = document.createElement('span');
     infoElem.setAttribute('id', 'tournesol-statistics-info');

--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -71,7 +71,7 @@ function addVideoStatistics() {
       const details = videoStatsResponse.body.collective_rating;
       if (details?.tournesol_score == null) {
         infoElem.textContent = chrome.i18n.getMessage(
-          'tournesolNotRatedMessage'
+          'videoNotRatedMessage'
         );
       } else {
         // Show sunflower icon, score, comparisons, contributors

--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -66,7 +66,7 @@ function addVideoStatistics() {
           resp.body.results.length === 1
         ) {
           const details = resp.body.results[0];
-          if (details.tournesol_score == 0) {
+          if (details.collective_rating?.tournesol_score == null) {
             infoElem.textContent = chrome.i18n.getMessage(
               'tournesolNotRatedMessage'
             );

--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -24,8 +24,8 @@ if (document.body) {
 }
 
 /*
-* Create the statistics container with the tournesol score, comparisons and contributors.
-*/
+ * Create the statistics container with the tournesol score, comparisons and contributors.
+ */
 function addVideoStatistics() {
   const videoId = new URL(location.href).searchParams.get('v');
   if (!location.pathname.startsWith('/watch') || !videoId) return;
@@ -59,15 +59,23 @@ function addVideoStatistics() {
         infoElem.setAttribute('id', 'tournesol-statistics-info');
         infoElem.className = 'tournesol-statistics-info';
 
-        if (resp && resp.body && resp.body.results && resp.body.results.length === 1) {
+        if (
+          resp &&
+          resp.body &&
+          resp.body.results &&
+          resp.body.results.length === 1
+        ) {
           const details = resp.body.results[0];
           if (details.tournesol_score == 0) {
-            infoElem.textContent = chrome.i18n.getMessage('tournesolNotRatedMessage');
+            infoElem.textContent = chrome.i18n.getMessage(
+              'tournesolNotRatedMessage'
+            );
           } else {
             // Show sunflower icon, score, comparisons, contributors
             const scoreSpan = document.createElement('span');
             scoreSpan.className = 'tournesol-statistics-score';
-            scoreSpan.textContent = details.collective_rating.tournesol_score.toFixed(0);
+            scoreSpan.textContent =
+              details.collective_rating.tournesol_score.toFixed(0);
 
             const sunflowerImg = document.createElement('img');
             sunflowerImg.src = `${frontendUrl}/svg/tournesol.svg`;
@@ -77,11 +85,17 @@ function addVideoStatistics() {
 
             const comparisonsSpan = document.createElement('span');
             comparisonsSpan.className = 'tournesol-statistics-comparisons';
-            comparisonsSpan.textContent = chrome.i18n.getMessage('comparisonsBy', details.collective_rating.n_contributors);
+            comparisonsSpan.textContent = chrome.i18n.getMessage(
+              'comparisonsBy',
+              details.collective_rating.n_contributors
+            );
 
             const contributorsSpan = document.createElement('span');
             contributorsSpan.className = 'tournesol-statistics-contributors';
-            contributorsSpan.textContent = chrome.i18n.getMessage('comparisonsContributors', details.collective_rating.n_comparisons);
+            contributorsSpan.textContent = chrome.i18n.getMessage(
+              'comparisonsContributors',
+              details.collective_rating.n_comparisons
+            );
 
             infoElem.appendChild(scoreSpan);
             infoElem.appendChild(comparisonsSpan);
@@ -89,10 +103,9 @@ function addVideoStatistics() {
           }
         } else {
           infoElem.textContent = chrome.i18n.getMessage('videoNotRatedMessage');
-        } 
+        }
         actionsRow.insertBefore(infoElem, actionsRow.firstChild);
       }
     );
   }
 }
-

--- a/browser-extension/src/addVideoStatistics.js
+++ b/browser-extension/src/addVideoStatistics.js
@@ -9,19 +9,8 @@ import { frontendUrl } from './config.js';
 const TS_ACTIONS_ROW_ID = 'ts-video-actions-row';
 var browser = browser || chrome;
 
-/**
- * Youtube doesnt completely load a video page, so content script doesn't
- * launch correctly without these events.
- *
- * This part is called on connection for the first time on youtube.com/*
- */
+// Refresh stats at the end of YT page transition
 document.addEventListener('yt-navigate-finish', addVideoStatistics);
-
-if (document.body) {
-  addVideoStatistics();
-} else {
-  document.addEventListener('DOMContentLoaded', addVideoStatistics);
-}
 
 /*
  * Create the statistics container with the tournesol score, comparisons and contributors.

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -10,6 +10,7 @@ import {
   getUserProof,
   getRecommendationsLanguagesAuthenticated,
   getSingleSetting,
+  getVideoStatistics,
 } from './utils.js';
 
 import { frontendHost } from './config.js';
@@ -145,7 +146,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 
   if (request.message == 'getVideoStatistics') {
-    // getVideoStatistics(request.video_id).then(sendResponse);
+    getVideoStatistics(request.video_id).then(sendResponse);
     return true;
   }
 

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -163,7 +163,9 @@ export const getRandomSubarray = (arr, size) => {
 
 export const getVideoStatistics = async (videoId) => {
   // videos/?videos=V6x9bXTU0vY
-  const videoStatistics = await fetchTournesolApi(`polls/videos/recommendations/?search=${videoId}`);
+  const videoStatistics = await fetchTournesolApi(
+    `polls/videos/recommendations/?search=${videoId}`
+  );
   if (videoStatistics.status === 200) {
     const responseJson = await videoStatistics.json();
 
@@ -176,7 +178,6 @@ export const getVideoStatistics = async (videoId) => {
 
   return { success: false };
 };
-
 
 const getObjectFromLocalStorage = async (key, default_ = null) => {
   return new Promise((resolve, reject) => {

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -161,9 +161,22 @@ export const getRandomSubarray = (arr, size) => {
   return shuffled.slice(0, size);
 };
 
-export const getVideoStatistics = (videoId) => {
-  return fetchTournesolApi(`videos/?video_id=${videoId}`);
+export const getVideoStatistics = async (videoId) => {
+  // videos/?videos=V6x9bXTU0vY
+  const videoStatistics = await fetchTournesolApi(`polls/videos/recommendations/?search=${videoId}`);
+  if (videoStatistics.status === 200) {
+    const responseJson = await videoStatistics.json();
+
+    return {
+      success: videoStatistics.ok,
+      status: videoStatistics.status,
+      body: responseJson,
+    };
+  }
+
+  return { success: false };
 };
+
 
 const getObjectFromLocalStorage = async (key, default_ = null) => {
   return new Promise((resolve, reject) => {

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -164,7 +164,7 @@ export const getRandomSubarray = (arr, size) => {
 export const getVideoStatistics = async (videoId) => {
   // videos/?videos=V6x9bXTU0vY
   const videoStatistics = await fetchTournesolApi(
-    `polls/videos/recommendations/?search=${videoId}`
+    `polls/videos/entities/yt:${videoId}`
   );
   if (videoStatistics.status === 200) {
     const responseJson = await videoStatistics.json();


### PR DESCRIPTION
**[extension] feat: Add information about the videos in youtube** #1599

---

### Description
With this call: `polls/videos/recommendations/?search=${videoId}`. 
I get information about the video (tournesol score and comparaison by contributors). For the front, I move the buttons into a separate container and then create a statistics container.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass