### PR TITLE
[ext] fix search suggestions displayed below tournesol container

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -26,7 +26,15 @@
     var(--ytd-rich-grid-items-per-row) *
       (var(--ytd-rich-grid-item-max-width) + var(--ytd-rich-grid-item-margin))
   );
-  z-index: 2020;
+}
+
+#header[hidden]+#tournesol_container {
+  /*
+  When YT history is disabled (and categories "header" is hidden),
+  in some cases (e.g when going back to the homepage from a watch page)
+  the container would be truncated without this extra margin.
+  */
+  margin-top: 56px;
 }
 
 /**


### PR DESCRIPTION
### Description

My fix in #2121 caused another bug related to YouTube search suggestions. I should have avoided messing with z-index values :face_with_diagonal_mouth:  


### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
