### PR TITLE
[infra] chore: remove obsolete "buster" repository

### DIFF
--- a/infra/ansible/roles/monitoring/tasks/main.yml
+++ b/infra/ansible/roles/monitoring/tasks/main.yml
@@ -24,17 +24,10 @@
     install_recommends: no
     update_cache: yes
 
-- name: Add Buster repository
+- name: Remove Buster repository
   apt_repository:
     repo: "deb {{buster_mirror}} buster main"
-    state: present
-
-- name: Install GeoIP database extra from Buster
-  apt:
-    name:
-      - geoip-database-extra
-    install_recommends: no
-    update_cache: yes
+    state: absent
 
 - name: Copy Nginx log format
   copy:


### PR DESCRIPTION
### Description

The "buster" repo is no longer available and had to be disabled manually on the servers. This PR makes sure it's removed properly and not reinstalled on future deployments.

The "buster" repo was used only to install package `geoip-database-extra`, not necessary anymore as we are using Plausible for analytics.


### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
