### PR TITLE
[front] remove duplicated icons from EntityCard

### DIFF
--- a/frontend/src/pages/videos/VideoAnalysisPage.tsx
+++ b/frontend/src/pages/videos/VideoAnalysisPage.tsx
@@ -11,11 +11,10 @@ import CriteriaScoresDistribution from 'src/features/charts/CriteriaScoresDistri
 import EntityContextBox from 'src/features/entity_context/EntityContextBox';
 import ContextualRecommendations from 'src/features/recommendation/ContextualRecommendations';
 import EntityCard from 'src/components/entity/EntityCard';
-import { useLoginState, useScrollToLocation } from 'src/hooks';
+import { useScrollToLocation } from 'src/hooks';
 import { ContributorRating, Recommendation } from 'src/services/openapi';
 import { SelectedCriterionProvider } from 'src/hooks/useSelectedCriterion';
 import PersonalScoreCheckbox from 'src/components/PersonalScoreCheckbox';
-import { CompareNowAction, AddToRateLaterList } from 'src/utils/action';
 import linkifyStr from 'linkify-string';
 import VideoAnalysisActionBar from './VideoAnalysisActionBar';
 import useContributorRating from 'src/hooks/useContributorRating';
@@ -27,7 +26,6 @@ export const VideoAnalysis = ({
 }) => {
   const { t } = useTranslation();
   const [descriptionCollapsed, setDescriptionCollapsed] = useState(false);
-  const actions = useLoginState() ? [CompareNowAction, AddToRateLaterList] : [];
   useScrollToLocation();
 
   const { contributorRating, loadContributorRating } = useContributorRating();
@@ -84,7 +82,6 @@ export const VideoAnalysis = ({
           <Grid2 size={12}>
             <EntityCard
               result={video}
-              actions={actions}
               displayImage={false}
               showEntitySeenIndicator={true}
             />


### PR DESCRIPTION
**related issues**
None, it felt faster to open a PR than an issue (few lines of diff). Don't hesitate to decline without explanation if you see fit.

---

### Description
`Add` and `Compare` icons are duplicated in 2 locations, next to one another (cf. img 1)
I suggest removing one of them.
It liberate some (small) vertical space on mobile (cf. img 2 vs 3)

| Duplicated icons | Before | After |
|--------|--------|--------|
| <img width="1017" height="734" alt="duplicate" src="https://github.com/user-attachments/assets/326f4198-09fc-4df8-ba2c-f36618bf0c13" /> | <img width="1044" height="2114" alt="iPhone-14-Plus-localhost (2)" src="https://github.com/user-attachments/assets/3b85b915-f364-4bc3-90ec-ce5a29209a5c" /> | <img width="1044" height="2114" alt="iPhone-14-Plus-localhost (1)" src="https://github.com/user-attachments/assets/8851ced3-d33c-4b76-a24d-00819a8caef6" /> |

### Details
`Add` and `Compare` icons are currently present in:
- `ActionBar` (4 buttons) in `VideoAnalysis` component.
- `EntityCard` right below in `VideoAnalysis` component.

Of the two, I removed the ones in EntityCard here.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines

### Tests
<img width="1293" height="88" alt="Screenshot 2026-04-21 at 20-10-03 Workflow runs · venturqx_tournesol" src="https://github.com/user-attachments/assets/d4cfb628-b359-4770-a01f-f9f2dda09e96" />
