### PR TITLE
[ext] fix: update obsolete CSS selector preventing import of YT history

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/rateLaterHistory.js
+++ b/browser-extension/src/rateLaterHistory.js
@@ -1,9 +1,9 @@
 const RATE_LATER_BULK_MAX_SIZE = 20;
 
-// These selectors can change regularly on YT, and become obsolete.
-// We need to check their validity from time to time.
+// /!\ These selectors can change regularly on YT, and become obsolete.
+// /!\ We need to check their validity from time to time.
 const YT_VIDEO_CARD_TAG = 'ytd-item-section-renderer yt-lockup-view-model';
-const YT_VIDEO_CARD_LINK = 'a.yt-lockup-metadata-view-model__title';
+const YT_VIDEO_CARD_LINK = 'a.ytLockupViewModelContentImage';
 
 const onYoutubeReady = (callback) => {
   /**


### PR DESCRIPTION
### Description

This branch updates the CSS selector used to identify video links in the YouTube history page, and fix the history import feature.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
