### PR TITLE
[ext] fix: update css variable names inherited from YouTube frontend

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -103,8 +103,8 @@
 }
 
 html[dark] #tournesol_banner {
-  color: var(--yt-spec-text-primary);
-  background-color: var(--yt-spec-button-chip-background-hover);
+  color: var(--yt-sys-color-baseline--text-primary);
+  background-color: var(--yt-sys-color-baseline--button-chip-background-hover);
 }
 
 html[dark] #tournesol_banner_close_icon {
@@ -120,14 +120,14 @@ html[dark] #tournesol_banner_close_icon {
 }
 
 #tournesol_title {
-  color: var(--yt-spec-text-primary);
+  color: var(--yt-sys-color-baseline--text-primary);
   font-family: 'Roboto', 'Arial', sans-serif;
   font-size: 22px;
   font-weight: normal;
 }
 
 #tournesol_link {
-  color: var(--yt-spec-text-secondary);
+  color: var(--yt-sys-color-baseline--text-secondary);
   font-family: 'Roboto', 'Arial', sans-serif;
   font-size: 12px;
   margin-right: auto;
@@ -150,11 +150,11 @@ html[dark] #tournesol_banner_close_icon {
 }
 
 .video_channel_link {
-  color: var(--yt-spec-text-secondary);
+  color: var(--yt-sys-color-baseline--text-secondary);
 }
 
 .video_channel_link:hover {
-  color: var(--yt-spec-text-primary);
+  color: var(--yt-sys-color-baseline--text-primary);
 }
 
 .tournesol_score_logo {
@@ -265,12 +265,11 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
 
 .video_thumb {
   width: 100%;
-  background: green;
   border-radius: 12px;
 }
 
 .video_title {
-  color: var(--yt-spec-text-primary);
+  color: var(--yt-sys-color-baseline--text-primary);
   margin-bottom: 6px;
   font-family: 'Roboto', 'Arial', sans-serif;
   letter-spacing: var(--yt-link-letter-spacing, normal);
@@ -313,7 +312,7 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
 
 .video_text,
 .video_criteria {
-  color: var(--yt-endpoint-color, var(--yt-spec-text-secondary));
+  color: var(--yt-endpoint-color, var(--yt-sys-color-baseline--text-secondary));
   font-family: 'Roboto', 'Arial', sans-serif;
   word-break: break-word;
   font-size: 1.4rem;
@@ -341,7 +340,7 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
   border-radius: 2px;
 
   color: white;
-  background-color: var(--yt-spec-static-overlay-background-heavy);
+  background-color: var(--yt-sys-color-baseline--overlay-background-heavy);
 
   cursor: pointer;
   font-size: var(--yt-badge-font-size, 1.2rem);
@@ -370,7 +369,7 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
 }
 
 #tournesol_container.search h2 {
-  min-height: auto;
+  min-height: initial;
   font-size: 1.8rem;
 }
 
@@ -378,11 +377,8 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
   width: 32px;
 }
 
-#tournesol_container.search .thumb_div,
-#tournesol_container.search .thumb_div img {
-  width: 100%;
-  min-width: 240px;
-  max-width: 360px;
+#tournesol_container.search .thumb_div {
+  max-width: min(360px, 50%);
   aspect-ratio: 16/9;
   height: 100%;
   margin: 0;
@@ -416,7 +412,7 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
 #tournesol_container.search .video_card .details_div strong {
   font-weight: 400;
   font-size: 2.4em;
-  color: var(--yt-spec-text-primary);
+  color: var(--yt-sys-color-baseline--text-primary);
   margin-right: 8px;
   font-style: normal;
 }

--- a/browser-extension/src/addTournesolRecommendations.css
+++ b/browser-extension/src/addTournesolRecommendations.css
@@ -4,6 +4,9 @@
   --ts-palette-primary-main: #ffc800;
   --ts-palette-primary-main-hover: #b28c00;
   --ts-palette-text-primary: #1d1a14;
+
+  --ts-yt-text-primary: var(--yt-sys-color-baseline--text-primary);
+  --ts-yt-text-secondary: var(--yt-sys-color-baseline--text-secondary);
 }
 
 #tournesol_container {
@@ -103,7 +106,7 @@
 }
 
 html[dark] #tournesol_banner {
-  color: var(--yt-sys-color-baseline--text-primary);
+  color: var(--ts-yt-text-primary);
   background-color: var(--yt-sys-color-baseline--button-chip-background-hover);
 }
 
@@ -120,14 +123,14 @@ html[dark] #tournesol_banner_close_icon {
 }
 
 #tournesol_title {
-  color: var(--yt-sys-color-baseline--text-primary);
+  color: var(--ts-yt-text-primary);
   font-family: 'Roboto', 'Arial', sans-serif;
   font-size: 22px;
   font-weight: normal;
 }
 
 #tournesol_link {
-  color: var(--yt-sys-color-baseline--text-secondary);
+  color: var(--ts-yt-text-secondary);
   font-family: 'Roboto', 'Arial', sans-serif;
   font-size: 12px;
   margin-right: auto;
@@ -150,11 +153,11 @@ html[dark] #tournesol_banner_close_icon {
 }
 
 .video_channel_link {
-  color: var(--yt-sys-color-baseline--text-secondary);
+  color: var(--ts-yt-text-secondary);
 }
 
 .video_channel_link:hover {
-  color: var(--yt-sys-color-baseline--text-primary);
+  color: var(--ts-yt-text-primary);
 }
 
 .tournesol_score_logo {
@@ -269,7 +272,7 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
 }
 
 .video_title {
-  color: var(--yt-sys-color-baseline--text-primary);
+  color: var(--ts-yt-text-primary);
   margin-bottom: 6px;
   font-family: 'Roboto', 'Arial', sans-serif;
   letter-spacing: var(--yt-link-letter-spacing, normal);
@@ -312,7 +315,7 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
 
 .video_text,
 .video_criteria {
-  color: var(--yt-endpoint-color, var(--yt-sys-color-baseline--text-secondary));
+  color: var(--yt-endpoint-color, var(--ts-yt-text-secondary));
   font-family: 'Roboto', 'Arial', sans-serif;
   word-break: break-word;
   font-size: 1.4rem;
@@ -412,7 +415,7 @@ html[darker-dark-theme][dark] .tournesol_simple_button:disabled img {
 #tournesol_container.search .video_card .details_div strong {
   font-weight: 400;
   font-size: 2.4em;
-  color: var(--yt-sys-color-baseline--text-primary);
+  color: var(--ts-yt-text-primary);
   margin-right: 8px;
   font-style: normal;
 }

--- a/browser-extension/src/addVideoStatistics.css
+++ b/browser-extension/src/addVideoStatistics.css
@@ -6,12 +6,12 @@
   padding: 0 8px;
   border-radius: 12px;
   background-color: #f3bd0020;
-  color: var(--yt-spec-text-secondary);
+  color: var(--yt-sys-color-baseline--text-secondary);
   min-height: 36px;
 }
 
 .tournesol-statistics-info span {
-  color: var(--yt-spec-text-primary);
+  color: var(--yt-sys-color-baseline--text-primary);
 }
 
 .tournesol-statistics-score {

--- a/browser-extension/src/addVideoStatistics.css
+++ b/browser-extension/src/addVideoStatistics.css
@@ -6,12 +6,12 @@
   padding: 0 8px;
   border-radius: 12px;
   background-color: #f3bd0020;
-  color: var(--yt-sys-color-baseline--text-secondary);
+  color: var(--ts-yt-text-secondary);
   min-height: 36px;
 }
 
 .tournesol-statistics-info span {
-  color: var(--yt-sys-color-baseline--text-primary);
+  color: var(--ts-yt-text-primary);
 }
 
 .tournesol-statistics-score {


### PR DESCRIPTION
### Description

CSS variables used to adapt the color of texts to the current YouTube theme (light or dark) have changed.
This MR uses the new variables prefixed by `--yt-sys-color-baseline`

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
