### PR TITLE
[front] ui: add password strength meter to help users set a strong passwd

### DIFF
--- a/backend/settings/settings.py
+++ b/backend/settings/settings.py
@@ -230,6 +230,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {
+            "min_length": 9,
+        },
     },
     {
         "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,8 @@
     "recharts": "^2.10.1",
     "redux": "^4.1.2",
     "redux-persist": "^6.0.0",
-    "typescript": "~4.9.5"
+    "typescript": "~4.9.5",
+    "zxcvbn-ts": "^2.2.0"
   },
   "scripts": {
     "start": "vite",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -61,8 +61,8 @@
   },
   "passwordStrengthIndicator": {
     "strength": {
-      "veryWeak": "Weak",
-      "weak": "Very weak",
+      "veryWeak": "Very weak",
+      "weak": "Weak",
       "medium": "Medium",
       "strong": "Strong",
       "veryStrong": "Very strong"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -59,6 +59,16 @@
     "showingCounts_one": "Showing {{firstElementIdx}} - {{lastElementIdx}} of {{count}}",
     "showingCounts_other": "Showing {{firstElementIdx}} - {{lastElementIdx}} of {{count}}"
   },
+  "passwordStrengthIndicator": {
+    "strength": {
+      "veryWeak": "Weak",
+      "weak": "Very weak",
+      "medium": "Medium",
+      "strong": "Strong",
+      "veryStrong": "Very strong"
+    },
+    "passwordStrength": "Password strength"
+  },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {
       "notLoggedIn": "You must be logged in to display personal scores.",
@@ -512,10 +522,10 @@
     "optionalCriteriaEmptyText": "All optional criteria will be displayed by default.",
     "alwaysDisplayedCriteria": "Always displayed criteria",
     "alwaysDisplayedCriteriaEmptyText": "No criteria selected. All optional criteria will be hidden by default.",
-    "includeTournesolResultsInYouTubeSearch": "Include Tournesol recommendations in the YouTube search results.",
-    "whenAVideoIsWatchedOnYouTube": "When a video is watched on YouTube",
     "onVideoWatchedDoNothing": "Do nothing",
     "onVideoWatchedMarkAsWatched": "Mark as watched",
+    "whenAVideoIsWatchedOnYouTube": "When a video is watched on YouTube",
+    "includeTournesolResultsInYouTubeSearch": "Include Tournesol recommendations in the YouTube search results.",
     "preferredLanguage": "Preferred language",
     "autoRemove": "Automatic removal",
     "autoRemoveHelpText_one": "Elements will be removed from your rate-later list after {{value}} comparison.",
@@ -944,11 +954,11 @@
     "compareButton": "Compare now",
     "installTheMobileAppTitle": "Use our app!",
     "installTheMobileAppDescription": "The mobile application is the best way to discover and watch quality videos identified by the Tournesol contributors, right on your phone.",
+    "readOurManifesto": "Read our manifesto",
+    "expandIntro": "Show introduction",
+    "collapseIntro": "Hide introduction",
     "collaborativeContentRecommendations": "Collaborative Content Recommendations",
     "tournesolIsAParticipatoryResearchProject": "Tournesol is a transparent participatory research project about the ethics of algorithms and recommendation systems.",
-    "readOurManifesto": "Read our manifesto",
-    "collapseIntro": "Hide introduction",
-    "expandIntro": "Show introduction",
     "useOurExtension": "Use our extension!",
     "webExtensionDescription": "The browser extension allows you to display videos recommended by the community directly on your YouTube home page. With just a few clicks you can rate any video or add them to your rate-later list.",
     "getTheExtensionButton": "Get the extension",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -63,6 +63,16 @@
     "showingCounts_many": "Éléments {{firstElementIdx}} à {{lastElementIdx}} sur {{count}}",
     "showingCounts_other": "Éléments {{firstElementIdx}} à {{lastElementIdx}} sur {{count}}"
   },
+  "passwordStrengthIndicator": {
+    "strength": {
+      "veryWeak": "Très faible",
+      "weak": "Faible",
+      "medium": "Moyenne",
+      "strong": "Forte",
+      "veryStrong": "Très forte"
+    },
+    "passwordStrength": "Force du mot de passe"
+  },
   "personalCriteriaScores": {
     "reasonWhyItCannotBeActivated": {
       "notLoggedIn": "Vous devez être connecté.e pour afficher les scores personnels.",
@@ -520,10 +530,10 @@
     "optionalCriteriaEmptyText": "Tous les critères optionnels seront affichés par défaut.",
     "alwaysDisplayedCriteria": "Critères toujours affichés",
     "alwaysDisplayedCriteriaEmptyText": "Aucun critère sélectionné. Tous les critères optionnels seront masqués par défaut.",
-    "includeTournesolResultsInYouTubeSearch": "Inclure les recommandations Tournesol dans les résultats de recherche sur YouTube.",
-    "whenAVideoIsWatchedOnYouTube": "Quand une vidéo est regardée sur YouTube",
     "onVideoWatchedDoNothing": "Ne rien faire",
     "onVideoWatchedMarkAsWatched": "Marquer la vidéo comme vue",
+    "whenAVideoIsWatchedOnYouTube": "Quand une vidéo est regardée sur YouTube",
+    "includeTournesolResultsInYouTubeSearch": "Inclure les recommandations Tournesol dans les résultats de recherche sur YouTube.",
     "preferredLanguage": "Langue préférée",
     "autoRemove": "Suppression automatique",
     "autoRemoveHelpText_one": "Les éléments seront supprimés de votre liste à comparer plus tard après {{value}} comparison.",
@@ -953,11 +963,11 @@
     "compareButton": "Commencer à comparer",
     "installTheMobileAppTitle": "Utilisez l'app",
     "installTheMobileAppDescription": "L'application mobile est la meilleure façon d'accéder aux vidéos de qualité identifiées par la communauté directement sur votre smartphone.",
+    "readOurManifesto": "Lire notre manifeste",
+    "expandIntro": "Afficher l'introduction",
+    "collapseIntro": "Masquer l'introduction",
     "collaborativeContentRecommendations": "Recommandations collaboratives de contenus",
     "tournesolIsAParticipatoryResearchProject": "Tournesol est un projet de recherche participatif et transparent sur l'éthique des systèmes de recommandations.",
-    "readOurManifesto": "Lire notre manifeste",
-    "collapseIntro": "Masquer l'introduction",
-    "expandIntro": "Afficher l'introduction",
     "useOurExtension": "Utilisez l'extension !",
     "webExtensionDescription": "L'extension navigateur vous permet de retrouver les vidéos recommandées par la communauté directement sur votre page d'accueil YouTube. Vous pourrez aussi marquer des vidéos pour les comparer plus tard, ou les comparer directement en quelques clics.",
     "getTheExtensionButton": "Installer l'extension",

--- a/frontend/src/components/PasswordStrengthIndicator.tsx
+++ b/frontend/src/components/PasswordStrengthIndicator.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, Chip, Typography } from '@mui/material';
+import zxcvbn from 'zxcvbn-ts';
+
+const PasswordStrengthIndicator = ({ pwd }: { pwd: string }) => {
+  const { t } = useTranslation();
+
+  const result = zxcvbn(pwd);
+
+  const passwordStrengths = [
+    {
+      score: 0,
+      label: t('passwordStrengthIndicator.strength.veryWeak'),
+      color: 'error',
+    },
+    {
+      score: 1,
+      label: t('passwordStrengthIndicator.strength.weak'),
+      color: 'warning',
+    },
+    {
+      score: 2,
+      label: t('passwordStrengthIndicator.strength.medium'),
+      color: 'info',
+    },
+    {
+      score: 3,
+      label: t('passwordStrengthIndicator.strength.strong'),
+      color: 'success',
+    },
+    {
+      score: 4,
+      label: t('passwordStrengthIndicator.strength.veryStrong'),
+      color: 'success',
+    },
+  ] as const;
+
+  return (
+    <>
+      <Typography gutterBottom>
+        {t('passwordStrengthIndicator.passwordStrength')}
+      </Typography>
+      <Box
+        sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}
+      >
+        {passwordStrengths.map((strength) => (
+          <Chip
+            key={strength.score}
+            size="small"
+            label={strength.label}
+            color={strength.color}
+            disabled={pwd === '' || strength.score != result.score}
+          />
+        ))}
+      </Box>
+    </>
+  );
+};
+
+export default PasswordStrengthIndicator;

--- a/frontend/src/components/PasswordStrengthIndicator.tsx
+++ b/frontend/src/components/PasswordStrengthIndicator.tsx
@@ -58,6 +58,7 @@ const PasswordStrengthIndicator = ({ passwd }: { passwd: string }) => {
               disabled={disabled}
               data-disabled={disabled}
               data-testid={strength.testId}
+              sx={(t) => ({ [t.breakpoints.down('sm')]: { fontSize: '11px' } })}
             />
           );
         })}

--- a/frontend/src/components/PasswordStrengthIndicator.tsx
+++ b/frontend/src/components/PasswordStrengthIndicator.tsx
@@ -13,26 +13,31 @@ const PasswordStrengthIndicator = ({ pwd }: { pwd: string }) => {
       score: 0,
       label: t('passwordStrengthIndicator.strength.veryWeak'),
       color: 'error',
+      testId: 'passwd_str_veryweak',
     },
     {
       score: 1,
       label: t('passwordStrengthIndicator.strength.weak'),
       color: 'warning',
+      testId: 'passwd_str_weak',
     },
     {
       score: 2,
       label: t('passwordStrengthIndicator.strength.medium'),
       color: 'info',
+      testId: 'passwd_str_medium',
     },
     {
       score: 3,
       label: t('passwordStrengthIndicator.strength.strong'),
       color: 'success',
+      testId: 'passwd_str_strong',
     },
     {
       score: 4,
       label: t('passwordStrengthIndicator.strength.veryStrong'),
       color: 'success',
+      testId: 'passwd_str_verystrong',
     },
   ] as const;
 
@@ -41,18 +46,21 @@ const PasswordStrengthIndicator = ({ pwd }: { pwd: string }) => {
       <Typography gutterBottom>
         {t('passwordStrengthIndicator.passwordStrength')}
       </Typography>
-      <Box
-        sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}
-      >
-        {passwordStrengths.map((strength) => (
-          <Chip
-            key={strength.score}
-            size="small"
-            label={strength.label}
-            color={strength.color}
-            disabled={pwd === '' || strength.score != result.score}
-          />
-        ))}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+        {passwordStrengths.map((strength) => {
+          const disabled = pwd === '' || strength.score != result.score;
+          return (
+            <Chip
+              key={strength.score}
+              size="small"
+              label={strength.label}
+              color={strength.color}
+              disabled={disabled}
+              data-disabled={disabled}
+              data-testid={strength.testId}
+            />
+          );
+        })}
       </Box>
     </>
   );

--- a/frontend/src/components/PasswordStrengthIndicator.tsx
+++ b/frontend/src/components/PasswordStrengthIndicator.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { Box, Chip, Typography } from '@mui/material';
 import zxcvbn from 'zxcvbn-ts';
 
-const PasswordStrengthIndicator = ({ pwd }: { pwd: string }) => {
+const PasswordStrengthIndicator = ({ passwd }: { passwd: string }) => {
   const { t } = useTranslation();
 
-  const result = zxcvbn(pwd);
+  const result = zxcvbn(passwd);
 
   const passwordStrengths = [
     {
@@ -48,7 +48,7 @@ const PasswordStrengthIndicator = ({ pwd }: { pwd: string }) => {
       </Typography>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
         {passwordStrengths.map((strength) => {
-          const disabled = pwd === '' || strength.score != result.score;
+          const disabled = passwd === '' || strength.score != result.score;
           return (
             <Chip
               key={strength.score}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -18,6 +18,7 @@ export { default as MenuButton } from './MenuButton';
 export { default as LanguageSelector } from './LanguageSelector';
 export { default as CriteriaIcon } from './CriteriaIcon';
 export { default as TitledPaper } from './TitledPaper';
+export { default as PasswordStrengthIndicator } from './PasswordStrengthIndicator';
 
 export { default as BackIconButton } from './buttons/BackIconButton';
 export { default as PreferencesIconButtonLink } from './buttons/PreferencesIconButtonLink';

--- a/frontend/src/features/settings/account/PasswordForm.spec.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.spec.tsx
@@ -195,4 +195,34 @@ describe('change password feature', () => {
       }
     );
   });
+
+  it('displays password strength indicators', () => {
+    const { password } = setup();
+
+    const strVeryWeak = screen.getByTestId('passwd_str_veryweak');
+    const strWeak = screen.getByTestId('passwd_str_weak');
+    const strMedium = screen.getByTestId('passwd_str_medium');
+    const strStrong = screen.getByTestId('passwd_str_strong');
+    const strVeryStrong = screen.getByTestId('passwd_str_verystrong');
+
+    expect(strVeryWeak).toBeVisible();
+    expect(strWeak).toBeVisible();
+    expect(strMedium).toBeVisible();
+    expect(strStrong).toBeVisible();
+    expect(strVeryStrong).toBeVisible();
+
+    fireEvent.change(password, { target: { value: 'veryweak' } });
+    expect(strVeryWeak.getAttribute('data-disabled')).toBe('false');
+    expect(strWeak.getAttribute('data-disabled')).toBe('true');
+    expect(strMedium.getAttribute('data-disabled')).toBe('true');
+    expect(strStrong.getAttribute('data-disabled')).toBe('true');
+    expect(strVeryStrong.getAttribute('data-disabled')).toBe('true');
+
+    fireEvent.change(password, { target: { value: 'QUITE strong p@$$w0rd!' } });
+    expect(strVeryWeak.getAttribute('data-disabled')).toBe('true');
+    expect(strWeak.getAttribute('data-disabled')).toBe('true');
+    expect(strMedium.getAttribute('data-disabled')).toBe('true');
+    expect(strStrong.getAttribute('data-disabled')).toBe('true');
+    expect(strVeryStrong.getAttribute('data-disabled')).toBe('false');
+  });
 });

--- a/frontend/src/features/settings/account/PasswordForm.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.tsx
@@ -4,9 +4,9 @@ import Button from '@mui/material/Button';
 import Grid2 from '@mui/material/Grid2';
 import TextField from '@mui/material/TextField';
 
+import { PasswordStrengthIndicator } from 'src/components';
 import { AccountsService, ApiError } from 'src/services/openapi';
 import { useNotifications } from 'src/hooks';
-import PasswordRecommendationAlert from 'src/components/PasswordStrengthIndicator';
 
 const PasswordForm = () => {
   const { t } = useTranslation();
@@ -123,7 +123,7 @@ const PasswordForm = () => {
           />
         </Grid2>
         <Grid2>
-          <PasswordRecommendationAlert pwd={password} />
+          <PasswordStrengthIndicator pwd={password} />
         </Grid2>
         <Grid2>
           <Button

--- a/frontend/src/features/settings/account/PasswordForm.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.tsx
@@ -123,7 +123,7 @@ const PasswordForm = () => {
           />
         </Grid2>
         <Grid2>
-          <PasswordStrengthIndicator pwd={password} />
+          <PasswordStrengthIndicator passwd={password} />
         </Grid2>
         <Grid2>
           <Button

--- a/frontend/src/features/settings/account/PasswordForm.tsx
+++ b/frontend/src/features/settings/account/PasswordForm.tsx
@@ -6,6 +6,7 @@ import TextField from '@mui/material/TextField';
 
 import { AccountsService, ApiError } from 'src/services/openapi';
 import { useNotifications } from 'src/hooks';
+import PasswordRecommendationAlert from 'src/components/PasswordStrengthIndicator';
 
 const PasswordForm = () => {
   const { t } = useTranslation();
@@ -120,6 +121,9 @@ const PasswordForm = () => {
               htmlInput: { 'data-testid': 'password_confirm' },
             }}
           />
+        </Grid2>
+        <Grid2>
+          <PasswordRecommendationAlert pwd={password} />
         </Grid2>
         <Grid2>
           <Button

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -21,6 +21,7 @@ import {
   Lines,
   FormTextField,
   InternalLink,
+  PasswordStrengthIndicator,
 } from 'src/components';
 import NotificationsEmailResearch from 'src/features/settings/preferences/fields/NotificationsEmailResearch';
 import NotificationsEmailNewFeatures from 'src/features/settings/preferences/fields/NotificationsEmailNewFeatures';
@@ -116,6 +117,7 @@ const Signup = () => {
   const [apiError, setApiError] = useState<ApiError | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
+  const [password, setPassword] = useState('');
   const [successEmailAddress, setSuccessEmailAddress] = useState<string | null>(
     null
   );
@@ -217,6 +219,8 @@ const Signup = () => {
                   name="password"
                   label={t('password')}
                   type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
                   autoComplete="new-password"
                   formError={formError}
                 />
@@ -229,6 +233,9 @@ const Signup = () => {
                   autoComplete="new-password"
                   formError={formError}
                 />
+              </Grid2>
+              <Grid2 size={12}>
+                <PasswordStrengthIndicator pwd={password} />
               </Grid2>
               <Grid2
                 sx={{

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -235,7 +235,7 @@ const Signup = () => {
                 />
               </Grid2>
               <Grid2 size={12}>
-                <PasswordStrengthIndicator pwd={password} />
+                <PasswordStrengthIndicator passwd={password} />
               </Grid2>
               <Grid2
                 sx={{

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6094,3 +6094,8 @@ yocto-queue@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
   integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==
+
+zxcvbn-ts@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/zxcvbn-ts/-/zxcvbn-ts-2.2.0.tgz#fcdc5db045f782d58cca30ee896980b40ac15c0f"
+  integrity sha512-MFdDVDDm7WjUkrllWbA5e5S9XWBlz/sSCVVyYAJpYNohD/9RfOKB/De30XRLr7E5PiClbxdjDRKEYXGY8h5/lg==


### PR DESCRIPTION
### Description

Add a password strength meter to invite users to use a strong password. And increase the minimum length from 8 to 9.

To not mix the responsibilities of the API and the front end, only the API can reject a password, while the front end only displays an indication without blocking the submission.

The library used is suggested by: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls

### Preview

(Weak and Very weak are swapped in the image, but not in the code)

<img width="1919" height="874" alt="cap" src="https://github.com/user-attachments/assets/d959fbd9-bc28-4f6a-bfa4-99d79483ea60" />

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
