### PR TITLE
[ext] Mark as watched and rate later

### DIFF
--- a/backend/core/serializers/user_settings.py
+++ b/backend/core/serializers/user_settings.py
@@ -91,6 +91,7 @@ class VideosPollUserSettingsSerializer(GenericPollUserSettingsSerializer):
     ON_VIDEO_WATCHED_CHOICES = [
         ("DO_NOTHING", "do_nothing"),
         ("MARK_AS_WATCHED", "mark_as_watched"),
+        ("MARK_AS_WATCHED_AND_RATE_LATER", "mark_as_watched_and_rate_later"),
     ]
 
     extension__search_reco = serializers.BooleanField(

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/prepareExtension.js
+++ b/browser-extension/prepareExtension.js
@@ -140,6 +140,15 @@ const manifest = {
       run_at: 'document_end',
       all_frames: true,
     },
+    {
+      matches: selectValue(env, {
+        production: ['https://tournesol.app/*'],
+        'dev-env': ['http://localhost/*'],
+      }),
+      js: ['signalExtensionPresence.js'],
+      run_at: 'document_start',
+      all_frames: false,
+    },
   ],
   options_ui: {
     page: 'options/options.html',

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -146,7 +146,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 
   if (request.message == 'addRateLater') {
-    addRateLater(request.video_id).then(sendResponse);
+    addRateLater(request.video_id, request.entitySeen).then(sendResponse);
     return true;
   }
 

--- a/browser-extension/src/detectVideoWatched.js
+++ b/browser-extension/src/detectVideoWatched.js
@@ -17,6 +17,26 @@ const PROGRESS_TICK_MS = 1000;
 // so it can be called on SPA navigation before setting up a new one.
 let cleanupWatchProgressTracking = null;
 
+// What to do when a video has been watched, depending on the user's
+// `extension__on_video_watched` setting. A missing entry (e.g. DO_NOTHING)
+// disables watch progress tracking entirely.
+const onVideoWatchedActions = {
+  MARK_AS_WATCHED: (videoId) => {
+    chrome.runtime.sendMessage({
+      message: 'updateContributorRatingEntitySeen',
+      videoId: videoId,
+      entitySeen: true,
+    });
+  },
+  MARK_AS_WATCHED_AND_RATE_LATER: (videoId) => {
+    chrome.runtime.sendMessage({
+      message: 'addRateLater',
+      video_id: videoId,
+      entitySeen: true,
+    });
+  },
+};
+
 document.addEventListener('yt-navigate-finish', onNavigateFinish);
 
 function onNavigateFinish() {
@@ -36,14 +56,11 @@ function onNavigateFinish() {
     chrome.runtime.sendMessage(
       { message: 'get:setting:extension__on_video_watched' },
       (setting) => {
-        if (setting?.value !== 'MARK_AS_WATCHED') return;
+        const onWatched = onVideoWatchedActions[setting?.value];
+        if (!onWatched) return;
 
         cleanupWatchProgressTracking = startWatchProgressTracking(() => {
-          chrome.runtime.sendMessage({
-            message: 'updateContributorRatingEntitySeen',
-            videoId: videoId,
-            entitySeen: true,
-          });
+          onWatched(videoId);
         });
       }
     );

--- a/browser-extension/src/signalExtensionPresence.js
+++ b/browser-extension/src/signalExtensionPresence.js
@@ -1,0 +1,11 @@
+/**
+ * Signal to the Tournesol frontend that the browser extension is installed.
+ *
+ * The frontend reads this attribute to adapt its UI (see `useIsExtensionInstalled`).
+ * Keep the attribute name in sync with the frontend.
+ */
+
+document.documentElement.setAttribute(
+  'data-tournesol-extension-installed',
+  'true'
+);

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -514,6 +514,7 @@
     "alwaysDisplayedCriteriaEmptyText": "No criteria selected. All optional criteria will be hidden by default.",
     "onVideoWatchedDoNothing": "Do nothing",
     "onVideoWatchedMarkAsWatched": "Mark as watched",
+    "onVideoWatchedMarkAsWatchedAndRateLater": "Mark as watched and rate later",
     "whenAVideoIsWatchedOnYouTube": "When a video is watched on YouTube",
     "includeTournesolResultsInYouTubeSearch": "Include Tournesol recommendations in the YouTube search results.",
     "preferredLanguage": "Preferred language",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -384,8 +384,9 @@
     "videoAdded": "Video added to your Rate Later list!",
     "addVideosToRateLaterList": "Add videos to your rate-later list",
     "addVideosToYourListToCompareThemLater": "Add videos to your list to compare them later.",
-    "useOurBrowserExtension": "We recommend using our <2>browser extension</2> to effortlessly add videos directly from YouTube.",
-    "orCopyPasteVideoUrlHere": "Or copy paste video URLs here.",
+    "addFromYoutube": "Add from YouTube",
+    "installExtensionToAddVideosEasily": "Install our <2>browser extension</2> to add videos to your rate-later list directly from YouTube.",
+    "extensionInstalledChooseOnVideoWatched": "The browser extension is installed. Choose what it should do when you watch a video on YouTube:",
     "listHasNbVideos_one": "Your rate-later list contains <1>{{entityCount}}</1> video. It will be automatically removed after <1>{{rateLaterSetting}}</1> comparison(s).",
     "listHasNbVideos_other": "Your rate-later list contains <1>{{entityCount}}</1> videos. They will be automatically removed after <1>{{rateLaterSetting}}</1> comparison(s)."
   },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -522,6 +522,7 @@
     "alwaysDisplayedCriteriaEmptyText": "Aucun critère sélectionné. Tous les critères optionnels seront masqués par défaut.",
     "onVideoWatchedDoNothing": "Ne rien faire",
     "onVideoWatchedMarkAsWatched": "Marquer la vidéo comme vue",
+    "onVideoWatchedMarkAsWatchedAndRateLater": "Marquer la vidéo comme vue et comparer plus tard",
     "whenAVideoIsWatchedOnYouTube": "Quand une vidéo est regardée sur YouTube",
     "includeTournesolResultsInYouTubeSearch": "Inclure les recommandations Tournesol dans les résultats de recherche sur YouTube.",
     "preferredLanguage": "Langue préférée",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -391,8 +391,9 @@
     "videoAdded": "Vidéo bien ajoutée à votre liste de vidéos à comparer plus tard.",
     "addVideosToRateLaterList": "Ajouter des videos à votre liste",
     "addVideosToYourListToCompareThemLater": "Ajoutez des vidéos à votre liste pour les comparer plus tard.",
-    "useOurBrowserExtension": "Utilisez notre <2>extension navigateur</2> pour ajouter sans effort des vidéos directement depuis YouTube.",
-    "orCopyPasteVideoUrlHere": "Ou copiez collez des URLs de vidéos ici.",
+    "addFromYoutube": "Ajouter depuis YouTube",
+    "installExtensionToAddVideosEasily": "Installez notre <2>extension navigateur</2> pour ajouter des vidéos à votre liste directement depuis YouTube.",
+    "extensionInstalledChooseOnVideoWatched": "L'extension navigateur est installée. Choisissez ce qu'elle doit faire quand vous regardez une vidéo sur YouTube :",
     "listHasNbVideos_one": "Votre liste contient actuellement <1>{{entityCount}}</1> vidéo. Elle sera automatiquement retirée après <1>{{rateLaterSetting}}</1> comparaison(s).",
     "listHasNbVideos_many": "Votre liste contient actuellement <1>{{entityCount}}</1> vidéos. Elles seront automatiquement retirées après <1>{{rateLaterSetting}}</1> comparaison(s).",
     "listHasNbVideos_other": "Votre liste contient actuellement <1>{{entityCount}}</1> vidéos. Elles seront automatiquement retirées après <1>{{rateLaterSetting}}</1> comparaison(s)."

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -3458,10 +3458,12 @@ components:
       enum:
       - DO_NOTHING
       - MARK_AS_WATCHED
+      - MARK_AS_WATCHED_AND_RATE_LATER
       type: string
       description: |-
         * `DO_NOTHING` - do_nothing
         * `MARK_AS_WATCHED` - mark_as_watched
+        * `MARK_AS_WATCHED_AND_RATE_LATER` - mark_as_watched_and_rate_later
     FAQEntry:
       type: object
       description: A translated question with its translated answer.
@@ -4947,6 +4949,7 @@ components:
 
             * `DO_NOTHING` - do_nothing
             * `MARK_AS_WATCHED` - mark_as_watched
+            * `MARK_AS_WATCHED_AND_RATE_LATER` - mark_as_watched_and_rate_later
           oneOf:
           - $ref: '#/components/schemas/Extension_onVideoWatchedEnum'
           - $ref: '#/components/schemas/BlankEnum'
@@ -5010,6 +5013,7 @@ components:
 
             * `DO_NOTHING` - do_nothing
             * `MARK_AS_WATCHED` - mark_as_watched
+            * `MARK_AS_WATCHED_AND_RATE_LATER` - mark_as_watched_and_rate_later
           oneOf:
           - $ref: '#/components/schemas/Extension_onVideoWatchedEnum'
           - $ref: '#/components/schemas/BlankEnum'

--- a/frontend/scripts/openapi.yaml
+++ b/frontend/scripts/openapi.yaml
@@ -1099,6 +1099,7 @@ paths:
           - tr
           - tt
           - udm
+          - ug
           - uk
           - ur
           - uz

--- a/frontend/src/features/rateLater/RateLaterExtensionSection.tsx
+++ b/frontend/src/features/rateLater/RateLaterExtensionSection.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { Alert, AlertTitle } from '@mui/material';
+
+import { ExternalLink } from 'src/components';
+import { useIsExtensionInstalled } from 'src/hooks';
+import { getWebExtensionUrl } from 'src/utils/extension';
+
+import RateLaterOnVideoWatchedSetting from './RateLaterOnVideoWatchedSetting';
+
+const RateLaterExtensionSection = () => {
+  const { t } = useTranslation();
+  const extensionInstalled = useIsExtensionInstalled();
+
+  if (extensionInstalled) {
+    return <RateLaterOnVideoWatchedSetting />;
+  }
+
+  return (
+    <Alert severity="info" sx={{ width: '100%' }}>
+      <AlertTitle>{t('ratelater.addFromYoutube')}</AlertTitle>
+      <Trans t={t} i18nKey="ratelater.installExtensionToAddVideosEasily">
+        Install our{' '}
+        <ExternalLink
+          href={getWebExtensionUrl() ?? getWebExtensionUrl('chrome')}
+        >
+          browser extension
+        </ExternalLink>{' '}
+        to add videos to your rate-later list directly from YouTube.
+      </Trans>
+    </Alert>
+  );
+};
+
+export default RateLaterExtensionSection;

--- a/frontend/src/features/rateLater/RateLaterOnVideoWatchedSetting.tsx
+++ b/frontend/src/features/rateLater/RateLaterOnVideoWatchedSetting.tsx
@@ -18,7 +18,10 @@ import {
   TournesolUserSettings,
   UsersService,
 } from 'src/services/openapi';
-import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
+import {
+  YOUTUBE_POLL_NAME,
+  YT_DEFAULT_EXTENSION_ON_VIDEO_WATHCED,
+} from 'src/utils/constants';
 
 const RateLaterOnVideoWatchedSetting = () => {
   const { t } = useTranslation();
@@ -31,7 +34,7 @@ const RateLaterOnVideoWatchedSetting = () => {
     Extension_onVideoWatchedEnum | BlankEnum
   >(
     pollSettings?.extension__on_video_watched ??
-      Extension_onVideoWatchedEnum.DO_NOTHING
+      YT_DEFAULT_EXTENSION_ON_VIDEO_WATHCED
   );
   const [disabled, setDisabled] = useState(false);
 

--- a/frontend/src/features/rateLater/RateLaterOnVideoWatchedSetting.tsx
+++ b/frontend/src/features/rateLater/RateLaterOnVideoWatchedSetting.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { Box, Button, Paper, Stack, Typography } from '@mui/material';
+import { Save } from '@mui/icons-material';
+
+import ExtOnVideoWatched from 'src/features/settings/preferences/fields/ExtOnVideoWatched';
+import {
+  replaceSettings,
+  selectSettings,
+} from 'src/features/settings/userSettingsSlice';
+import { useNotifications } from 'src/hooks';
+import {
+  ApiError,
+  BlankEnum,
+  Extension_onVideoWatchedEnum,
+  TournesolUserSettings,
+  UsersService,
+} from 'src/services/openapi';
+import { YOUTUBE_POLL_NAME } from 'src/utils/constants';
+
+const RateLaterOnVideoWatchedSetting = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { showSuccessAlert, showErrorAlert } = useNotifications();
+
+  const pollSettings = useSelector(selectSettings).settings?.videos;
+
+  const [onVideoWatchedSetting, setOnVideoWatchedSetting] = useState<
+    Extension_onVideoWatchedEnum | BlankEnum
+  >(
+    pollSettings?.extension__on_video_watched ??
+      Extension_onVideoWatchedEnum.DO_NOTHING
+  );
+  const [disabled, setDisabled] = useState(false);
+
+  useEffect(() => {
+    if (pollSettings?.extension__on_video_watched != undefined) {
+      setOnVideoWatchedSetting(pollSettings.extension__on_video_watched);
+    }
+  }, [pollSettings?.extension__on_video_watched]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setDisabled(true);
+
+    const response: void | TournesolUserSettings =
+      await UsersService.usersMeSettingsPartialUpdate({
+        requestBody: {
+          [YOUTUBE_POLL_NAME]: {
+            extension__on_video_watched: onVideoWatchedSetting,
+          },
+        },
+      }).catch((reason: ApiError) => {
+        showErrorAlert(
+          t('pollUserSettingsForm.errorOccurredDuringPreferencesUpdate')
+        );
+        console.error(reason);
+      });
+
+    if (response) {
+      showSuccessAlert(
+        t('pollUserSettingsForm.preferencesUpdatedSuccessfully')
+      );
+      dispatch(replaceSettings(response));
+    }
+
+    setDisabled(false);
+  };
+
+  return (
+    <Paper sx={{ p: 2, width: '100%' }}>
+      <Box component="form" onSubmit={handleSubmit}>
+        <Typography sx={{ mb: 2 }}>
+          {t('ratelater.extensionInstalledChooseOnVideoWatched')}
+        </Typography>
+        <ExtOnVideoWatched
+          value={onVideoWatchedSetting}
+          onChange={setOnVideoWatchedSetting}
+          pollName={YOUTUBE_POLL_NAME}
+        />
+        <Stack direction="row" sx={{ justifyContent: 'flex-end', mt: 2 }}>
+          <Button
+            type="submit"
+            size="small"
+            color="secondary"
+            variant="contained"
+            startIcon={<Save />}
+            disabled={disabled}
+          >
+            {t('pollUserSettingsForm.updatePreferences')}
+          </Button>
+        </Stack>
+      </Box>
+    </Paper>
+  );
+};
+
+export default RateLaterOnVideoWatchedSetting;

--- a/frontend/src/features/settings/preferences/TournesolUserSettingsForm.tsx
+++ b/frontend/src/features/settings/preferences/TournesolUserSettingsForm.tsx
@@ -31,6 +31,7 @@ import {
   DEFAULT_RATE_LATER_AUTO_REMOVAL,
   YOUTUBE_POLL_NAME,
   YT_DEFAULT_AUTO_SELECT_ENTITIES,
+  YT_DEFAULT_EXTENSION_ON_VIDEO_WATHCED,
   YT_DEFAULT_UI_WEEKLY_COL_GOAL_MOBILE,
   polls,
 } from 'src/utils/constants';
@@ -97,7 +98,7 @@ const TournesolUserSettingsForm = () => {
     Extension_onVideoWatchedEnum | BlankEnum
   >(
     pollSettings?.extension__on_video_watched ??
-      Extension_onVideoWatchedEnum.DO_NOTHING
+      YT_DEFAULT_EXTENSION_ON_VIDEO_WATHCED
   );
 
   // Comparison

--- a/frontend/src/features/settings/preferences/fields/ExtOnVideoWatched.tsx
+++ b/frontend/src/features/settings/preferences/fields/ExtOnVideoWatched.tsx
@@ -27,6 +27,10 @@ const ExtOnVideoWatched = ({
       label: t('pollUserSettingsForm.onVideoWatchedMarkAsWatched'),
       value: Extension_onVideoWatchedEnum.MARK_AS_WATCHED,
     },
+    {
+      label: t('pollUserSettingsForm.onVideoWatchedMarkAsWatchedAndRateLater'),
+      value: Extension_onVideoWatchedEnum.MARK_AS_WATCHED_AND_RATE_LATER,
+    },
   ];
 
   return (

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export { useCurrentPoll } from './useCurrentPoll';
 export { useDocumentTitle } from './useDocumentTitle';
 export { useEntityAvailable } from './useEntityAvailable';
+export { useIsExtensionInstalled } from './useIsExtensionInstalled';
 export { useSearchParams } from './useSearchParams';
 export { useLoginState } from './useLoginState';
 export { useListFilter } from './useListFilter';

--- a/frontend/src/hooks/useIsExtensionInstalled.spec.tsx
+++ b/frontend/src/hooks/useIsExtensionInstalled.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { useIsExtensionInstalled } from './useIsExtensionInstalled';
+
+const EXTENSION_INSTALLED_ATTRIBUTE = 'data-tournesol-extension-installed';
+
+const ExtensionProbe = () => {
+  const isInstalled = useIsExtensionInstalled();
+  return <span>{isInstalled ? 'installed' : 'not-installed'}</span>;
+};
+
+describe('useIsExtensionInstalled', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute(EXTENSION_INSTALLED_ATTRIBUTE);
+  });
+
+  it('returns false when the marker is absent', () => {
+    render(<ExtensionProbe />);
+    expect(screen.getByText('not-installed')).toBeInTheDocument();
+  });
+
+  it('returns true when the marker is already present at mount', () => {
+    document.documentElement.setAttribute(
+      EXTENSION_INSTALLED_ATTRIBUTE,
+      'true'
+    );
+    render(<ExtensionProbe />);
+    expect(screen.getByText('installed')).toBeInTheDocument();
+  });
+
+  it('detects the marker added after mount', async () => {
+    render(<ExtensionProbe />);
+    expect(screen.getByText('not-installed')).toBeInTheDocument();
+
+    document.documentElement.setAttribute(
+      EXTENSION_INSTALLED_ATTRIBUTE,
+      'true'
+    );
+
+    expect(await screen.findByText('installed')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/useIsExtensionInstalled.ts
+++ b/frontend/src/hooks/useIsExtensionInstalled.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+// Set on the document root by the browser extension when it is installed
+// (see browser-extension/src/signalExtensionPresence.js). Keep in sync.
+const EXTENSION_INSTALLED_ATTRIBUTE = 'data-tournesol-extension-installed';
+
+const isExtensionMarkerPresent = (): boolean =>
+  document.documentElement.getAttribute(EXTENSION_INSTALLED_ATTRIBUTE) ===
+  'true';
+
+/**
+ * Return whether the Tournesol browser extension is installed.
+ *
+ * The extension content script can run after React has mounted, so this hook
+ * also watches for the marker attribute to appear.
+ */
+export const useIsExtensionInstalled = (): boolean => {
+  const [isInstalled, setIsInstalled] = useState<boolean>(
+    isExtensionMarkerPresent
+  );
+
+  useEffect(() => {
+    if (isInstalled) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (isExtensionMarkerPresent()) {
+        setIsInstalled(true);
+      }
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: [EXTENSION_INSTALLED_ATTRIBUTE],
+    });
+
+    return () => observer.disconnect();
+  }, [isInstalled]);
+
+  return isInstalled;
+};

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -220,7 +220,7 @@ const RateLaterPage = () => {
         >
           <Grid
             item
-            sm={6}
+            md={6}
             sx={{
               display: 'flex',
               width: '100%',
@@ -267,7 +267,7 @@ const RateLaterPage = () => {
 
           <Grid
             item
-            sm={6}
+            md={6}
             sx={{
               display: 'flex',
               width: '100%',

--- a/frontend/src/pages/rateLater/RateLater.tsx
+++ b/frontend/src/pages/rateLater/RateLater.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback, useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import { Box, Divider, Grid, IconButton, Paper, Stack } from '@mui/material';
+import { Box, Grid, IconButton, Paper, Stack } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import Typography from '@mui/material/Typography';
 import InfoIcon from '@mui/icons-material/Info';
@@ -25,13 +25,13 @@ import {
 } from 'src/utils/action';
 import { addToRateLaterList } from 'src/utils/api/rateLaters';
 import { UID_YT_NAMESPACE, YOUTUBE_POLL_NAME } from 'src/utils/constants';
-import { getWebExtensionUrl } from 'src/utils/extension';
 
 import { selectSettings } from 'src/features/settings/userSettingsSlice';
 import { DEFAULT_RATE_LATER_AUTO_REMOVAL } from 'src/utils/constants';
 import PreferencesIconButtonLink from 'src/components/buttons/PreferencesIconButtonLink';
 import DialogBox from 'src/components/DialogBox';
 import { PollUserSettingsKeys } from 'src/utils/types';
+import RateLaterExtensionSection from 'src/features/rateLater/RateLaterExtensionSection';
 
 const useStyles = makeStyles({
   rateLaterContent: {
@@ -273,41 +273,7 @@ const RateLaterPage = () => {
               width: '100%',
             }}
           >
-            <Paper sx={{ p: 2, width: '100%' }}>
-              <Typography
-                sx={{
-                  marginBottom: 2,
-                }}
-              >
-                {t('ratelater.addVideosToYourListToCompareThemLater')}
-              </Typography>
-              <Divider />
-              <ul>
-                <li>
-                  <Trans t={t} i18nKey="ratelater.useOurBrowserExtension">
-                    Use our{' '}
-                    <ExternalLink
-                      href={
-                        getWebExtensionUrl() ?? getWebExtensionUrl('chrome')
-                      }
-                    >
-                      browser extension
-                    </ExternalLink>{' '}
-                    to effortlessly add videos directly from YouTube.
-                  </Trans>
-                </li>
-                <li>
-                  <Typography
-                    sx={{
-                      mt: 2,
-                      mb: 0,
-                    }}
-                  >
-                    {t('ratelater.orCopyPasteVideoUrlHere')}
-                  </Typography>
-                </li>
-              </ul>
-            </Paper>
+            <RateLaterExtensionSection />
           </Grid>
         </Grid>
 

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -1,7 +1,10 @@
 import { TFunction } from 'i18next';
 import { YouTube, HowToVote } from '@mui/icons-material';
 
-import { RelatedEntity } from 'src/services/openapi';
+import {
+  Extension_onVideoWatchedEnum,
+  RelatedEntity,
+} from 'src/services/openapi';
 
 import { AddToRateLaterList, CompareNowAction } from './action';
 import {
@@ -188,6 +191,9 @@ export const getFeedTopItemsPageName = (t: TFunction, pollName: string) => {
 export const DEFAULT_RATE_LATER_AUTO_REMOVAL = 4;
 
 export const YT_DEFAULT_AUTO_SELECT_ENTITIES = true;
+
+export const YT_DEFAULT_EXTENSION_ON_VIDEO_WATHCED =
+  Extension_onVideoWatchedEnum.DO_NOTHING;
 
 export const YT_DEFAULT_UI_WEEKLY_COL_GOAL_MOBILE = false;
 


### PR DESCRIPTION
**Related issue:** #2224

---

### Description

Adds a "Mark as watched and rate later" option to the "When a video is watched on YouTube" setting (French: "Marquer la vidéo comme vue et comparer plus tard"), and updates the extension to act accordingly.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
