### PR TITLE
[front] video player: fix partial black border, round edges

### DIFF
--- a/frontend/src/components/entity/EntityImagery.tsx
+++ b/frontend/src/components/entity/EntityImagery.tsx
@@ -44,6 +44,11 @@ export const DurationWrapper = React.forwardRef(function DurationWrapper(
         position: 'relative',
         height: '100%',
         width: '100%',
+        overflow: 'hidden',
+        borderRadius: 1,
+        '& .react-player__preview': {
+          transform: 'scale(1.01)',
+        },
       }}
     >
       {isDurationVisible && formattedDuration && (


### PR DESCRIPTION
### Description
- An ugly black line appears at the top and bottom of the video player thumbnail
- The video player corner radius does not match that of the other elements

e.g. black lines @ top/bot visible here:
<img width="2564" height="1656" alt="2026-06-18-230017_hyprshot" src="https://github.com/user-attachments/assets/22abebd0-31be-4149-a314-43861aefb7e9" />

### Changes
- Rounded video player corners
- 1pct scaling on the video player thumbnail to remove ugly black lines

| Bug | Fix |
|--------|--------|
| <img width="1499" height="1299" alt="2026-06-18-225911_hyprshot" src="https://github.com/user-attachments/assets/e38ffff3-c3df-46eb-8160-53fe54ca9a70" /> | <img width="1499" height="1298" alt="2026-06-18-225921_hyprshot" src="https://github.com/user-attachments/assets/381cd9b8-64d5-49ea-8526-ac0618b1841f" /> |


### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
