### PR TITLE
[infra] Add feed server deployment

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -47,10 +47,38 @@ If for any reason you're not able to set up a virtual machine on your computer -
 <VM_IP> tournesol-vm tournesol-api tournesol-grafana tournesol-webanalytics
 ```
 in your `/etc/hosts` file
-- Check the administrators list in `ansible/group_vars/tournesol.yml`
-- Add users dot files in `ansible/roles/users/files/admin-users` to match administrators tastes and set the `authorized_keys` for each of them either in `ansible/group_vars/tournesol.yml` or in `ansible/roles/users/files/admin-users/<username>/.ssh/authorized_keys`
+- Check the administrators list in `ansible/group_vars/all.yml`
+- Add users dot files in `ansible/roles/users/files/admin-users` to match administrators tastes and set the `authorized_keys` for each of them either in `ansible/group_vars/all.yml` or in `ansible/roles/users/files/admin-users/<username>/.ssh/authorized_keys`
 - Run `source ./ansible/scripts/generate-secrets.sh` to generate secrets
 - Run `./ansible/scripts/provisioning-vm.sh apply` (without `apply` it's a dry-run)
+
+## AT Proto Feed Server
+
+The AT Proto feed server (`feed-server/`) runs on its own dedicated host.
+`feed-server.yml` provisions a fresh Debian (trixie).
+
+To provision the local development VM:
+
+- Create a VM as described above, but with hostname `tournesol-feed` and only an SSH server. Add `<VM_IP> tournesol-feed-vm` to your `/etc/hosts`.
+- Push your SSH key and enable passwordless sudo (same steps as Provisioning).
+- Dry-run, then apply:
+
+```bash
+cd infra
+./ansible/scripts/deploy-feed-server.sh tournesol-feed-vm # dry-run (--check), but some steps are expected to fail when the VM has never been set up
+./ansible/scripts/deploy-feed-server.sh tournesol-feed-vm apply
+```
+
+The development VM is served over plain HTTP (because `letsencrypt_email` is left undefined). You can check by accessing http://tournesol-feed-vm/.well-known/did.json.
+
+The deployment defaults to the current git HEAD; override with the `GIT_REFERENCE` environment variable. The commit must be pushed to GitHub, since the `repository` role clones it from there.
+
+To actually register the feeds on Bluesky you need the system to be reachable from a public hostname and use that name in `feed_server_domain_name`. You also need an HTTPS certificate, that will be created if you define  `letsencrypt_email` in the inventory. Then to register the feeds on Bluesky:
+
+- `ssh <feed_server_domain_name>`
+- `sudo -u feedserver -s`
+- `cd /srv/feed-server`
+- `uv run python scripts/feedgen.py publish --handle <email of the bluesky account hosting the feed> --hostname <feed_server_domain_name> --record-name <name of the feed> --display-name <name of the feed that'll be displayed on bluesky>` (see `feed-server/src/feed_server/feeds/__init__.py` for the available feed names)
 
 ## TODO
 

--- a/infra/ansible/feed-server.yml
+++ b/infra/ansible/feed-server.yml
@@ -1,0 +1,12 @@
+- hosts: feed_server
+  roles:
+    - upgrade
+    - base
+    - nftables
+    - zsh
+    - users
+    - nginx
+    - repository
+    - redis
+    - feed_server
+  become: true

--- a/infra/ansible/group_vars/all.yml
+++ b/infra/ansible/group_vars/all.yml
@@ -1,4 +1,8 @@
-# users appearing here should also have a (possibly empty) roles/users/files/admin-users/<user_name> directory
+ansible_python_interpreter: /usr/bin/python3
+ansible_ssh_pipelining: true
+
+# Admin users granted SSH + sudo access on every managed host.
+# Each user should also have a (possibly empty) roles/users/files/admin-users/<user_name> directory.
 admin_users:
   - name: jst
     # keys can be put here or into roles/users/files/admin-users/<user_name>/.ssh/authorized_keys

--- a/infra/ansible/inventory.yml
+++ b/infra/ansible/inventory.yml
@@ -229,6 +229,19 @@ all:
           export_backups_bucket_name: tournesol-app-backups
           export_backups_path: prod
 
-      vars:
-        ansible_python_interpreter: /usr/bin/python3
-        ansible_ssh_pipelining: true
+    feed_server:
+      hosts:
+        # VM for local development
+        tournesol-feed-vm:
+          ansible_host: tournesol-feed-vm
+          machine_name: tournesol-feed
+          feed_server_domain_name: tournesol-feed-vm
+          upgrade_packages: true
+
+        # tournesol-feed-prod:
+        #   ansible_host: feeds.tournesol.app
+        #   machine_name: tournesol-feed
+        #   feed_server_domain_name: feeds.tournesol.app
+        #   upgrade_packages: false
+        #   letsencrypt_email: tournesol.application@gmail.com
+        #   feed_server_web_workers: 4

--- a/infra/ansible/roles/base/tasks/main.yml
+++ b/infra/ansible/roles/base/tasks/main.yml
@@ -7,8 +7,8 @@
     path: "{{ item }}"
     create: true
     block: |
-    
-      127.0.1.1    {{machine_name}} {{domain_name}} {{api_domain_name}}
+
+      127.0.1.1    {{machine_name}}
   loop:
     - /etc/hosts
     - /etc/cloud/templates/hosts.debian.tmpl  # Template used by cloud-init on startup
@@ -17,7 +17,6 @@
   apt:
     name:
       - unattended-upgrades
-      - software-properties-common
       - apt-transport-https
       - ca-certificates
       - curl
@@ -26,7 +25,7 @@
       - htop
       - net-tools
       - dnsutils
-      - netcat
+      - netcat-traditional
       - python3
       - git
       - build-essential

--- a/infra/ansible/roles/django/tasks/main.yml
+++ b/infra/ansible/roles/django/tasks/main.yml
@@ -1,3 +1,15 @@
+- name: Map the tournesol domains to loopback
+  blockinfile:
+    path: "{{ item }}"
+    create: true
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: tournesol domains"
+    block: |
+
+      127.0.1.1    {{domain_name}} {{api_domain_name}}
+  loop:
+    - /etc/hosts
+    - /etc/cloud/templates/hosts.debian.tmpl  # Template used by cloud-init on startup
+
 - name: Install Python and virtualenv
   apt:
     name:
@@ -208,6 +220,42 @@
     when: find_snippet.matched == 0
   notify:
     - Reload Nginx
+
+- name: Check if certificates for frontend are already present
+  stat:
+    path: /etc/letsencrypt/live/{{domain_name}}/fullchain.pem
+  register: cert_file
+  when: letsencrypt_email is defined
+
+- name: Stop Nginx if certificates for frontend are not present
+  systemd:
+    name: nginx
+    state: stopped
+  when: letsencrypt_email is defined and cert_file.stat.exists == False
+
+- name: Run Certbot for frontend
+  shell:
+    cmd: "certbot certonly --standalone -d {{domain_name}} -n --agree-tos -m {{letsencrypt_email}}"
+    creates: /etc/letsencrypt/live/{{domain_name}}/fullchain.pem
+  when: letsencrypt_email is defined
+
+- name: Check if certificates for backend are already present
+  stat:
+    path: /etc/letsencrypt/live/{{api_domain_name}}/fullchain.pem
+  register: api_cert_file
+  when: letsencrypt_email is defined
+
+- name: Stop Nginx if certificates for backend are not present
+  systemd:
+    name: nginx
+    state: stopped
+  when: letsencrypt_email is defined and api_cert_file.stat.exists == False
+
+- name: Run Certbot for backend
+  shell:
+    cmd: "certbot certonly --standalone -d {{api_domain_name}} -n --agree-tos -m {{letsencrypt_email}}"
+    creates: /etc/letsencrypt/live/{{api_domain_name}}/fullchain.pem
+  when: letsencrypt_email is defined
 
 - name: Copy Nginx configuration
   template:

--- a/infra/ansible/roles/feed_server/defaults/main.yml
+++ b/infra/ansible/roles/feed_server/defaults/main.yml
@@ -1,0 +1,2 @@
+# Number of gunicorn worker processes serving the HTTP API. Overridable per host.
+feed_server_web_workers: 1

--- a/infra/ansible/roles/feed_server/files/feed-server.socket
+++ b/infra/ansible/roles/feed_server/files/feed-server.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=feed server socket
+
+[Socket]
+ListenStream=/run/feed-server.sock
+# nginx connects to the socket, so it must own it. The feed server process
+# receives the socket as an inherited file descriptor and does not need to own
+# the socket file.
+SocketUser=www-data
+
+[Install]
+WantedBy=sockets.target

--- a/infra/ansible/roles/feed_server/handlers/main.yml
+++ b/infra/ansible/roles/feed_server/handlers/main.yml
@@ -1,0 +1,12 @@
+- name: Restart feed server
+  systemd:
+    name: "{{ item }}"
+    state: restarted
+    daemon_reload: true
+  loop: "{{ ['feed-server'] + (feed_server_workers | map(attribute='name') | map('regex_replace', '^', 'feed-server-') | list) }}"
+
+- name: Reload Nginx
+  systemd:
+    name: nginx
+    state: reloaded
+    daemon_reload: true

--- a/infra/ansible/roles/feed_server/tasks/main.yml
+++ b/infra/ansible/roles/feed_server/tasks/main.yml
@@ -1,0 +1,153 @@
+- name: Create feed server user
+  user:
+    name: feedserver
+    system: yes
+    create_home: yes
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: feedserver
+    group: feedserver
+  loop:
+    - /srv/feed-server  # Application directory (synchronized from the checkout)
+    - /home/feedserver/.ansible/tmp  # remote_tmp directory
+
+- name: Copy feed server application
+  synchronize:
+    src: /home/git/tournesol/feed-server/
+    dest: /srv/feed-server
+    archive: no
+    recursive: yes
+    delete: yes
+    checksum: yes
+    rsync_opts:
+      - "--exclude=.venv/"
+      - "--exclude=venv/"
+      - "--exclude=*.pyc"
+  delegate_to: "{{ inventory_hostname }}"
+  become: yes
+  become_user: feedserver
+  notify: Restart feed server
+
+- name: Check the installed uv version
+  command: /usr/local/bin/uv --version
+  register: installed_uv_version
+  failed_when: false
+  changed_when: false
+
+- name: Install the pinned uv version
+  shell:
+    cmd: "curl -LsSf https://astral.sh/uv/{{ feed_server_uv_version }}/install.sh | env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh"
+  when: feed_server_uv_version not in installed_uv_version.stdout
+  become: yes
+
+# solidago pulls in numpy, which has no wheel for this Python version and is compiled from source.
+- name: Install build dependencies for native Python packages
+  apt:
+    name:
+      - python3-dev
+      - pkg-config
+    install_recommends: no
+    update_cache: yes
+  become: yes
+
+- name: Synchronize virtualenv with uv.lock
+  ansible.builtin.shell:
+    chdir: /srv/feed-server
+    cmd: |
+      export UV_PROJECT_ENVIRONMENT=/srv/feed-server/venv
+      export UV_LOCKED=1
+      export UV_NO_DEV=1
+
+      if uv sync --check; then
+        # No change to apply
+        exit 10
+      fi
+      uv sync
+  register: uv_sync_result
+  failed_when: uv_sync_result.rc not in [0, 10] # 10 for ok, 0 for changed
+  changed_when: uv_sync_result.rc == 0
+  become: yes
+  become_user: feedserver
+  notify: Restart feed server
+
+- name: Create configuration directory
+  file:
+    path: /etc/feed-server
+    state: directory
+    mode: 0750
+    owner: root
+    group: feedserver
+
+- name: Copy environment file
+  template:
+    src: feed-server.env.j2
+    dest: /etc/feed-server/feed-server.env
+    mode: 0640
+    owner: root
+    group: feedserver
+  notify: Restart feed server
+
+- name: Copy systemd socket file
+  copy:
+    src: feed-server.socket
+    dest: /etc/systemd/system/feed-server.socket
+  notify: Restart feed server
+
+- name: Copy systemd service file
+  template:
+    src: feed-server.service.j2
+    dest: /etc/systemd/system/feed-server.service
+  notify: Restart feed server
+
+- name: Enable and start feed server socket
+  systemd:
+    name: feed-server.socket
+    enabled: true
+    state: started
+    daemon_reload: true
+
+- name: Enable and start feed server
+  systemd:
+    name: feed-server
+    enabled: true
+    state: started
+    daemon_reload: true
+
+- name: Copy systemd worker service files
+  template:
+    src: feed-server-worker.service.j2
+    dest: "/etc/systemd/system/feed-server-{{ item.name }}.service"
+  loop: "{{ feed_server_workers }}"
+  notify: Restart feed server
+
+- name: Enable and start feed server workers
+  systemd:
+    name: "feed-server-{{ item.name }}"
+    enabled: true
+    state: started
+    daemon_reload: true
+  loop: "{{ feed_server_workers }}"
+
+- name: Obtain certificate for the feed server
+  shell:
+    cmd: "certbot certonly --nginx -d {{ feed_server_domain_name }} -n --agree-tos -m {{ letsencrypt_email }}"
+    creates: "/etc/letsencrypt/live/{{ feed_server_domain_name }}/fullchain.pem"
+  when: letsencrypt_email is defined
+
+- name: Copy Nginx configuration
+  template:
+    src: feed-server.j2
+    dest: /etc/nginx/sites-available/feed-server
+  notify: Reload Nginx
+
+- name: Enable Nginx configuration
+  file:
+    src: /etc/nginx/sites-available/feed-server
+    dest: /etc/nginx/sites-enabled/feed-server
+    state: link
+  notify: Reload Nginx
+
+- meta: flush_handlers

--- a/infra/ansible/roles/feed_server/templates/feed-server-worker.service.j2
+++ b/infra/ansible/roles/feed_server/templates/feed-server-worker.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=AT Proto feed server - {{ item.description }}
+Requires=redis-server.service
+After=network.target redis-server.service
+
+[Service]
+User=feedserver
+Group=feedserver
+WorkingDirectory=/srv/feed-server
+EnvironmentFile=/etc/feed-server/feed-server.env
+ExecStart=/srv/feed-server/venv/bin/python -m feed_server.{{ item.module }}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/ansible/roles/feed_server/templates/feed-server.env.j2
+++ b/infra/ansible/roles/feed_server/templates/feed-server.env.j2
@@ -1,0 +1,2 @@
+FEED_SERVER_HOSTNAME={{ feed_server_domain_name }}
+REDIS_URL=redis://localhost:6379

--- a/infra/ansible/roles/feed_server/templates/feed-server.j2
+++ b/infra/ansible/roles/feed_server/templates/feed-server.j2
@@ -1,0 +1,37 @@
+server {
+    server_name {{ feed_server_domain_name }};
+
+    keepalive_timeout 5;
+
+    location / {
+        proxy_pass http://unix:/run/feed-server.sock;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+{% if letsencrypt_email is defined %}
+    listen 443 ssl;
+    http2 on;
+    ssl_certificate /etc/letsencrypt/live/{{ feed_server_domain_name }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ feed_server_domain_name }}/privkey.pem;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    add_header Strict-Transport-Security "max-age=15552000; includeSubDomains; preload;" always;
+{% else %}
+    listen 80;
+{% endif %}
+}
+
+{% if letsencrypt_email is defined %}
+server {
+    if ($host = {{ feed_server_domain_name }}) {
+        return 301 https://$host$request_uri;
+    }
+
+    listen 80;
+    server_name {{ feed_server_domain_name }};
+    return 404;
+}
+{% endif %}

--- a/infra/ansible/roles/feed_server/templates/feed-server.service.j2
+++ b/infra/ansible/roles/feed_server/templates/feed-server.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=AT Proto feed server
+Requires=feed-server.socket redis-server.service
+After=network.target redis-server.service feed-server.socket
+
+[Service]
+Type=notify
+User=feedserver
+Group=feedserver
+WorkingDirectory=/srv/feed-server
+EnvironmentFile=/etc/feed-server/feed-server.env
+ExecStart=/srv/feed-server/venv/bin/gunicorn feed_server.main:app -k uvicorn.workers.UvicornWorker -w {{ feed_server_web_workers }}
+Restart=always
+RestartSec=5
+KillMode=mixed
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/ansible/roles/feed_server/vars/main.yml
+++ b/infra/ansible/roles/feed_server/vars/main.yml
@@ -1,0 +1,11 @@
+feed_server_uv_version: "0.9.9"
+
+# Ingestion worker processes, each deployed as its own systemd unit
+# (feed-server-<name>.service running python -m feed_server.<module>).
+feed_server_workers:
+  - name: jetstream
+    module: worker_jetstream
+    description: jetstream firehose listener
+  - name: process
+    module: worker_process
+    description: post processing worker

--- a/infra/ansible/roles/nginx/tasks/main.yml
+++ b/infra/ansible/roles/nginx/tasks/main.yml
@@ -6,42 +6,6 @@
     install_recommends: no
     update_cache: yes
 
-- name: Check if certificates for frontend are already present
-  stat:
-    path: /etc/letsencrypt/live/{{domain_name}}/fullchain.pem
-  register: cert_file
-  when: letsencrypt_email is defined
-
-- name: Stop Nginx if certificates for frontend are not present
-  systemd:
-    name: nginx
-    state: stopped
-  when: letsencrypt_email is defined and cert_file.stat.exists == False
-
-- name: Run Certbot for frontend
-  shell:
-    cmd: "certbot certonly --standalone -d {{domain_name}} -n --agree-tos -m {{letsencrypt_email}}"
-    creates: /etc/letsencrypt/live/{{domain_name}}/fullchain.pem
-  when: letsencrypt_email is defined
-
-- name: Check if certificates for backend are already present
-  stat:
-    path: /etc/letsencrypt/live/{{api_domain_name}}/fullchain.pem
-  register: api_cert_file
-  when: letsencrypt_email is defined
-
-- name: Stop Nginx if certificates for backend are not present
-  systemd:
-    name: nginx
-    state: stopped
-  when: letsencrypt_email is defined and api_cert_file.stat.exists == False
-
-- name: Run Certbot for backend
-  shell:
-    cmd: "certbot certonly --standalone -d {{api_domain_name}} -n --agree-tos -m {{letsencrypt_email}}"
-    creates: /etc/letsencrypt/live/{{api_domain_name}}/fullchain.pem
-  when: letsencrypt_email is defined
-
 - name: Generate DH parameters
   shell:
     cmd: "openssl dhparam -out /etc/letsencrypt/ssl-dhparams.pem 2048"

--- a/infra/ansible/roles/plausible_analytics/tasks/main.yml
+++ b/infra/ansible/roles/plausible_analytics/tasks/main.yml
@@ -38,6 +38,14 @@
     path: /opt/plausible_analytics
     state: directory
 
+- name: Checkout Plausible Analytics self-hosting repository
+  git:
+    repo: 'https://github.com/tournesol-app/plausible-self-hosting'
+    dest: /home/git/plausible_hosting
+    version: "{{ plausible_hosting_tag }}"
+  become: yes
+  become_user: git
+
 - name: Copy Plausible Analytics self-hosting repository
   synchronize:
     src: "/home/git/plausible_hosting/"

--- a/infra/ansible/roles/redis/tasks/main.yml
+++ b/infra/ansible/roles/redis/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: Install Redis
+  apt:
+    name: redis-server
+    install_recommends: no
+    update_cache: yes
+
+- name: Ensure Redis is enabled and started
+  systemd:
+    name: redis-server
+    state: started
+    enabled: true

--- a/infra/ansible/roles/repository/tasks/main.yml
+++ b/infra/ansible/roles/repository/tasks/main.yml
@@ -4,6 +4,14 @@
     system: yes
     create_home: yes
 
+# Service users (gunicorn, feedserver) rsync their code from this checkout, so
+# they need to traverse the home. Debian 13 creates homes as 0750 by default.
+- name: Make the git home traversable
+  file:
+    path: /home/git
+    state: directory
+    mode: "0755"
+
 - name: Create remote_tmp directory for git user
   file:
     path: /home/git/.ansible/tmp
@@ -16,13 +24,5 @@
     repo: 'https://github.com/tournesol-app/tournesol.git'
     dest: /home/git/tournesol
     version: "{{git_reference}}"
-  become: yes
-  become_user: git
-
-- name: Checkout Plausible Analytics self-hosting repository
-  git:
-    repo: 'https://github.com/tournesol-app/plausible-self-hosting'
-    dest: /home/git/plausible_hosting
-    version: "{{ plausible_hosting_tag }}"
   become: yes
   become_user: git

--- a/infra/ansible/roles/upgrade/tasks/main.yml
+++ b/infra/ansible/roles/upgrade/tasks/main.yml
@@ -1,10 +1,3 @@
-# Temporary:
-# To remove after yarn repo (defined in role "frontend") has been deployed on all environments.
-- name: Remove old entry for Yarn Repository
-  apt_repository:
-    repo: "deb https://dl.yarnpkg.com/debian/ stable main"
-    state: absent
-
 - name: Update all packages to their latest version
   apt:
     name: "*"

--- a/infra/ansible/scripts/deploy-feed-server.sh
+++ b/infra/ansible/scripts/deploy-feed-server.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ANSIBLE_HOST="${1:?usage: deploy-feed-server.sh <ansible-host> [apply]}"
+
+CURRENT_DIR="$(realpath -e "$(dirname "$0")")"
+
+cd "$CURRENT_DIR/.."
+
+if [[ "${2:-""}" == "apply" ]]
+then
+  CHECK=""
+else
+  CHECK="--check"
+fi
+
+GIT_REFERENCE="${GIT_REFERENCE:-$(git rev-parse HEAD)}"
+
+ansible-playbook -i inventory.yml -l "$ANSIBLE_HOST" feed-server.yml \
+  $CHECK \
+  -e "git_reference=${GIT_REFERENCE}"


### PR DESCRIPTION
**related PR** #2222

---

### Description

This PR adds the infra configuration to deploy the feed server.

- It assumes it'll be deployed on a Debian 13 (trixie).
- It sets up the exact same admin users as tournesol (moved to `group_vars/all`)
- It moves the `ansible_python_interpreter` and `ansible_ssh_pipelining` settings to all hosts (by default)
- It removes the temporary yarn task (assumed to have been completed)
- It splits the host file definition so that the `base` role can be reused for the feed server
- It moves the tournesol certificate generation into the `gunicorn` role, so that the `nginx` role can be reused
- It moves the plausible repository checkout into the `plausible` role so that the `repository` role can be reused
- It doesn't install `software-properties-common` anymore (doesn't seem to be used, and doesn't exist on Debian 13 anymore)

Since the feed server is not merged into main, the deployment must be done with a `GIT_REFERENCE` env var.

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

❤️ Thank you for your contribution!

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines