### PR TITLE
[back] feat: support Bilibili videos in the videos poll

### DIFF
--- a/backend/tournesol/entities/test_video_bilibili.py
+++ b/backend/tournesol/entities/test_video_bilibili.py
@@ -1,0 +1,76 @@
+import re
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, TestCase
+
+from tournesol.serializers.metadata import VideoMetadata
+from tournesol.tests.factories.entity import BilibiliVideoFactory, VideoFactory
+
+from .video import BILIBILI_UID_NAMESPACE, YOUTUBE_UID_NAMESPACE, VideoEntity
+
+
+class BilibiliUidRegexTestCase(SimpleTestCase):
+
+    def test_uid_regex_matches_bilibili_uid(self):
+        regex = VideoEntity.get_uid_regex(BILIBILI_UID_NAMESPACE)
+        self.assertTrue(re.fullmatch(regex, "bili:BV1GJ411x7h7"))
+
+    def test_uid_regex_rejects_invalid_bilibili_id(self):
+        regex = VideoEntity.get_uid_regex(BILIBILI_UID_NAMESPACE)
+        # "0", "I", "O" and "l" are not part of the base58 alphabet
+        self.assertIsNone(re.fullmatch(regex, "bili:BV0GJ411x7hI"))
+        # A YouTube video id is not a valid Bilibili video id
+        self.assertIsNone(re.fullmatch(regex, "bili:NeADlWSDFAQ"))
+
+    def test_uid_namespaces_are_not_interchangeable(self):
+        yt_regex = VideoEntity.get_uid_regex(YOUTUBE_UID_NAMESPACE)
+        bilibili_regex = VideoEntity.get_uid_regex(BILIBILI_UID_NAMESPACE)
+        self.assertIsNone(re.fullmatch(yt_regex, "yt:BV1GJ411x7h7"))
+        self.assertIsNone(re.fullmatch(bilibili_regex, "yt:NeADlWSDFAQ"))
+
+
+class VideoMetadataVideoIdTestCase(SimpleTestCase):
+
+    def test_video_id_accepts_youtube_id(self):
+        serializer = VideoMetadata(data={"video_id": "NeADlWSDFAQ"})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_video_id_accepts_bilibili_id(self):
+        serializer = VideoMetadata(data={"video_id": "BV1GJ411x7h7"})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_video_id_rejects_invalid_id(self):
+        # Note: an 11-symbol Bilibili-looking id such as "BV1GJ411x7h" cannot
+        # be rejected, as it is undistinguishable from a YouTube video id.
+        for video_id in ["", "BV1GJ411x7", "BV1GJ411x7h7x", "invalid id!"]:
+            serializer = VideoMetadata(data={"video_id": video_id})
+            self.assertFalse(serializer.is_valid())
+
+
+@patch("tournesol.utils.api_bilibili.get_bilibili_video_metadata")
+@patch("tournesol.utils.api_youtube.get_video_metadata")
+class VideoEntityMetadataSourceTestCase(TestCase):
+
+    def test_update_metadata_uses_bilibili_api_for_bilibili_uid(
+        self, mock_youtube, mock_bilibili
+    ):
+        mock_bilibili.return_value = {"views": 42}
+        video = BilibiliVideoFactory()
+
+        VideoEntity(video).update_metadata_field()
+
+        mock_bilibili.assert_called_once()
+        mock_youtube.assert_not_called()
+        self.assertEqual(video.metadata["views"], 42)
+
+    def test_update_metadata_uses_youtube_api_for_youtube_uid(
+        self, mock_youtube, mock_bilibili
+    ):
+        mock_youtube.return_value = {"views": 42}
+        video = VideoFactory()
+
+        VideoEntity(video).update_metadata_field()
+
+        mock_youtube.assert_called_once()
+        mock_bilibili.assert_not_called()
+        self.assertEqual(video.metadata["views"], 42)

--- a/backend/tournesol/entities/video.py
+++ b/backend/tournesol/entities/video.py
@@ -7,7 +7,7 @@ from django.db.models.fields.json import KeyTextTransform
 from django.utils import timezone
 
 from tournesol.serializers.metadata import VideoMetadata
-from tournesol.utils.constants import YOUTUBE_VIDEO_ID_REGEX
+from tournesol.utils.constants import BILIBILI_VIDEO_ID_REGEX, YOUTUBE_VIDEO_ID_REGEX
 
 from .base import UID_DELIMITER, EntityType
 
@@ -19,12 +19,19 @@ YOUTUBE_UID_REGEX = (
     rf"({YOUTUBE_UID_NAMESPACE})({UID_DELIMITER})({YOUTUBE_VIDEO_ID_REGEX})"
 )
 
+BILIBILI_UID_NAMESPACE = "bili"
+BILIBILI_UID_REGEX = (
+    rf"({BILIBILI_UID_NAMESPACE})({UID_DELIMITER})({BILIBILI_VIDEO_ID_REGEX})"
+)
+
 
 class VideoEntity(EntityType):
     """
     Video entity type
 
-    Handles the metadata specific to videos, retrieved from the YouTube API.
+    Handles the metadata specific to videos, retrieved from the API of the
+    platform hosting the video (YouTube or Bilibili, depending on the UID
+    namespace).
     """
 
     name = TYPE_VIDEO
@@ -54,14 +61,22 @@ class VideoEntity(EntityType):
     def get_uid_regex(cls, namespace: str) -> str:
         if namespace == YOUTUBE_UID_NAMESPACE:
             return YOUTUBE_UID_REGEX
+        if namespace == BILIBILI_UID_NAMESPACE:
+            return BILIBILI_UID_REGEX
         return ""
 
     def update_metadata_field(self, compute_language=False, **kwargs) -> None:
         # pylint: disable=import-outside-toplevel
+        from tournesol.utils.api_bilibili import get_bilibili_video_metadata
         from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata
 
+        if self.instance.uid.startswith(f"{BILIBILI_UID_NAMESPACE}{UID_DELIMITER}"):
+            get_metadata = get_bilibili_video_metadata
+        else:
+            get_metadata = get_video_metadata
+
         try:
-            metadata = get_video_metadata(
+            metadata = get_metadata(
                 self.instance.metadata["video_id"], compute_language=compute_language
             )
         except VideoNotFound:

--- a/backend/tournesol/models/entity.py
+++ b/backend/tournesol/models/entity.py
@@ -21,7 +21,7 @@ from django.utils.html import format_html
 
 from tournesol.entities import ENTITY_TYPE_CHOICES, ENTITY_TYPE_NAME_TO_CLASS
 from tournesol.entities.base import UID_DELIMITER, EntityType
-from tournesol.entities.video import TYPE_VIDEO, YOUTUBE_UID_NAMESPACE
+from tournesol.entities.video import BILIBILI_UID_NAMESPACE, TYPE_VIDEO, YOUTUBE_UID_NAMESPACE
 from tournesol.models.entity_score import EntityCriteriaScore, ScoreMode
 from tournesol.models.rate_later import RATE_LATER_AUTO_REMOVE_DEFAULT, RateLater
 from tournesol.serializers.metadata import VideoMetadata
@@ -321,7 +321,7 @@ class Entity(models.Model):
             return None
 
         video_uri = urljoin(
-            settings.TOURNESOL_MAIN_URL, f"entities/yt:{self.video_id}"
+            settings.TOURNESOL_MAIN_URL, f"entities/{self.uid}"
         )
         return format_html('<a href="{}" target="_blank">Play ▶</a>', video_uri)
 
@@ -359,17 +359,23 @@ class Entity(models.Model):
         return criteria_distributions
 
     @classmethod
-    def create_from_video_id(cls, video_id, fetch_metadata=True):
+    def create_from_video_id(cls, video_id, fetch_metadata=True, namespace=YOUTUBE_UID_NAMESPACE):
         # pylint: disable=import-outside-toplevel
+        from tournesol.utils.api_bilibili import get_bilibili_video_metadata
         from tournesol.utils.api_youtube import VideoNotFound, get_video_metadata
+
+        if namespace == BILIBILI_UID_NAMESPACE:
+            get_metadata = get_bilibili_video_metadata
+        else:
+            get_metadata = get_video_metadata
 
         last_metadata_request_at = None
         if fetch_metadata:
             last_metadata_request_at = timezone.now()
             try:
-                extra_data = get_video_metadata(video_id)
+                extra_data = get_metadata(video_id)
             except VideoNotFound:
-                logging.warning("Failed to fetch YT metadata about %s", video_id)
+                logging.warning("Failed to fetch metadata about %s", video_id)
                 raise
         else:
             extra_data = {}
@@ -391,18 +397,18 @@ class Entity(models.Model):
         try:
             return cls.objects.create(
                 type=TYPE_VIDEO,
-                uid=f"{YOUTUBE_UID_NAMESPACE}{UID_DELIMITER}{video_id}",
+                uid=f"{namespace}{UID_DELIMITER}{video_id}",
                 metadata=metadata,
                 metadata_timestamp=timezone.now(),
                 last_metadata_request_at=last_metadata_request_at,
             )
         except IntegrityError:
             # A concurrent request may have created the video
-            return cls.get_from_video_id(video_id)
+            return cls.get_from_video_id(video_id, namespace=namespace)
 
     @classmethod
-    def get_from_video_id(cls, video_id):
-        return cls.objects.get(uid=f"{YOUTUBE_UID_NAMESPACE}{UID_DELIMITER}{video_id}")
+    def get_from_video_id(cls, video_id, namespace=YOUTUBE_UID_NAMESPACE):
+        return cls.objects.get(uid=f"{namespace}{UID_DELIMITER}{video_id}")
 
     def clean(self):
         # An empty dict is considered as an empty value for JSONField,

--- a/backend/tournesol/serializers/entity.py
+++ b/backend/tournesol/serializers/entity.py
@@ -275,10 +275,10 @@ class RelatedEntitySerializer(EntitySerializer):
         except ObjectDoesNotExist as error:
             created = False
             if self.context["poll"].entity_type == VideoEntity.name:
-                # A video entity can be created dynamically from a YouTube video id
-                video_id = uid.split(UID_DELIMITER)[1]
+                # A video entity can be created dynamically from its platform video id
+                namespace, video_id = uid.split(UID_DELIMITER, 1)
                 try:
-                    entity = Entity.create_from_video_id(video_id)
+                    entity = Entity.create_from_video_id(video_id, namespace=namespace)
                     attrs["pk"] = entity.pk
                     created = True
                 except VideoNotFound:

--- a/backend/tournesol/serializers/metadata.py
+++ b/backend/tournesol/serializers/metadata.py
@@ -1,11 +1,13 @@
 from rest_framework import serializers
 
-from tournesol.utils.constants import YOUTUBE_VIDEO_ID_REGEX
+from tournesol.utils.constants import BILIBILI_VIDEO_ID_REGEX, YOUTUBE_VIDEO_ID_REGEX
 
 
 class VideoMetadata(serializers.Serializer):
     source = serializers.CharField(allow_blank=True, default="")
-    video_id = serializers.RegexField(rf"^({YOUTUBE_VIDEO_ID_REGEX})$")
+    video_id = serializers.RegexField(
+        rf"^({YOUTUBE_VIDEO_ID_REGEX}|{BILIBILI_VIDEO_ID_REGEX})$"
+    )
     name = serializers.CharField(allow_blank=True, default="")
     description = serializers.CharField(allow_blank=True, default="")
     uploader = serializers.CharField(allow_blank=True, default="")
@@ -20,6 +22,12 @@ class VideoMetadata(serializers.Serializer):
     language = serializers.CharField(allow_null=True, default=None)
     tags = serializers.ListField(child=serializers.CharField(), default=list)
     is_unlisted = serializers.BooleanField(default=False)
+    thumbnail_url = serializers.URLField(
+        allow_null=True,
+        default=None,
+        help_text="Thumbnail URL. Remains null for sources whose thumbnail"
+        " URLs can be derived from the video id (e.g. YouTube).",
+    )
 
 
 class CandidateMetadata(serializers.Serializer):

--- a/backend/tournesol/tests/factories/entity.py
+++ b/backend/tournesol/tests/factories/entity.py
@@ -88,6 +88,23 @@ class VideoFactory(EntityFactory):
     uid = factory.LazyAttribute(lambda e: f"yt:{e.metadata['video_id']}")
 
 
+BILIBILI_BASE58_SYMBOLS = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def generate_bilibili_id():
+    return "BV" + "".join(random.choices(BILIBILI_BASE58_SYMBOLS, k=10))
+
+
+class BilibiliVideoMetadataFactory(VideoMetadataFactory):
+    source = "bilibili"
+    video_id = factory.LazyFunction(generate_bilibili_id)
+
+
+class BilibiliVideoFactory(VideoFactory):
+    metadata = factory.SubFactory(BilibiliVideoMetadataFactory)
+    uid = factory.LazyAttribute(lambda e: f"bili:{e.metadata['video_id']}")
+
+
 class VideoCriteriaScoreFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = EntityCriteriaScore

--- a/backend/tournesol/tests/test_api_comparison.py
+++ b/backend/tournesol/tests/test_api_comparison.py
@@ -1339,6 +1339,35 @@ class ComparisonApiTestCase(TestCase):
         # No additional call to YouTube API should be visible.
         self.assertEqual(len(mock_get_video_metadata.mock_calls), 2)
 
+    @patch("tournesol.utils.api_bilibili.get_bilibili_video_metadata")
+    def test_comparison_creation_with_bilibili_video(self, mock_get_bilibili_video_metadata):
+        """
+        A comparison involving a non-existing Bilibili video should create
+        the entity dynamically, using the Bilibili API to fetch its metadata.
+        """
+        mock_get_bilibili_video_metadata.return_value = {
+            "source": "bilibili",
+            "name": "video title",
+        }
+        self.client.force_authenticate(self.user)
+
+        bilibili_uid = "bili:BV1GJ411x7h7"
+        data = {
+            "entity_a": {"uid": bilibili_uid},
+            "entity_b": {"uid": self._uid_01},
+            "criteria_scores": [
+                {"criteria": "largely_recommended", "score": 10, "score_max": 10, "weight": 10}
+            ],
+        }
+        response = self.client.post(self.comparisons_base_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+
+        mock_get_bilibili_video_metadata.assert_called_once_with("BV1GJ411x7h7")
+        entity = Entity.objects.get(uid=bilibili_uid)
+        self.assertEqual(entity.type, "video")
+        self.assertEqual(entity.metadata["source"], "bilibili")
+        self.assertEqual(entity.metadata["name"], "video title")
+
     def test_invalid_criteria_in_comparison(self):
         self.client.force_authenticate(self.user)
         data = deepcopy(self.non_existing_comparison)

--- a/backend/tournesol/tests/test_utils_api_bilibili.py
+++ b/backend/tournesol/tests/test_utils_api_bilibili.py
@@ -1,0 +1,63 @@
+"""
+All test cases of the Bilibili API utilities.
+"""
+from unittest.mock import patch
+
+import requests
+from django.test import SimpleTestCase
+
+from tournesol.utils.api_bilibili import get_bilibili_video_metadata
+from tournesol.utils.api_youtube import VideoNotFound
+
+
+@patch("tournesol.utils.api_bilibili.get_bilibili_video_details")
+class GetBilibiliVideoMetadataTestCase(SimpleTestCase):
+
+    def test_metadata_mapping(self, mock_details):
+        mock_details.return_value = {
+            "code": 0,
+            "message": "0",
+            "data": {
+                "bvid": "BV1GJ411x7h7",
+                "title": "视频标题",
+                "desc": "视频简介",
+                "pubdate": 1577836800,
+                "duration": 213,
+                "pic": "http://i0.hdslb.com/bfs/archive/example.jpg",
+                "owner": {"mid": 928123, "name": "UP主"},
+                "stat": {"view": 320000},
+            },
+        }
+
+        metadata = get_bilibili_video_metadata("BV1GJ411x7h7", compute_language=False)
+
+        self.assertEqual(metadata["source"], "bilibili")
+        self.assertEqual(metadata["name"], "视频标题")
+        self.assertEqual(metadata["description"], "视频简介")
+        self.assertEqual(metadata["publication_date"], "2020-01-01T00:00:00+00:00")
+        self.assertEqual(metadata["duration"], 213)
+        self.assertEqual(metadata["views"], 320000)
+        self.assertEqual(metadata["uploader"], "UP主")
+        self.assertEqual(metadata["channel_id"], "928123")
+        self.assertEqual(
+            metadata["thumbnail_url"], "http://i0.hdslb.com/bfs/archive/example.jpg"
+        )
+        self.assertIsNone(metadata["language"])
+
+    def test_video_not_found(self, mock_details):
+        mock_details.return_value = {"code": -404, "message": "啥都木有", "data": None}
+
+        with self.assertRaises(VideoNotFound):
+            get_bilibili_video_metadata("BV1GJ411x7h7", compute_language=False)
+
+    def test_unexpected_error_code_returns_no_metadata(self, mock_details):
+        mock_details.return_value = {"code": -509, "message": "请求过于频繁", "data": None}
+
+        metadata = get_bilibili_video_metadata("BV1GJ411x7h7", compute_language=False)
+        self.assertEqual(metadata, {})
+
+    def test_request_error_returns_no_metadata(self, mock_details):
+        mock_details.side_effect = requests.RequestException
+
+        metadata = get_bilibili_video_metadata("BV1GJ411x7h7", compute_language=False)
+        self.assertEqual(metadata, {})

--- a/backend/tournesol/utils/api_bilibili.py
+++ b/backend/tournesol/utils/api_bilibili.py
@@ -1,0 +1,101 @@
+"""
+Utilities to fetch video metadata from the Bilibili web API.
+
+Unlike the YouTube API, the Bilibili web API doesn't require an API key.
+
+See https://github.com/SocialSisterYi/bilibili-API-collect for a community
+documentation of this API.
+"""
+import logging
+from datetime import datetime, timezone
+
+import requests
+
+from tournesol.utils.api_youtube import VideoNotFound
+from tournesol.utils.constants import REQUEST_TIMEOUT
+from tournesol.utils.video_language import compute_video_language
+
+logger = logging.getLogger(__name__)
+
+BILIBILI_VIDEO_VIEW_API_URL = "https://api.bilibili.com/x/web-interface/view"
+
+# Error codes returned by the Bilibili API when a video doesn't exist, has
+# been deleted, or cannot be accessed.
+BILIBILI_VIDEO_NOT_FOUND_CODES = {-400, -404, 62002, 62004, 62012}
+
+# The Bilibili API rejects requests having no usual browser User-Agent.
+BILIBILI_REQUEST_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+    "Referer": "https://www.bilibili.com",
+}
+
+
+def get_bilibili_video_details(video_id):
+    logger.info("Fetching Bilibili metadata for video_id '%s'", video_id)
+    resp = requests.get(
+        BILIBILI_VIDEO_VIEW_API_URL,
+        params={"bvid": video_id},
+        headers=BILIBILI_REQUEST_HEADERS,
+        timeout=REQUEST_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_bilibili_video_metadata(video_id, compute_language=True):
+    try:
+        response = get_bilibili_video_details(video_id)
+    except Exception:  # pylint: disable=broad-except
+        logger.error(
+            "Failed to retrieve video metadata from Bilibili for video_id '%s'",
+            video_id,
+            exc_info=True,
+        )
+        return {}
+
+    if response.get("code") != 0:
+        if response.get("code") in BILIBILI_VIDEO_NOT_FOUND_CODES:
+            raise VideoNotFound
+
+        logger.error(
+            "Unexpected error code %s from the Bilibili API for video_id '%s': %s",
+            response.get("code"),
+            video_id,
+            response.get("message"),
+        )
+        return {}
+
+    data = response["data"]
+    title = data.get("title", "")
+    description = data.get("desc", "")
+    uploader = data.get("owner", {}).get("name", "")
+    channel_id = data.get("owner", {}).get("mid")
+    publication_timestamp = data.get("pubdate")
+
+    if compute_language:
+        language = compute_video_language(uploader, title, description)
+    else:
+        language = None
+
+    return {
+        "source": "bilibili",
+        "name": title,
+        "description": description,
+        "publication_date": (
+            datetime.fromtimestamp(publication_timestamp, tz=timezone.utc).isoformat()
+            if publication_timestamp is not None
+            else None
+        ),
+        "views": data.get("stat", {}).get("view"),
+        "uploader": uploader,
+        "channel_id": str(channel_id) if channel_id is not None else None,
+        "language": language,
+        # The Bilibili API exposes no tags in this endpoint.
+        "tags": [],
+        "duration": data.get("duration"),
+        # Bilibili has no equivalent of the YouTube unlisted status.
+        "is_unlisted": False,
+        # Unlike YouTube thumbnails, Bilibili thumbnail URLs cannot be
+        # derived from the video id, so they must be stored.
+        "thumbnail_url": data.get("pic"),
+    }

--- a/backend/tournesol/utils/constants.py
+++ b/backend/tournesol/utils/constants.py
@@ -8,6 +8,10 @@ YOUTUBE_VIDEO_ID_REGEX_SYMBOL = "[A-Za-z0-9-_]"
 # The whole video ID
 YOUTUBE_VIDEO_ID_REGEX = rf"{YOUTUBE_VIDEO_ID_REGEX_SYMBOL}{{11}}"
 
+# The whole Bilibili video ID ("BV-id"): "BV" followed by 10 symbols of the
+# base58 alphabet (which excludes the characters 0, I, O and l)
+BILIBILI_VIDEO_ID_REGEX = r"BV[1-9A-HJ-NP-Za-km-z]{10}"
+
 # 3 seconds timeout to avoid staying blocked if an outgoing HTTP request fails
 REQUEST_TIMEOUT = 3
 


### PR DESCRIPTION
Related issue: none — happy to open one if you prefer tracking this feature in an issue first.

## Description

This PR adds **backend support for Bilibili videos** in the `videos` poll, as a first step towards supporting video platforms other than YouTube.

Bilibili is the leading video platform for Chinese-speaking audiences, and its catalog (notably science / education content) is largely disjoint from YouTube's, so this would open Tournesol to a large new pool of content and contributors.

### Design

Rather than introducing a new entity type, this PR leans on the existing namespace dispatch built into `EntityType.get_uid_regex(namespace)`: the `video` entity type now accepts a second UID namespace, `bili:<BV-id>` (e.g. `bili:BV1GJ411x7h7`), next to `yt:<video-id>`. The `source` metadata field distinguishes the platforms (`youtube` / `bilibili`).

This keeps Bilibili videos inside the existing `videos` poll — comparable with YouTube videos — with **no DB migration and no API schema change** (the generated OpenAPI spec is unchanged, since entity `metadata` is a free-form object in the schema).

### Changes

- `utils/api_bilibili.py` (new): metadata fetching through the public Bilibili web API (`api.bilibili.com/x/web-interface/view`). No API key required. Maps the response to the existing `VideoMetadata` shape (`name`, `description`, `uploader`, `channel_id`, `publication_date`, `duration`, `views`, …).
- `entities/video.py`: `VideoEntity` accepts the `bili` namespace, and `update_metadata_field()` dispatches to the YouTube or Bilibili client based on the UID namespace.
- `serializers/metadata.py`: `video_id` accepts either a YouTube id or a Bilibili BV-id; new optional `thumbnail_url` field, since Bilibili thumbnail URLs (unlike YouTube's) cannot be derived from the video id and must be stored at fetch time.
- `models/entity.py`: `create_from_video_id()` / `get_from_video_id()` take an optional `namespace` (default `yt`, so all existing callers are unaffected); `link_to_tournesol()` now builds the URL from `self.uid` instead of hardcoding `yt:`.
- `serializers/entity.py`: the dynamic entity creation on comparison/rate-later now passes the validated UID namespace through, so comparing a `bili:` UID in a video poll creates the entity from the Bilibili API.

### Tests

- `entities/test_video_bilibili.py`: UID regex validation (base58 BV-ids, non-interchangeability of namespaces), `VideoMetadata` video_id validation, and metadata refresh dispatch (Bilibili UID → Bilibili API, YouTube UID → YouTube API).
- `tests/test_utils_api_bilibili.py`: response mapping, video-not-found error codes, unexpected error codes, request errors.
- `tests/test_api_comparison.py`: a comparison with a non-existing `bili:` UID dynamically creates the entity with metadata fetched from the Bilibili API (mocked).

### Out of scope / follow-ups

This PR is intentionally backend-only so it stays reviewable. If the approach suits you, I'd follow up with:

1. **Front end**: parse `bilibili.com/video/BVxxxx` URLs in the entity selector / rate-later form, render Bilibili embeds (`player.bilibili.com`) and thumbnails (`metadata.thumbnail_url`) in `EntityImagery`, and stop hardcoding the `yt:` prefix.
2. **Previews**: use `metadata.thumbnail_url` in the preview endpoints instead of `img.youtube.com` when the source is not YouTube (currently a Bilibili entity would fall back to YouTube's grey placeholder thumbnail).
3. Possibly language handling: Bilibili content is mostly `zh`, which currently maps to the `simple` Postgres search config.

Notes for reviewers:
- The 11-character edge case: an 11-char string starting with `BV` is indistinguishable from a YouTube video id, but since the platform is determined by the UID namespace (not the id shape), this is only a theoretical concern for the shared `video_id` metadata regex.
- The Bilibili API needs a browser-like `User-Agent` and `Referer` header, hence the hardcoded values in `api_bilibili.py`.

## Checklist

- [ ] I referenced the issue id, if any.
- [x] I added a description of the problem and its solution.
- [x] I read the [guidelines about contributing](https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md), including the code quality requirements.
- [x] The automated tests pass, and I updated them if required.
- [x] The automated code quality checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
