### PR TITLE
Add Safari extension build support

### DIFF
--- a/browser-extension/.gitignore
+++ b/browser-extension/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 src/manifest.json
 src/config.js
 src/importWrappers/
+safari/

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -48,6 +48,36 @@ By default, the script creates an extension that connects to the production Tour
 
 The default is also to build a Manifest V2 extension for Firefox. To build a Manifest V3 extension for Chrome, run `EXTENSION_BROWSER=chrome MANIFEST_VERSION=3 yarn configure`.
 
+To prepare a Manifest V2 extension compatible with Safari, run:
+
+```shell
+yarn configure:safari
+```
+
+Safari uses Manifest V2 because the background script is an ECMAScript module.
+Safari does not currently support the `type: "module"` service worker declaration
+used by the Chrome Manifest V3 build.
+
+### Package for Safari
+
+On macOS with Xcode installed, generate a macOS app and Safari Web Extension
+Xcode project with:
+
+```shell
+./build-safari.sh
+```
+
+The project is generated in `safari/Tournesol/Tournesol.xcodeproj`. To use a
+different output directory or bundle identifier prefix:
+
+```shell
+./build-safari.sh -o /path/to/output -b org.example
+```
+
+Open the generated project in Xcode, select your development team under Signing
+& Capabilities, then build and run the `Tournesol` scheme. Enable the extension
+in Safari under Settings > Extensions.
+
 ### Code Quality
 
 We use `ESLint` to find and fix problems in the JavaScript code.

--- a/browser-extension/build-safari.sh
+++ b/browser-extension/build-safari.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+#
+# Build an Xcode project containing the Tournesol Safari Web Extension.
+#
+
+set -eu
+
+usage() {
+    echo "Usage: $0 [-o output-directory] [-b bundle-identifier-prefix]" 1>&2
+}
+
+SCRIPT_PATH="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+OUTPUT_DIRECTORY="${SCRIPT_PATH}/safari"
+BUNDLE_IDENTIFIER_PREFIX='app.tournesol'
+
+while getopts "ho:b:" opt; do
+    case $opt in
+        o ) OUTPUT_DIRECTORY=$OPTARG;;
+        b ) BUNDLE_IDENTIFIER_PREFIX=$OPTARG;;
+        h )
+            usage
+            exit 0
+            ;;
+        * )
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if ! xcrun --find safari-web-extension-packager > /dev/null 2>&1; then
+    echo "The Safari Web Extension packager was not found. Install Xcode first." 1>&2
+    exit 1
+fi
+
+pushd "${SCRIPT_PATH}" > /dev/null
+
+EXTENSION_BROWSER=safari MANIFEST_VERSION=2 node prepareExtension.js
+
+xcrun safari-web-extension-packager src \
+    --project-location "${OUTPUT_DIRECTORY}" \
+    --app-name Tournesol \
+    --bundle-identifier "${BUNDLE_IDENTIFIER_PREFIX}.Tournesol" \
+    --swift \
+    --macos-only \
+    --copy-resources \
+    --no-open \
+    --no-prompt \
+    --force
+
+popd > /dev/null

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "configure": "node prepareExtension.js",
     "configure:dev": "TOURNESOL_ENV=dev-env node prepareExtension.js",
+    "configure:safari": "EXTENSION_BROWSER=safari MANIFEST_VERSION=2 node prepareExtension.js",
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
   },

--- a/browser-extension/prepareExtension.js
+++ b/browser-extension/prepareExtension.js
@@ -49,7 +49,7 @@ const permissions = [
   'activeTab',
   'contextMenus',
   'storage',
-  'webNavigation',
+  ...(browser !== 'safari' ? ['webNavigation'] : []),
   // webRequest and webReauestBlocking were used to overwrite
   // headers in the API response. This is no longer the case
   // with version > 3.5.2.

--- a/browser-extension/prepareExtension.js
+++ b/browser-extension/prepareExtension.js
@@ -12,10 +12,16 @@ const browser = process.env.EXTENSION_BROWSER || 'firefox';
 if (process.env.EXTENSION_BROWSER && !process.env.MANIFEST_VERSION) {
   throw new Error(`MANIFEST_VERSION is required with EXTENSION_BROWSER`);
 }
+if (!['chrome', 'firefox', 'safari'].includes(browser)) {
+  throw new Error(`Invalid browser: ${browser}`);
+}
 
 const manifestVersion = parseInt(process.env.MANIFEST_VERSION || 2);
 if (manifestVersion != 2 && manifestVersion != 3)
   throw new Error(`Invalid manifest version: ${manifestVersion}`);
+if (browser === 'safari' && manifestVersion !== 2) {
+  throw new Error('Safari builds require manifest version 2');
+}
 if (manifestVersion === 2) {
   console.info(
     `Extension will be configured with manifest version ${manifestVersion}.`
@@ -49,10 +55,10 @@ const permissions = [
   // with version > 3.5.2.
   // These permissions can be removed as soon as we are confident
   // the next release works as expected.
-  ...selectValue(manifestVersion, {
-    2: ['webRequest', 'webRequestBlocking'],
-    3: ['scripting'],
-  }),
+  ...(manifestVersion === 2 && browser !== 'safari'
+    ? ['webRequest', 'webRequestBlocking']
+    : []),
+  ...(manifestVersion === 3 ? ['scripting'] : []),
 ];
 
 const allPermissions = selectValue(manifestVersion, {
@@ -80,22 +86,25 @@ const manifest = {
     128: 'Logo128.png',
     512: 'Logo512.png',
   },
-  background: selectValue(manifestVersion, {
-    2: { page: 'background.html', persistent: true },
-    3: selectValue(browser, {
-      // It's possible to make a browser-independent background value but
-      // Chrome only supports that since version 121 released in January 2024.
-      // See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background
-      firefox: {
-        scripts: ['background.js'],
-        type: 'module',
-      },
-      chrome: {
-        service_worker: 'background.js',
-        type: 'module',
-      },
-    }),
-  }),
+  background:
+    manifestVersion === 2
+      ? {
+          page: 'background.html',
+          persistent: true,
+        }
+      : selectValue(browser, {
+          // It's possible to make a browser-independent background value but
+          // Chrome only supports that since version 121 released in January 2024.
+          // See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background
+          firefox: {
+            scripts: ['background.js'],
+            type: 'module',
+          },
+          chrome: {
+            service_worker: 'background.js',
+            type: 'module',
+          },
+        }),
   [selectValue(manifestVersion, { 2: 'browser_action', 3: 'action' })]: {
     default_icon: {
       16: 'Logo16.png',
@@ -156,11 +165,25 @@ const manifest = {
       all_frames: false,
     },
   ],
-  options_ui: {
-    page: 'options/options.html',
-    open_in_tab: true,
-  },
+  options_ui:
+    browser === 'safari'
+      ? {
+          page: 'options/options.html',
+        }
+      : {
+          page: 'options/options.html',
+          open_in_tab: true,
+        },
   default_locale: 'en',
+  ...(browser === 'safari'
+    ? {
+        browser_specific_settings: {
+          safari: {
+            strict_min_version: '14.0',
+          },
+        },
+      }
+    : {}),
   web_accessible_resources: selectValue(manifestVersion, {
     2: webAccessibleResourcesFromYouTube,
     3: [

--- a/browser-extension/prepareExtension.js
+++ b/browser-extension/prepareExtension.js
@@ -43,7 +43,7 @@ const hostPermissions = [
     ],
   }),
   'https://www.youtube.com/',
-];
+].map((permission) => (browser === 'safari' ? `${permission}*` : permission));
 
 const permissions = [
   'activeTab',

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -372,12 +372,21 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 
 // Send message to Tournesol tab on URL change, to sync access token
-// during navigation (after login, logout, etc.)
-chrome.webNavigation.onHistoryStateUpdated.addListener(
-  (event) => {
-    chrome.tabs.sendMessage(event.tabId, 'historyStateUpdated');
-  },
-  {
-    url: [{ hostEquals: frontendHost }],
-  }
-);
+// during navigation (after login, logout, etc.). Safari does not expose the
+// webNavigation API, but tabs.onUpdated reports the same SPA URL changes.
+if (chrome.webNavigation?.onHistoryStateUpdated) {
+  chrome.webNavigation.onHistoryStateUpdated.addListener(
+    (event) => {
+      chrome.tabs.sendMessage(event.tabId, 'historyStateUpdated');
+    },
+    {
+      url: [{ hostEquals: frontendHost }],
+    }
+  );
+} else if (chrome.tabs?.onUpdated) {
+  chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+    if (changeInfo.url && new URL(changeInfo.url).host === frontendHost) {
+      chrome.tabs.sendMessage(tabId, 'historyStateUpdated');
+    }
+  });
+}

--- a/browser-extension/src/utils.js
+++ b/browser-extension/src/utils.js
@@ -142,6 +142,11 @@ export const addRateLaterBulk = async (videoIds) => {
       data: videoIds.map((videoId) => ({ entity: { uid: 'yt:' + videoId } })),
     }
   );
+
+  if (!rateLaterBulkResponse) {
+    return { success: false };
+  }
+
   const responseJson = await rateLaterBulkResponse.json();
   return {
     success: rateLaterBulkResponse.ok,
@@ -157,6 +162,10 @@ export const getUserProof = async (keyword) => {
   const userProofResponse = await fetchTournesolApi(
     `users/me/proof/videos?keyword=${keyword}`
   );
+
+  if (!userProofResponse) {
+    return { success: false };
+  }
 
   if ([200, 401].includes(userProofResponse.status)) {
     const responseJson = await userProofResponse.json();
@@ -182,6 +191,10 @@ export const updateSingleSetting = async (name, value, scope = 'videos') => {
 
 export const getUserSettings = async () => {
   const userSettingsResponse = await fetchTournesolApi('users/me/settings/');
+
+  if (!userSettingsResponse) {
+    return { success: false };
+  }
 
   if ([200, 401].includes(userSettingsResponse.status)) {
     const responseJson = await userSettingsResponse.json();
@@ -220,7 +233,7 @@ export const getVideoStatistics = async (videoId) => {
   const videoStatistics = await fetchTournesolApi(
     `polls/videos/entities/yt:${videoId}`
   );
-  if (videoStatistics.status === 200) {
+  if (videoStatistics && videoStatistics.status === 200) {
     const responseJson = await videoStatistics.json();
 
     return {


### PR DESCRIPTION
## What changed

- add Safari as a supported manifest-generation target
- generate a Safari-compatible Manifest V2 build without unsupported permissions or options
- use full-path Safari host patterns so background API requests are authorized
- fall back to tabs.onUpdated because Safari does not expose the webNavigation namespace
- handle failed API fetches without crashing the background page
- add a macOS/Xcode packaging script using Apples Safari Web Extension packager
- document local packaging, signing, and enablement in Safari

## Why

Tournesol publishes Chrome and Firefox extensions, but Safari users currently have no build target. Reusing the existing Manifest V2 background page preserves its ECMAScript module imports; the Safari packager does not support the Manifest V3 type: module service-worker declaration used by the Chrome build.

Safari also lacks the webNavigation namespace exposed to the existing build and requires complete scheme, host, and path match patterns for website access. The compatibility fallbacks preserve navigation and API behavior without crashing the background page.

## User impact

A developer on macOS can run ./build-safari.sh, select a signing team in the generated Xcode project, and build the Tournesol Safari Web Extension from the same source as Chrome and Firefox.

## Validation

- yarn lint
- Firefox MV2, Chrome MV3, and Safari MV2 manifest-generation assertions
- Safari MV3 rejection assertion
- Safari manifest assertions for wildcard host permissions and omitted webNavigation permission
- live Tournesol API reachability checks for anonymous settings and recommendations
- Safari Web Extension packaging with no manifest warnings on Xcode 26.6
- unsigned Xcode Release build of the generated host app and extension