### PR TITLE
ci: workaround crash in "e2e-browser-extension" with cypress flag `experimentalFastVisibility=true`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
           browser: chromium
           headed: true
           spec: "cypress/e2e/browser-extension/**/*"
-          config: baseUrl=https://www.youtube.com
+          config: baseUrl=https://www.youtube.com,experimentalMemoryManagement=true
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           EXTENSION_BROWSER=chrome MANIFEST_VERSION=3 yarn configure
 
-      - uses: cypress-io/github-action@v6
+      - uses: cypress-io/github-action@v7
         with:
           working-directory: tests
           browser: chromium
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: '22'
 
-      - uses: cypress-io/github-action@v6
+      - uses: cypress-io/github-action@v7
         with:
           working-directory: tests
           browser: chrome

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
           browser: chromium
           headed: true
           spec: "cypress/e2e/browser-extension/**/*"
-          config: baseUrl=https://www.youtube.com,experimentalMemoryManagement=true
+          config: baseUrl=https://www.youtube.com,experimentalMemoryManagement=true,experimentalFastVisibility=true
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
           browser: chromium
           headed: true
           spec: "cypress/e2e/browser-extension/**/*"
-          config: baseUrl=https://www.youtube.com,experimentalMemoryManagement=true,experimentalFastVisibility=true
+          config: baseUrl=https://www.youtube.com,experimentalFastVisibility=true
 
       - uses: actions/upload-artifact@v4
         if: failure()


### PR DESCRIPTION
### Description

Attempt to fix crash in e2e CI workflow.

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
