### PR TITLE
[ext] chore: add the key browser_specific_settings to the manifest

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tournesol-extension",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/browser-extension/prepareExtension.js
+++ b/browser-extension/prepareExtension.js
@@ -69,12 +69,31 @@ const webAccessibleResourcesFromYouTube = [
   'config.js',
 ];
 
+const specificSettings = {
+  browser_specific_settings: {
+    gecko: {
+      data_collection_permissions: {
+        required: ['none'],
+      },
+    },
+  },
+};
+
+const browserSpecificSettings = {
+  firefox: { ...specificSettings },
+  // The manifest key `browser_specific_settings` is not yet supported by
+  // Chrome.
+  // See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#browser_compatibility
+  chrome: {},
+};
+
 const manifest = {
   name: 'Tournesol Extension',
   version,
   description: 'Open Tournesol directly from YouTube',
-  ...allPermissions,
   manifest_version: manifestVersion,
+  ...allPermissions,
+  ...selectValue(browser, browserSpecificSettings),
   icons: {
     64: 'Logo64.png',
     128: 'Logo128.png',

--- a/browser-extension/prepareExtension.js
+++ b/browser-extension/prepareExtension.js
@@ -72,6 +72,8 @@ const webAccessibleResourcesFromYouTube = [
 const specificSettings = {
   browser_specific_settings: {
     gecko: {
+      // GUID initially assigned by addons.mozilla.org
+      id: "{e8e831e8-8a2b-4fd8-b9f0-cd11155b476d}",
       data_collection_permissions: {
         required: ['none'],
       },

--- a/browser-extension/prepareExtension.js
+++ b/browser-extension/prepareExtension.js
@@ -73,7 +73,7 @@ const specificSettings = {
   browser_specific_settings: {
     gecko: {
       // GUID initially assigned by addons.mozilla.org
-      id: "{e8e831e8-8a2b-4fd8-b9f0-cd11155b476d}",
+      id: '{e8e831e8-8a2b-4fd8-b9f0-cd11155b476d}',
       data_collection_permissions: {
         required: ['none'],
       },


### PR DESCRIPTION
### Description

In the future, Firefox will expect the extension id and data collection permissions to be explicitly defined in the manifest (even if the extension doesn't collect any data).

This branch adds new keys to the manifest:
- `data_collection_permissions` set to none
- `id` set to the GUID generated by Mozilla the first time we uploaded the browser extension

 This fixes the two warnings currently displayed on Firefox Add-ons:

<img width="978" height="647" alt="capture1" src="https://github.com/user-attachments/assets/59eecd3d-1f5f-485b-a25d-7560e8723ff4" />

In the capture below we can see the new statement displayed in the extension settings:

<img width="672" height="416" alt="capture" src="https://github.com/user-attachments/assets/c46c90fd-1da1-4e79-9b10-32e95b6c32b1" />

Read more about the data collection permissions here:
- https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#data_collection_permissions

### Checklist

- [x] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [x] I described my changes and my decisions in the PR description
- [x] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [x] The tests pass and have been updated if relevant
- [x] The code quality check pass

[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
