### PR TITLE
e2e: use firefox headless to run browser extension tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,15 +21,15 @@ jobs:
       - name: Prepare extension
         working-directory: browser-extension
         run: |
-          EXTENSION_BROWSER=chrome MANIFEST_VERSION=3 yarn configure
+          EXTENSION_BROWSER=firefox MANIFEST_VERSION=2 yarn configure
 
       - uses: cypress-io/github-action@v7
         with:
           working-directory: tests
-          browser: chromium
-          headed: true
+          browser: firefox
+          headed: false
           spec: "cypress/e2e/browser-extension/**/*"
-          config: baseUrl=https://www.youtube.com,experimentalMemoryManagement=true,experimentalFastVisibility=true
+          config: baseUrl=https://www.youtube.com
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,9 +41,12 @@ For more options see [Cypress documentation](https://docs.cypress.io/guides/guid
 
 ## Testing the browser extension
 
-Currently, the browser extension tests support only Chromium and Chrome, and need to be run in "headed" (windowed) mode.  
-The tests related to the browser extension will be skipped if these conditions are not met.
-
+Currently, the browser extension tests support only Chromium (not Chrome) and Firefox.
 ```
-yarn run cypress run --browser chrome --headed
+yarn run cypress run --browser firefox --spec 'cypress/e2e/browser-extension/**'
+```
+
+On Chromium they need to be run in "headed" (windowed) mode.
+```
+yarn run cypress run --browser chromium --headed --spec 'cypress/e2e/browser-extension/**'
 ```

--- a/tests/cypress/e2e/browser-extension/extension.cy.ts
+++ b/tests/cypress/e2e/browser-extension/extension.cy.ts
@@ -1,85 +1,82 @@
 import { onlyOn } from "@cypress/skip-test";
 
-onlyOn("headed", () => {
-  describe(
-    "Tournesol extension",
-    {
-      browser: ["chromium", "chrome"],
-      defaultCommandTimeout: 16000,
-    },
-    () => {
-      // Close consent modal
-      const consent = () => {
-        cy.get("body")
-          .then(body => body.find("#dialog").length > 0)
-          .then((has_dialog: boolean) => {
-            if (!has_dialog) {
-              return
-            }
-            cy.get("body #dialog #content button")
-              .first()
-              .click()
-          })
-      };
+describe(
+  "Tournesol extension",
+  {
+    defaultCommandTimeout: 16000,
+  },
+  () => {
+    // Close consent modal
+    const consent = () => {
+      cy.get("body")
+        .then(body => body.find("#dialog").length > 0)
+        .then((has_dialog: boolean) => {
+          if (!has_dialog) {
+            return
+          }
+          cy.get("body #dialog #content button")
+            .first()
+            .click()
+        })
+    };
 
-      beforeEach(() => {
-        cy.on("uncaught:exception", (err, runnable) => {
-          // returning false here prevents Cypress from failing the test,
-          // because of unrelated YouTube errors
-          return false;
-        });
+    beforeEach(() => {
+      cy.on("uncaught:exception", (err, runnable) => {
+        // returning false here prevents Cypress from failing the test,
+        // because of unrelated YouTube errors
+        return false;
+      });
+    });
+
+
+    describe("Home page", () => {
+      it("shows the recommendations", () => {
+        cy.visit("https://www.youtube.com");
+        consent();
+        cy.contains("Recommended by Tournesol").should("be.visible");
+
+        // Reloading the page should not duplicate the Tournesol container.
+        cy.reload();
+        cy.get("#tournesol_container").should("have.length", 1);
+      });
+    });
+
+    describe("Search page", () => {
+      // We use an accented character to ensure that the search URL
+      // parameter is properly decoded.
+      const searchQuery = 'tournésol';
+
+      it("shows Tournesol search results when the search is on", () => {
+        cy.visit(`https://www.youtube.com/results?search_query=${searchQuery}&tournesolSearch=1`);
+        consent();
+        cy.contains("Recommended by Tournesol", { timeout: 20000 });
       });
 
+      it("doesn't show Tournesol search results when the search is off", () => {
+        cy.visit(`https://www.youtube.com/results?search_query=${searchQuery}`);
+        consent();
+        cy.contains("Recommended by Tournesol").should("not.exist");
+      });
+    });
 
-      describe("Home page", () => {
-        it("shows the recommendations", () => {
-          cy.visit("https://www.youtube.com");
-          consent();
-          cy.contains("Recommended by Tournesol").should("be.visible");
+    describe("Video page", () => {
+      it('shows the "Rate Later" and "Rate Now" buttons', () => {
+        cy.visit("https://www.youtube.com/watch?v=6jK9bFWE--g");
+        consent();
 
-          // Reloading the page should not duplicate the Tournesol container.
-          cy.reload();
-          cy.get("#tournesol_container").should("have.length", 1);
+        // Dismiss YouTube ad if present.
+        cy.get("body").then(($body) => {
+          if ($body.find("button:contains('Dismiss')").length > 0) {
+            cy.contains('button', 'Dismiss', { matchCase: false }).click();
+          }
+          cy.contains("button", "Rate Later", { matchCase: false }).should(
+            "be.visible", { timeout: 20000 }
+          );
+          cy.contains("button", "Rate Now", { matchCase: false }).should(
+            "be.visible", { timeout: 20000 }
+          );
         });
       });
-
-      describe("Search page", () => {
-        // We use an accented character to ensure that the search URL
-        // parameter is properly decoded.
-        const searchQuery = 'tournésol';
-
-        it("shows Tournesol search results when the search is on", () => {
-          cy.visit(`https://www.youtube.com/results?search_query=${searchQuery}&tournesolSearch=1`);
-          consent();
-          cy.contains("Recommended by Tournesol", { timeout: 20000 });
-        });
-
-        it("doesn't show Tournesol search results when the search is off", () => {
-          cy.visit(`https://www.youtube.com/results?search_query=${searchQuery}`);
-          consent();
-          cy.contains("Recommended by Tournesol").should("not.exist");
-        });
-      });
-
-      describe("Video page", () => {
-        it('shows the "Rate Later" and "Rate Now" buttons', () => {
-          cy.visit("https://www.youtube.com/watch?v=6jK9bFWE--g");
-          consent();
-
-          // Dismiss YouTube ad if present.
-          cy.get("body").then(($body) => {
-            if ($body.find("button:contains('Dismiss')").length > 0) {
-              cy.contains('button', 'Dismiss', { matchCase: false }).click();
-            }
-            cy.contains("button", "Rate Later", { matchCase: false }).should(
-              "be.visible", { timeout: 20000 }
-            );
-            cy.contains("button", "Rate Now", { matchCase: false }).should(
-              "be.visible", { timeout: 20000 }
-            );
-          });
-        });
-      });
-    }
-  );
-});
+    });
+  }
+);


### PR DESCRIPTION
### Description
This approach seems to be less heavy on GitHub CI,
as chromium does not support using extensions in headless mode.

### Checklist

- [ ] I added the related issue(s) id in the related issues section (if any)
  - if not, delete the related issues section
- [ ] I described my changes and my decisions in the PR description
- [ ] I read the development guidelines of the [CONTRIBUTING.md][development-guidelines]
- [ ] The tests pass and have been updated if relevant
- [ ] The code quality check pass


[development-guidelines]: https://github.com/tournesol-app/tournesol/blob/main/CONTRIBUTING.md#development-guidelines
