### PR TITLE
[front] Upgrade to React 18

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,11 +11,11 @@
     "@mui/styles": "^6.4.11",
     "@react-hook/resize-observer": "^1.2.5",
     "@reduxjs/toolkit": "^1.7.1",
-    "@types/react": "^17",
-    "@types/react-dom": "^17.0.11",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
     "@types/react-redux": "^7.1.7",
     "@use-gesture/react": "^10.3.1",
-    "i18next": "^22.4.0",
+    "i18next": "^23",
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-http-backend": "^3.0.5",
     "linkify-string": "^4.1",
@@ -23,9 +23,9 @@
     "notistack": "^3.0.2",
     "plausible-tracker": "^0.3.8",
     "precompress": "7.0.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-i18next": "^12",
+    "react": "^18",
+    "react-dom": "^18",
+    "react-i18next": "^14",
     "react-player": "^2.9.0",
     "react-redux": "^7.2.6",
     "react-router-dom": "^6.30.4",
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@testing-library/dom": ">=5",
     "@testing-library/jest-dom": "^5.16",
-    "@testing-library/react": "^12.1.2",
+    "@testing-library/react": "^16",
     "@testing-library/user-event": "^13.5.0",
     "@types/redux-mock-store": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^5.8.1",
@@ -87,6 +87,6 @@
     ]
   },
   "resolutions": {
-    "@types/react": "^17"
+    "@types/react": "^18"
   }
 }

--- a/frontend/src/components/CriteriaBarChart.tsx
+++ b/frontend/src/components/CriteriaBarChart.tsx
@@ -370,7 +370,7 @@ const SizedBarChart = ({
   const svgRef = useRef<SVGSVGElement>(null);
 
   const handleClick = useCallback(
-    (event) => {
+    (event: React.MouseEvent<SVGSVGElement>) => {
       event.preventDefault();
 
       const clickY = event.clientY;

--- a/frontend/src/components/Links.tsx
+++ b/frontend/src/components/Links.tsx
@@ -13,6 +13,9 @@ interface ExternalLinkProps {
 interface InternalLinkProps {
   children: React.ReactNode;
   to: string;
+  // Arbitrary value attached to the target history entry (not the URL),
+  // readable at the destination via the router's `useLocation().state`.
+  state?: unknown;
   target?: string;
   id?: string;
   ariaLabel?: string;
@@ -64,6 +67,7 @@ export const InternalLink = React.forwardRef<
   {
     children,
     to,
+    state,
     target,
     id,
     ariaLabel,
@@ -79,6 +83,7 @@ export const InternalLink = React.forwardRef<
       component={RouterLink}
       ref={ref}
       to={to}
+      state={state}
       target={target}
       id={id}
       aria-label={ariaLabel}

--- a/frontend/src/components/PersonalScoreCheckbox.tsx
+++ b/frontend/src/components/PersonalScoreCheckbox.tsx
@@ -46,7 +46,7 @@ const PersonalScoreCheckbox = () => {
               disabled={!canActivatePersonalScores}
             />
           }
-          label={t<string>('personalCriteriaScores.activatePersonalScores')}
+          label={t('personalCriteriaScores.activatePersonalScores')}
         />
       </FormGroup>
     </Tooltip>

--- a/frontend/src/components/buttons/BackIconButton.tsx
+++ b/frontend/src/components/buttons/BackIconButton.tsx
@@ -1,22 +1,13 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
 
 import { IconButton } from '@mui/material';
 import { Undo } from '@mui/icons-material';
 
 import { InternalLink } from 'src/components';
-import { clearBackNavigation } from 'src/features/login/loginSlice';
 
 const BackIconButton = ({ path = '' }: { path: string }) => {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    return () => {
-      dispatch(clearBackNavigation());
-    };
-  }, [dispatch]);
 
   return (
     <InternalLink

--- a/frontend/src/components/buttons/SearchIconButtonLink.tsx
+++ b/frontend/src/components/buttons/SearchIconButtonLink.tsx
@@ -6,13 +6,29 @@ import { Search } from '@mui/icons-material';
 
 import { InternalLink } from 'src/components';
 
-const SearchIconButtonLink = ({ params = '' }: { params?: string }) => {
+/**
+ * Where the search page's back button should return to, carried as the
+ * search link's location state and read there via `useLocation().state`.
+ */
+export interface BackNavigationState {
+  backPath: string;
+  backParams?: string;
+}
+
+const SearchIconButtonLink = ({
+  params = '',
+  backNavigation,
+}: {
+  params?: string;
+  backNavigation?: BackNavigationState;
+}) => {
   const { t } = useTranslation();
   const searchParams = params ? '?' + params : '';
 
   return (
     <InternalLink
       to={`/search${searchParams}`}
+      state={backNavigation}
       ariaLabel={t('searchButtonLink.linkToTheSearchPage')}
       data-testid="icon-link-to-search-page"
     >

--- a/frontend/src/features/comparisons/Comparison.tsx
+++ b/frontend/src/features/comparisons/Comparison.tsx
@@ -127,7 +127,7 @@ const Comparison = ({
   const { name: pollName, options } = useCurrentPoll();
   const mainCriterion = options?.mainCriterionName;
 
-  const initializeWithSuggestions = useRef(true);
+  const autoFillStarted = useRef(false);
   const [isLoading, setIsLoading] = useState(true);
 
   const selectorAHistory = useRef(new SuggestionHistory(autoSuggestionPool));
@@ -145,6 +145,9 @@ const Comparison = ({
     uid: uidB,
     rating: null,
   });
+
+  // True while the auto-fill effect is still choosing the starting entities.
+  const [isAutoFilling, setIsAutoFilling] = useState(true);
 
   const [pageTitle, setPageTitle] = useState(
     `${t('comparison.newComparison')}`
@@ -215,9 +218,10 @@ const Comparison = ({
    * are true.
    */
   useEffect(() => {
-    if (initializeWithSuggestions.current === false) {
+    if (autoFillStarted.current) {
       return;
     }
+    autoFillStarted.current = true;
 
     const autoFillComparison = async () => {
       let autoUidA = null;
@@ -247,18 +251,16 @@ const Comparison = ({
       if (autoUidB) {
         onChangeB({ uid: autoUidB, rating: null });
       }
-
-      initializeWithSuggestions.current = false;
     };
 
-    autoFillComparison();
+    autoFillComparison().finally(() => setIsAutoFilling(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     // Wait for the potential initialization of the suggested entities before
     // retrieving the comparison.
-    if (initializeWithSuggestions.current) {
+    if (isAutoFilling) {
       return;
     }
 
@@ -286,7 +288,7 @@ const Comparison = ({
           setInitialComparison(null);
           setIsLoading(false);
         });
-  }, [pollName, uidA, uidB, selectorA.uid, selectorB.uid]);
+  }, [pollName, uidA, uidB, selectorA.uid, selectorB.uid, isAutoFilling]);
 
   /**
    * When the UI language changes, refresh the ratings to retrieve the

--- a/frontend/src/features/comparisons/ComparisonSliders.tsx
+++ b/frontend/src/features/comparisons/ComparisonSliders.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useContext } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -83,7 +83,6 @@ const ComparisonSliders = ({
   const userSettings = useSelector(selectSettings)?.settings;
   const critAlwaysDisplayed = userSettings.videos?.comparison__criteria_order;
 
-  const isMounted = useRef(true);
   const [disableSubmit, setDisableSubmit] = useState(false);
 
   const castToComparison = (
@@ -137,13 +136,6 @@ const ComparisonSliders = ({
     [initialComparison]
   );
 
-  useEffect(() => {
-    // the cleanup function will be called when the component is unmounted
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
-
   const submitComparison = async () => {
     setDisableSubmit(true);
     resetPendingRatings();
@@ -155,10 +147,7 @@ const ComparisonSliders = ({
       refreshStats(pollName);
     }
 
-    // avoid a "memory leak" warning if the component is unmounted on submit.
-    if (isMounted.current) {
-      setSubmitted(true);
-    }
+    setSubmitted(true);
   };
 
   const handleSliderChange = (

--- a/frontend/src/features/entity_selector/SelectorPopper.tsx
+++ b/frontend/src/features/entity_selector/SelectorPopper.tsx
@@ -10,9 +10,10 @@ import {
 import { ArrowBack } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 
-interface Props extends PopperProps {
+interface Props extends Omit<PopperProps, 'children'> {
   onClose: () => void;
   modal?: boolean;
+  children?: React.ReactNode;
 }
 
 const SelectorPopper = ({

--- a/frontend/src/features/login/LoginState.model.ts
+++ b/frontend/src/features/login/LoginState.model.ts
@@ -4,6 +4,4 @@ export interface LoginState {
   refresh_token?: string;
   status: 'idle' | 'loading' | 'failed';
   username?: string;
-  backPath?: string;
-  backParams?: string;
 }

--- a/frontend/src/features/login/loginSlice.ts
+++ b/frontend/src/features/login/loginSlice.ts
@@ -74,29 +74,12 @@ export const loginSlice = createSlice({
       state.refresh_token = undefined;
       state.access_token_expiration_date = undefined;
       state.username = undefined;
-      state.backPath = undefined;
-      state.backParams = undefined;
     },
     updateUsername: (
       state: LoginState,
       action: PayloadAction<{ username: string }>
     ) => {
       state.username = action.payload.username;
-    },
-    /**
-     * Save the given path and URL parameters to allow the back buttons to
-     * return to the desired location.
-     */
-    updateBackNagivation: (
-      state: LoginState,
-      action: PayloadAction<{ backPath: string; backParams: string }>
-    ) => {
-      state.backPath = action.payload.backPath;
-      state.backParams = action.payload.backParams;
-    },
-    clearBackNavigation: (state: LoginState) => {
-      state.backPath = undefined;
-      state.backParams = undefined;
     },
   },
   extraReducers: (builder) => {
@@ -142,11 +125,6 @@ export const loginSlice = createSlice({
 });
 
 export const selectLogin = (state: RootState) => state.token;
-export const {
-  clearBackNavigation,
-  logout,
-  updateUsername,
-  updateBackNagivation,
-} = loginSlice.actions;
+export const { logout, updateUsername } = loginSlice.actions;
 
 export default loginSlice.reducer;

--- a/frontend/src/features/recommendation/LanguageFilter.tsx
+++ b/frontend/src/features/recommendation/LanguageFilter.tsx
@@ -27,7 +27,7 @@ export const LanguageField = ({
   const { t, i18n } = useTranslation();
 
   const getOptionLabel = useCallback(
-    (option) => getLanguageName(t, option),
+    (option: string) => getLanguageName(t, option),
     [t]
   );
 

--- a/frontend/src/features/recommendation/SearchFilter.spec.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.spec.tsx
@@ -25,10 +25,15 @@ import { PollProvider } from 'src/hooks/useCurrentPoll';
 import { PollsService } from 'src/services/openapi';
 import loginReducer, { initialState } from '../login/loginSlice';
 
+import { BackNavigationState } from 'src/components/buttons/SearchIconButtonLink';
+
 import SearchFilter from './SearchFilter';
 
 describe('Filters feature', () => {
-  async function renderSearchFilters(loggedIn: boolean) {
+  async function renderSearchFilters(
+    loggedIn: boolean,
+    initialLocationState?: BackNavigationState
+  ) {
     const routes = [
       {
         path: '/search',
@@ -43,7 +48,7 @@ describe('Filters feature', () => {
     ];
 
     const router = createMemoryRouter(routes, {
-      initialEntries: ['/search'],
+      initialEntries: [{ pathname: '/search', state: initialLocationState }],
       initialIndex: 0,
     });
 
@@ -307,6 +312,18 @@ describe('Filters feature', () => {
     });
 
     expect(router.state.location.search).toEqual('?duration_gte=20');
+  });
+
+  it('Preserves the back-navigation location state across a filter change', async () => {
+    // The search page keeps its back button target in the location state. A
+    // filter change navigates to a new URL, and must not drop that state.
+    const backNavigation = { backPath: '/feed', backParams: 'date=Month' };
+    const { router } = await renderSearchFilters(true, backNavigation);
+    clickOnShowMore();
+
+    clickOnDateCheckbox({ checkbox: 'Week' });
+    expect(router.state.location.search).toEqual('?date=Week');
+    expect(router.state.location.state).toEqual(backNavigation);
   });
 
   it('Can fold and unfold the multiple criteria', async () => {

--- a/frontend/src/features/recommendation/SearchFilter.tsx
+++ b/frontend/src/features/recommendation/SearchFilter.tsx
@@ -69,7 +69,8 @@ function SearchFilter({
   );
 
   const setFilterCallback = useCallback(
-    (filter) => setFilter(filter.param, filter.value),
+    (filter: { param: string; value: string | null }) =>
+      setFilter(filter.param, filter.value),
     [setFilter]
   );
 

--- a/frontend/src/features/settings/profile/ProfileForm.tsx
+++ b/frontend/src/features/settings/profile/ProfileForm.tsx
@@ -52,7 +52,7 @@ const ProfileForm = () => {
     // handle success and malformed success
     if (response) {
       if ('detail' in response) {
-        showSuccessAlert(response['detail']);
+        showSuccessAlert(String(response['detail']));
       } else {
         showSuccessAlert(t('settings.profileChangedSuccessfully'));
       }

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -5,6 +5,7 @@ export { useIsExtensionInstalled } from './useIsExtensionInstalled';
 export { useSearchParams } from './useSearchParams';
 export { useLoginState } from './useLoginState';
 export { useListFilter } from './useListFilter';
+export { useUpdateSearchParams } from './useUpdateSearchParams';
 export { useNotifications } from './useNotifications';
 export { useRefreshSettings } from './useRefreshSettings';
 export { useScrollToLocation } from './useScrollToLocation';

--- a/frontend/src/hooks/useCriteriaChartData.ts
+++ b/frontend/src/hooks/useCriteriaChartData.ts
@@ -56,14 +56,16 @@ const useCriteriaChartData = ({
     useContributorRating();
 
   const clipScore = useCallback(
-    (score) =>
-      between(
-        SCORE_MIN,
-        SCORE_MAX,
-        // Below is a bad hack necessary because scores on "presidentielle2022"
-        // are frozen, and the latest Mehestan scaling is not applied on this poll.
-        pollName === PRESIDENTIELLE_2022_POLL_NAME ? 400 * score : score
-      ),
+    (score: number | undefined) =>
+      score === undefined
+        ? undefined
+        : between(
+            SCORE_MIN,
+            SCORE_MAX,
+            // Below is a bad hack necessary because scores on "presidentielle2022"
+            // are frozen, and the latest Mehestan scaling is not applied on this poll.
+            pollName === PRESIDENTIELLE_2022_POLL_NAME ? 400 * score : score
+          ),
     [pollName]
   );
 

--- a/frontend/src/hooks/useListFilter.ts
+++ b/frontend/src/hooks/useListFilter.ts
@@ -1,4 +1,6 @@
-import { useLocation, useNavigate } from 'react-router';
+import { useLocation } from 'react-router';
+
+import { useUpdateSearchParams } from './useUpdateSearchParams';
 
 export const useListFilter = ({
   defaults = [],
@@ -8,7 +10,7 @@ export const useListFilter = ({
   setEmptyValues?: boolean;
 } = {}): [URLSearchParams, (key: string, value: string | null) => void] => {
   const location = useLocation();
-  const navigate = useNavigate();
+  const updateSearchParams = useUpdateSearchParams();
   const searchParams = new URLSearchParams(location.search);
 
   // Initialize the filters with the default values provided.
@@ -36,7 +38,7 @@ export const useListFilter = ({
         searchParams.delete('offset');
       }
 
-      navigate({ search: searchParams.toString() });
+      updateSearchParams(searchParams.toString());
     }
   };
 

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -100,13 +100,13 @@ export const useNotifications = () => {
   );
 
   const displayMessagesFromReasonBody = useCallback(
-    (reasonBody) => {
+    (reasonBody: unknown) => {
       if (typeof reasonBody === 'string') {
         showErrorAlert(reasonBody);
       } else if (
         Object.prototype.toString.call(reasonBody) === '[object Object]'
       ) {
-        Object.values(reasonBody).map((value) =>
+        Object.values(reasonBody as Record<string, unknown>).map((value) =>
           displayMessagesFromReasonBody(value)
         );
       } else if (Array.isArray(reasonBody)) {

--- a/frontend/src/hooks/useUpdateSearchParams.ts
+++ b/frontend/src/hooks/useUpdateSearchParams.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+/**
+ * Update the query string of the current page.
+ *
+ * This is the write counterpart to `useSearchParams`: it stays on the current
+ * path and only changes the search parameters. Because the navigation doesn't
+ * leave the page, the current `location.state` is carried forward. React
+ * Router would otherwise reset it to `null`, dropping data that belongs to the
+ * current visit (for instance the search page's back-button target, kept in
+ * the location state while the user changes filters or turns pages).
+ */
+export const useUpdateSearchParams = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  return useCallback(
+    (search: string, { replace = false }: { replace?: boolean } = {}) => {
+      navigate({ search }, { replace, state: location.state });
+    },
+    [navigate, location.state]
+  );
+};

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -8,6 +8,7 @@ import packageJson from '../package.json';
 declare module 'i18next' {
   interface CustomTypeOptions {
     returnNull: false;
+    allowObjectInHTMLChildren: true;
   }
 }
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
@@ -24,7 +24,8 @@ declare module '@mui/styles/defaultTheme' {
   interface DefaultTheme extends Theme {}
 }
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root') as HTMLElement);
+root.render(
   <React.StrictMode>
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
@@ -51,6 +52,5 @@ ReactDOM.render(
         </StyledEngineProvider>
       </PersistGate>
     </Provider>
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );

--- a/frontend/src/pages/feed/FeedForYou.tsx
+++ b/frontend/src/pages/feed/FeedForYou.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Alert, Box } from '@mui/material';
@@ -15,7 +15,6 @@ import {
   SearchIconButtonLink,
 } from 'src/components';
 import EntityList from 'src/features/entities/EntityList';
-import { updateBackNagivation } from 'src/features/login/loginSlice';
 import { selectSettings } from 'src/features/settings/userSettingsSlice';
 import { useCurrentPoll } from 'src/hooks';
 import { PaginatedRecommendationList } from 'src/services/openapi';
@@ -26,7 +25,6 @@ const ENTITIES_LIMIT = 20;
 
 const FeedForYou = () => {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -57,15 +55,6 @@ const FeedForYou = () => {
     searchParams.set('offset', newOffset.toString());
     navigate({ search: searchParams.toString() });
   };
-
-  useEffect(() => {
-    dispatch(
-      updateBackNagivation({
-        backPath: location.pathname,
-        backParams: offset > 0 ? `offset=${offset}` : '',
-      })
-    );
-  }, [dispatch, location.pathname, offset]);
 
   useEffect(() => {
     const searchString = new URLSearchParams(userPreferences);
@@ -118,7 +107,13 @@ const FeedForYou = () => {
             gap: 1,
           }}
         >
-          <SearchIconButtonLink params={userPreferences.toString()} />
+          <SearchIconButtonLink
+            params={userPreferences.toString()}
+            backNavigation={{
+              backPath: location.pathname,
+              backParams: offset > 0 ? `offset=${offset}` : '',
+            }}
+          />
           <PreferencesIconButtonLink hash={`#${pollName}-feed-foryou`} />
         </Box>
         {!isLoading && entities.count === 0 && (

--- a/frontend/src/pages/feed/FeedTopItems.tsx
+++ b/frontend/src/pages/feed/FeedTopItems.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Alert, Box } from '@mui/material';
@@ -15,7 +15,6 @@ import {
 } from 'src/components';
 import { useCurrentPoll } from 'src/hooks';
 import EntityList from 'src/features/entities/EntityList';
-import { updateBackNagivation } from 'src/features/login/loginSlice';
 import ShareMenuButton from 'src/features/menus/ShareMenuButton';
 import SearchFilter from 'src/features/recommendation/SearchFilter';
 import { selectSettings } from 'src/features/settings/userSettingsSlice';
@@ -54,7 +53,6 @@ const filterAllowedParams = (
 
 const FeedTopItems = () => {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -79,20 +77,6 @@ const FeedTopItems = () => {
     searchParams.set('offset', newOffset.toString());
     navigate({ search: searchParams.toString() });
   };
-
-  useEffect(() => {
-    const currentParams = filterAllowedParams(
-      new URLSearchParams(location.search),
-      ALLOWED_SEARCH_PARAMS
-    );
-
-    dispatch(
-      updateBackNagivation({
-        backPath: location.pathname,
-        backParams: currentParams.toString(),
-      })
-    );
-  }, [dispatch, location.pathname, location.search]);
 
   useEffect(() => {
     // `searchParams` is defined as a mutable object outside of this effect.
@@ -185,6 +169,13 @@ const FeedTopItems = () => {
                 <ShareMenuButton isIcon />
                 <SearchIconButtonLink
                   params={makeSearchPageSearchParams().toString()}
+                  backNavigation={{
+                    backPath: location.pathname,
+                    backParams: filterAllowedParams(
+                      new URLSearchParams(location.search),
+                      ALLOWED_SEARCH_PARAMS
+                    ).toString(),
+                  }}
                 />
                 <PreferencesIconButtonLink hash={`#${pollName}-feed-top`} />
               </Box>

--- a/frontend/src/pages/search/SearchPage.tsx
+++ b/frontend/src/pages/search/SearchPage.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { Alert, Box } from '@mui/material';
 
@@ -13,9 +12,9 @@ import {
   Pagination,
   PreferencesIconButtonLink,
 } from 'src/components';
-import { useCurrentPoll } from 'src/hooks';
+import { BackNavigationState } from 'src/components/buttons/SearchIconButtonLink';
+import { useCurrentPoll, useUpdateSearchParams } from 'src/hooks';
 import EntityList from 'src/features/entities/EntityList';
-import { selectLogin } from 'src/features/login/loginSlice';
 import ShareMenuButton from 'src/features/menus/ShareMenuButton';
 import SearchFilter from 'src/features/recommendation/SearchFilter';
 import { PaginatedRecommendationList } from 'src/services/openapi';
@@ -26,13 +25,12 @@ const ENTITIES_LIMIT = 20;
 const SearchPage = () => {
   const { t } = useTranslation();
 
-  const navigate = useNavigate();
+  const updateSearchParams = useUpdateSearchParams();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const offset = Number(searchParams.get('offset') || 0);
 
   const { name: pollName, criterias, options } = useCurrentPoll();
-  const loginState = useSelector(selectLogin);
 
   const [isLoading, setIsLoading] = useState(true);
   const [loadingError, setLoadingError] = useState(false);
@@ -43,7 +41,7 @@ const SearchPage = () => {
 
   const onOffsetChange = (newOffset: number) => {
     searchParams.set('offset', newOffset.toString());
-    navigate({ search: searchParams.toString() });
+    updateSearchParams(searchParams.toString());
   };
 
   useEffect(() => {
@@ -55,7 +53,7 @@ const SearchPage = () => {
 
     if (searchString.get('language') === null) {
       searchString.set('language', '');
-      navigate({ search: searchString.toString() }, { replace: true });
+      updateSearchParams(searchString.toString(), { replace: true });
       return;
     }
 
@@ -80,11 +78,20 @@ const SearchPage = () => {
     };
 
     fetchEntities();
-  }, [criterias, location.search, navigate, offset, options, pollName]);
+  }, [
+    criterias,
+    location.search,
+    updateSearchParams,
+    offset,
+    options,
+    pollName,
+  ]);
+
+  const backNavigation = location.state as BackNavigationState | null;
 
   const createBackButtonPath = () => {
-    const backPath = loginState.backPath;
-    const backParams = loginState.backParams;
+    const backPath = backNavigation?.backPath;
+    const backParams = backNavigation?.backParams;
 
     if (!backPath) {
       return '';

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -23,7 +23,13 @@ export interface JSONObject {
 }
 
 export type ActionList = Array<
-  | (({ uid, entity }: { uid: string; entity?: EntityResult }) => JSX.Element)
+  | (({
+      uid,
+      entity,
+    }: {
+      uid: string;
+      entity?: EntityResult;
+    }) => JSX.Element | null)
   | React.ReactNode
 >;
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -182,7 +182,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.6", "@babel/runtime@^7.23.2", "@babel/runtime@^7.26.0", "@babel/runtime@^7.28.6", "@babel/runtime@^7.29.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.26.0", "@babel/runtime@^7.28.6", "@babel/runtime@^7.29.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
   integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
@@ -1075,20 +1075,6 @@
     picocolors "1.1.1"
     pretty-format "^27.0.2"
 
-"@testing-library/dom@^8.0.0":
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.1.tgz#2e52a32e46fc88369eef7eef634ac2a192decd9f"
-  integrity sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^5.0.1"
-    aria-query "5.1.3"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.9"
-    lz-string "^1.5.0"
-    pretty-format "^27.0.2"
-
 "@testing-library/jest-dom@^5.16":
   version "5.17.0"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz#5e97c8f9a15ccf4656da00fecab505728de81e0c"
@@ -1104,14 +1090,12 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@^12.1.2":
-  version "12.1.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
-  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+"@testing-library/react@^16":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.3.2.tgz#672883b7acb8e775fc0492d9e9d25e06e89786d0"
+  integrity sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^8.0.0"
-    "@types/react-dom" "<18.0.0"
 
 "@testing-library/user-event@^13.5.0":
   version "13.5.0"
@@ -1290,10 +1274,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.15.tgz#e6e5a86d602beaca71ce5163fadf5f95d70931c7"
   integrity sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==
 
-"@types/react-dom@<18.0.0", "@types/react-dom@^17.0.11":
-  version "17.0.26"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.26.tgz#fa7891ba70fd39ddbaa7e85b6ff9175bb546bc1b"
-  integrity sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==
+"@types/react-dom@^18":
+  version "18.3.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
+  integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
 "@types/react-redux@^7.1.20", "@types/react-redux@^7.1.7":
   version "7.1.34"
@@ -1310,13 +1294,12 @@
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
-"@types/react@*", "@types/react@^17":
-  version "17.0.91"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.91.tgz#0a972a41c430f56d2feb7c15368bc51642495e0b"
-  integrity sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==
+"@types/react@*", "@types/react@^18":
+  version "18.3.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.31.tgz#b5e95e28ffcceab8d982f33f2eb076e17653c2a4"
+  integrity sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "^0.16"
     csstype "^3.2.2"
 
 "@types/redux-mock-store@^1.0.3":
@@ -1325,11 +1308,6 @@
   integrity sha512-jcscBazm6j05Hs6xYCca6psTUBbFT2wqMxT7wZEHAYFxHB/I8jYk7d5msrHUlDiSL02HdTqTmkK2oIV8i3C8DA==
   dependencies:
     redux "^4.0.5"
-
-"@types/scheduler@^0.16":
-  version "0.16.8"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
-  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12":
   version "7.7.1"
@@ -1585,13 +1563,6 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-query@5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
-  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
-  dependencies:
-    deep-equal "^2.0.5"
-
 aria-query@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
@@ -1604,7 +1575,7 @@ aria-query@^5.0.0:
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
 
-array-buffer-byte-length@^1.0.0, array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
+array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz#384d12a37295aec3769ab022ad323a18a51ccf8b"
   integrity sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==
@@ -1776,7 +1747,7 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
-call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.7, call-bind@^1.0.8, call-bind@^1.0.9:
+call-bind@^1.0.7, call-bind@^1.0.8, call-bind@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
   integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
@@ -1827,7 +1798,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2114,30 +2085,6 @@ decimal.js@^10.6.0:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
   integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
 
-deep-equal@^2.0.5:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.3.tgz#af89dafb23a396c7da3e862abc0be27cf51d56e1"
-  integrity sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==
-  dependencies:
-    array-buffer-byte-length "^1.0.0"
-    call-bind "^1.0.5"
-    es-get-iterator "^1.1.3"
-    get-intrinsic "^1.2.2"
-    is-arguments "^1.1.1"
-    is-array-buffer "^3.0.2"
-    is-date-object "^1.0.5"
-    is-regex "^1.1.4"
-    is-shared-array-buffer "^1.0.2"
-    isarray "^2.0.5"
-    object-is "^1.1.5"
-    object-keys "^1.1.1"
-    object.assign "^4.1.4"
-    regexp.prototype.flags "^1.5.1"
-    side-channel "^1.0.4"
-    which-boxed-primitive "^1.0.2"
-    which-collection "^1.0.1"
-    which-typed-array "^1.1.13"
-
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -2305,21 +2252,6 @@ es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
-
-es-get-iterator@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
-  integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.3"
-    has-symbols "^1.0.3"
-    is-arguments "^1.1.1"
-    is-map "^2.0.2"
-    is-set "^2.0.2"
-    is-string "^1.0.7"
-    isarray "^2.0.5"
-    stop-iteration-iterator "^1.0.0"
 
 es-iterator-helpers@^1.2.1:
   version "1.3.1"
@@ -2766,7 +2698,7 @@ get-east-asian-width@^1.5.0:
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
   integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
 
-get-intrinsic@^1.1.3, get-intrinsic@^1.2.2, get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -3048,12 +2980,12 @@ i18next-resources-for-ts@^2.1.0:
     chokidar "^5.0.0"
     yaml "^2.8.2"
 
-i18next@^22.4.0:
-  version "22.5.1"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-22.5.1.tgz#99df0b318741a506000c243429a7352e5f44d424"
-  integrity sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==
+i18next@^23:
+  version "23.16.8"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.16.8.tgz#3ae1373d344c2393f465556f394aba5a9233b93a"
+  integrity sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==
   dependencies:
-    "@babel/runtime" "^7.20.6"
+    "@babel/runtime" "^7.23.2"
 
 i18next@^26.3.1:
   version "26.3.6"
@@ -3134,15 +3066,7 @@ internal-slot@^1.1.0:
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
   integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
-is-arguments@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
-  integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
-  dependencies:
-    call-bound "^1.0.2"
-    has-tostringtag "^1.0.2"
-
-is-array-buffer@^3.0.2, is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
+is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
   integrity sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==
@@ -3251,7 +3175,7 @@ is-interactive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-2.0.0.tgz#40c57614593826da1100ade6059778d597f16e90"
   integrity sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==
 
-is-map@^2.0.2, is-map@^2.0.3:
+is-map@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.3.tgz#ede96b7fe1e270b3c4465e3a465658764926d62e"
   integrity sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==
@@ -3289,7 +3213,7 @@ is-potential-custom-element-name@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
-is-regex@^1.1.4, is-regex@^1.2.1:
+is-regex@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
   integrity sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==
@@ -3299,12 +3223,12 @@ is-regex@^1.1.4, is-regex@^1.2.1:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
-is-set@^2.0.2, is-set@^2.0.3:
+is-set@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.3.tgz#8ab209ea424608141372ded6e0cb200ef1d9d01d"
   integrity sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==
 
-is-shared-array-buffer@^1.0.2, is-shared-array-buffer@^1.0.4:
+is-shared-array-buffer@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz#9b67844bd9b7f246ba0708c3a93e34269c774f6f"
   integrity sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==
@@ -3316,7 +3240,7 @@ is-stream@^4.0.1:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-4.0.1.tgz#375cf891e16d2e4baec250b85926cffc14720d9b"
   integrity sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==
 
-is-string@^1.0.7, is-string@^1.1.1:
+is-string@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.1.1.tgz#92ea3f3d5c5b6e039ca8677e5ac8d07ea773cbb9"
   integrity sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==
@@ -3939,14 +3863,6 @@ object-inspect@^1.13.3, object-inspect@^1.13.4:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
-object-is@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
-  integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
-  dependencies:
-    call-bind "^1.0.7"
-    define-properties "^1.2.1"
-
 object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -4251,26 +4167,25 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^18:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.2"
 
 react-fast-compare@^3.0.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
   integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
-react-i18next@^12:
-  version "12.3.1"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-12.3.1.tgz#30134a41a2a71c61dc69c6383504929aed1c99e7"
-  integrity sha512-5v8E2XjZDFzK7K87eSwC7AJcAkcLt5xYZ4+yTPDAW1i7C93oOY1dnr4BaQM7un4Hm+GmghuiPvevWwlca5PwDA==
+react-i18next@^14:
+  version "14.1.3"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-14.1.3.tgz#85525c4294ef870ddd3f5d184e793cae362f47cb"
+  integrity sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==
   dependencies:
-    "@babel/runtime" "^7.20.6"
+    "@babel/runtime" "^7.23.9"
     html-parse-stringify "^3.0.1"
 
 react-i18next@^17.0.8:
@@ -4374,13 +4289,12 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 react@^19.2.7:
   version "19.2.8"
@@ -4459,7 +4373,7 @@ reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
     get-proto "^1.0.1"
     which-builtin-type "^1.2.1"
 
-regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
+regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
   integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
@@ -4603,13 +4517,12 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 semver@^6.3.1:
   version "6.3.1"
@@ -4693,7 +4606,7 @@ side-channel-weakmap@^1.0.2:
     object-inspect "^1.13.3"
     side-channel-map "^1.0.1"
 
-side-channel@^1.0.4, side-channel@^1.1.0:
+side-channel@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
   integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
@@ -4756,7 +4669,7 @@ stdin-discarder@^0.3.2:
   resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.3.2.tgz#998ab3b9a988661e6036a9bfdc96f43649e8e83e"
   integrity sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==
 
-stop-iteration-iterator@^1.0.0, stop-iteration-iterator@^1.1.0:
+stop-iteration-iterator@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
   integrity sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==
@@ -5204,7 +5117,7 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
-which-boxed-primitive@^1.0.2, which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
+which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz#d76ec27df7fa165f18d5808374a5fe23c29b176e"
   integrity sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==
@@ -5234,7 +5147,7 @@ which-builtin-type@^1.2.1:
     which-collection "^1.0.2"
     which-typed-array "^1.1.16"
 
-which-collection@^1.0.1, which-collection@^1.0.2:
+which-collection@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.2.tgz#627ef76243920a107e7ce8e96191debe4b16c2a0"
   integrity sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==
@@ -5244,7 +5157,7 @@ which-collection@^1.0.1, which-collection@^1.0.2:
     is-weakmap "^2.0.2"
     is-weakset "^2.0.3"
 
-which-typed-array@^1.1.13, which-typed-array@^1.1.16, which-typed-array@^1.1.19:
+which-typed-array@^1.1.16, which-typed-array@^1.1.19:
   version "1.1.22"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
   integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==


### PR DESCRIPTION
This PR upgrades React from 17 to 18.

The upgrade itself was not really a problem: it was mostly type fixes and using `createRoot` (2039cede73fdf4d2ee28519fc6423461c2f4d8e1).

The difficulty was the [StrictMode](https://18.react.dev/reference/react/StrictMode) because of the [effects re-running](https://18.react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-effects-in-development). This `StrictMode` change triggers problems only in development so we can also choose to disable it.

I identified 3 problems and fixed them as described below. I'm pretty confident there are no other problems, but I might have missed some.

## The "back" button on the search page

The back parameters were stored in redux when the feed pages mount, and were cleared when the "back" button was unmounted. The mount/unmount/remount while preserving state of the new `StrictMode` made the "back" button clear the back parameters when it appeared.

There was no easy fix for that. The options I examined were (there may be others):

1. keep the back parameters in redux and clear them on each event that moves the user to the search page. Error prone, we might forget about that.
2. move the back parameters into the URL. Would be kind of ugly and it's probably not something users would want to carry if they share the URL.
3. move the back parameters into the location.state. It's hidden from the user and attached to the location which seems like a good fit. But since the search page rewrites the URL when the search parameters change, we have to propagate the state during these operations.

I chose option 3, and added a new hook to "update the query string while preserving the state" (`useUpdateSearchParams`).

Done in 79a02c7fff4430388b6bcb5d26d35030b8b0f77e.

## The comparison sliders' mount check

`ComparisonSliders` had a guard against changing the component state while unmounted because of React 17's warning about that. It broke in StrictMode (because the mount/unmount/remount kept `isMounted` false) and React 18 removed this warning so I just removed the guard.

Done in 09809b09a040aea24da3a015051aa56eead5f9be.

## Comparison auto-fill

The mount/unmount/remount didn't work well with the `initializeWithSuggestions` guard. The component was unmounted before the auto-fill finished so a second auto-fill was triggered. So I set the "auto-fill already started" flag earlier, and added a new state that let the comparison fetch effect run only when the auto-fill is complete.

Done in 4848d0044a4a758c15947f37f1a02e3cdcdbfcbb.